### PR TITLE
android: user-friendly CSV import for trunking data (channel maps, talkgroups, keys)

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -288,6 +288,7 @@ jobs:
             dsd-neo_test_ui_qt_persistence \
             dsd-neo_test_ui_qt_call_history_model \
             dsd-neo_test_ui_qt_session_args \
+            dsd-neo_test_ui_qt_imported_files_model \
             dsd-neo_test_ui_qt_call_history_merge \
             dsd-neo_test_ui_qt_call_line \
             dsd-neo_test_ui_qt_session_state \

--- a/android/README.md
+++ b/android/README.md
@@ -36,6 +36,30 @@ The service state machine, the native `g_running` atomic and the failure path ar
 folded into that one phase by `session_state_map.h`, which is deliberately free of
 Qt and JNI so `UI_QT_SESSION_STATE` can test it on the host.
 
+## Imported files (trunking CSVs)
+
+The C core only opens real filesystem paths (`src/runtime/path_policy.c` requires
+a regular file, `O_NOFOLLOW`), so SAF content URIs are always materialized into a
+copy first. There are two copy paths, with different lifetimes:
+
+- `AppSupport.copyContentUriToCache` → `cacheDir`, for one-shot opens (the
+  wizard's audio/capture "File" source). Android may evict it.
+- `AppSupport.importDocumentToFiles` → `files/imports/`, for the CSV library
+  (channel maps, talkgroup lists, key files). These must survive restarts —
+  saved systems reference the path, and the engine appends learned talkgroup
+  rows to the group list in place. Display-name collisions are unique-ified
+  (`chan.csv` → `chan (2).csv`); updates stage a temp file and rename over the
+  target so a half-copied CSV is never observable.
+
+Both are reached through `DecoderHost` virtuals (`importContentUri` /
+`importDocument`); the desktop default of `importDocument` implements the same
+semantics under `QStandardPaths::AppDataLocation`, which is what
+`UI_QT_IMPORTED_FILES` tests on the host. The library itself (one JSON-persisted
+row per stored file, with dry-run validation counts from
+`<dsd-neo/core/csv_validate.h>`) is `src/ui/qt/imported_files_model.{h,cpp}`,
+surfaced as Settings → Imported files and the wizard's Trunking data pickers.
+No storage permissions are involved; SAF needs none.
+
 ## Build
 
 Prerequisites:

--- a/android/decoder_host_android.cpp
+++ b/android/decoder_host_android.cpp
@@ -237,6 +237,22 @@ DecoderHostAndroid::importContentUri(const QString& reference, const QString& fi
     return result.isValid() ? result.toString() : QString();
 }
 
+QString
+DecoderHostAndroid::importDocument(const QString& reference, const QString& fileName, const QString& replacePath) {
+    QJniObject context = android_context();
+    if (!context.isValid()) {
+        return QString();
+    }
+    QJniObject uri = QJniObject::fromString(reference);
+    QJniObject name = QJniObject::fromString(fileName);
+    QJniObject replace = QJniObject::fromString(replacePath);
+    QJniObject result = QJniObject::callStaticObjectMethod(
+        kSupportClass, "importDocumentToFiles",
+        "(Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+        context.object(), uri.object(), name.object(), replace.object());
+    return result.isValid() ? result.toString() : QString();
+}
+
 void
 DecoderHostAndroid::refresh() {
     const bool running = engine_is_running();

--- a/android/decoder_host_android.h
+++ b/android/decoder_host_android.h
@@ -57,6 +57,10 @@ class DecoderHostAndroid : public dsd_qt::DecoderHost {
     /** @brief Materialize a SAF content URI into cacheDir; returns "" on failure. */
     QString importContentUri(const QString& reference, const QString& fileName) override;
 
+    /** @brief Materialize a SAF content URI into filesDir/imports; returns "" on failure. */
+    QString importDocument(const QString& reference, const QString& fileName,
+                           const QString& replacePath = QString()) override;
+
   private:
     /** @brief Record a start that never reached the service. Always returns false. */
     bool failStart(const QString& reason);

--- a/android/decoder_host_android.h
+++ b/android/decoder_host_android.h
@@ -57,9 +57,14 @@ class DecoderHostAndroid : public dsd_qt::DecoderHost {
     /** @brief Materialize a SAF content URI into cacheDir; returns "" on failure. */
     QString importContentUri(const QString& reference, const QString& fileName) override;
 
-    /** @brief Materialize a SAF content URI into filesDir/imports; returns "" on failure. */
-    QString importDocument(const QString& reference, const QString& fileName,
-                           const QString& replacePath = QString()) override;
+    /**
+     * @brief Materialize a SAF content URI into filesDir/imports; returns "" on failure.
+     *
+     * No default argument: on a virtual it would be bound from the static type of
+     * the call, so a base-class default that ever changed would silently mean two
+     * different things depending on which pointer type the caller held.
+     */
+    QString importDocument(const QString& reference, const QString& fileName, const QString& replacePath) override;
 
   private:
     /** @brief Record a start that never reached the service. Always returns false. */

--- a/android/package/src/io/github/arancormonk/dsdneo/AppSupport.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/AppSupport.kt
@@ -95,4 +95,79 @@ object AppSupport {
             ""
         }
     }
+
+    /** chan.csv, chan (2).csv, chan (3).csv … first name not already taken. */
+    private fun uniqueTarget(dir: File, name: String): File? {
+        var target = File(dir, name)
+        if (!target.exists()) {
+            return target
+        }
+        val dot = name.lastIndexOf('.')
+        val base = if (dot > 0) name.substring(0, dot) else name
+        val ext = if (dot > 0) name.substring(dot) else ""
+        for (i in 2 until 1000) {
+            target = File(dir, "$base ($i)$ext")
+            if (!target.exists()) {
+                return target
+            }
+        }
+        return null
+    }
+
+    /**
+     * Copy a SAF content URI into filesDir/imports and return the real path.
+     *
+     * Unlike copyContentUriToCache, this copy must outlive the session: saved
+     * systems reference the returned path across restarts, and the engine
+     * appends learned talkgroup rows to a group list in place, neither of which
+     * survives cache eviction. Name collisions are unique-ified rather than
+     * overwritten — two different documents may share a display name. A
+     * non-empty replacePath that resolves inside the imports directory is
+     * updated atomically instead (staging file + rename), so a half-copied CSV
+     * is never observable; a replacePath outside it is not a write target and
+     * falls back to a fresh copy.
+     *
+     * @return absolute path, or an empty string on failure.
+     */
+    @JvmStatic
+    fun importDocumentToFiles(context: Context, uriText: String, fileName: String, replacePath: String): String {
+        return try {
+            val uri = Uri.parse(uriText)
+            val importsDir = File(context.filesDir, "imports")
+            importsDir.mkdirs()
+
+            var target: File? = null
+            if (replacePath.isNotEmpty()) {
+                val candidate = File(replacePath)
+                if (candidate.canonicalFile.parent == importsDir.canonicalPath) {
+                    target = candidate
+                }
+            }
+            if (target == null) {
+                target = uniqueTarget(importsDir, displayNameFor(context, uri, fileName))
+            }
+            if (target == null) {
+                return ""
+            }
+
+            val staging = File.createTempFile(".import", ".tmp", importsDir)
+            try {
+                context.contentResolver.openInputStream(uri).use { input ->
+                    if (input == null) {
+                        return ""
+                    }
+                    staging.outputStream().use { output -> input.copyTo(output) }
+                }
+                if (!staging.renameTo(target)) {
+                    return ""
+                }
+            } finally {
+                staging.delete() // no-op once the rename has landed
+            }
+            target.absolutePath
+        } catch (e: Exception) {
+            Log.e(TAG, "failed to import $uriText", e)
+            ""
+        }
+    }
 }

--- a/android/package/src/io/github/arancormonk/dsdneo/AppSupport.kt
+++ b/android/package/src/io/github/arancormonk/dsdneo/AppSupport.kt
@@ -136,6 +136,12 @@ object AppSupport {
             val importsDir = File(context.filesDir, "imports")
             importsDir.mkdirs()
 
+            // A process death mid-copy skips the finally below, and filesDir is
+            // not cache, so nothing else ever reclaims the staging file. Sweep
+            // leftovers here rather than letting them accumulate forever.
+            importsDir.listFiles { f -> f.isFile && f.name.startsWith(".import") && f.name.endsWith(".tmp") }
+                ?.forEach { it.delete() }
+
             var target: File? = null
             if (replacePath.isNotEmpty()) {
                 val candidate = File(replacePath)

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -241,8 +241,11 @@ Build files: `src/protocol/CMakeLists.txt` and per‑protocol `src/protocol/<nam
 
 Qt Quick frontend (`src/ui/qt`):
 
-- QML plus C++ view-models (metrics, call history + per-view filters, saved systems, app preferences, command bridge)
-  that poll app-control on a timer; used by the Android app today and intended as the shared basis for a desktop GUI.
+- QML plus C++ view-models (metrics, call history + per-view filters, saved systems, imported CSV files, app
+  preferences, command bridge) that poll app-control on a timer; used by the Android app today and intended as the
+  shared basis for a desktop GUI. `imported_files_model.{h,cpp}` is the library behind the CSV pickers: it copies
+  picked documents into durable app storage through `DecoderHost::importDocument()` and dry-run validates them via
+  `<dsd-neo/core/csv_validate.h>` (`src/core/file/dsd_import.c`) for row-count feedback.
 - Platform-free by rule: it may include Qt and `include/dsd-neo/app_control/` headers, never engine/io/protocol
   internals, and never platform APIs (`QJniObject`, `<android/*.h>`). Platform specifics live behind the `DecoderHost`
   interface, implemented per host (`android/decoder_host_android.cpp` today).

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -24,7 +24,19 @@ app-private storage (`files/imports/`), so the original can live anywhere (Downl
 after import — use "Update from file" to pull in a changed original. Each import is validated immediately and the row
 shows how many entries loaded ("412 talkgroups · 3 rows skipped"); a file whose rows all fail to parse is flagged
 "No usable rows". While a session is running, long-press its title on the monitor screen to edit that system; saving
-applies its files to the live session immediately.
+applies the files that changed to the live session immediately, including clearing a field to "None" — that unloads the
+channel map, talkgroup list or keys from the running session. One limit is worth knowing: the gesture only works for a
+session this app instance started (after the Activity is recreated while the service kept running, there is no
+saved-system row to write back to).
+
+Applying a channel map **replaces** the live one rather than merging into it, so anything the decoder learned on the
+air is discarded along with the previous file's entries; a grant for a channel the new file omits stays unresolved
+until the site announces it again.
+
+The library validates against the kind you picked, by content rather than by file name. A channel map and a decimal key
+file share the same `number,number` grammar and the header line is free text, so what separates them is the frequency
+column: picking a key list as a channel map reports "No usable rows". Two files of the same kind are still
+indistinguishable — nothing stops one site's map being picked for another.
 
 Programmatic validation uses the same dry-run parser: `dsd_csv_validate_*` in `<dsd-neo/core/csv_validate.h>` reports
 accepted/skipped/total row counts without touching live decoder state.
@@ -41,6 +53,10 @@ Required columns:
 Notes:
 
 - `frequency_hz` is parsed as an integer (no `K/M/G` suffixes).
+- `frequency_hz` must be between 100000 (100 kHz) and 6000000000 (6 GHz) — the range any supported front end can
+  reach. A row outside it (including `0`) is skipped with a warning, and its slot in the LCN list below is left at 0 so
+  later rows keep their LCN numbers. This is what tells a channel map apart from a decimal key list, which has the same
+  `number,number` shape.
 - Extra columns are ignored; use them for labels like "default CC".
 - For EDACS-style workflows, DSD-neo also records the `frequency_hz` values in **row order** as an LCN frequency list,
   so keep rows in the LCN order you want. The LCN list stores at most 26 frequencies.

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -23,7 +23,8 @@ channel map, talkgroup list, or key file to a system. Files are picked with the 
 app-private storage (`files/imports/`), so the original can live anywhere (Downloads, Drive, …) and is not read again
 after import — use "Update from file" to pull in a changed original. Each import is validated immediately and the row
 shows how many entries loaded ("412 talkgroups · 3 rows skipped"); a file whose rows all fail to parse is flagged
-"No usable rows". Saving the system a running session was started from applies its files to that session live.
+"No usable rows". While a session is running, long-press its title on the monitor screen to edit that system; saving
+applies its files to the live session immediately.
 
 Programmatic validation uses the same dry-run parser: `dsd_csv_validate_*` in `<dsd-neo/core/csv_validate.h>` reports
 accepted/skipped/total row counts without touching live decoder state.

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -15,6 +15,19 @@ If you want known-good starting points, see `examples/` in the repository.
 - Imported text fields are copied into fixed-size runtime buffers. Keep short fields concise; long `mode` and `name`
   values are truncated in runtime display/policy state.
 
+## Importing on Android
+
+The Android app does not take CLI flags directly. Import CSVs through the UI instead: **Settings → Imported files**
+manages the library (import, update, remove), and the add/edit-system wizard's **Trunking data** panel assigns a
+channel map, talkgroup list, or key file to a system. Files are picked with the system document picker and copied into
+app-private storage (`files/imports/`), so the original can live anywhere (Downloads, Drive, …) and is not read again
+after import — use "Update from file" to pull in a changed original. Each import is validated immediately and the row
+shows how many entries loaded ("412 talkgroups · 3 rows skipped"); a file whose rows all fail to parse is flagged
+"No usable rows". Saving the system a running session was started from applies its files to that session live.
+
+Programmatic validation uses the same dry-run parser: `dsd_csv_validate_*` in `<dsd-neo/core/csv_validate.h>` reports
+accepted/skipped/total row counts without touching live decoder state.
+
 ## Channel Map CSV (`-C <file>` / `[trunking] chan_csv`)
 
 Purpose: Map a trunking channel number to an RF frequency.

--- a/include/dsd-neo/app_control/commands.h
+++ b/include/dsd-neo/app_control/commands.h
@@ -202,6 +202,15 @@ enum dsd_app_command_id {
     DSD_APP_CMD_IMPORT_KEYS_DEC = 562,    // payload: char path[]
     DSD_APP_CMD_IMPORT_KEYS_HEX = 563,    // payload: char path[]
 
+    // Unload what those imported. A frontend that lets a system clear its CSV
+    // selection needs to express "none", and re-importing cannot: every command
+    // above takes a path, and the services reject an empty one. Without these,
+    // clearing a picker left the previous file naming talkgroups and mapping
+    // channels for the rest of the session.
+    DSD_APP_CMD_IMPORT_CHANNEL_MAP_CLEAR = 564, // no payload
+    DSD_APP_CMD_IMPORT_GROUP_LIST_CLEAR = 565,  // no payload
+    DSD_APP_CMD_IMPORT_KEYS_CLEAR = 566,        // no payload; dec and hex share one keyring
+
     // P25 helpers
     DSD_APP_CMD_P25_P2_PARAMS_SET = 580, // payload: struct { uint64_t wacn, sysid, cc; }
 

--- a/include/dsd-neo/core/csv_validate.h
+++ b/include/dsd-neo/core/csv_validate.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Dry-run CSV validation with row counts for UI feedback.
+ *
+ * Parses a CSV through the same loops as the real importers but into
+ * throwaway state, so a frontend can report "N rows loaded, M skipped"
+ * before wiring the file into a live session. Engine state is never touched.
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_CORE_CSV_VALIDATE_H_H
+#define DSD_NEO_INCLUDE_DSD_NEO_CORE_CSV_VALIDATE_H_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct dsd_csv_validation {
+    unsigned int accepted; /* data rows that would load */
+    unsigned int skipped;  /* malformed or out-of-range data rows */
+    unsigned int total;    /* data rows seen (header line excluded) */
+} dsd_csv_validation;
+
+/*
+ * Each returns 0 when the file opened and was parsed (counts are valid, and
+ * accepted may legitimately be 0), or -1 when the file could not be opened.
+ */
+int dsd_csv_validate_group_file(const char* path, dsd_csv_validation* out);
+int dsd_csv_validate_chan_file(const char* path, dsd_csv_validation* out);
+int dsd_csv_validate_key_file_dec(const char* path, dsd_csv_validation* out);
+int dsd_csv_validate_key_file_hex(const char* path, dsd_csv_validation* out);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_CORE_CSV_VALIDATE_H_H */

--- a/include/dsd-neo/core/talkgroup_policy.h
+++ b/include/dsd-neo/core/talkgroup_policy.h
@@ -143,6 +143,19 @@ int dsd_tg_policy_clear_active_call(dsd_state* state, int slot);
 
 int dsd_tg_policy_reload_group_file(const dsd_opts* opts, dsd_state* state);
 
+/**
+ * @brief Drop every loaded talkgroup entry, leaving an empty policy.
+ *
+ * The counterpart to dsd_tg_policy_reload_group_file() for a frontend that lets
+ * a running session deselect its group file: re-importing cannot express "no
+ * list", so without this the previous one keeps naming and blocking talkgroups.
+ * Generations advance as they do on a reload, so readers holding one re-read.
+ *
+ * @return 0 when the policy is empty afterwards (including when none was
+ *         loaded), -1 on a null state or allocation failure.
+ */
+int dsd_tg_policy_clear(dsd_state* state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -1546,12 +1546,64 @@ ui_cmd_handle_import_keys_hex(dsd_opts* opts, dsd_state* state, const struct dsd
 }
 
 static int
+ui_cmd_handle_import_channel_map_clear(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    (void)c;
+    if (!state) {
+        return UI_CMD_APPLY_COMPLETED;
+    }
+    const int rc = svc_clear_channel_map(opts, state);
+    if (rc == 0) {
+        ui_set_toast(state, 3, "Applied: Channel map cleared");
+    } else {
+        ui_set_toast(state, 4, "Failed: Channel map clear");
+    }
+    return ui_cmd_apply_status_from_service_rc(rc);
+}
+
+static int
+ui_cmd_handle_import_group_list_clear(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    (void)c;
+    if (!state) {
+        return UI_CMD_APPLY_COMPLETED;
+    }
+    const int rc = svc_clear_group_list(opts, state);
+    if (rc == 0) {
+        ui_set_toast(state, 3, "Applied: Group list cleared");
+    } else {
+        ui_set_toast(state, 4, "Failed: Group list clear");
+    }
+    return ui_cmd_apply_status_from_service_rc(rc);
+}
+
+static int
+ui_cmd_handle_import_keys_clear(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    (void)c;
+    if (!state) {
+        return UI_CMD_APPLY_COMPLETED;
+    }
+    const int rc = svc_clear_keys(opts, state);
+    if (rc == 0) {
+        // The lockout ledger is keyed on the key epoch, so targets skipped for
+        // want of a key have to be reconsidered against the empty keyring the
+        // same way they are against a newly imported one.
+        dsd_enc_lockout_bump_key_epoch(state);
+        ui_set_toast(state, 3, "Applied: Keys cleared");
+    } else {
+        ui_set_toast(state, 4, "Failed: Keys clear");
+    }
+    return ui_cmd_apply_status_from_service_rc(rc);
+}
+
+static int
 apply_cmd_io_and_import_imports(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     static const struct dsd_app_command_handler_entry k_handlers[] = {
         {DSD_APP_CMD_IMPORT_CHANNEL_MAP, ui_cmd_handle_import_channel_map},
         {DSD_APP_CMD_IMPORT_GROUP_LIST, ui_cmd_handle_import_group_list},
         {DSD_APP_CMD_IMPORT_KEYS_DEC, ui_cmd_handle_import_keys_dec},
         {DSD_APP_CMD_IMPORT_KEYS_HEX, ui_cmd_handle_import_keys_hex},
+        {DSD_APP_CMD_IMPORT_CHANNEL_MAP_CLEAR, ui_cmd_handle_import_channel_map_clear},
+        {DSD_APP_CMD_IMPORT_GROUP_LIST_CLEAR, ui_cmd_handle_import_group_list_clear},
+        {DSD_APP_CMD_IMPORT_KEYS_CLEAR, ui_cmd_handle_import_keys_clear},
     };
     if (!opts || !c) {
         return 0;

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -24,6 +24,7 @@
 #include <dsd-neo/runtime/log.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "dsd-neo/core/dibit.h"
 #include "dsd-neo/core/opts_fwd.h"
@@ -307,6 +308,22 @@ svc_udp_output_config(dsd_opts* opts, dsd_state* state, const char* host, int po
 }
 
 // Trunking & control --------------------------------------------------------
+
+/*
+ * Adopt an imported channel map wholesale. The importer is additive
+ * (lcn_freq_count only grows, stale trunk_chan_map slots survive), so a
+ * runtime re-import must replace the previous map rather than append to it.
+ */
+static void
+chan_map_adopt(dsd_state* dst, const dsd_state* src) {
+    DSD_MEMCPY(dst->trunk_chan_map, src->trunk_chan_map, sizeof dst->trunk_chan_map);
+    DSD_MEMCPY(dst->trunk_chan_map_used, src->trunk_chan_map_used, sizeof dst->trunk_chan_map_used);
+    dst->trunk_chan_map_used_count = src->trunk_chan_map_used_count;
+    DSD_MEMCPY(dst->trunk_lcn_freq, src->trunk_lcn_freq, sizeof dst->trunk_lcn_freq);
+    dst->lcn_freq_count = src->lcn_freq_count;
+    dst->trunk_chan_map_seq++;
+}
+
 int
 svc_import_channel_map(dsd_opts* opts, dsd_state* state, const char* path) {
     if (!opts || !state || !path || !*path) {
@@ -314,7 +331,20 @@ svc_import_channel_map(dsd_opts* opts, dsd_state* state, const char* path) {
     }
     DSD_STRNCPY(opts->chan_in_file, path, sizeof opts->chan_in_file - 1);
     opts->chan_in_file[sizeof opts->chan_in_file - 1] = '\0';
-    return csvChanImport(opts, state);
+
+    // Import into throwaway heap state (dsd_state is multi-megabyte) so a
+    // failed import leaves the live map untouched.
+    dsd_state* imported = (dsd_state*)calloc(1, sizeof(*imported));
+    if (!imported) {
+        return -1;
+    }
+    if (csvChanImport(opts, imported) != 0) {
+        free(imported);
+        return -1;
+    }
+    chan_map_adopt(state, imported);
+    free(imported);
+    return 0;
 }
 
 int

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/string_utils.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/io/control.h>
@@ -313,6 +314,22 @@ svc_udp_output_config(dsd_opts* opts, dsd_state* state, const char* host, int po
  * Adopt an imported channel map wholesale. The importer is additive
  * (lcn_freq_count only grows, stale trunk_chan_map slots survive), so a
  * runtime re-import must replace the previous map rather than append to it.
+ *
+ * Replace, deliberately, and not a merge: what the protocol layer learned on
+ * the air (dmr_csbk, p25_frequency, edacs-fme) is discarded along with the old
+ * CSV's entries, so a grant for an LCN the new file omits resolves to 0 Hz
+ * until the site re-announces it. A merge was considered and rejected -- "apply
+ * this file" would stop meaning the map is what the file says, a re-import
+ * could no longer shrink a map, and correcting a wrong frequency in the CSV
+ * would not take on a site that had already announced it. Emptying the map is
+ * svc_clear_channel_map()'s job, so nothing needs the merge to express it.
+ *
+ * dmr_lcn_trust is provenance for the map, not a separate table: leaving it
+ * behind would let a stale "learned on the control channel" byte authorize an
+ * off-CC tune to a frequency that only the new CSV asserts. Clearing it matches
+ * what -C produces at startup, and dmr_learn_chan_map() re-earns trust for any
+ * LCN the new map leaves empty. lcn_freq_roll indexes trunk_lcn_freq, so a
+ * shorter list has to restart the hunt rather than resume mid-way.
  */
 static void
 chan_map_adopt(dsd_state* dst, const dsd_state* src) {
@@ -321,6 +338,8 @@ chan_map_adopt(dsd_state* dst, const dsd_state* src) {
     dst->trunk_chan_map_used_count = src->trunk_chan_map_used_count;
     DSD_MEMCPY(dst->trunk_lcn_freq, src->trunk_lcn_freq, sizeof dst->trunk_lcn_freq);
     dst->lcn_freq_count = src->lcn_freq_count;
+    dst->lcn_freq_roll = 0;
+    DSD_MEMSET(dst->dmr_lcn_trust, 0, sizeof dst->dmr_lcn_trust);
     dst->trunk_chan_map_seq++;
 }
 
@@ -329,21 +348,83 @@ svc_import_channel_map(dsd_opts* opts, dsd_state* state, const char* path) {
     if (!opts || !state || !path || !*path) {
         return -1;
     }
+    // Same invariant the CLI enforces for -C: a trunk-scan run gets its channel
+    // maps per target, and adopting a global one here would wipe the target's.
+    if (opts->trunk_scan_enabled == 1) {
+        return -1;
+    }
     DSD_STRNCPY(opts->chan_in_file, path, sizeof opts->chan_in_file - 1);
     opts->chan_in_file[sizeof opts->chan_in_file - 1] = '\0';
 
     // Import into throwaway heap state (dsd_state is multi-megabyte) so a
-    // failed import leaves the live map untouched.
+    // failed import leaves the live map untouched. The allocation is large and
+    // this runs on the decoder thread, but it happens once per user import
+    // rather than per frame, and it is the same validate-then-swap shape
+    // dsd_tg_policy_reload_group_file() uses for the same reason.
     dsd_state* imported = (dsd_state*)calloc(1, sizeof(*imported));
     if (!imported) {
         return -1;
     }
-    if (csvChanImport(opts, imported) != 0) {
-        free(imported);
+    const int import_rc = csvChanImport(opts, imported);
+    // The importer reports success for any file it could open, so a mispicked
+    // CSV (a talkgroup list, a header-only file) parses to an empty map. Adopting
+    // that would replace the live map with zeros; refuse instead, which is what
+    // the additive import used to do by doing nothing.
+    const int mapped_any = (imported->trunk_chan_map_used_count > 0);
+    if (import_rc == 0 && mapped_any) {
+        chan_map_adopt(state, imported);
+    }
+    dsd_state_ext_free_all(imported);
+    free(imported);
+    return (import_rc == 0 && mapped_any) ? 0 : -1;
+}
+
+int
+svc_clear_channel_map(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
         return -1;
     }
-    chan_map_adopt(state, imported);
-    free(imported);
+    // The same invariant svc_import_channel_map() enforces: under trunk scan the
+    // per-target maps are not this frontend's to empty.
+    if (opts->trunk_scan_enabled == 1) {
+        return -1;
+    }
+    opts->chan_in_file[0] = '\0';
+    DSD_MEMSET(state->trunk_chan_map, 0, sizeof state->trunk_chan_map);
+    DSD_MEMSET(state->trunk_chan_map_used, 0, sizeof state->trunk_chan_map_used);
+    state->trunk_chan_map_used_count = 0;
+    DSD_MEMSET(state->trunk_lcn_freq, 0, sizeof state->trunk_lcn_freq);
+    state->lcn_freq_count = 0;
+    state->lcn_freq_roll = 0;
+    // Provenance goes with the map, exactly as in chan_map_adopt(): a surviving
+    // "learned on the control channel" byte would authorize an off-CC tune to a
+    // frequency no longer in the map.
+    DSD_MEMSET(state->dmr_lcn_trust, 0, sizeof state->dmr_lcn_trust);
+    state->trunk_chan_map_seq++;
+    return 0;
+}
+
+int
+svc_clear_group_list(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return -1;
+    }
+    opts->group_in_file[0] = '\0';
+    return dsd_tg_policy_clear(state);
+}
+
+int
+svc_clear_keys(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return -1;
+    }
+    // One keyring behind both CSV kinds, so one clear covers dec and hex.
+    opts->key_in_file[0] = '\0';
+    DSD_MEMSET(state->rkey_array, 0, sizeof state->rkey_array);
+    DSD_MEMSET(state->rkey_array_loaded, 0, sizeof state->rkey_array_loaded);
+    // Disarm the keyring the way svc_import_keys_dec() arms it. Leaving it set
+    // would keep every consumer treating the now-zeroed array as loaded keys.
+    state->keyloader = 0;
     return 0;
 }
 
@@ -364,7 +445,15 @@ svc_import_keys_dec(dsd_opts* opts, dsd_state* state, const char* path) {
     }
     DSD_STRNCPY(opts->key_in_file, path, sizeof opts->key_in_file - 1);
     opts->key_in_file[sizeof opts->key_in_file - 1] = '\0';
-    return csvKeyImportDec(opts, state);
+    const int rc = csvKeyImportDec(opts, state);
+    if (rc == 0) {
+        // Arm the keyring, exactly as -k does. Without this the rows land in
+        // rkey_array but every consumer (dsd_mbe, P25/NXDN crypto) gates on
+        // keyloader, so a session that started without a key file would report
+        // the import as applied and keep failing to decrypt.
+        state->keyloader = 1;
+    }
+    return rc;
 }
 
 int
@@ -374,7 +463,11 @@ svc_import_keys_hex(dsd_opts* opts, dsd_state* state, const char* path) {
     }
     DSD_STRNCPY(opts->key_in_file, path, sizeof opts->key_in_file - 1);
     opts->key_in_file[sizeof opts->key_in_file - 1] = '\0';
-    return csvKeyImportHex(opts, state);
+    const int rc = csvKeyImportHex(opts, state);
+    if (rc == 0) {
+        state->keyloader = 1; // see svc_import_keys_dec
+    }
+    return rc;
 }
 
 void

--- a/src/app_control/services.h
+++ b/src/app_control/services.h
@@ -110,6 +110,19 @@ int svc_import_group_list(dsd_opts* opts, dsd_state* state, const char* path);
 int svc_import_keys_dec(dsd_opts* opts, dsd_state* state, const char* path);
 /** @brief Import keys from a hexadecimal CSV. */
 int svc_import_keys_hex(dsd_opts* opts, dsd_state* state, const char* path);
+
+/*
+ * Unload counterparts. The importers all take a path and reject an empty one,
+ * so a frontend whose system can deselect a CSV has no way to say "none"
+ * without these; the previous file would otherwise stay live for the session.
+ * Each returns 0 when the data is gone afterwards, -1 when it could not be.
+ */
+/** @brief Drop the runtime channel map, its LCN list and its trust bytes. */
+int svc_clear_channel_map(dsd_opts* opts, dsd_state* state);
+/** @brief Drop every loaded talkgroup entry. */
+int svc_clear_group_list(dsd_opts* opts, dsd_state* state);
+/** @brief Drop the keyring and disarm the key loader (covers dec and hex). */
+int svc_clear_keys(dsd_opts* opts, dsd_state* state);
 /** @brief Set the current talkgroup hold value. */
 void svc_set_tg_hold(dsd_state* state, unsigned tg);
 /** @brief Set trunking hang time (seconds, clamped to >=0). */

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -2,9 +2,11 @@
 #include <ctype.h>
 #include <dsd-neo/core/bit_packing.h>
 #include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/csv_validate.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/crypto/dmr_keystream.h>
 #include <dsd-neo/platform/posix_compat.h>
@@ -550,18 +552,18 @@ group_apply_policy_fields(const group_policy_header* header, const char* filenam
     group_enforce_media_constraints(filename, row_count, entry, mode_blocking, has_audio, has_record, has_stream);
 }
 
-static void
+static int
 group_commit_entry(dsd_state* state, const dsd_tg_policy_entry* entry, int is_range, const char* filename,
                    unsigned int row_count, size_t* dropped_policy_alloc_rows) {
     int rc = 0;
     if (!state || !entry || !filename || !dropped_policy_alloc_rows) {
-        return;
+        return -1;
     }
 
     rc = is_range ? dsd_tg_policy_add_range_entry(state, entry) : dsd_tg_policy_append_exact(state, entry);
     if (rc == -1) {
         (*dropped_policy_alloc_rows)++;
-        return;
+        return rc;
     }
     if (rc == 1) {
         if (!is_range) {
@@ -570,10 +572,12 @@ group_commit_entry(dsd_state* state, const dsd_tg_policy_entry* entry, int is_ra
             LOG_WARN("WARNING: Group file '%s' row %u has invalid range and was skipped.\n", filename, row_count);
         }
     }
+    return rc;
 }
 
-int
-csvGroupImportPath(const char* group_file_path, dsd_state* state) {
+/* stats may be NULL; when set, counts data rows so a dry run can report them. */
+static int
+group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_validation* stats) {
     char filename[CSV_IMPORT_PATH_MAX] = "filename.csv";
     char buffer[BSIZE];
     FILE* fp = NULL;
@@ -619,6 +623,10 @@ csvGroupImportPath(const char* group_file_path, dsd_state* state) {
             continue; //don't want labels
         }
 
+        if (stats) {
+            stats->total++;
+        }
+
         field_count = group_split_csv_preserve_empty(buffer, fields, sizeof(fields) / sizeof(fields[0]));
         if (field_count < 3) {
             LOG_WARN("WARNING: Group file '%s' row %u missing required fields; skipping.\n", filename, row_count);
@@ -635,7 +643,10 @@ csvGroupImportPath(const char* group_file_path, dsd_state* state) {
         name_field = fields[2];
         group_entry_init(&entry, id_start, id_end, is_range, mode_field, name_field, row_count, &mode_blocking);
         group_apply_policy_fields(&header, filename, row_count, field_count, fields, &entry, mode_blocking);
-        group_commit_entry(state, &entry, is_range, filename, row_count, &dropped_policy_alloc_rows);
+        if (group_commit_entry(state, &entry, is_range, filename, row_count, &dropped_policy_alloc_rows) == 0
+            && stats) {
+            stats->accepted++;
+        }
     }
 
     if (dropped_policy_alloc_rows > 0) {
@@ -648,6 +659,11 @@ csvGroupImportPath(const char* group_file_path, dsd_state* state) {
 }
 
 int
+csvGroupImportPath(const char* group_file_path, dsd_state* state) {
+    return group_import_path_stats(group_file_path, state, NULL);
+}
+
+int
 csvGroupImport(const dsd_opts* opts, dsd_state* state) {
     if (!opts || !state) {
         return -1;
@@ -656,7 +672,8 @@ csvGroupImport(const dsd_opts* opts, dsd_state* state) {
 }
 
 static void
-csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field, long int* chan_number) {
+csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field, long int* chan_number,
+                            int* freq_parsed) {
     if (!state || !field || !chan_number) {
         return;
     }
@@ -680,6 +697,9 @@ csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field
     long int freq = 0;
     if (parse_dec_long_strict(field, &freq)) {
         dsd_state_set_trunk_chan_freq(state, (uint32_t)*chan_number, freq);
+        if (freq_parsed) {
+            *freq_parsed = 1;
+        }
     }
 
     if (state->lcn_freq_count < 0
@@ -716,7 +736,7 @@ csv_key_import_dec_normalize_keynumber(const char* field) {
     return hash & 0xFFFFULL; // make sure its no larger than 16-bits
 }
 
-static void
+static int
 csv_key_import_dec_store_value(dsd_state* state, unsigned long long keynumber, const char* field) {
     unsigned long long keyvalue = 0;
     const int parsed_keyvalue = parse_dec_u64_strict(field, &keyvalue);
@@ -728,31 +748,36 @@ csv_key_import_dec_store_value(dsd_state* state, unsigned long long keynumber, c
     if (csv_rkey_index(keynumber, 0ULL, &key_index)) {
         state->rkey_array[key_index] = keyvalue & 0xFFFFFFFFFFULL; // doesn't exceed 40-bit value
         state->rkey_array_loaded[key_index] = parsed_keyvalue ? 1U : 0U;
+        return parsed_keyvalue ? 1 : 0;
     }
+    return 0;
 }
 
 static void
-csv_key_import_dec_apply_field(dsd_state* state, int field_count, const char* field, unsigned long long* keynumber) {
+csv_key_import_dec_apply_field(dsd_state* state, int field_count, const char* field, unsigned long long* keynumber,
+                               int* stored) {
     if (field_count == 0) {
         *keynumber = csv_key_import_dec_normalize_keynumber(field);
         return;
     }
     if (field_count == 1) {
-        csv_key_import_dec_store_value(state, *keynumber, field);
+        if (csv_key_import_dec_store_value(state, *keynumber, field) && stored) {
+            *stored = 1;
+        }
     }
 }
 
-int
-csvChanImport(const dsd_opts* opts, dsd_state* state) //channel map import
-{
-    if (!opts || !state || opts->chan_in_file[0] == '\0') {
+/* stats may be NULL; when set, counts data rows so a dry run can report them. */
+static int
+chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validation* stats) {
+    if (!chan_file_path || chan_file_path[0] == '\0' || !state) {
         return -1;
     }
 
     char filename[CSV_IMPORT_PATH_MAX] = "filename.csv";
 
     char buffer[BSIZE];
-    FILE* fp = csv_open_user_read_file("channel map file", opts->chan_in_file, filename, sizeof filename);
+    FILE* fp = csv_open_user_read_file("channel map file", chan_file_path, filename, sizeof filename);
     if (fp == NULL) {
         return -1;
     }
@@ -762,17 +787,24 @@ csvChanImport(const dsd_opts* opts, dsd_state* state) //channel map import
 
     while (fgets(buffer, BSIZE, fp)) {
         int field_count = 0;
+        int freq_parsed = 0;
         chan_number = -1;
         row_count++;
         if (row_count == 1) {
             continue; //don't want labels
         }
+        if (stats) {
+            stats->total++;
+        }
         char* saveptr = NULL;
         const char* field = dsd_strtok_r(buffer, ",", &saveptr); //seperate by comma
         while (field) {
-            csv_chan_import_apply_field(state, field_count, field, &chan_number);
+            csv_chan_import_apply_field(state, field_count, field, &chan_number, &freq_parsed);
             field = dsd_strtok_r(NULL, ",", &saveptr);
             field_count++;
+        }
+        if (stats && freq_parsed) {
+            stats->accepted++;
         }
         if (field_count >= 2 && chan_number >= 0 && chan_number < 0xFFFF) {
             LOG_INFO("Channel [%05ld] [%09ld]", chan_number, state->trunk_chan_map[chan_number]);
@@ -783,18 +815,27 @@ csvChanImport(const dsd_opts* opts, dsd_state* state) //channel map import
     return 0;
 }
 
-//Decimal Variant of Key Import
 int
-csvKeyImportDec(const dsd_opts* opts, dsd_state* state) //multi-key support
+csvChanImport(const dsd_opts* opts, dsd_state* state) //channel map import
 {
-    if (!opts || !state || opts->key_in_file[0] == '\0') {
+    if (!opts || !state) {
+        return -1;
+    }
+    return chan_import_stats(opts->chan_in_file, state, NULL);
+}
+
+//Decimal Variant of Key Import
+/* stats may be NULL; when set, counts data rows so a dry run can report them. */
+static int
+key_import_dec_stats(const dsd_opts* opts, const char* key_file_path, dsd_state* state, dsd_csv_validation* stats) {
+    if (!key_file_path || key_file_path[0] == '\0' || !state) {
         return -1;
     }
 
     char filename[CSV_IMPORT_PATH_MAX] = "filename.csv";
 
     char buffer[BSIZE];
-    FILE* fp = csv_open_user_read_file("key file", opts->key_in_file, filename, sizeof filename);
+    FILE* fp = csv_open_user_read_file("key file", key_file_path, filename, sizeof filename);
     if (fp == NULL) {
         return -1;
     }
@@ -803,16 +844,23 @@ csvKeyImportDec(const dsd_opts* opts, dsd_state* state) //multi-key support
     while (fgets(buffer, BSIZE, fp)) {
         unsigned long long int keynumber = 0;
         int field_count = 0;
+        int stored = 0;
         row_count++;
         if (row_count == 1) {
             continue; //don't want labels
         }
+        if (stats) {
+            stats->total++;
+        }
         char* saveptr = NULL;
         const char* field = dsd_strtok_r(buffer, ",", &saveptr); //seperate by comma
         while (field) {
-            csv_key_import_dec_apply_field(state, field_count, field, &keynumber);
+            csv_key_import_dec_apply_field(state, field_count, field, &keynumber, &stored);
             field = dsd_strtok_r(NULL, ",", &saveptr);
             field_count++;
+        }
+        if (stats && stored) {
+            stats->accepted++;
         }
         char key_id_text[32];
         (void)DSD_SNPRINTF(key_id_text, sizeof key_id_text, "%03lld", keynumber);
@@ -832,21 +880,32 @@ csvKeyImportDec(const dsd_opts* opts, dsd_state* state) //multi-key support
     return 0;
 }
 
-static void
+int
+csvKeyImportDec(const dsd_opts* opts, dsd_state* state) //multi-key support
+{
+    if (!opts || !state) {
+        return -1;
+    }
+    return key_import_dec_stats(opts, opts->key_in_file, state, NULL);
+}
+
+static int
 csv_key_import_hex_store_value(dsd_state* state, unsigned long long keynumber, unsigned long long offset,
                                const char* field) {
     if (!state || !field) {
-        return;
+        return 0;
     }
     size_t idx = 0;
     if (!csv_rkey_index(keynumber, offset, &idx)) {
-        return;
+        return 0;
     }
     unsigned long long v = 0;
     if (parse_hex_u64_strict(field, &v)) {
         state->rkey_array[idx] = v;
         state->rkey_array_loaded[idx] = 1U;
+        return 1;
     }
+    return 0;
 }
 
 static void
@@ -885,7 +944,7 @@ csv_key_import_hex_log_offsets(const dsd_state* state, unsigned long long keynum
 }
 
 static unsigned long long
-csv_key_import_hex_parse_row(dsd_state* state, char* buffer) {
+csv_key_import_hex_parse_row(dsd_state* state, char* buffer, int* stored_segments) {
     static const unsigned long long offsets[] = {0x0ULL, 0x101ULL, 0x201ULL, 0x301ULL};
     unsigned long long keynumber = 0;
     char* saveptr = NULL;
@@ -896,7 +955,9 @@ csv_key_import_hex_parse_row(dsd_state* state, char* buffer) {
                 keynumber = 0;
             }
         } else if (field_count <= (int)(sizeof(offsets) / sizeof(offsets[0]))) {
-            csv_key_import_hex_store_value(state, keynumber, offsets[field_count - 1], field);
+            if (csv_key_import_hex_store_value(state, keynumber, offsets[field_count - 1], field) && stored_segments) {
+                (*stored_segments)++;
+            }
         }
         field = dsd_strtok_r(NULL, ",", &saveptr);
     }
@@ -1005,27 +1066,34 @@ vertex_ks_apply_to_state(dsd_state* state, const vertex_map_tmp_t* tmp, const ch
 }
 
 //Hex Variant of Key Import
-int
-csvKeyImportHex(const dsd_opts* opts, dsd_state* state) //key import for hex keys
-{
-    if (!opts || !state || opts->key_in_file[0] == '\0') {
+/* stats may be NULL; when set, counts data rows so a dry run can report them. */
+static int
+key_import_hex_stats(const dsd_opts* opts, const char* key_file_path, dsd_state* state, dsd_csv_validation* stats) {
+    if (!key_file_path || key_file_path[0] == '\0' || !state) {
         return -1;
     }
 
     char filename[CSV_IMPORT_PATH_MAX] = "filename.csv";
     char buffer[BSIZE];
-    FILE* fp = csv_open_user_read_file("key file", opts->key_in_file, filename, sizeof filename);
+    FILE* fp = csv_open_user_read_file("key file", key_file_path, filename, sizeof filename);
     if (fp == NULL) {
         return -1;
     }
     int row_count = 0;
 
     while (fgets(buffer, BSIZE, fp)) {
+        int stored_segments = 0;
         row_count++;
         if (row_count == 1) {
             continue; //don't want labels
         }
-        unsigned long long keynumber = csv_key_import_hex_parse_row(state, buffer);
+        if (stats) {
+            stats->total++;
+        }
+        unsigned long long keynumber = csv_key_import_hex_parse_row(state, buffer, &stored_segments);
+        if (stats && stored_segments > 0) {
+            stats->accepted++;
+        }
         size_t key_index = 0;
         if (csv_rkey_index(keynumber, 0ULL, &key_index)) {
             char key_id_text[32];
@@ -1052,6 +1120,85 @@ csvKeyImportHex(const dsd_opts* opts, dsd_state* state) //key import for hex key
     }
     fclose(fp);
     return 0;
+}
+
+int
+csvKeyImportHex(const dsd_opts* opts, dsd_state* state) //key import for hex keys
+{
+    if (!opts || !state) {
+        return -1;
+    }
+    return key_import_hex_stats(opts, opts->key_in_file, state, NULL);
+}
+
+typedef int (*csv_validate_run_fn)(const dsd_opts* opts, const char* path, dsd_state* state, dsd_csv_validation* out);
+
+/*
+ * Dry-run harness: parses through the real import loop, but into throwaway
+ * heap state (dsd_state is multi-megabyte, and the group import allocates a
+ * TG-policy state extension that must be freed) so no live state is touched.
+ */
+static int
+csv_validate_into_throwaway(const char* path, dsd_csv_validation* out, csv_validate_run_fn run) {
+    if (!path || path[0] == '\0' || !out || !run) {
+        return -1;
+    }
+    out->accepted = 0U;
+    out->skipped = 0U;
+    out->total = 0U;
+
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    int rc = -1;
+    if (opts && state) {
+        rc = run(opts, path, state, out);
+    }
+    if (state) {
+        dsd_state_ext_free_all(state);
+    }
+    free(state);
+    free(opts);
+
+    if (rc != 0) {
+        out->accepted = 0U;
+        out->skipped = 0U;
+        out->total = 0U;
+        return -1;
+    }
+    out->skipped = out->total - out->accepted;
+    return 0;
+}
+
+static int
+csv_validate_run_group(const dsd_opts* opts, const char* path, dsd_state* state, dsd_csv_validation* out) {
+    (void)opts;
+    return group_import_path_stats(path, state, out);
+}
+
+static int
+csv_validate_run_chan(const dsd_opts* opts, const char* path, dsd_state* state, dsd_csv_validation* out) {
+    (void)opts;
+    return chan_import_stats(path, state, out);
+}
+
+int
+dsd_csv_validate_group_file(const char* path, dsd_csv_validation* out) {
+    return csv_validate_into_throwaway(path, out, csv_validate_run_group);
+}
+
+int
+dsd_csv_validate_chan_file(const char* path, dsd_csv_validation* out) {
+    return csv_validate_into_throwaway(path, out, csv_validate_run_chan);
+}
+
+int
+dsd_csv_validate_key_file_dec(const char* path, dsd_csv_validation* out) {
+    return csv_validate_into_throwaway(path, out, key_import_dec_stats);
+}
+
+int
+dsd_csv_validate_key_file_hex(const char* path, dsd_csv_validation* out) {
+    return csv_validate_into_throwaway(path, out, key_import_hex_stats);
 }
 
 int

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -70,6 +70,24 @@ is_ascii_space(unsigned char c) {
     return (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v');
 }
 
+/*
+ * A blank line is filler, not a data row. Editors and several exporters leave a
+ * trailing empty line; counting it would make the dry-run validators report a
+ * clean file as "N rows skipped" (and the group importer warn about it).
+ */
+static int
+csv_line_is_blank(const char* s) {
+    if (!s) {
+        return 1;
+    }
+    for (const unsigned char* p = (const unsigned char*)s; *p != '\0'; p++) {
+        if (!is_ascii_space(*p)) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 static char*
 trim_ws(char* s) {
     if (s == NULL) {
@@ -643,6 +661,9 @@ group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_v
             continue; //don't want labels
         }
 
+        if (csv_line_is_blank(buffer)) {
+            continue;
+        }
         if (stats) {
             stats->total++;
         }
@@ -673,6 +694,30 @@ csvGroupImport(const dsd_opts* opts, dsd_state* state) {
     return csvGroupImportPath(opts->group_in_file, state);
 }
 
+/*
+ * A channel map row is `channel,frequency_hz`, which is the same shape as a
+ * decimal key row (`key_id,value`) -- nothing in the file distinguishes them,
+ * and the header line is free text by convention, so it cannot either. Picking
+ * a key list as a channel map used to load its values as frequencies: the
+ * doc's own example row `2,70` became a channel at 70 Hz, which the trunking SM
+ * would then try to tune.
+ *
+ * The range is what the front ends can actually reach, generously bounded: the
+ * low end sits under any HF-capable SoapySDR device, the high end above the
+ * 6 GHz ceiling of the widest-tuning ones (LimeSDR, B210, HackRF). It is not a
+ * band plan -- it only rejects numbers that cannot be radio frequencies at all,
+ * including the 0 a blank column parses to. Long is 32-bit on the MSVC presets,
+ * so the comparison is done in long long or the upper bound would not fit.
+ */
+#define CSV_CHAN_FREQ_MIN_HZ 100000LL
+#define CSV_CHAN_FREQ_MAX_HZ 6000000000LL
+
+static int
+csv_chan_freq_plausible(long int freq) {
+    const long long hz = (long long)freq;
+    return hz >= CSV_CHAN_FREQ_MIN_HZ && hz <= CSV_CHAN_FREQ_MAX_HZ;
+}
+
 static void
 csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field, long int* chan_number,
                             int* freq_parsed) {
@@ -697,7 +742,8 @@ csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field
     }
 
     long int freq = 0;
-    if (parse_dec_long_strict(field, &freq)) {
+    const int usable = parse_dec_long_strict(field, &freq) && csv_chan_freq_plausible(freq);
+    if (usable) {
         dsd_state_set_trunk_chan_freq(state, (uint32_t)*chan_number, freq);
         if (freq_parsed) {
             *freq_parsed = 1;
@@ -709,19 +755,22 @@ csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field
         return;
     }
 
-    if (parse_dec_long_strict(field, &freq)) {
-        state->trunk_lcn_freq[state->lcn_freq_count] = freq;
-    } else {
-        state->trunk_lcn_freq[state->lcn_freq_count] = 0;
-    }
+    // The LCN list is positional -- EDACS reads it in row order -- so a row the
+    // map refused still has to take its slot, as a 0 every consumer reads as
+    // "unknown". Dropping it would renumber every LCN below it.
+    state->trunk_lcn_freq[state->lcn_freq_count] = usable ? freq : 0L;
     state->lcn_freq_count++; // keep tally of number of Frequencies imported
 }
 
+/* id_ok may be NULL; set when the key-id column actually parsed as decimal. */
 static unsigned long long
-csv_key_import_dec_normalize_keynumber(const char* field) {
+csv_key_import_dec_normalize_keynumber(const char* field, int* id_ok) {
     unsigned long long keynumber = 0;
     if (!parse_dec_u64_strict(field, &keynumber)) {
         return 0;
+    }
+    if (id_ok) {
+        *id_ok = 1;
     }
 
     if (keynumber <= 0xFFFFULL) {
@@ -757,9 +806,9 @@ csv_key_import_dec_store_value(dsd_state* state, unsigned long long keynumber, c
 
 static void
 csv_key_import_dec_apply_field(dsd_state* state, int field_count, const char* field, unsigned long long* keynumber,
-                               int* stored) {
+                               int* id_ok, int* stored) {
     if (field_count == 0) {
-        *keynumber = csv_key_import_dec_normalize_keynumber(field);
+        *keynumber = csv_key_import_dec_normalize_keynumber(field, id_ok);
         return;
     }
     if (field_count == 1) {
@@ -767,6 +816,25 @@ csv_key_import_dec_apply_field(dsd_state* state, int field_count, const char* fi
             *stored = 1;
         }
     }
+}
+
+/** @brief Parse one channel row into @p state. @return 1 when a frequency loaded. */
+static int
+chan_import_row(dsd_state* state, char* buffer, int* out_field_count, long int* out_chan_number) {
+    int field_count = 0;
+    int freq_parsed = 0;
+    long int chan_number = -1;
+    char* saveptr = NULL;
+
+    const char* field = dsd_strtok_r(buffer, ",", &saveptr); //seperate by comma
+    while (field) {
+        csv_chan_import_apply_field(state, field_count, field, &chan_number, &freq_parsed);
+        field = dsd_strtok_r(NULL, ",", &saveptr);
+        field_count++;
+    }
+    *out_field_count = field_count;
+    *out_chan_number = chan_number;
+    return freq_parsed;
 }
 
 /* stats may be NULL; when set, counts data rows so a dry run can report them. */
@@ -785,28 +853,30 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
     }
     int row_count = 0;
 
-    long int chan_number;
-
     while (fgets(buffer, BSIZE, fp)) {
         int field_count = 0;
-        int freq_parsed = 0;
-        chan_number = -1;
+        long int chan_number = -1;
         row_count++;
         if (row_count == 1) {
             continue; //don't want labels
         }
+        if (csv_line_is_blank(buffer)) {
+            continue;
+        }
+        const int freq_parsed = chan_import_row(state, buffer, &field_count, &chan_number);
         if (stats) {
+            // A dry run exists to produce the three counters; echoing every row
+            // through the process-global logger would put thousands of records
+            // on the caller's thread for an import that never happened.
             stats->total++;
+            stats->accepted += (freq_parsed ? 1U : 0U);
+            continue;
         }
-        char* saveptr = NULL;
-        const char* field = dsd_strtok_r(buffer, ",", &saveptr); //seperate by comma
-        while (field) {
-            csv_chan_import_apply_field(state, field_count, field, &chan_number, &freq_parsed);
-            field = dsd_strtok_r(NULL, ",", &saveptr);
-            field_count++;
-        }
-        if (stats && freq_parsed) {
-            stats->accepted++;
+        if (!freq_parsed) {
+            // Say so rather than echoing the map slot, which still holds
+            // whatever was there before this row failed to land.
+            LOG_WARN("WARNING: Channel map file '%s' row %d has no usable frequency; skipping.\n", filename, row_count);
+            continue;
         }
         if (field_count >= 2 && chan_number >= 0 && chan_number < 0xFFFF) {
             LOG_INFO("Channel [%05ld] [%09ld]", chan_number, state->trunk_chan_map[chan_number]);
@@ -829,7 +899,7 @@ csvChanImport(const dsd_opts* opts, dsd_state* state) //channel map import
 //Decimal Variant of Key Import
 /* stats may be NULL; when set, counts data rows so a dry run can report them. */
 static int
-key_import_dec_stats(const dsd_opts* opts, const char* key_file_path, dsd_state* state, dsd_csv_validation* stats) {
+key_import_dec_stats(int show_keys, const char* key_file_path, dsd_state* state, dsd_csv_validation* stats) {
     if (!key_file_path || key_file_path[0] == '\0' || !state) {
         return -1;
     }
@@ -846,10 +916,14 @@ key_import_dec_stats(const dsd_opts* opts, const char* key_file_path, dsd_state*
     while (fgets(buffer, BSIZE, fp)) {
         unsigned long long int keynumber = 0;
         int field_count = 0;
+        int id_ok = 0;
         int stored = 0;
         row_count++;
         if (row_count == 1) {
             continue; //don't want labels
+        }
+        if (csv_line_is_blank(buffer)) {
+            continue;
         }
         if (stats) {
             stats->total++;
@@ -857,24 +931,28 @@ key_import_dec_stats(const dsd_opts* opts, const char* key_file_path, dsd_state*
         char* saveptr = NULL;
         const char* field = dsd_strtok_r(buffer, ",", &saveptr); //seperate by comma
         while (field) {
-            csv_key_import_dec_apply_field(state, field_count, field, &keynumber, &stored);
+            csv_key_import_dec_apply_field(state, field_count, field, &keynumber, &id_ok, &stored);
             field = dsd_strtok_r(NULL, ",", &saveptr);
             field_count++;
         }
-        if (stats && stored) {
+        // An unparsed key-id column normalizes to 0, so the row would still
+        // "store" — onto slot 0, together with every other broken row. Counting
+        // that as loaded is how a hex-id file validates as "N keys".
+        if (stats && stored && id_ok) {
             stats->accepted++;
+        }
+        if (stats) {
+            continue; // dry run: the counters are the product, not the log
         }
         char key_id_text[32];
         (void)DSD_SNPRINTF(key_id_text, sizeof key_id_text, "%03lld", keynumber);
         char key_text[16];
-        if (opts->show_keys != 0) {
+        if (show_keys != 0) {
             LOG_INFO("Key [%s] [%s]", key_id_text,
-                     dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->rkey_array[keynumber],
-                                               5U));
+                     dsd_secret_format_decimal(key_text, sizeof key_text, show_keys, state->rkey_array[keynumber], 5U));
         } else {
             LOG_INFO("Key [%s] loaded: %s", key_id_text,
-                     dsd_secret_format_decimal(key_text, sizeof key_text, opts->show_keys, state->rkey_array[keynumber],
-                                               5U));
+                     dsd_secret_format_decimal(key_text, sizeof key_text, show_keys, state->rkey_array[keynumber], 5U));
         }
         LOG_INFO("\n");
     }
@@ -888,7 +966,7 @@ csvKeyImportDec(const dsd_opts* opts, dsd_state* state) //multi-key support
     if (!opts || !state) {
         return -1;
     }
-    return key_import_dec_stats(opts, opts->key_in_file, state, NULL);
+    return key_import_dec_stats(opts->show_keys, opts->key_in_file, state, NULL);
 }
 
 static int
@@ -1070,7 +1148,7 @@ vertex_ks_apply_to_state(dsd_state* state, const vertex_map_tmp_t* tmp, const ch
 //Hex Variant of Key Import
 /* stats may be NULL; when set, counts data rows so a dry run can report them. */
 static int
-key_import_hex_stats(const dsd_opts* opts, const char* key_file_path, dsd_state* state, dsd_csv_validation* stats) {
+key_import_hex_stats(int show_keys, const char* key_file_path, dsd_state* state, dsd_csv_validation* stats) {
     if (!key_file_path || key_file_path[0] == '\0' || !state) {
         return -1;
     }
@@ -1089,6 +1167,9 @@ key_import_hex_stats(const dsd_opts* opts, const char* key_file_path, dsd_state*
         if (row_count == 1) {
             continue; //don't want labels
         }
+        if (csv_line_is_blank(buffer)) {
+            continue;
+        }
         if (stats) {
             stats->total++;
         }
@@ -1096,22 +1177,25 @@ key_import_hex_stats(const dsd_opts* opts, const char* key_file_path, dsd_state*
         if (stats && stored_segments > 0) {
             stats->accepted++;
         }
+        if (stats) {
+            continue; // dry run: the counters are the product, not the log
+        }
         size_t key_index = 0;
         if (csv_rkey_index(keynumber, 0ULL, &key_index)) {
             char key_id_text[32];
             (void)DSD_SNPRINTF(key_id_text, sizeof key_id_text, "%04llX", keynumber);
             char key_text[17];
-            if (opts->show_keys != 0) {
-                LOG_INFO("Key [%s] [%s]", key_id_text,
-                         dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->rkey_array[key_index],
-                                               16U, 0));
+            if (show_keys != 0) {
+                LOG_INFO(
+                    "Key [%s] [%s]", key_id_text,
+                    dsd_secret_format_hex(key_text, sizeof key_text, show_keys, state->rkey_array[key_index], 16U, 0));
             } else {
-                LOG_INFO("Key [%s] loaded: %s", key_id_text,
-                         dsd_secret_format_hex(key_text, sizeof key_text, opts->show_keys, state->rkey_array[key_index],
-                                               16U, 0));
+                LOG_INFO(
+                    "Key [%s] loaded: %s", key_id_text,
+                    dsd_secret_format_hex(key_text, sizeof key_text, show_keys, state->rkey_array[key_index], 16U, 0));
             }
             // If longer key is loaded (or clash with the 0x101, 0x201, 0x301 offset), then print the full key listing.
-            csv_key_import_hex_log_offsets(state, keynumber, opts->show_keys);
+            csv_key_import_hex_log_offsets(state, keynumber, show_keys);
         } else {
             char key_id_text[32];
             (void)DSD_SNPRINTF(key_id_text, sizeof key_id_text, "%04llX", keynumber);
@@ -1130,10 +1214,10 @@ csvKeyImportHex(const dsd_opts* opts, dsd_state* state) //key import for hex key
     if (!opts || !state) {
         return -1;
     }
-    return key_import_hex_stats(opts, opts->key_in_file, state, NULL);
+    return key_import_hex_stats(opts->show_keys, opts->key_in_file, state, NULL);
 }
 
-typedef int (*csv_validate_run_fn)(const dsd_opts* opts, const char* path, dsd_state* state, dsd_csv_validation* out);
+typedef int (*csv_validate_run_fn)(const char* path, dsd_state* state, dsd_csv_validation* out);
 
 /*
  * Dry-run harness: parses through the real import loop, but into throwaway
@@ -1149,17 +1233,13 @@ csv_validate_into_throwaway(const char* path, dsd_csv_validation* out, csv_valid
     out->skipped = 0U;
     out->total = 0U;
 
-    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
     int rc = -1;
-    if (opts && state) {
-        rc = run(opts, path, state, out);
-    }
     if (state) {
+        rc = run(path, state, out);
         dsd_state_ext_free_all(state);
     }
     free(state);
-    free(opts);
 
     if (rc != 0) {
         out->accepted = 0U;
@@ -1172,35 +1252,33 @@ csv_validate_into_throwaway(const char* path, dsd_csv_validation* out, csv_valid
 }
 
 static int
-csv_validate_run_group(const dsd_opts* opts, const char* path, dsd_state* state, dsd_csv_validation* out) {
-    (void)opts;
-    return group_import_path_stats(path, state, out);
+csv_validate_run_key_dec(const char* path, dsd_state* state, dsd_csv_validation* out) {
+    return key_import_dec_stats(0, path, state, out);
 }
 
 static int
-csv_validate_run_chan(const dsd_opts* opts, const char* path, dsd_state* state, dsd_csv_validation* out) {
-    (void)opts;
-    return chan_import_stats(path, state, out);
+csv_validate_run_key_hex(const char* path, dsd_state* state, dsd_csv_validation* out) {
+    return key_import_hex_stats(0, path, state, out);
 }
 
 int
 dsd_csv_validate_group_file(const char* path, dsd_csv_validation* out) {
-    return csv_validate_into_throwaway(path, out, csv_validate_run_group);
+    return csv_validate_into_throwaway(path, out, group_import_path_stats);
 }
 
 int
 dsd_csv_validate_chan_file(const char* path, dsd_csv_validation* out) {
-    return csv_validate_into_throwaway(path, out, csv_validate_run_chan);
+    return csv_validate_into_throwaway(path, out, chan_import_stats);
 }
 
 int
 dsd_csv_validate_key_file_dec(const char* path, dsd_csv_validation* out) {
-    return csv_validate_into_throwaway(path, out, key_import_dec_stats);
+    return csv_validate_into_throwaway(path, out, csv_validate_run_key_dec);
 }
 
 int
 dsd_csv_validate_key_file_hex(const char* path, dsd_csv_validation* out) {
-    return csv_validate_into_throwaway(path, out, key_import_hex_stats);
+    return csv_validate_into_throwaway(path, out, csv_validate_run_key_hex);
 }
 
 int

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -575,6 +575,38 @@ group_commit_entry(dsd_state* state, const dsd_tg_policy_entry* entry, int is_ra
     return rc;
 }
 
+/** @brief Parse and commit one group data row. @return 0 when the row loaded. */
+static int
+group_import_row(dsd_state* state, const char* filename, unsigned int row_count, char* buffer,
+                 const group_policy_header* header, size_t* dropped_policy_alloc_rows) {
+    char* fields[32];
+    size_t field_count = 0;
+    uint32_t id_start = 0;
+    uint32_t id_end = 0;
+    int is_range = 0;
+    const char* mode_field = NULL;
+    const char* name_field = NULL;
+    dsd_tg_policy_entry entry;
+    int mode_blocking = 0;
+
+    field_count = group_split_csv_preserve_empty(buffer, fields, sizeof(fields) / sizeof(fields[0]));
+    if (field_count < 3) {
+        LOG_WARN("WARNING: Group file '%s' row %u missing required fields; skipping.\n", filename, row_count);
+        return -1;
+    }
+
+    if (!group_parse_id_field(fields[0], &id_start, &id_end, &is_range)) {
+        LOG_WARN("WARNING: Group file '%s' row %u has invalid id '%s'; skipping.\n", filename, row_count, fields[0]);
+        return -1;
+    }
+
+    mode_field = trim_ws(fields[1]);
+    name_field = fields[2];
+    group_entry_init(&entry, id_start, id_end, is_range, mode_field, name_field, row_count, &mode_blocking);
+    group_apply_policy_fields(header, filename, row_count, field_count, fields, &entry, mode_blocking);
+    return group_commit_entry(state, &entry, is_range, filename, row_count, dropped_policy_alloc_rows);
+}
+
 /* stats may be NULL; when set, counts data rows so a dry run can report them. */
 static int
 group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_validation* stats) {
@@ -584,7 +616,6 @@ group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_v
     unsigned int row_count = 0;
     size_t dropped_policy_alloc_rows = 0;
     group_policy_header header = {0, 0, 0};
-    int warned_header_order = 0;
 
     if (!group_file_path || group_file_path[0] == '\0' || !state) {
         return -1;
@@ -596,16 +627,6 @@ group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_v
     }
 
     while (fgets(buffer, BSIZE, fp)) {
-        char* fields[32];
-        size_t field_count = 0;
-        uint32_t id_start = 0;
-        uint32_t id_end = 0;
-        int is_range = 0;
-        const char* mode_field = NULL;
-        const char* name_field = NULL;
-        dsd_tg_policy_entry entry;
-        int mode_blocking = 0;
-
         row_count++;
         trim_eol(buffer);
 
@@ -613,8 +634,7 @@ group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_v
             char header_copy[BSIZE];
             DSD_SNPRINTF(header_copy, sizeof(header_copy), "%s", buffer);
             header = group_parse_policy_header(header_copy);
-            if (header.policy_active && header.invalid_order && !warned_header_order) {
-                warned_header_order = 1;
+            if (header.policy_active && header.invalid_order) {
                 LOG_WARN("WARNING: Group file '%s' header optional policy columns are out of order; ignoring "
                          "mismatched and later "
                          "optional columns.\n",
@@ -626,25 +646,7 @@ group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_v
         if (stats) {
             stats->total++;
         }
-
-        field_count = group_split_csv_preserve_empty(buffer, fields, sizeof(fields) / sizeof(fields[0]));
-        if (field_count < 3) {
-            LOG_WARN("WARNING: Group file '%s' row %u missing required fields; skipping.\n", filename, row_count);
-            continue;
-        }
-
-        if (!group_parse_id_field(fields[0], &id_start, &id_end, &is_range)) {
-            LOG_WARN("WARNING: Group file '%s' row %u has invalid id '%s'; skipping.\n", filename, row_count,
-                     fields[0]);
-            continue;
-        }
-
-        mode_field = trim_ws(fields[1]);
-        name_field = fields[2];
-        group_entry_init(&entry, id_start, id_end, is_range, mode_field, name_field, row_count, &mode_blocking);
-        group_apply_policy_fields(&header, filename, row_count, field_count, fields, &entry, mode_blocking);
-        if (group_commit_entry(state, &entry, is_range, filename, row_count, &dropped_policy_alloc_rows) == 0
-            && stats) {
+        if (group_import_row(state, filename, row_count, buffer, &header, &dropped_policy_alloc_rows) == 0 && stats) {
             stats->accepted++;
         }
     }

--- a/src/core/util/talkgroup_policy.c
+++ b/src/core/util/talkgroup_policy.c
@@ -1593,3 +1593,39 @@ dsd_tg_policy_reload_group_file(const dsd_opts* opts, dsd_state* state) {
     free(imported);
     return 0;
 }
+
+int
+dsd_tg_policy_clear(dsd_state* state) {
+    const dsd_tg_policy_context* current_ctx = NULL;
+    dsd_tg_policy_context* empty_ctx = NULL;
+    unsigned int next_table_generation = 1u;
+    unsigned int next_active_generation = 1u;
+
+    if (!state) {
+        return -1;
+    }
+
+    current_ctx = tg_policy_ctx_get_const(state);
+    if (!current_ctx) {
+        return 0; // nothing loaded; already the state the caller asked for
+    }
+    next_table_generation = current_ctx->table.generation + 1u;
+    next_active_generation = current_ctx->active.generation + 1u;
+
+    /* An empty context rather than no context: readers that hold a generation
+     * need to see it move, and dropping the extension slot outright would leave
+     * them comparing against a context id that never existed. This is the same
+     * swap dsd_tg_policy_reload_group_file() performs, with nothing imported. */
+    empty_ctx = tg_policy_context_alloc();
+    if (!empty_ctx) {
+        return -1;
+    }
+    empty_ctx->table.generation = next_table_generation;
+    empty_ctx->active.generation = next_active_generation;
+
+    if (dsd_state_ext_set(state, DSD_STATE_EXT_CORE_TG_POLICY, empty_ctx, tg_policy_context_free) != 0) {
+        tg_policy_context_free(empty_ctx);
+        return -1;
+    }
+    return 0;
+}

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(
         call_history_model.cpp
         command_bridge.cpp
         decoder_host.cpp
+        imported_files_model.cpp
         json_store.cpp
         metrics_model.cpp
         qt_ui.cpp

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -43,6 +43,7 @@ qt_add_resources(
         qml/BottomNav.qml
         qml/CallRow.qml
         qml/Caret.qml
+        qml/CsvTypeBadge.qml
         qml/DashedActionButton.qml
         qml/DecodeChip.qml
         qml/EncTag.qml
@@ -53,6 +54,7 @@ qt_add_resources(
         qml/GradientButton.qml
         qml/HistoryScreen.qml
         qml/HomeScreen.qml
+        qml/ImportsScreen.qml
         qml/LevelMeter.qml
         qml/LogoMark.qml
         qml/MicroLabel.qml

--- a/src/ui/qt/command_bridge.cpp
+++ b/src/ui/qt/command_bridge.cpp
@@ -141,4 +141,22 @@ CommandBridge::importKeys(const QString& path, bool hex) const {
                                                path.toUtf8().constData()));
 }
 
+bool
+// cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
+CommandBridge::clearChannelMap() const {
+    return accepted(dsd_app_command_action(DSD_APP_CMD_IMPORT_CHANNEL_MAP_CLEAR));
+}
+
+bool
+// cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
+CommandBridge::clearGroupList() const {
+    return accepted(dsd_app_command_action(DSD_APP_CMD_IMPORT_GROUP_LIST_CLEAR));
+}
+
+bool
+// cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
+CommandBridge::clearKeys() const {
+    return accepted(dsd_app_command_action(DSD_APP_CMD_IMPORT_KEYS_CLEAR));
+}
+
 } // namespace dsd_qt

--- a/src/ui/qt/command_bridge.cpp
+++ b/src/ui/qt/command_bridge.cpp
@@ -116,4 +116,29 @@ CommandBridge::cycleHistoryMode() const {
     return dsd_app_frontend_history_cycle_mode();
 }
 
+bool
+CommandBridge::importChannelMap(const QString& path) const {
+    if (path.isEmpty()) {
+        return false;
+    }
+    return accepted(dsd_app_command_set_string(DSD_APP_CMD_IMPORT_CHANNEL_MAP, path.toUtf8().constData()));
+}
+
+bool
+CommandBridge::importGroupList(const QString& path) const {
+    if (path.isEmpty()) {
+        return false;
+    }
+    return accepted(dsd_app_command_set_string(DSD_APP_CMD_IMPORT_GROUP_LIST, path.toUtf8().constData()));
+}
+
+bool
+CommandBridge::importKeys(const QString& path, bool hex) const {
+    if (path.isEmpty()) {
+        return false;
+    }
+    return accepted(dsd_app_command_set_string(hex ? DSD_APP_CMD_IMPORT_KEYS_HEX : DSD_APP_CMD_IMPORT_KEYS_DEC,
+                                               path.toUtf8().constData()));
+}
+
 } // namespace dsd_qt

--- a/src/ui/qt/command_bridge.h
+++ b/src/ui/qt/command_bridge.h
@@ -125,6 +125,20 @@ class CommandBridge : public QObject {
 
     /** @brief Import an encryption key CSV; @p hex picks -K semantics over -k. */
     Q_INVOKABLE bool importKeys(const QString& path, bool hex) const;
+
+    /*
+     * Unloading. A system that clears its CSV selection has to say so: the
+     * import calls above all reject an empty path, so re-importing cannot
+     * express "none" and the previous file would stay live for the session.
+     */
+    /** @brief Drop the running session's channel map, LCN list and trust bytes. */
+    Q_INVOKABLE bool clearChannelMap() const;
+
+    /** @brief Drop the running session's talkgroup list. */
+    Q_INVOKABLE bool clearGroupList() const;
+
+    /** @brief Drop the running session's keyring (both CSV kinds share one). */
+    Q_INVOKABLE bool clearKeys() const;
 };
 
 } // namespace dsd_qt

--- a/src/ui/qt/command_bridge.h
+++ b/src/ui/qt/command_bridge.h
@@ -109,6 +109,22 @@ class CommandBridge : public QObject {
 
     /** @brief Cycle the event-history display mode. */
     Q_INVOKABLE int cycleHistoryMode() const;
+
+    /**
+     * @brief Import a channel map CSV into the running session.
+     *
+     * The runtime handler replaces the previous map atomically; a file that
+     * cannot be opened leaves the live map untouched. Like every command here,
+     * the queue only drains while the engine runs — callers gate on
+     * decoderHost.running and treat an idle-time import as library-only.
+     */
+    Q_INVOKABLE bool importChannelMap(const QString& path) const;
+
+    /** @brief Import a talkgroup list CSV into the running session (atomic swap). */
+    Q_INVOKABLE bool importGroupList(const QString& path) const;
+
+    /** @brief Import an encryption key CSV; @p hex picks -K semantics over -k. */
+    Q_INVOKABLE bool importKeys(const QString& path, bool hex) const;
 };
 
 } // namespace dsd_qt

--- a/src/ui/qt/decoder_host.cpp
+++ b/src/ui/qt/decoder_host.cpp
@@ -5,7 +5,43 @@
 
 #include "decoder_host.h"
 
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QIODevice>
+#include <QSaveFile>
+#include <QStandardPaths>
+#include <QUrl>
+
 namespace dsd_qt {
+
+namespace {
+
+QString
+imports_dir_path() {
+    return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + QStringLiteral("/imports");
+}
+
+/** @brief chan.csv, chan (2).csv, chan (3).csv … first name not already taken. */
+QString
+unique_destination(const QDir& dir, const QString& fileName) {
+    if (!dir.exists(fileName)) {
+        return dir.filePath(fileName);
+    }
+    const QFileInfo info(fileName);
+    const QString base = info.completeBaseName();
+    const QString suffix = info.suffix();
+    for (int i = 2; i < 1000; i++) {
+        const QString candidate = suffix.isEmpty() ? QStringLiteral("%1 (%2)").arg(base).arg(i)
+                                                   : QStringLiteral("%1 (%2).%3").arg(base).arg(i).arg(suffix);
+        if (!dir.exists(candidate)) {
+            return dir.filePath(candidate);
+        }
+    }
+    return QString();
+}
+
+} // namespace
 
 DecoderHost::DecoderHost(QObject* parent) : QObject(parent) {
     /* sessionState(), and the three properties derived from it, default to a view of
@@ -20,5 +56,63 @@ DecoderHost::DecoderHost(QObject* parent) : QObject(parent) {
 }
 
 DecoderHost::~DecoderHost() = default;
+
+QString
+DecoderHost::importDocument(const QString& reference, const QString& fileName, const QString& replacePath) {
+    const QUrl url(reference);
+    const QString sourcePath = url.isLocalFile() ? url.toLocalFile() : reference;
+    QFile source(sourcePath);
+    if (!source.open(QIODevice::ReadOnly)) {
+        return QString();
+    }
+
+    QDir importsDir(imports_dir_path());
+    if (!importsDir.mkpath(QStringLiteral("."))) {
+        return QString();
+    }
+
+    // The display name comes from the picker; keep only its last component so
+    // it cannot navigate out of the imports directory.
+    QString name = QFileInfo(fileName).fileName();
+    if (name.isEmpty()) {
+        name = QFileInfo(sourcePath).fileName();
+    }
+    if (name.isEmpty()) {
+        return QString();
+    }
+
+    QString destination;
+    if (!replacePath.isEmpty()) {
+        const QString canonicalDir = QFileInfo(importsDir.absolutePath()).canonicalFilePath();
+        const QString canonicalTarget = QFileInfo(replacePath).canonicalPath();
+        if (!canonicalDir.isEmpty() && canonicalTarget == canonicalDir) {
+            destination = replacePath;
+        }
+    }
+    if (destination.isEmpty()) {
+        destination = unique_destination(importsDir, name);
+    }
+    if (destination.isEmpty()) {
+        return QString();
+    }
+
+    // QSaveFile stages beside the target and renames over it on commit, so an
+    // update never leaves a half-written CSV where a saved system points.
+    QSaveFile out(destination);
+    if (!out.open(QIODevice::WriteOnly)) {
+        return QString();
+    }
+    while (!source.atEnd()) {
+        const QByteArray chunk = source.read(1 << 16);
+        if (out.write(chunk) != chunk.size()) {
+            out.cancelWriting();
+            return QString();
+        }
+    }
+    if (!out.commit()) {
+        return QString();
+    }
+    return destination;
+}
 
 } // namespace dsd_qt

--- a/src/ui/qt/decoder_host.cpp
+++ b/src/ui/qt/decoder_host.cpp
@@ -5,13 +5,15 @@
 
 #include "decoder_host.h"
 
+#include <QByteArray>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QIODevice>
 #include <QSaveFile>
-#include <QStandardPaths>
 #include <QUrl>
+
+#include "json_store.h"
 
 namespace dsd_qt {
 
@@ -19,7 +21,9 @@ namespace {
 
 QString
 imports_dir_path() {
-    return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + QStringLiteral("/imports");
+    // Same root json_store uses, so the library index and the files it points at
+    // can never end up under different app-data locations.
+    return json_store_path(QStringLiteral("imports"));
 }
 
 /** @brief chan.csv, chan (2).csv, chan (3).csv … first name not already taken. */
@@ -39,6 +43,55 @@ unique_destination(const QDir& dir, const QString& fileName) {
         }
     }
     return QString();
+}
+
+/**
+ * @brief @p replacePath when it names a file directly inside @p dir, else empty.
+ *
+ * Canonicalizes the *directory*, not the file: QFileInfo::canonicalPath() gives
+ * up on a missing leaf and returns ".", which would silently turn an update of a
+ * copy that vanished behind the app's back into a fresh unique copy the caller
+ * then rejects and never cleans up. The Android host resolves the parent too, so
+ * this keeps the two in step.
+ */
+QString
+replace_destination(const QDir& dir, const QString& replacePath) {
+    if (replacePath.isEmpty()) {
+        return QString();
+    }
+    const QString canonicalDir = QFileInfo(dir.absolutePath()).canonicalFilePath();
+    const QString canonicalTarget = QFileInfo(QFileInfo(replacePath).absolutePath()).canonicalFilePath();
+    if (canonicalDir.isEmpty() || canonicalTarget != canonicalDir) {
+        return QString();
+    }
+    return replacePath;
+}
+
+/**
+ * @brief Copy @p source to @p out in chunks; false on any read or write error.
+ *
+ * Loops on the read result rather than atEnd(): a read error returns an empty
+ * chunk without advancing pos(), so an atEnd()-driven loop would spin forever on
+ * it, and a readable source QFile reports size 0 for (a FIFO, /proc) claims to be
+ * at its end before a byte has been read.
+ */
+bool
+copy_stream(QIODevice& source, QSaveFile& out) {
+    QByteArray chunk(1 << 16, Qt::Uninitialized);
+    for (;;) {
+        const qint64 n = source.read(chunk.data(), chunk.size());
+        if (n < 0) {
+            out.cancelWriting();
+            return false;
+        }
+        if (n == 0) {
+            return true;
+        }
+        if (out.write(chunk.constData(), n) != n) {
+            out.cancelWriting();
+            return false;
+        }
+    }
 }
 
 } // namespace
@@ -81,14 +134,7 @@ DecoderHost::importDocument(const QString& reference, const QString& fileName, c
         return QString();
     }
 
-    QString destination;
-    if (!replacePath.isEmpty()) {
-        const QString canonicalDir = QFileInfo(importsDir.absolutePath()).canonicalFilePath();
-        const QString canonicalTarget = QFileInfo(replacePath).canonicalPath();
-        if (!canonicalDir.isEmpty() && canonicalTarget == canonicalDir) {
-            destination = replacePath;
-        }
-    }
+    QString destination = replace_destination(importsDir, replacePath);
     if (destination.isEmpty()) {
         destination = unique_destination(importsDir, name);
     }
@@ -102,14 +148,7 @@ DecoderHost::importDocument(const QString& reference, const QString& fileName, c
     if (!out.open(QIODevice::WriteOnly)) {
         return QString();
     }
-    while (!source.atEnd()) {
-        const QByteArray chunk = source.read(1 << 16);
-        if (out.write(chunk) != chunk.size()) {
-            out.cancelWriting();
-            return QString();
-        }
-    }
-    if (!out.commit()) {
+    if (!copy_stream(source, out) || !out.commit()) {
         return QString();
     }
     return destination;

--- a/src/ui/qt/decoder_host.h
+++ b/src/ui/qt/decoder_host.h
@@ -186,6 +186,25 @@ class DecoderHost : public QObject {
     }
 
     /**
+     * @brief Materialize a picked document into durable app storage.
+     *
+     * Unlike importContentUri(), which serves a one-shot open (its Android copy
+     * lands in the evictable cache), this copy must outlive the session: saved
+     * systems keep the returned path. Collisions on @p fileName are unique-ified,
+     * never overwritten — two different documents may share a display name.
+     *
+     * @param reference   Platform file reference from the picker (file:// URL or
+     *                    Android SAF content URI).
+     * @param fileName    Display name to store the copy under.
+     * @param replacePath Existing stored file to update in place, or empty for a
+     *                    new copy. A path outside the app's imports directory is
+     *                    not a write target and is treated as a new copy.
+     * @return Absolute filesystem path of the stored copy, or empty on failure.
+     */
+    virtual QString importDocument(const QString& reference, const QString& fileName,
+                                   const QString& replacePath = QString());
+
+    /**
      * @brief Ask the platform for access to a directly attached SDR.
      *
      * May show a permission prompt, so the answer arrives later: watch

--- a/src/ui/qt/imported_files_model.cpp
+++ b/src/ui/qt/imported_files_model.cpp
@@ -6,6 +6,7 @@
 #include "imported_files_model.h"
 
 #include <QByteArray>
+#include <QChar>
 #include <QDateTime>
 #include <QFile>
 #include <QHash>
@@ -13,6 +14,7 @@
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QLatin1String>
+#include <QMap>
 #include <QVariant>
 
 #include <dsd-neo/core/csv_validate.h>

--- a/src/ui/qt/imported_files_model.cpp
+++ b/src/ui/qt/imported_files_model.cpp
@@ -131,6 +131,7 @@ ImportedFilesModel::importFile(const QString& reference, const QString& fileName
     result.insert(QStringLiteral("error"), accepted == 0 ? QStringLiteral("empty") : QString());
     result.insert(QStringLiteral("path"), row.path);
     result.insert(QStringLiteral("name"), row.name);
+    result.insert(QStringLiteral("type"), row.type);
     result.insert(QStringLiteral("accepted"), accepted);
     result.insert(QStringLiteral("skipped"), skipped);
     return result;
@@ -145,12 +146,19 @@ ImportedFilesModel::updateFile(int row, const QString& reference, const QString&
         return result;
     }
 
-    Row& stored = m_rows[row];
-    const QString path = m_host->importDocument(reference, fileName, stored.path);
-    if (path != stored.path || path.isEmpty()) {
+    const QString target = m_rows.at(row).path;
+    const QString path = m_host->importDocument(reference, fileName, target);
+    if (path != target || path.isEmpty()) {
+        // The host wrote somewhere other than the row's file (its replace target
+        // was not usable), so the copy that just landed belongs to no row and
+        // nothing else would ever delete it. Same rollback importFile() does.
+        if (!path.isEmpty()) {
+            QFile::remove(path);
+        }
         return result;
     }
 
+    Row& stored = m_rows[row];
     int accepted = 0;
     int skipped = 0;
     if (!validate(path, stored.type, &accepted, &skipped)) {
@@ -168,6 +176,7 @@ ImportedFilesModel::updateFile(int row, const QString& reference, const QString&
     result.insert(QStringLiteral("error"), accepted == 0 ? QStringLiteral("empty") : QString());
     result.insert(QStringLiteral("path"), stored.path);
     result.insert(QStringLiteral("name"), stored.name);
+    result.insert(QStringLiteral("type"), stored.type);
     result.insert(QStringLiteral("accepted"), accepted);
     result.insert(QStringLiteral("skipped"), skipped);
     return result;
@@ -197,11 +206,9 @@ ImportedFilesModel::get(int row) const {
 QVariantList
 ImportedFilesModel::entriesForType(const QString& type) const {
     QVariantList entries;
-    for (int i = 0; i < m_rows.size(); i++) {
-        if (m_rows.at(i).type == type) {
-            QVariantMap entry = mapFromRow(m_rows.at(i));
-            entry.insert(QStringLiteral("row"), i);
-            entries.append(entry);
+    for (const Row& row : m_rows) {
+        if (row.type == type) {
+            entries.append(mapFromRow(row));
         }
     }
     return entries;
@@ -230,7 +237,7 @@ ImportedFilesModel::rowFromMap(const QVariantMap& map) {
 }
 
 QVariantMap
-ImportedFilesModel::mapFromRow(const Row& row) const {
+ImportedFilesModel::mapFromRow(const Row& row) {
     QVariantMap map;
     map.insert(QStringLiteral("name"), row.name);
     map.insert(QStringLiteral("path"), row.path);
@@ -253,14 +260,30 @@ ImportedFilesModel::load() {
         // A copy Android or the user deleted behind the app's back must not
         // survive as a ghost row pointing nowhere.
         if (row.path.isEmpty() || !QFile::exists(row.path)) {
+            if (!row.path.isEmpty() && !m_pruned_paths.contains(row.path)) {
+                m_pruned_paths.append(row.path);
+            }
             continue;
         }
         rows.append(row);
     }
+    const bool pruned = rows.size() != array.size();
     beginResetModel();
     m_rows = rows;
     endResetModel();
     Q_EMIT countChanged();
+    if (pruned) {
+        // Persist the prune, or every launch re-stats files that are gone and
+        // the index keeps advertising rows the library no longer has.
+        save();
+    }
+}
+
+QStringList
+ImportedFilesModel::takePrunedPaths() {
+    QStringList paths;
+    paths.swap(m_pruned_paths);
+    return paths;
 }
 
 void

--- a/src/ui/qt/imported_files_model.cpp
+++ b/src/ui/qt/imported_files_model.cpp
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "imported_files_model.h"
+
+#include <QByteArray>
+#include <QDateTime>
+#include <QFile>
+#include <QHash>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QLatin1String>
+#include <QVariant>
+
+#include <dsd-neo/core/csv_validate.h>
+
+#include "decoder_host.h"
+#include "json_store.h"
+
+namespace dsd_qt {
+
+namespace {
+
+constexpr const char kStoreFileName[] = "imported_files.json";
+
+} // namespace
+
+ImportedFilesModel::ImportedFilesModel(DecoderHost* host, QObject* parent) : QAbstractListModel(parent), m_host(host) {
+    load();
+}
+
+ImportedFilesModel::~ImportedFilesModel() = default;
+
+int
+ImportedFilesModel::rowCount(const QModelIndex& parent) const {
+    return parent.isValid() ? 0 : static_cast<int>(m_rows.size());
+}
+
+QVariant
+ImportedFilesModel::data(const QModelIndex& index, int role) const {
+    if (!index.isValid() || index.row() < 0 || index.row() >= m_rows.size()) {
+        return QVariant();
+    }
+    const Row& row = m_rows.at(index.row());
+    switch (role) {
+        case NameRole: return row.name;
+        case PathRole: return row.path;
+        case TypeRole: return row.type;
+        case ImportedAtRole: return row.importedAt;
+        case AcceptedRole: return row.accepted;
+        case SkippedRole: return row.skipped;
+        default: return QVariant();
+    }
+}
+
+QHash<int, QByteArray>
+ImportedFilesModel::roleNames() const {
+    QHash<int, QByteArray> roles;
+    roles.insert(NameRole, QByteArrayLiteral("name"));
+    roles.insert(PathRole, QByteArrayLiteral("path"));
+    roles.insert(TypeRole, QByteArrayLiteral("type"));
+    roles.insert(ImportedAtRole, QByteArrayLiteral("importedAt"));
+    roles.insert(AcceptedRole, QByteArrayLiteral("accepted"));
+    roles.insert(SkippedRole, QByteArrayLiteral("skipped"));
+    return roles;
+}
+
+bool
+ImportedFilesModel::validate(const QString& path, const QString& type, int* accepted, int* skipped) {
+    dsd_csv_validation counts = {0U, 0U, 0U};
+    const QByteArray local = path.toUtf8();
+    int rc = -1;
+    if (type == QLatin1String("chan")) {
+        rc = dsd_csv_validate_chan_file(local.constData(), &counts);
+    } else if (type == QLatin1String("group")) {
+        rc = dsd_csv_validate_group_file(local.constData(), &counts);
+    } else if (type == QLatin1String("keysDec")) {
+        rc = dsd_csv_validate_key_file_dec(local.constData(), &counts);
+    } else if (type == QLatin1String("keysHex")) {
+        rc = dsd_csv_validate_key_file_hex(local.constData(), &counts);
+    }
+    if (rc != 0) {
+        return false;
+    }
+    *accepted = static_cast<int>(counts.accepted);
+    *skipped = static_cast<int>(counts.skipped);
+    return true;
+}
+
+QVariantMap
+ImportedFilesModel::importFile(const QString& reference, const QString& fileName, const QString& type) {
+    QVariantMap result;
+    result.insert(QStringLiteral("ok"), false);
+    result.insert(QStringLiteral("error"), QStringLiteral("open"));
+    if (m_host == nullptr) {
+        return result;
+    }
+
+    const QString path = m_host->importDocument(reference, fileName);
+    if (path.isEmpty()) {
+        return result;
+    }
+
+    int accepted = 0;
+    int skipped = 0;
+    if (!validate(path, type, &accepted, &skipped)) {
+        // The copy landed but cannot be parsed as this type; a library row for
+        // it would just be a dead entry, so take the copy back out.
+        QFile::remove(path);
+        return result;
+    }
+
+    Row row;
+    row.path = path;
+    row.name = path.section(QLatin1Char('/'), -1);
+    row.type = type;
+    row.importedAt = QDateTime::currentSecsSinceEpoch();
+    row.accepted = accepted;
+    row.skipped = skipped;
+
+    beginInsertRows(QModelIndex(), static_cast<int>(m_rows.size()), static_cast<int>(m_rows.size()));
+    m_rows.append(row);
+    endInsertRows();
+    Q_EMIT countChanged();
+    save();
+
+    result.insert(QStringLiteral("ok"), true);
+    result.insert(QStringLiteral("error"), accepted == 0 ? QStringLiteral("empty") : QString());
+    result.insert(QStringLiteral("path"), row.path);
+    result.insert(QStringLiteral("name"), row.name);
+    result.insert(QStringLiteral("accepted"), accepted);
+    result.insert(QStringLiteral("skipped"), skipped);
+    return result;
+}
+
+QVariantMap
+ImportedFilesModel::updateFile(int row, const QString& reference, const QString& fileName) {
+    QVariantMap result;
+    result.insert(QStringLiteral("ok"), false);
+    result.insert(QStringLiteral("error"), QStringLiteral("open"));
+    if (m_host == nullptr || row < 0 || row >= m_rows.size()) {
+        return result;
+    }
+
+    Row& stored = m_rows[row];
+    const QString path = m_host->importDocument(reference, fileName, stored.path);
+    if (path != stored.path || path.isEmpty()) {
+        return result;
+    }
+
+    int accepted = 0;
+    int skipped = 0;
+    if (!validate(path, stored.type, &accepted, &skipped)) {
+        return result;
+    }
+
+    stored.importedAt = QDateTime::currentSecsSinceEpoch();
+    stored.accepted = accepted;
+    stored.skipped = skipped;
+    const QModelIndex idx = index(row);
+    Q_EMIT dataChanged(idx, idx);
+    save();
+
+    result.insert(QStringLiteral("ok"), true);
+    result.insert(QStringLiteral("error"), accepted == 0 ? QStringLiteral("empty") : QString());
+    result.insert(QStringLiteral("path"), stored.path);
+    result.insert(QStringLiteral("name"), stored.name);
+    result.insert(QStringLiteral("accepted"), accepted);
+    result.insert(QStringLiteral("skipped"), skipped);
+    return result;
+}
+
+void
+ImportedFilesModel::remove(int row) {
+    if (row < 0 || row >= m_rows.size()) {
+        return;
+    }
+    QFile::remove(m_rows.at(row).path);
+    beginRemoveRows(QModelIndex(), row, row);
+    m_rows.removeAt(row);
+    endRemoveRows();
+    Q_EMIT countChanged();
+    save();
+}
+
+QVariantMap
+ImportedFilesModel::get(int row) const {
+    if (row < 0 || row >= m_rows.size()) {
+        return QVariantMap();
+    }
+    return mapFromRow(m_rows.at(row));
+}
+
+QVariantList
+ImportedFilesModel::entriesForType(const QString& type) const {
+    QVariantList entries;
+    for (int i = 0; i < m_rows.size(); i++) {
+        if (m_rows.at(i).type == type) {
+            QVariantMap entry = mapFromRow(m_rows.at(i));
+            entry.insert(QStringLiteral("row"), i);
+            entries.append(entry);
+        }
+    }
+    return entries;
+}
+
+int
+ImportedFilesModel::rowForPath(const QString& path) const {
+    for (int i = 0; i < m_rows.size(); i++) {
+        if (m_rows.at(i).path == path) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+ImportedFilesModel::Row
+ImportedFilesModel::rowFromMap(const QVariantMap& map) {
+    Row row;
+    row.name = map.value(QStringLiteral("name")).toString();
+    row.path = map.value(QStringLiteral("path")).toString();
+    row.type = map.value(QStringLiteral("type")).toString();
+    row.importedAt = map.value(QStringLiteral("importedAt")).toLongLong();
+    row.accepted = map.value(QStringLiteral("accepted")).toInt();
+    row.skipped = map.value(QStringLiteral("skipped")).toInt();
+    return row;
+}
+
+QVariantMap
+ImportedFilesModel::mapFromRow(const Row& row) const {
+    QVariantMap map;
+    map.insert(QStringLiteral("name"), row.name);
+    map.insert(QStringLiteral("path"), row.path);
+    map.insert(QStringLiteral("type"), row.type);
+    map.insert(QStringLiteral("importedAt"), row.importedAt);
+    map.insert(QStringLiteral("accepted"), row.accepted);
+    map.insert(QStringLiteral("skipped"), row.skipped);
+    return map;
+}
+
+void
+ImportedFilesModel::load() {
+    QList<Row> rows;
+    const QJsonArray array = json_store_load_array(QLatin1String(kStoreFileName));
+    for (const auto& value : array) {
+        if (!value.isObject()) {
+            continue;
+        }
+        Row row = rowFromMap(value.toObject().toVariantMap());
+        // A copy Android or the user deleted behind the app's back must not
+        // survive as a ghost row pointing nowhere.
+        if (row.path.isEmpty() || !QFile::exists(row.path)) {
+            continue;
+        }
+        rows.append(row);
+    }
+    beginResetModel();
+    m_rows = rows;
+    endResetModel();
+    Q_EMIT countChanged();
+}
+
+void
+ImportedFilesModel::save() const {
+    QJsonArray array;
+    for (const Row& row : m_rows) {
+        array.append(QJsonObject::fromVariantMap(mapFromRow(row)));
+    }
+    json_store_save_array(QLatin1String(kStoreFileName), array);
+}
+
+} // namespace dsd_qt

--- a/src/ui/qt/imported_files_model.h
+++ b/src/ui/qt/imported_files_model.h
@@ -80,6 +80,19 @@ class ImportedFilesModel : public QAbstractListModel {
     /** @brief Row index whose stored path matches, or -1. */
     Q_INVOKABLE int rowForPath(const QString& path) const;
 
+    /**
+     * @brief Stored paths dropped by load() because the file was gone, then forgets them.
+     *
+     * Pruning a ghost row is only half the repair: saved systems reference stored
+     * paths, and one left pointing at a deleted file makes the session fail to
+     * start on `-G <missing>` with a parse error that names the input settings
+     * rather than the CSV. The owner has to hand these to
+     * SavedSystemsModel::clearCsvPath(), which is what the library's own remove
+     * flow does. A signal cannot carry them: load() runs from the constructor,
+     * before anything could have connected to one.
+     */
+    Q_INVOKABLE QStringList takePrunedPaths();
+
   Q_SIGNALS:
     void countChanged();
 
@@ -94,7 +107,7 @@ class ImportedFilesModel : public QAbstractListModel {
     };
 
     static Row rowFromMap(const QVariantMap& map);
-    QVariantMap mapFromRow(const Row& row) const;
+    static QVariantMap mapFromRow(const Row& row);
 
     /** @brief Dry-run validate @p path as @p type; false when it cannot be parsed. */
     static bool validate(const QString& path, const QString& type, int* accepted, int* skipped);
@@ -104,6 +117,7 @@ class ImportedFilesModel : public QAbstractListModel {
 
     DecoderHost* m_host = nullptr;
     QList<Row> m_rows;
+    QStringList m_pruned_paths;
 };
 
 } // namespace dsd_qt

--- a/src/ui/qt/imported_files_model.h
+++ b/src/ui/qt/imported_files_model.h
@@ -20,6 +20,7 @@
 #include <QList>
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QVariantList>
 #include <QVariantMap>
 #include <Qt>

--- a/src/ui/qt/imported_files_model.h
+++ b/src/ui/qt/imported_files_model.h
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Library of imported CSV files (channel maps, talkgroups, keys), persisted as JSON.
+ *
+ * The wizard's pickers and the imports screen share this model: importing copies
+ * the picked document into durable app storage through DecoderHost::importDocument(),
+ * dry-run validates it for row counts, and records one library row per stored file.
+ * Saved systems reference stored paths, so one file can serve several systems.
+ */
+
+#ifndef DSD_NEO_SRC_UI_QT_IMPORTED_FILES_MODEL_H_
+#define DSD_NEO_SRC_UI_QT_IMPORTED_FILES_MODEL_H_
+
+#include <QAbstractListModel>
+#include <QList>
+#include <QObject>
+#include <QString>
+#include <QVariantList>
+#include <QVariantMap>
+#include <Qt>
+#include <QtGlobal>
+
+namespace dsd_qt {
+
+class DecoderHost;
+
+class ImportedFilesModel : public QAbstractListModel {
+    Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+
+  public:
+    enum Roles {
+        NameRole = Qt::UserRole + 1,
+        PathRole,       // absolute stored path; the row's identity
+        TypeRole,       // "chan" | "group" | "keysDec" | "keysHex"
+        ImportedAtRole, // seconds since epoch
+        AcceptedRole,   // usable rows at the last validation
+        SkippedRole     // malformed rows at the last validation
+    };
+
+    explicit ImportedFilesModel(DecoderHost* host, QObject* parent = nullptr);
+    ~ImportedFilesModel() override;
+
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    int
+    count() const {
+        return static_cast<int>(m_rows.size());
+    }
+
+    /**
+     * @brief Copy a picked document into the library, validate it, record a row.
+     *
+     * @return {ok, path, name, accepted, skipped, error}. error is "" on success,
+     *         "open" when the copy or parse failed (no row is added), or "empty"
+     *         when the file parsed but no row was usable — the row is kept, so
+     *         the user can fix the file and update, but the UI should warn.
+     */
+    Q_INVOKABLE QVariantMap importFile(const QString& reference, const QString& fileName, const QString& type);
+
+    /** @brief Re-pick flow: overwrite the row's stored file in place and re-validate. */
+    Q_INVOKABLE QVariantMap updateFile(int row, const QString& reference, const QString& fileName);
+
+    /** @brief Delete the stored file, then the row. Persists immediately. */
+    Q_INVOKABLE void remove(int row);
+
+    /** @brief One library row as a field map. */
+    Q_INVOKABLE QVariantMap get(int row) const;
+
+    /** @brief Rows of one type, for the wizard's picker sheets. */
+    Q_INVOKABLE QVariantList entriesForType(const QString& type) const;
+
+    /** @brief Row index whose stored path matches, or -1. */
+    Q_INVOKABLE int rowForPath(const QString& path) const;
+
+  Q_SIGNALS:
+    void countChanged();
+
+  private:
+    struct Row {
+        QString name;
+        QString path;
+        QString type;
+        qint64 importedAt = 0;
+        int accepted = 0;
+        int skipped = 0;
+    };
+
+    static Row rowFromMap(const QVariantMap& map);
+    QVariantMap mapFromRow(const Row& row) const;
+
+    /** @brief Dry-run validate @p path as @p type; false when it cannot be parsed. */
+    static bool validate(const QString& path, const QString& type, int* accepted, int* skipped);
+
+    void load();
+    void save() const;
+
+    DecoderHost* m_host = nullptr;
+    QList<Row> m_rows;
+};
+
+} // namespace dsd_qt
+
+#endif /* DSD_NEO_SRC_UI_QT_IMPORTED_FILES_MODEL_H_ */

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -17,7 +17,6 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/runtime/decode_mode.h>
-#include <stdint.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -20,6 +20,7 @@
 #include <QTimer>
 #include <QtGlobal>
 #include <dsd-neo/app_control/call_view.h>
+#include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/core/synctype_ids.h>

--- a/src/ui/qt/qml/CsvTypeBadge.qml
+++ b/src/ui/qt/qml/CsvTypeBadge.qml
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+
+// The imported-file kind marker: mono uppercase in a quiet control-border chip,
+// the same register as EncTag but deliberately neutral — a file's type is a
+// fact, not a warning.
+Rectangle {
+    // "chan" | "group" | "keysDec" | "keysHex", as ImportedFilesModel stores it.
+    property string type: ""
+
+    implicitWidth: tag.implicitWidth + 14
+    implicitHeight: 20
+    radius: 5
+    color: "transparent"
+    border.width: 1
+    border.color: Theme.controlBorder
+
+    Text {
+        id: tag
+        anchors.centerIn: parent
+        text: parent.type === "chan" ? qsTr("CHANNELS")
+              : parent.type === "group" ? qsTr("TALKGROUPS")
+              : parent.type === "keysDec" ? qsTr("KEYS · DEC")
+              : parent.type === "keysHex" ? qsTr("KEYS · HEX")
+              : qsTr("FILE")
+        font.family: Theme.mono
+        font.pixelSize: 10
+        font.letterSpacing: 1
+        color: Theme.textSecondary
+    }
+}

--- a/src/ui/qt/qml/ImportsScreen.qml
+++ b/src/ui/qt/qml/ImportsScreen.qml
@@ -53,17 +53,24 @@ Item {
             screen.noticeIsProblem = true
             return
         }
-        var type = result.path.length > 0 && importedFiles.rowForPath(result.path) >= 0
-                   ? importedFiles.get(importedFiles.rowForPath(result.path)).type : ""
-        screen.notice = verb + " · " + result.accepted + " " + screen.nounFor(type, result.accepted)
+        // The model already knew the kind when it built this result; reverse-
+        // looking it up by path would scan the library twice and quietly name a
+        // channel map "keys" if the lookup missed.
+        screen.notice = verb + " · " + result.accepted + " " + screen.nounFor(result.type, result.accepted)
         screen.noticeIsProblem = false
     }
 
     // No CSV name filter: on Android it becomes a SAF MIME filter, and the
     // Files app indexes .csv as text/comma-separated-values — not the text/csv
     // Qt asks for — which greys out exactly the files the user came to pick.
-    // The kind was already chosen in the sheet, and validation rejects files
-    // that do not parse as it.
+    //
+    // The kind was already chosen in the sheet, and the dry run counts rows
+    // against that kind, so a file of the wrong kind lands here as "no usable
+    // rows". That check is by content, not by name: a channel map and a decimal
+    // key list are both `number,number`, and the header line is free text, so
+    // what separates them is the channel importer refusing a second column that
+    // cannot be a radio frequency. Two lists of the same kind are still
+    // indistinguishable — nothing stops one site's map being picked for another.
     FileDialog {
         id: fileDialog
 

--- a/src/ui/qt/qml/ImportsScreen.qml
+++ b/src/ui/qt/qml/ImportsScreen.qml
@@ -59,10 +59,13 @@ Item {
         screen.noticeIsProblem = false
     }
 
+    // No CSV name filter: on Android it becomes a SAF MIME filter, and the
+    // Files app indexes .csv as text/comma-separated-values — not the text/csv
+    // Qt asks for — which greys out exactly the files the user came to pick.
+    // The kind was already chosen in the sheet, and validation rejects files
+    // that do not parse as it.
     FileDialog {
         id: fileDialog
-
-        nameFilters: [qsTr("CSV files (*.csv)"), qsTr("All files (*)")]
 
         onAccepted: {
             var reference = selectedFile.toString()

--- a/src/ui/qt/qml/ImportsScreen.qml
+++ b/src/ui/qt/qml/ImportsScreen.qml
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import QtQuick.Dialogs
+
+// The imported-files library: every channel map, talkgroup list, and key file
+// that has been copied into app storage, with import/update/remove flows. The
+// wizard's pickers reference the same library, so a file imported here serves
+// any saved system.
+Item {
+    id: screen
+
+    signal closed()
+
+    // FileDialog routing: a row index means "update that row in place";
+    // -1 means a new import of pendingType.
+    property int pendingRow: -1
+    property string pendingType: "chan"
+    property bool pendingKeyHex: false
+    // Row the action sheet is open on.
+    property int actionRow: -1
+    // Transient outcome line under the header; magenta when it reports a problem.
+    property string notice: ""
+    property bool noticeIsProblem: false
+
+    function nounFor(type, count) {
+        if (type === "chan")
+            return count === 1 ? qsTr("channel") : qsTr("channels")
+        if (type === "group")
+            return count === 1 ? qsTr("talkgroup") : qsTr("talkgroups")
+        return count === 1 ? qsTr("key") : qsTr("keys")
+    }
+
+    function summaryFor(type, accepted, skipped, importedAt) {
+        if (accepted === 0)
+            return qsTr("No usable rows — check the file format")
+        var parts = [accepted + " " + nounFor(type, accepted)]
+        if (skipped > 0)
+            parts.push(skipped === 1 ? qsTr("1 row skipped") : qsTr("%1 rows skipped").arg(skipped))
+        parts.push(Qt.formatDate(new Date(importedAt * 1000), "MMM d"))
+        return parts.join(" · ")
+    }
+
+    function resultNotice(verb, result) {
+        if (!result.ok) {
+            screen.notice = qsTr("Could not read that file")
+            screen.noticeIsProblem = true
+            return
+        }
+        if (result.error === "empty") {
+            screen.notice = qsTr("%1 — no usable rows. Check the file format, then update it.").arg(verb)
+            screen.noticeIsProblem = true
+            return
+        }
+        var type = result.path.length > 0 && importedFiles.rowForPath(result.path) >= 0
+                   ? importedFiles.get(importedFiles.rowForPath(result.path)).type : ""
+        screen.notice = verb + " · " + result.accepted + " " + screen.nounFor(type, result.accepted)
+        screen.noticeIsProblem = false
+    }
+
+    FileDialog {
+        id: fileDialog
+
+        nameFilters: [qsTr("CSV files (*.csv)"), qsTr("All files (*)")]
+
+        onAccepted: {
+            var reference = selectedFile.toString()
+            var hint = reference.substring(reference.lastIndexOf('/') + 1)
+            if (screen.pendingRow >= 0) {
+                screen.resultNotice(qsTr("Updated"), importedFiles.updateFile(screen.pendingRow, reference, hint))
+            } else {
+                var type = screen.pendingType === "keys"
+                           ? (screen.pendingKeyHex ? "keysHex" : "keysDec") : screen.pendingType
+                screen.resultNotice(qsTr("Imported"), importedFiles.importFile(reference, hint, type))
+            }
+            screen.pendingRow = -1
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.bg
+    }
+
+    // Header: back chevron, title, count.
+    Item {
+        id: header
+
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.margins: Theme.screenPadding
+        height: 46
+
+        Text {
+            id: back
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            text: "‹"
+            font.pixelSize: 28
+            color: Theme.textSecondary
+
+            TapHandler {
+                onTapped: screen.closed()
+            }
+        }
+
+        Text {
+            anchors.left: back.right
+            anchors.leftMargin: 14
+            anchors.verticalCenter: parent.verticalCenter
+            text: qsTr("Imported files")
+            font.family: Theme.sans
+            font.pixelSize: 22
+            font.weight: Font.Bold
+            font.letterSpacing: -0.22
+            color: Theme.textPrimary
+        }
+    }
+
+    MicroLabel {
+        id: countLabel
+        anchors.top: header.bottom
+        anchors.left: parent.left
+        anchors.topMargin: 6
+        anchors.leftMargin: Theme.screenPadding
+        text: importedFiles.count === 1 ? qsTr("1 file") : qsTr("%1 files").arg(importedFiles.count)
+    }
+
+    Text {
+        id: noticeLine
+
+        anchors.top: countLabel.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: 8
+        anchors.leftMargin: Theme.screenPadding
+        anchors.rightMargin: Theme.screenPadding
+        visible: screen.notice.length > 0
+        text: screen.notice
+        font.family: Theme.sans
+        font.pixelSize: 13
+        color: screen.noticeIsProblem ? Theme.magenta : Theme.textSubdued
+        wrapMode: Text.Wrap
+    }
+
+    ListView {
+        id: fileList
+
+        anchors.top: noticeLine.visible ? noticeLine.bottom : countLabel.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: importButton.top
+        anchors.topMargin: 14
+        anchors.bottomMargin: 14
+        clip: true
+        model: importedFiles
+        spacing: Theme.gap
+
+        delegate: UiPanel {
+            id: fileRow
+
+            required property int index
+            required property string name
+            required property string path
+            required property string type
+            required property int accepted
+            required property int skipped
+            required property var importedAt
+
+            width: fileList.width - 2 * Theme.screenPadding
+            x: Theme.screenPadding
+            height: rowColumn.height + 2 * Theme.cardPadding
+
+            Column {
+                id: rowColumn
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.margins: Theme.cardPadding
+                spacing: 5
+
+                Item {
+                    width: parent.width
+                    height: Math.max(fileName.implicitHeight, badge.implicitHeight)
+
+                    Text {
+                        id: fileName
+                        anchors.left: parent.left
+                        anchors.right: badge.left
+                        anchors.rightMargin: 10
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: fileRow.name
+                        font.family: Theme.sans
+                        font.pixelSize: 15
+                        font.weight: Font.DemiBold
+                        color: Theme.textPrimary
+                        elide: Text.ElideRight
+                    }
+
+                    CsvTypeBadge {
+                        id: badge
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        type: fileRow.type
+                    }
+                }
+
+                Text {
+                    width: parent.width
+                    text: screen.summaryFor(fileRow.type, fileRow.accepted, fileRow.skipped, Number(fileRow.importedAt))
+                    font.family: Theme.sans
+                    font.pixelSize: 12
+                    color: fileRow.accepted === 0 ? Theme.magenta : Theme.textSubdued
+                    elide: Text.ElideRight
+                }
+            }
+
+            TapHandler {
+                onTapped: {
+                    screen.actionRow = fileRow.index
+                    actionSheet.visible = true
+                }
+            }
+        }
+
+        // Empty state: an invitation to act, not mood.
+        Text {
+            anchors.centerIn: parent
+            width: parent.width - 4 * Theme.screenPadding
+            visible: importedFiles.count === 0
+            text: qsTr("No imported files yet. Import a channel map, talkgroup list, or key file to use it in your systems.")
+            font.family: Theme.sans
+            font.pixelSize: 14
+            color: Theme.textSubdued
+            wrapMode: Text.Wrap
+            horizontalAlignment: Text.AlignHCenter
+        }
+    }
+
+    GradientButton {
+        id: importButton
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: Theme.screenPadding
+        anchors.bottomMargin: 22
+        text: qsTr("Import file")
+        onClicked: {
+            screen.notice = ""
+            typeSheet.visible = true
+        }
+    }
+
+    // What kind of file is being imported; the parser and the flag differ per kind.
+    ModalSheet {
+        id: typeSheet
+
+        MicroLabel {
+            text: qsTr("Import file")
+        }
+
+        Text {
+            width: parent.width
+            text: qsTr("What does this file contain?")
+            font.family: Theme.sans
+            font.pixelSize: 15
+            font.weight: Font.DemiBold
+            color: Theme.textPrimary
+            wrapMode: Text.Wrap
+        }
+
+        SegmentedControl {
+            width: parent.width
+            model: [qsTr("Channel map"), qsTr("Talkgroups"), qsTr("Keys")]
+            currentIndex: screen.pendingType === "chan" ? 0 : screen.pendingType === "group" ? 1 : 2
+            onSelected: function (index) {
+                screen.pendingType = index === 0 ? "chan" : index === 1 ? "group" : "keys"
+            }
+        }
+
+        SegmentedControl {
+            width: parent.width
+            visible: screen.pendingType === "keys"
+            model: [qsTr("Decimal keys"), qsTr("Hex keys")]
+            currentIndex: screen.pendingKeyHex ? 1 : 0
+            onSelected: function (index) { screen.pendingKeyHex = index === 1 }
+        }
+
+        GradientButton {
+            width: parent.width
+            text: qsTr("Choose file")
+            onClicked: {
+                typeSheet.visible = false
+                screen.pendingRow = -1
+                fileDialog.open()
+            }
+        }
+    }
+
+    // Actions on one library file.
+    ModalSheet {
+        id: actionSheet
+
+        Text {
+            width: parent.width
+            text: screen.actionRow >= 0 ? importedFiles.get(screen.actionRow).name : ""
+            font.family: Theme.sans
+            font.pixelSize: 15
+            font.weight: Font.DemiBold
+            color: Theme.textPrimary
+            elide: Text.ElideRight
+        }
+
+        OutlineButton {
+            width: parent.width
+            text: qsTr("Update from file")
+            onClicked: {
+                actionSheet.visible = false
+                screen.notice = ""
+                screen.pendingRow = screen.actionRow
+                fileDialog.open()
+            }
+        }
+
+        OutlineButton {
+            width: parent.width
+            visible: decoderHost.running
+            text: qsTr("Apply to running session")
+            onClicked: {
+                actionSheet.visible = false
+                var entry = importedFiles.get(screen.actionRow)
+                var sent = entry.type === "chan" ? commands.importChannelMap(entry.path)
+                           : entry.type === "group" ? commands.importGroupList(entry.path)
+                           : commands.importKeys(entry.path, entry.type === "keysHex")
+                screen.notice = sent ? qsTr("Sent to decoder") : qsTr("The decoder is not accepting commands")
+                screen.noticeIsProblem = !sent
+            }
+        }
+
+        OutlineButton {
+            width: parent.width
+            text: qsTr("Remove")
+            onClicked: {
+                actionSheet.visible = false
+                removeSheet.visible = true
+            }
+        }
+    }
+
+    // Removing deletes the stored copy; systems that reference it lose the file,
+    // so say which ones before it happens.
+    ModalSheet {
+        id: removeSheet
+
+        readonly property var usedBy: visible && screen.actionRow >= 0
+                                      ? savedSystems.systemsReferencingPath(importedFiles.get(screen.actionRow).path)
+                                      : []
+
+        Text {
+            width: parent.width
+            text: screen.actionRow >= 0
+                  ? qsTr("Remove %1?").arg(importedFiles.get(screen.actionRow).name) : ""
+            font.family: Theme.sans
+            font.pixelSize: 15
+            font.weight: Font.DemiBold
+            color: Theme.textPrimary
+            wrapMode: Text.Wrap
+        }
+
+        Text {
+            width: parent.width
+            visible: removeSheet.usedBy.length > 0
+            text: removeSheet.usedBy.length === 1
+                  ? qsTr("Used by %1 — removing clears it from that system.").arg(removeSheet.usedBy[0])
+                  : qsTr("Used by %1 — removing clears it from those systems.").arg(removeSheet.usedBy.join(", "))
+            font.family: Theme.sans
+            font.pixelSize: 13
+            color: Theme.textSubdued
+            wrapMode: Text.Wrap
+        }
+
+        OutlineButton {
+            width: parent.width
+            text: qsTr("Remove file")
+            onClicked: {
+                removeSheet.visible = false
+                var path = importedFiles.get(screen.actionRow).path
+                savedSystems.clearCsvPath(path)
+                importedFiles.remove(screen.actionRow)
+                screen.actionRow = -1
+                screen.notice = qsTr("Removed")
+                screen.noticeIsProblem = false
+            }
+        }
+    }
+}

--- a/src/ui/qt/qml/ImportsScreen.qml
+++ b/src/ui/qt/qml/ImportsScreen.qml
@@ -158,12 +158,21 @@ Item {
     ListView {
         id: fileList
 
+        // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
+        objectName: "importedFilesList"
+
         anchors.top: noticeLine.visible ? noticeLine.bottom : countLabel.bottom
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: importButton.top
         anchors.topMargin: 14
         anchors.bottomMargin: 14
+        // The screen padding is the view's, not the delegate's: a vertical
+        // ListView writes each item's x itself on every layout pass, so an x
+        // declared in the delegate is overwritten with 0 and the cards end up
+        // flush against the left edge with the whole inset piled on the right.
+        anchors.leftMargin: Theme.screenPadding
+        anchors.rightMargin: Theme.screenPadding
         clip: true
         model: importedFiles
         spacing: Theme.gap
@@ -179,8 +188,7 @@ Item {
             required property int skipped
             required property var importedAt
 
-            width: fileList.width - 2 * Theme.screenPadding
-            x: Theme.screenPadding
+            width: ListView.view.width
             height: rowColumn.height + 2 * Theme.cardPadding
 
             Column {
@@ -238,8 +246,13 @@ Item {
 
         // Empty state: an invitation to act, not mood.
         Text {
+            // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
+            objectName: "importsEmptyMessage"
+
             anchors.centerIn: parent
-            width: parent.width - 4 * Theme.screenPadding
+            // The view is already inset by the screen padding, so this is the
+            // second step in from the edge, not the first.
+            width: parent.width - 2 * Theme.screenPadding
             visible: importedFiles.count === 0
             text: qsTr("No imported files yet. Import a channel map, talkgroup list, or key file to use it in your systems.")
             font.family: Theme.sans
@@ -252,6 +265,9 @@ Item {
 
     GradientButton {
         id: importButton
+
+        // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
+        objectName: "importFileButton"
 
         anchors.left: parent.left
         anchors.right: parent.right

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -115,6 +115,10 @@ Window {
                 prefs.exploreFreqMhz = mainRoot.lastExploreFreqMhz
             mainRoot.exploring = false
             mainRoot.spectrumOpen = false
+            // Row indices shift when a system is removed, and Home is reachable
+            // again from here; a row remembered past its session would name a
+            // different system by the time anything read it.
+            mainRoot.sessionRow = -1
         }
         if (monitorMode) {
             // The frequency field usually still holds focus; the keyboard would
@@ -458,6 +462,10 @@ Window {
                     mainRoot.sessionSystem ? mainRoot.sessionSystem.host : "",
                     mainRoot.sessionSystem ? mainRoot.sessionSystem.port : 0,
                     exploreFreqMhz)
+                // Which also means the saved row is no longer this session's, so
+                // the monitor's edit gesture must not open — and push CSVs into —
+                // a system the session detached from.
+                mainRoot.sessionRow = -1
                 uiController.flushHistory()
                 callHistory.sessionLabel = qsTr("Exploring")
             }
@@ -494,14 +502,39 @@ Window {
             // Saving the system the running session was started from applies its
             // CSV files live — the session's argv was built at start, so without
             // this a changed talkgroup list would silently wait for a restart.
+            // Only files that actually changed are pushed: re-importing a channel
+            // map replaces the live one wholesale (discarding anything the
+            // protocol learned since), and re-importing keys bumps the
+            // encrypted-target key epoch, so a name-only edit must not do either.
             if (decoderHost.running && row >= 0 && row === mainRoot.sessionRow) {
+                var was = mainRoot.sessionSystem || {}
                 var sys = savedSystems.get(row)
-                if (sys.chanCsvPath.length > 0)
-                    commands.importChannelMap(sys.chanCsvPath)
-                if (sys.groupCsvPath.length > 0)
-                    commands.importGroupList(sys.groupCsvPath)
-                if (sys.keyCsvPath.length > 0)
-                    commands.importKeys(sys.keyCsvPath, sys.keyCsvHex)
+                // Clearing a picker to "None" is a change like any other, and
+                // only the clear commands can express it — the import commands
+                // all reject an empty path. Without this the file the user just
+                // deselected keeps mapping channels, naming talkgroups and
+                // decrypting for the rest of the session.
+                if (sys.chanCsvPath !== was.chanCsvPath) {
+                    if (sys.chanCsvPath.length > 0)
+                        commands.importChannelMap(sys.chanCsvPath)
+                    else if ((was.chanCsvPath || "").length > 0)
+                        commands.clearChannelMap()
+                }
+                if (sys.groupCsvPath !== was.groupCsvPath) {
+                    if (sys.groupCsvPath.length > 0)
+                        commands.importGroupList(sys.groupCsvPath)
+                    else if ((was.groupCsvPath || "").length > 0)
+                        commands.clearGroupList()
+                }
+                if (sys.keyCsvPath !== was.keyCsvPath || sys.keyCsvHex !== was.keyCsvHex) {
+                    if (sys.keyCsvPath.length > 0)
+                        commands.importKeys(sys.keyCsvPath, sys.keyCsvHex)
+                    else if ((was.keyCsvPath || "").length > 0)
+                        commands.clearKeys()
+                }
+                // The monitor header reads sessionSystem; without this it keeps
+                // naming and metering the system as it was before the edit.
+                mainRoot.sessionSystem = sys
             }
             mainRoot.wizardOpen = false
             mainRoot.currentTab = 0
@@ -510,9 +543,15 @@ Window {
     }
 
     // ---- Imported-files library (pushed from Settings) ----
+    // The monitor owns the screen once a session goes active, so this layer
+    // stands down for it the way the explore setup and onboarding do — two lit,
+    // enabled full-screen layers means one tap lands on both, and the bottom
+    // "Import file" button sits exactly over "Stop listening".
     ImportsScreen {
+        objectName: "importsScreen"
+
         anchors.fill: safeArea
-        opacity: mainRoot.importsOpen ? 1.0 : 0.0
+        opacity: mainRoot.importsOpen && !mainRoot.monitorMode ? 1.0 : 0.0
         visible: opacity > 0.0
         enabled: opacity > 0.9
 

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -43,6 +43,10 @@ Window {
     property int currentTab: 0
     property bool wizardOpen: false
     property bool exploreSetupOpen: false
+    property bool importsOpen: false
+    // The saved-systems row the running session was started from, or -1. Lets a
+    // wizard save on that same row push its CSV files into the live session.
+    property int sessionRow: -1
     // The spectrum view is pushed over the monitor, so it can only be open
     // while a session is; ending one has to take it down with it.
     property bool spectrumOpen: false
@@ -189,6 +193,7 @@ Window {
             return
         }
         mainRoot.sessionSystem = sys
+        mainRoot.sessionRow = row
         // The session's intent, decided here and nowhere else: a system someone
         // saved is a thing to listen to, and the spectrum watches it. Only a
         // session with no saved system behind it is free to wander.
@@ -264,7 +269,7 @@ Window {
 
         anchors.fill: safeArea
         opacity: (mainRoot.monitorMode || mainRoot.wizardOpen || mainRoot.exploreSetupOpen
-                  || !prefs.onboardingDone) ? 0.0 : 1.0
+                  || mainRoot.importsOpen || !prefs.onboardingDone) ? 0.0 : 1.0
         visible: opacity > 0.0
         enabled: opacity > 0.9
 
@@ -314,6 +319,8 @@ Window {
             anchors.right: parent.right
             anchors.bottom: nav.top
             visible: mainRoot.currentTab === 2
+
+            onOpenImports: mainRoot.importsOpen = true
         }
 
         BottomNav {
@@ -476,10 +483,36 @@ Window {
             Qt.inputMethod.hide()
         }
         onSaved: function (row) {
+            // Saving the system the running session was started from applies its
+            // CSV files live — the session's argv was built at start, so without
+            // this a changed talkgroup list would silently wait for a restart.
+            if (decoderHost.running && row >= 0 && row === mainRoot.sessionRow) {
+                var sys = savedSystems.get(row)
+                if (sys.chanCsvPath.length > 0)
+                    commands.importChannelMap(sys.chanCsvPath)
+                if (sys.groupCsvPath.length > 0)
+                    commands.importGroupList(sys.groupCsvPath)
+                if (sys.keyCsvPath.length > 0)
+                    commands.importKeys(sys.keyCsvPath, sys.keyCsvHex)
+            }
             mainRoot.wizardOpen = false
             mainRoot.currentTab = 0
             Qt.inputMethod.hide()
         }
+    }
+
+    // ---- Imported-files library (pushed from Settings) ----
+    ImportsScreen {
+        anchors.fill: safeArea
+        opacity: mainRoot.importsOpen ? 1.0 : 0.0
+        visible: opacity > 0.0
+        enabled: opacity > 0.9
+
+        Behavior on opacity {
+            NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
+        }
+
+        onClosed: mainRoot.importsOpen = false
     }
 
     // ---- First-run onboarding ----

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -392,6 +392,14 @@ Window {
             spectrumLoader.active = true
             mainRoot.spectrumOpen = true
         }
+        onEditSystem: {
+            // Only a session started from a saved row has a system to edit; a
+            // reattached or quick-start session has no row to write back to.
+            if (mainRoot.sessionRow >= 0) {
+                wizard.openForEdit(mainRoot.sessionRow)
+                mainRoot.wizardOpen = true
+            }
+        }
     }
 
     // ---- Spectrum (pushed over the monitor) ----

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -12,6 +12,11 @@ Item {
     // Raised by the header's spectrum button; Main.qml owns the layer.
     signal openSpectrum()
 
+    // Raised by a long-press on the header title, the same gesture that edits a
+    // card on Home. Main.qml opens the wizard on the running system — the only
+    // way to change its imported CSVs while the session is live.
+    signal editSystem()
+
     // The saved-system map the session was started from (may be null for a
     // network/file quick start).
     property var system: null
@@ -115,6 +120,10 @@ Item {
                 font.letterSpacing: 0.8
                 color: Theme.textSubdued
                 elide: Text.ElideRight
+            }
+
+            TapHandler {
+                onLongPressed: screen.editSystem()
             }
         }
 

--- a/src/ui/qt/qml/SettingsScreen.qml
+++ b/src/ui/qt/qml/SettingsScreen.qml
@@ -10,6 +10,8 @@ Item {
 
     property bool advancedOpen: false
 
+    signal openImports()
+
     Rectangle {
         anchors.fill: parent
         color: Theme.bg
@@ -316,6 +318,74 @@ Item {
                         subtitle: qsTr("Fixes frequency drift on long runs")
                         checked: prefs.autoPpm
                         onToggled: function (state) { prefs.autoPpm = state }
+                    }
+                }
+            }
+
+            // TRUNKING DATA
+            UiPanel {
+                width: parent.width
+                height: importsColumn.height + Theme.cardPadding + 4
+
+                Column {
+                    id: importsColumn
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.topMargin: Theme.cardPadding
+                    spacing: 0
+
+                    MicroLabel {
+                        text: qsTr("Trunking data")
+                        leftPadding: Theme.cardPadding
+                        bottomPadding: 6
+                    }
+
+                    Item {
+                        width: parent.width
+                        height: 58
+
+                        Column {
+                            anchors.left: parent.left
+                            anchors.right: importsCaret.left
+                            anchors.leftMargin: Theme.cardPadding
+                            anchors.rightMargin: 12
+                            anchors.verticalCenter: parent.verticalCenter
+                            spacing: 3
+
+                            Text {
+                                width: parent.width
+                                text: qsTr("Imported files")
+                                font.family: Theme.sans
+                                font.pixelSize: 15
+                                font.weight: Font.DemiBold
+                                color: Theme.textPrimary
+                                elide: Text.ElideRight
+                            }
+
+                            Text {
+                                width: parent.width
+                                text: qsTr("Channel maps, talkgroups, and keys")
+                                font.family: Theme.sans
+                                font.pixelSize: 12
+                                color: Theme.textSubdued
+                                elide: Text.ElideRight
+                            }
+                        }
+
+                        Caret {
+                            id: importsCaret
+                            anchors.right: parent.right
+                            anchors.rightMargin: Theme.cardPadding
+                            anchors.verticalCenter: parent.verticalCenter
+                            rotation: -90
+                            color: Theme.textSubdued
+                        }
+
+                        TapHandler {
+                            onTapped: screen.openImports()
+                        }
                     }
                 }
             }

--- a/src/ui/qt/qml/WizardScreen.qml
+++ b/src/ui/qt/qml/WizardScreen.qml
@@ -46,6 +46,11 @@ Item {
     property string pickerTarget: "source"
     // Dec/hex choice for a new key-file import from the picker sheet.
     property bool pickerKeyHex: false
+    // Outcome of the last trunking-data import, shown under the picker rows.
+    // Without it a file that could not be read, or that parsed to nothing,
+    // leaves the row reading "None" with no explanation.
+    property string csvNotice: ""
+    property bool csvNoticeIsProblem: false
 
     // Step 3 state
     property alias nameText: nameField.text
@@ -94,6 +99,8 @@ Item {
         groupCsvPath = ""
         keyCsvPath = ""
         keyCsvHex = false
+        csvNotice = ""
+        csvNoticeIsProblem = false
     }
 
     /**
@@ -126,6 +133,8 @@ Item {
         groupCsvPath = ""
         keyCsvPath = ""
         keyCsvHex = false
+        csvNotice = ""
+        csvNoticeIsProblem = false
     }
 
     function openForEdit(row) {
@@ -150,6 +159,8 @@ Item {
         groupCsvPath = sys.groupCsvPath
         keyCsvPath = sys.keyCsvPath
         keyCsvHex = sys.keyCsvHex
+        csvNotice = ""
+        csvNoticeIsProblem = false
     }
 
     // Display line for a picker row: the file's name, or "None".
@@ -287,6 +298,8 @@ Item {
 
     // Assign an imported/picked library path to the field the picker serves.
     function assignCsvPath(target, path, hex) {
+        csvNotice = ""
+        csvNoticeIsProblem = false
         if (target === "chan") {
             chanCsvPath = path
         } else if (target === "group") {
@@ -316,8 +329,19 @@ Item {
             var type = wizard.pickerTarget === "keys"
                        ? (wizard.pickerKeyHex ? "keysHex" : "keysDec") : wizard.pickerTarget
             var result = importedFiles.importFile(reference, hint, type)
-            if (result.ok)
-                wizard.assignCsvPath(wizard.pickerTarget, result.path, wizard.pickerKeyHex)
+            if (!result.ok) {
+                wizard.csvNotice = qsTr("Could not read that file")
+                wizard.csvNoticeIsProblem = true
+                return
+            }
+            wizard.assignCsvPath(wizard.pickerTarget, result.path, wizard.pickerKeyHex)
+            if (result.error === "empty") {
+                wizard.csvNotice = qsTr("%1 has no usable rows — check the file format.").arg(result.name)
+                wizard.csvNoticeIsProblem = true
+            } else {
+                wizard.csvNotice = ""
+                wizard.csvNoticeIsProblem = false
+            }
         }
     }
 
@@ -718,6 +742,19 @@ Item {
                             leftPadding: Theme.cardPadding
                             rightPadding: Theme.cardPadding
                             bottomPadding: 6
+                            visible: wizard.csvNotice.length > 0
+                            text: wizard.csvNotice
+                            font.family: Theme.sans
+                            font.pixelSize: 12
+                            color: wizard.csvNoticeIsProblem ? Theme.magenta : Theme.textSubdued
+                            wrapMode: Text.Wrap
+                        }
+
+                        Text {
+                            width: parent.width
+                            leftPadding: Theme.cardPadding
+                            rightPadding: Theme.cardPadding
+                            bottomPadding: 6
                             text: qsTr("Imported files are shared between systems. Manage them in Settings.")
                             font.family: Theme.sans
                             font.pixelSize: 12
@@ -1036,45 +1073,65 @@ Item {
                   : qsTr("Encryption keys")
         }
 
-        Repeater {
-            model: csvSheet.entries
+        // The library is unbounded, and the sheet is centred with no scrolling of
+        // its own: past a handful of files an unclipped Repeater would push the
+        // "None"/import controls off the bottom and the title off the top, with
+        // no way to reach either. Cap the list and let it scroll instead.
+        Flickable {
+            width: parent.width
+            height: Math.min(entryColumn.height, 46 * 5)
+            visible: csvSheet.entries && csvSheet.entries.length > 0
+            clip: true
+            contentHeight: entryColumn.height
+            boundsBehavior: Flickable.StopAtBounds
 
-            Item {
-                required property var modelData
+            Column {
+                id: entryColumn
 
                 width: parent.width
-                height: 46
 
-                Column {
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                    spacing: 2
+                Repeater {
+                    model: csvSheet.entries
 
-                    Text {
-                        width: parent.width
-                        text: modelData.name
-                        font.family: Theme.sans
-                        font.pixelSize: 15
-                        font.weight: Font.DemiBold
-                        color: modelData.path === csvSheet.currentPath ? Theme.cyan : Theme.textPrimary
-                        elide: Text.ElideRight
-                    }
+                    Item {
+                        required property var modelData
 
-                    Text {
-                        width: parent.width
-                        text: csvSheet.entrySummary(modelData)
-                        font.family: Theme.sans
-                        font.pixelSize: 12
-                        color: Theme.textSubdued
-                        elide: Text.ElideRight
-                    }
-                }
+                        width: entryColumn.width
+                        height: 46
 
-                TapHandler {
-                    onTapped: {
-                        wizard.assignCsvPath(wizard.pickerTarget, modelData.path, modelData.type === "keysHex")
-                        csvSheet.visible = false
+                        Column {
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            spacing: 2
+
+                            Text {
+                                width: parent.width
+                                text: modelData.name
+                                font.family: Theme.sans
+                                font.pixelSize: 15
+                                font.weight: Font.DemiBold
+                                color: modelData.path === csvSheet.currentPath ? Theme.cyan : Theme.textPrimary
+                                elide: Text.ElideRight
+                            }
+
+                            Text {
+                                width: parent.width
+                                text: csvSheet.entrySummary(modelData)
+                                font.family: Theme.sans
+                                font.pixelSize: 12
+                                color: Theme.textSubdued
+                                elide: Text.ElideRight
+                            }
+                        }
+
+                        TapHandler {
+                            onTapped: {
+                                wizard.assignCsvPath(wizard.pickerTarget, modelData.path,
+                                                     modelData.type === "keysHex")
+                                csvSheet.visible = false
+                            }
+                        }
                     }
                 }
             }
@@ -1095,7 +1152,14 @@ Item {
             visible: wizard.pickerTarget === "keys"
             model: [qsTr("Decimal keys"), qsTr("Hex keys")]
             currentIndex: wizard.pickerKeyHex ? 1 : 0
-            onSelected: function (index) { wizard.pickerKeyHex = index === 1 }
+            // Also re-reads the already-assigned file: the control opens showing
+            // that file's dec/hex state, so flipping it has to change it —
+            // otherwise it looks like a setting and silently does nothing.
+            onSelected: function (index) {
+                wizard.pickerKeyHex = index === 1
+                if (wizard.pickerTarget === "keys" && wizard.keyCsvPath.length > 0)
+                    wizard.keyCsvHex = wizard.pickerKeyHex
+            }
         }
 
         GradientButton {

--- a/src/ui/qt/qml/WizardScreen.qml
+++ b/src/ui/qt/qml/WizardScreen.qml
@@ -36,6 +36,16 @@ Item {
     // antenna must not be fed the tee's 4.5 V.
     property int biasTee: -1
     property alias extraText: extraField.text
+    // Imported trunking-data files; stored library paths, empty = none.
+    property string chanCsvPath: ""
+    property string groupCsvPath: ""
+    property string keyCsvPath: ""
+    property bool keyCsvHex: false
+    // Which field the shared FileDialog is serving: "source" is the step-1
+    // audio/capture pick; "chan"/"group"/"keys" are the trunking-data picks.
+    property string pickerTarget: "source"
+    // Dec/hex choice for a new key-file import from the picker sheet.
+    property bool pickerKeyHex: false
 
     // Step 3 state
     property alias nameText: nameField.text
@@ -80,6 +90,10 @@ Item {
         biasTee = -1
         extraField.text = ""
         nameField.text = ""
+        chanCsvPath = ""
+        groupCsvPath = ""
+        keyCsvPath = ""
+        keyCsvHex = false
     }
 
     /**
@@ -108,6 +122,10 @@ Item {
         biasTee = -1
         extraField.text = ""
         nameField.text = ""
+        chanCsvPath = ""
+        groupCsvPath = ""
+        keyCsvPath = ""
+        keyCsvHex = false
     }
 
     function openForEdit(row) {
@@ -128,6 +146,18 @@ Item {
         biasTee = sys.biasTee
         extraField.text = sys.extraArgs
         nameField.text = sys.name
+        chanCsvPath = sys.chanCsvPath
+        groupCsvPath = sys.groupCsvPath
+        keyCsvPath = sys.keyCsvPath
+        keyCsvHex = sys.keyCsvHex
+    }
+
+    // Display line for a picker row: the file's name, or "None".
+    function csvLabel(path) {
+        if (path.length === 0)
+            return qsTr("None")
+        var row = importedFiles.rowForPath(path)
+        return row >= 0 ? importedFiles.get(row).name : path.substring(path.lastIndexOf('/') + 1)
     }
 
     // parseInt alone lets a hardware-keyboard "abc" become NaN, which QVariant
@@ -172,7 +202,11 @@ Item {
             bandwidthKhz: bwText.length > 0 ? intOr(bwText, -1) : -1,
             biasTee: biasTee,
             extraArgs: extraText.trim(),
-            filePath: fileText
+            filePath: fileText,
+            chanCsvPath: chanCsvPath,
+            groupCsvPath: groupCsvPath,
+            keyCsvPath: keyCsvPath,
+            keyCsvHex: keyCsvHex
         }
         if (editRow >= 0) {
             savedSystems.update(editRow, sys)
@@ -183,15 +217,105 @@ Item {
         }
     }
 
+    // One trunking-data picker row: title, current file (or "None"), caret.
+    component CsvPickerRow: Item {
+        id: pickerRow
+
+        property string title: ""
+        property string target: ""
+        property string path: ""
+        property bool showDivider: false
+
+        width: parent ? parent.width : 0
+        height: 58
+
+        Column {
+            anchors.left: parent.left
+            anchors.right: rowCaret.left
+            anchors.leftMargin: Theme.cardPadding
+            anchors.rightMargin: 12
+            anchors.verticalCenter: parent.verticalCenter
+            spacing: 3
+
+            Text {
+                width: parent.width
+                text: pickerRow.title
+                font.family: Theme.sans
+                font.pixelSize: 15
+                font.weight: Font.DemiBold
+                color: Theme.textPrimary
+                elide: Text.ElideRight
+            }
+
+            Text {
+                width: parent.width
+                text: wizard.csvLabel(pickerRow.path)
+                font.family: Theme.sans
+                font.pixelSize: 12
+                color: pickerRow.path.length > 0 ? Theme.textSecondary : Theme.textSubdued
+                elide: Text.ElideRight
+            }
+        }
+
+        Caret {
+            id: rowCaret
+            anchors.right: parent.right
+            anchors.rightMargin: Theme.cardPadding
+            anchors.verticalCenter: parent.verticalCenter
+            rotation: -90
+            color: Theme.textSubdued
+        }
+
+        Rectangle {
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.leftMargin: Theme.cardPadding
+            height: 1
+            visible: pickerRow.showDivider
+            color: Theme.divider
+        }
+
+        TapHandler {
+            onTapped: {
+                wizard.pickerTarget = pickerRow.target
+                wizard.pickerKeyHex = wizard.pickerTarget === "keys" ? wizard.keyCsvHex : false
+                csvSheet.visible = true
+            }
+        }
+    }
+
+    // Assign an imported/picked library path to the field the picker serves.
+    function assignCsvPath(target, path, hex) {
+        if (target === "chan") {
+            chanCsvPath = path
+        } else if (target === "group") {
+            groupCsvPath = path
+        } else if (target === "keys") {
+            keyCsvPath = path
+            keyCsvHex = hex
+        }
+    }
+
     FileDialog {
         id: fileDialog
+
+        nameFilters: wizard.pickerTarget === "source" ? [] : [qsTr("CSV files (*.csv)"), qsTr("All files (*)")]
 
         onAccepted: {
             var reference = selectedFile.toString()
             var hint = reference.substring(reference.lastIndexOf('/') + 1)
-            var path = decoderHost.importContentUri(reference, hint)
-            if (path.length > 0)
-                fileField.text = path
+            if (wizard.pickerTarget === "source") {
+                var path = decoderHost.importContentUri(reference, hint)
+                if (path.length > 0)
+                    fileField.text = path
+                return
+            }
+            var type = wizard.pickerTarget === "keys"
+                       ? (wizard.pickerKeyHex ? "keysHex" : "keysDec") : wizard.pickerTarget
+            var result = importedFiles.importFile(reference, hint, type)
+            if (result.ok)
+                wizard.assignCsvPath(wizard.pickerTarget, result.path, wizard.pickerKeyHex)
         }
     }
 
@@ -416,7 +540,10 @@ Item {
                             id: browse
                             width: 96
                             text: qsTr("Browse")
-                            onClicked: fileDialog.open()
+                            onClicked: {
+                                wizard.pickerTarget = "source"
+                                fileDialog.open()
+                            }
                         }
                     }
                 }
@@ -540,6 +667,61 @@ Item {
                         anchors.verticalCenter: parent.verticalCenter
                         checked: wizard.trunking
                         onToggled: function (state) { wizard.trunking = state }
+                    }
+                }
+
+                // Trunking data: the imported CSVs this system starts with. One
+                // reusable row per file kind, each opening the shared picker sheet.
+                UiPanel {
+                    width: parent.width
+                    height: csvColumn.height + Theme.cardPadding + 4
+
+                    Column {
+                        id: csvColumn
+
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        anchors.topMargin: Theme.cardPadding
+                        spacing: 0
+
+                        MicroLabel {
+                            text: qsTr("Trunking data")
+                            leftPadding: Theme.cardPadding
+                            bottomPadding: 6
+                        }
+
+                        CsvPickerRow {
+                            title: qsTr("Channel map")
+                            target: "chan"
+                            path: wizard.chanCsvPath
+                            showDivider: true
+                        }
+
+                        CsvPickerRow {
+                            title: qsTr("Talkgroups")
+                            target: "group"
+                            path: wizard.groupCsvPath
+                            showDivider: true
+                        }
+
+                        CsvPickerRow {
+                            title: qsTr("Encryption keys")
+                            target: "keys"
+                            path: wizard.keyCsvPath
+                        }
+
+                        Text {
+                            width: parent.width
+                            leftPadding: Theme.cardPadding
+                            rightPadding: Theme.cardPadding
+                            bottomPadding: 6
+                            text: qsTr("Imported files are shared between systems. Manage them in Settings.")
+                            font.family: Theme.sans
+                            font.pixelSize: 12
+                            color: Theme.textSubdued
+                            wrapMode: Text.Wrap
+                        }
                     }
                 }
 
@@ -817,4 +999,110 @@ Item {
         }
     }
 
+    // Picker for one trunking-data field: the library's files of that kind,
+    // "None", and a fresh import.
+    ModalSheet {
+        id: csvSheet
+
+        readonly property string currentPath: wizard.pickerTarget === "chan" ? wizard.chanCsvPath
+                                              : wizard.pickerTarget === "group" ? wizard.groupCsvPath
+                                              : wizard.keyCsvPath
+        readonly property var entries: {
+            var n = importedFiles.count // dependency: recompute when the library changes
+            if (!visible || wizard.pickerTarget === "source")
+                return []
+            return wizard.pickerTarget === "keys"
+                   ? importedFiles.entriesForType("keysDec").concat(importedFiles.entriesForType("keysHex"))
+                   : importedFiles.entriesForType(wizard.pickerTarget)
+        }
+
+        function entrySummary(entry) {
+            var noun = wizard.pickerTarget === "chan"
+                       ? (entry.accepted === 1 ? qsTr("channel") : qsTr("channels"))
+                       : wizard.pickerTarget === "group"
+                         ? (entry.accepted === 1 ? qsTr("talkgroup") : qsTr("talkgroups"))
+                         : (entry.accepted === 1 ? qsTr("key") : qsTr("keys"))
+            var line = entry.accepted + " " + noun
+            if (wizard.pickerTarget === "keys")
+                line += " · " + (entry.type === "keysHex" ? qsTr("hex") : qsTr("decimal"))
+            return line
+        }
+
+        MicroLabel {
+            text: wizard.pickerTarget === "chan" ? qsTr("Channel map")
+                  : wizard.pickerTarget === "group" ? qsTr("Talkgroups")
+                  : qsTr("Encryption keys")
+        }
+
+        Repeater {
+            model: csvSheet.entries
+
+            Item {
+                required property var modelData
+
+                width: parent.width
+                height: 46
+
+                Column {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: 2
+
+                    Text {
+                        width: parent.width
+                        text: modelData.name
+                        font.family: Theme.sans
+                        font.pixelSize: 15
+                        font.weight: Font.DemiBold
+                        color: modelData.path === csvSheet.currentPath ? Theme.cyan : Theme.textPrimary
+                        elide: Text.ElideRight
+                    }
+
+                    Text {
+                        width: parent.width
+                        text: csvSheet.entrySummary(modelData)
+                        font.family: Theme.sans
+                        font.pixelSize: 12
+                        color: Theme.textSubdued
+                        elide: Text.ElideRight
+                    }
+                }
+
+                TapHandler {
+                    onTapped: {
+                        wizard.assignCsvPath(wizard.pickerTarget, modelData.path, modelData.type === "keysHex")
+                        csvSheet.visible = false
+                    }
+                }
+            }
+        }
+
+        OutlineButton {
+            width: parent.width
+            visible: csvSheet.currentPath.length > 0
+            text: qsTr("None")
+            onClicked: {
+                wizard.assignCsvPath(wizard.pickerTarget, "", false)
+                csvSheet.visible = false
+            }
+        }
+
+        SegmentedControl {
+            width: parent.width
+            visible: wizard.pickerTarget === "keys"
+            model: [qsTr("Decimal keys"), qsTr("Hex keys")]
+            currentIndex: wizard.pickerKeyHex ? 1 : 0
+            onSelected: function (index) { wizard.pickerKeyHex = index === 1 }
+        }
+
+        GradientButton {
+            width: parent.width
+            text: qsTr("Import new file")
+            onClicked: {
+                csvSheet.visible = false
+                fileDialog.open()
+            }
+        }
+    }
 }

--- a/src/ui/qt/qml/WizardScreen.qml
+++ b/src/ui/qt/qml/WizardScreen.qml
@@ -297,10 +297,12 @@ Item {
         }
     }
 
+    // No CSV name filter for the trunking-data picks: on Android it becomes a
+    // SAF MIME filter, and the Files app indexes .csv as
+    // text/comma-separated-values — not the text/csv Qt asks for — which greys
+    // out exactly the files the user came to pick.
     FileDialog {
         id: fileDialog
-
-        nameFilters: wizard.pickerTarget === "source" ? [] : [qsTr("CSV files (*.csv)"), qsTr("All files (*)")]
 
         onAccepted: {
             var reference = selectedFile.toString()

--- a/src/ui/qt/qt_ui.cpp
+++ b/src/ui/qt/qt_ui.cpp
@@ -88,6 +88,15 @@ ui_load(QQmlApplicationEngine& engine, DecoderHost* host) {
     monitorView->setSourceModel(history);
     auto* controller = new UiController(host, metrics, history, &engine);
 
+    // The library drops rows whose stored copy vanished behind the app's back;
+    // saved systems that still point at one would build a `-G <missing>` argv and
+    // fail to start with a parse error naming the input settings, not the file.
+    // Reconciled here because the library cannot: it loads in its constructor,
+    // and it has no business knowing what references it.
+    for (const QString& gone : importedFiles->takePrunedPaths()) {
+        systems->clearCsvPath(gone);
+    }
+
     // The keep-awake preference is storage; the effect is the host's (an Android
     // window flag). Re-asserted here on every process start because the platform
     // recreates the window without consulting anyone's QSettings.

--- a/src/ui/qt/qt_ui.cpp
+++ b/src/ui/qt/qt_ui.cpp
@@ -23,6 +23,7 @@
 #include "call_history_model.h"
 #include "command_bridge.h"
 #include "decoder_host.h"
+#include "imported_files_model.h"
 #include "metrics_model.h"
 #include "saved_systems_model.h"
 #include "session_args.h"
@@ -76,6 +77,7 @@ ui_load(QQmlApplicationEngine& engine, DecoderHost* host) {
     auto* prefs = new AppPrefs(&engine);
     auto* sessionArgs = new SessionArgsBuilder(prefs, &engine);
     auto* systems = new SavedSystemsModel(&engine);
+    auto* importedFiles = new ImportedFilesModel(host, &engine);
     auto* history = new CallHistoryModel(&engine);
     auto* spectrum = new SpectrumModel(&engine);
     // Each view that shows the call log owns its filter state: the history tab's
@@ -107,6 +109,7 @@ ui_load(QQmlApplicationEngine& engine, DecoderHost* host) {
     context->setContextProperty(QStringLiteral("prefs"), prefs);
     context->setContextProperty(QStringLiteral("sessionArgs"), sessionArgs);
     context->setContextProperty(QStringLiteral("savedSystems"), systems);
+    context->setContextProperty(QStringLiteral("importedFiles"), importedFiles);
     context->setContextProperty(QStringLiteral("callHistory"), history);
     context->setContextProperty(QStringLiteral("historyView"), historyView);
     context->setContextProperty(QStringLiteral("monitorView"), monitorView);

--- a/src/ui/qt/saved_systems_model.cpp
+++ b/src/ui/qt/saved_systems_model.cpp
@@ -120,63 +120,60 @@ SavedSystemsModel::roleNames() const {
     return roles;
 }
 
+namespace {
+
+/** @brief Overwrite @p target only when @p key is present; absent keys keep the base value. */
+void
+map_take_string(const QVariantMap& map, const char* key, QString* target) {
+    const QString name = QLatin1String(key);
+    if (map.contains(name)) {
+        *target = map.value(name).toString();
+    }
+}
+
+void
+map_take_int(const QVariantMap& map, const char* key, int* target) {
+    const QString name = QLatin1String(key);
+    if (map.contains(name)) {
+        *target = map.value(name).toInt();
+    }
+}
+
+void
+map_take_bool(const QVariantMap& map, const char* key, bool* target) {
+    const QString name = QLatin1String(key);
+    if (map.contains(name)) {
+        *target = map.value(name).toBool();
+    }
+}
+
+} // namespace
+
 SavedSystemsModel::Row
 SavedSystemsModel::rowFromMap(const QVariantMap& map, const Row& base) {
     Row row = base;
-    if (map.contains(QStringLiteral("name"))) {
-        row.name = map.value(QStringLiteral("name")).toString();
-    }
-    if (map.contains(QStringLiteral("sourceType"))) {
-        row.sourceType = map.value(QStringLiteral("sourceType")).toString();
-    }
-    if (map.contains(QStringLiteral("host"))) {
-        row.host = map.value(QStringLiteral("host")).toString();
-    }
-    if (map.contains(QStringLiteral("port"))) {
-        row.port = map.value(QStringLiteral("port")).toInt();
-    }
-    if (map.contains(QStringLiteral("freqMhz"))) {
-        row.freqMhz = map.value(QStringLiteral("freqMhz")).toString();
-    }
-    if (map.contains(QStringLiteral("decodeFlag"))) {
-        row.decodeFlag = map.value(QStringLiteral("decodeFlag")).toString();
-    }
-    if (map.contains(QStringLiteral("trunking"))) {
-        row.trunking = map.value(QStringLiteral("trunking")).toBool();
-    }
-    if (map.contains(QStringLiteral("gainDb"))) {
-        row.gainDb = map.value(QStringLiteral("gainDb")).toInt();
-    }
-    if (map.contains(QStringLiteral("ppm"))) {
-        row.ppm = map.value(QStringLiteral("ppm")).toString();
-    }
-    if (map.contains(QStringLiteral("bandwidthKhz"))) {
-        row.bandwidthKhz = map.value(QStringLiteral("bandwidthKhz")).toInt();
-    }
+    map_take_string(map, "name", &row.name);
+    map_take_string(map, "sourceType", &row.sourceType);
+    map_take_string(map, "host", &row.host);
+    map_take_int(map, "port", &row.port);
+    map_take_string(map, "freqMhz", &row.freqMhz);
+    map_take_string(map, "decodeFlag", &row.decodeFlag);
+    map_take_bool(map, "trunking", &row.trunking);
+    map_take_int(map, "gainDb", &row.gainDb);
+    map_take_string(map, "ppm", &row.ppm);
+    map_take_int(map, "bandwidthKhz", &row.bandwidthKhz);
     if (map.contains(QStringLiteral("biasTee"))) {
         row.biasTee = bias_tee_from_stored(map.value(QStringLiteral("biasTee")));
     }
-    if (map.contains(QStringLiteral("extraArgs"))) {
-        row.extraArgs = map.value(QStringLiteral("extraArgs")).toString();
-    }
-    if (map.contains(QStringLiteral("filePath"))) {
-        row.filePath = map.value(QStringLiteral("filePath")).toString();
-    }
+    map_take_string(map, "extraArgs", &row.extraArgs);
+    map_take_string(map, "filePath", &row.filePath);
     if (map.contains(QStringLiteral("lastHeard"))) {
         row.lastHeard = map.value(QStringLiteral("lastHeard")).toLongLong();
     }
-    if (map.contains(QStringLiteral("chanCsvPath"))) {
-        row.chanCsvPath = map.value(QStringLiteral("chanCsvPath")).toString();
-    }
-    if (map.contains(QStringLiteral("groupCsvPath"))) {
-        row.groupCsvPath = map.value(QStringLiteral("groupCsvPath")).toString();
-    }
-    if (map.contains(QStringLiteral("keyCsvPath"))) {
-        row.keyCsvPath = map.value(QStringLiteral("keyCsvPath")).toString();
-    }
-    if (map.contains(QStringLiteral("keyCsvHex"))) {
-        row.keyCsvHex = map.value(QStringLiteral("keyCsvHex")).toBool();
-    }
+    map_take_string(map, "chanCsvPath", &row.chanCsvPath);
+    map_take_string(map, "groupCsvPath", &row.groupCsvPath);
+    map_take_string(map, "keyCsvPath", &row.keyCsvPath);
+    map_take_bool(map, "keyCsvHex", &row.keyCsvHex);
     return row;
 }
 

--- a/src/ui/qt/saved_systems_model.cpp
+++ b/src/ui/qt/saved_systems_model.cpp
@@ -78,6 +78,10 @@ SavedSystemsModel::tuningRoleValue(const Row& row, int role) {
         case BiasTeeRole: return row.biasTee;
         case ExtraArgsRole: return row.extraArgs;
         case LastHeardRole: return row.lastHeard;
+        case ChanCsvPathRole: return row.chanCsvPath;
+        case GroupCsvPathRole: return row.groupCsvPath;
+        case KeyCsvPathRole: return row.keyCsvPath;
+        case KeyCsvHexRole: return row.keyCsvHex;
         default: return QVariant();
     }
 }
@@ -109,6 +113,10 @@ SavedSystemsModel::roleNames() const {
     roles.insert(ExtraArgsRole, QByteArrayLiteral("extraArgs"));
     roles.insert(FilePathRole, QByteArrayLiteral("filePath"));
     roles.insert(LastHeardRole, QByteArrayLiteral("lastHeard"));
+    roles.insert(ChanCsvPathRole, QByteArrayLiteral("chanCsvPath"));
+    roles.insert(GroupCsvPathRole, QByteArrayLiteral("groupCsvPath"));
+    roles.insert(KeyCsvPathRole, QByteArrayLiteral("keyCsvPath"));
+    roles.insert(KeyCsvHexRole, QByteArrayLiteral("keyCsvHex"));
     return roles;
 }
 
@@ -157,6 +165,18 @@ SavedSystemsModel::rowFromMap(const QVariantMap& map, const Row& base) {
     if (map.contains(QStringLiteral("lastHeard"))) {
         row.lastHeard = map.value(QStringLiteral("lastHeard")).toLongLong();
     }
+    if (map.contains(QStringLiteral("chanCsvPath"))) {
+        row.chanCsvPath = map.value(QStringLiteral("chanCsvPath")).toString();
+    }
+    if (map.contains(QStringLiteral("groupCsvPath"))) {
+        row.groupCsvPath = map.value(QStringLiteral("groupCsvPath")).toString();
+    }
+    if (map.contains(QStringLiteral("keyCsvPath"))) {
+        row.keyCsvPath = map.value(QStringLiteral("keyCsvPath")).toString();
+    }
+    if (map.contains(QStringLiteral("keyCsvHex"))) {
+        row.keyCsvHex = map.value(QStringLiteral("keyCsvHex")).toBool();
+    }
     return row;
 }
 
@@ -177,6 +197,10 @@ SavedSystemsModel::mapFromRow(const Row& row) const {
     map.insert(QStringLiteral("extraArgs"), row.extraArgs);
     map.insert(QStringLiteral("filePath"), row.filePath);
     map.insert(QStringLiteral("lastHeard"), row.lastHeard);
+    map.insert(QStringLiteral("chanCsvPath"), row.chanCsvPath);
+    map.insert(QStringLiteral("groupCsvPath"), row.groupCsvPath);
+    map.insert(QStringLiteral("keyCsvPath"), row.keyCsvPath);
+    map.insert(QStringLiteral("keyCsvHex"), row.keyCsvHex);
     return map;
 }
 
@@ -232,6 +256,52 @@ SavedSystemsModel::touch(int row) {
     Q_EMIT dataChanged(idx, idx, {LastHeardRole});
     Q_EMIT mostRecentRowChanged();
     save();
+}
+
+QStringList
+SavedSystemsModel::systemsReferencingPath(const QString& path) const {
+    QStringList names;
+    if (path.isEmpty()) {
+        return names;
+    }
+    for (const Row& row : m_rows) {
+        if (row.chanCsvPath == path || row.groupCsvPath == path || row.keyCsvPath == path) {
+            names.append(row.name);
+        }
+    }
+    return names;
+}
+
+void
+SavedSystemsModel::clearCsvPath(const QString& path) {
+    if (path.isEmpty()) {
+        return;
+    }
+    bool changed = false;
+    for (int i = 0; i < m_rows.size(); i++) {
+        Row& row = m_rows[i];
+        bool rowChanged = false;
+        if (row.chanCsvPath == path) {
+            row.chanCsvPath.clear();
+            rowChanged = true;
+        }
+        if (row.groupCsvPath == path) {
+            row.groupCsvPath.clear();
+            rowChanged = true;
+        }
+        if (row.keyCsvPath == path) {
+            row.keyCsvPath.clear();
+            rowChanged = true;
+        }
+        if (rowChanged) {
+            const QModelIndex idx = index(i);
+            Q_EMIT dataChanged(idx, idx);
+            changed = true;
+        }
+    }
+    if (changed) {
+        save();
+    }
 }
 
 int

--- a/src/ui/qt/saved_systems_model.cpp
+++ b/src/ui/qt/saved_systems_model.cpp
@@ -122,28 +122,30 @@ SavedSystemsModel::roleNames() const {
 
 namespace {
 
-/** @brief Overwrite @p target only when @p key is present; absent keys keep the base value. */
+/**
+ * @brief Overwrite @p target only when @p key is present; absent keys keep the base value.
+ *
+ * @p key is a QString so callers can pass QStringLiteral: building one from a
+ * `const char*` here would heap-allocate on every field of every stored row.
+ */
 void
-map_take_string(const QVariantMap& map, const char* key, QString* target) {
-    const QString name = QLatin1String(key);
-    if (map.contains(name)) {
-        *target = map.value(name).toString();
+map_take_string(const QVariantMap& map, const QString& key, QString* target) {
+    if (map.contains(key)) {
+        *target = map.value(key).toString();
     }
 }
 
 void
-map_take_int(const QVariantMap& map, const char* key, int* target) {
-    const QString name = QLatin1String(key);
-    if (map.contains(name)) {
-        *target = map.value(name).toInt();
+map_take_int(const QVariantMap& map, const QString& key, int* target) {
+    if (map.contains(key)) {
+        *target = map.value(key).toInt();
     }
 }
 
 void
-map_take_bool(const QVariantMap& map, const char* key, bool* target) {
-    const QString name = QLatin1String(key);
-    if (map.contains(name)) {
-        *target = map.value(name).toBool();
+map_take_bool(const QVariantMap& map, const QString& key, bool* target) {
+    if (map.contains(key)) {
+        *target = map.value(key).toBool();
     }
 }
 
@@ -152,28 +154,28 @@ map_take_bool(const QVariantMap& map, const char* key, bool* target) {
 SavedSystemsModel::Row
 SavedSystemsModel::rowFromMap(const QVariantMap& map, const Row& base) {
     Row row = base;
-    map_take_string(map, "name", &row.name);
-    map_take_string(map, "sourceType", &row.sourceType);
-    map_take_string(map, "host", &row.host);
-    map_take_int(map, "port", &row.port);
-    map_take_string(map, "freqMhz", &row.freqMhz);
-    map_take_string(map, "decodeFlag", &row.decodeFlag);
-    map_take_bool(map, "trunking", &row.trunking);
-    map_take_int(map, "gainDb", &row.gainDb);
-    map_take_string(map, "ppm", &row.ppm);
-    map_take_int(map, "bandwidthKhz", &row.bandwidthKhz);
+    map_take_string(map, QStringLiteral("name"), &row.name);
+    map_take_string(map, QStringLiteral("sourceType"), &row.sourceType);
+    map_take_string(map, QStringLiteral("host"), &row.host);
+    map_take_int(map, QStringLiteral("port"), &row.port);
+    map_take_string(map, QStringLiteral("freqMhz"), &row.freqMhz);
+    map_take_string(map, QStringLiteral("decodeFlag"), &row.decodeFlag);
+    map_take_bool(map, QStringLiteral("trunking"), &row.trunking);
+    map_take_int(map, QStringLiteral("gainDb"), &row.gainDb);
+    map_take_string(map, QStringLiteral("ppm"), &row.ppm);
+    map_take_int(map, QStringLiteral("bandwidthKhz"), &row.bandwidthKhz);
     if (map.contains(QStringLiteral("biasTee"))) {
         row.biasTee = bias_tee_from_stored(map.value(QStringLiteral("biasTee")));
     }
-    map_take_string(map, "extraArgs", &row.extraArgs);
-    map_take_string(map, "filePath", &row.filePath);
+    map_take_string(map, QStringLiteral("extraArgs"), &row.extraArgs);
+    map_take_string(map, QStringLiteral("filePath"), &row.filePath);
     if (map.contains(QStringLiteral("lastHeard"))) {
         row.lastHeard = map.value(QStringLiteral("lastHeard")).toLongLong();
     }
-    map_take_string(map, "chanCsvPath", &row.chanCsvPath);
-    map_take_string(map, "groupCsvPath", &row.groupCsvPath);
-    map_take_string(map, "keyCsvPath", &row.keyCsvPath);
-    map_take_bool(map, "keyCsvHex", &row.keyCsvHex);
+    map_take_string(map, QStringLiteral("chanCsvPath"), &row.chanCsvPath);
+    map_take_string(map, QStringLiteral("groupCsvPath"), &row.groupCsvPath);
+    map_take_string(map, QStringLiteral("keyCsvPath"), &row.keyCsvPath);
+    map_take_bool(map, QStringLiteral("keyCsvHex"), &row.keyCsvHex);
     return row;
 }
 

--- a/src/ui/qt/saved_systems_model.h
+++ b/src/ui/qt/saved_systems_model.h
@@ -20,6 +20,7 @@
 #include <QList>
 #include <QObject>
 #include <QString>
+#include <QStringList>
 #include <QVariant>
 #include <QVariantMap>
 #include <Qt>
@@ -47,7 +48,11 @@ class SavedSystemsModel : public QAbstractListModel {
         BiasTeeRole,      // tri-state: -1 = follow the app-wide pref, 0 = off, 1 = on
         ExtraArgsRole,
         FilePathRole,
-        LastHeardRole // seconds since epoch; 0 = never
+        LastHeardRole,    // seconds since epoch; 0 = never
+        ChanCsvPathRole,  // imported channel map (-C); empty = none
+        GroupCsvPathRole, // imported group list (-G); empty = none
+        KeyCsvPathRole,   // imported key file (-k/-K); empty = none
+        KeyCsvHexRole     // true = hex keys (-K), false = decimal (-k)
     };
 
     explicit SavedSystemsModel(QObject* parent = nullptr);
@@ -84,6 +89,18 @@ class SavedSystemsModel : public QAbstractListModel {
      */
     int mostRecentRow() const;
 
+    /** @brief Names of systems whose CSV fields reference @p path; for delete warnings. */
+    Q_INVOKABLE QStringList systemsReferencingPath(const QString& path) const;
+
+    /**
+     * @brief Blank every CSV field matching @p path, in every system. Persists.
+     *
+     * Called when a library file is removed: a saved system pointing at a
+     * deleted file would otherwise fail its next start with an opaque
+     * "configure failed".
+     */
+    Q_INVOKABLE void clearCsvPath(const QString& path);
+
   Q_SIGNALS:
     void countChanged();
     void mostRecentRowChanged();
@@ -107,6 +124,10 @@ class SavedSystemsModel : public QAbstractListModel {
         QString extraArgs;
         QString filePath;
         qint64 lastHeard = 0;
+        QString chanCsvPath;
+        QString groupCsvPath;
+        QString keyCsvPath;
+        bool keyCsvHex = false;
     };
 
     static Row rowFromMap(const QVariantMap& map, const Row& base);

--- a/src/ui/qt/session_args.cpp
+++ b/src/ui/qt/session_args.cpp
@@ -73,8 +73,11 @@ append_input_args(QStringList& args, const QVariantMap& system, const QString& s
     } else if (sourceType == QLatin1String("rtltcp")) {
         // The engine parses a trailing bias token on rtltcp specs exactly as it
         // does on rtl ones; a remote dongle feeding an LNA needs it just as much.
+        // The host is spliced into the ':'-delimited spec verbatim, so stray
+        // whitespace from the soft keyboard or a paste must be trimmed here —
+        // "10.0.2.2 " resolves to nothing and the start fails opaquely.
         QString spec = QStringLiteral("rtltcp:%1:%2")
-                           .arg(system.value(QStringLiteral("host")).toString())
+                           .arg(system.value(QStringLiteral("host")).toString().trimmed())
                            .arg(system.value(QStringLiteral("port")).toInt())
                        + tail;
         if (bias) {
@@ -87,7 +90,7 @@ append_input_args(QStringList& args, const QVariantMap& system, const QString& s
     } else if (sourceType == QLatin1String("tcp")) {
         args << QStringLiteral("-i")
              << QStringLiteral("tcp:%1:%2")
-                    .arg(system.value(QStringLiteral("host")).toString())
+                    .arg(system.value(QStringLiteral("host")).toString().trimmed())
                     .arg(system.value(QStringLiteral("port")).toInt());
     } else {
         args << QStringLiteral("-i") << system.value(QStringLiteral("filePath")).toString();

--- a/src/ui/qt/session_args.cpp
+++ b/src/ui/qt/session_args.cpp
@@ -94,6 +94,30 @@ append_input_args(QStringList& args, const QVariantMap& system, const QString& s
     }
 }
 
+/**
+ * @brief Append the per-system CSV paths as discrete argv elements.
+ *
+ * Discrete, not folded into extraArgs: the extras field is whitespace-split
+ * with no quoting, so an imported file whose display name carries a space
+ * ("chan map.csv") only survives as its own element.
+ */
+void
+append_csv_args(QStringList& args, const QVariantMap& system) {
+    const QString chan = system.value(QStringLiteral("chanCsvPath")).toString();
+    if (!chan.isEmpty()) {
+        args << QStringLiteral("-C") << chan;
+    }
+    const QString group = system.value(QStringLiteral("groupCsvPath")).toString();
+    if (!group.isEmpty()) {
+        args << QStringLiteral("-G") << group;
+    }
+    const QString key = system.value(QStringLiteral("keyCsvPath")).toString();
+    if (!key.isEmpty()) {
+        args << (system.value(QStringLiteral("keyCsvHex")).toBool() ? QStringLiteral("-K") : QStringLiteral("-k"))
+             << key;
+    }
+}
+
 /** @brief Append the decode chip, trunking, policy flags, and extra CLI args. */
 void
 append_flag_args(QStringList& args, const QVariantMap& system, const SessionArgPrefs& prefs) {
@@ -166,6 +190,7 @@ session_args_build(const QVariantMap& system, const SessionArgPrefs& prefs, Sess
     QStringList args{QStringLiteral("--frontend"), QStringLiteral("none")};
     append_input_args(args, system, sourceType, tail, bias);
     args << QStringLiteral("-o") << QStringLiteral("pulse");
+    append_csv_args(args, system);
     append_flag_args(args, system, prefs);
     return args;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -510,6 +510,12 @@ dsd_neo_add_public_header_smoke_test(
   C
 )
 dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_core_csv_validate
+  HEADERS_PUBLIC_CORE_CSV_VALIDATE
+  dsd-neo/core/csv_validate.h
+  C
+)
+dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_core_talkgroup_policy
   HEADERS_PUBLIC_CORE_TALKGROUP_POLICY
   dsd-neo/core/talkgroup_policy.h
@@ -3026,6 +3032,17 @@ target_link_libraries(
     PRIVATE dsd-neo_core dsd-neo_proto_dmr
 )
 add_test(NAME CORE_CSV_IMPORT COMMAND dsd-neo_test_core_csv_import)
+
+add_executable(dsd-neo_test_core_csv_validate core/test_core_csv_validate.c)
+target_include_directories(
+    dsd-neo_test_core_csv_validate
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_core_csv_validate
+    PRIVATE dsd-neo_core dsd-neo_proto_dmr
+)
+add_test(NAME CORE_CSV_VALIDATE COMMAND dsd-neo_test_core_csv_validate)
 
 add_executable(
     dsd-neo_test_core_talkgroup_policy

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2401,6 +2401,19 @@ if(DSD_ENABLE_QT_UI)
             ${PROJECT_SOURCE_DIR}/src/ui/qt/call_history_filter.cpp
             ${PROJECT_SOURCE_DIR}/src/ui/qt/spectrum_model.cpp
             ${PROJECT_SOURCE_DIR}/src/ui/qt/spectrum_view_item.cpp
+            # The home screen, the imports library, the wizard's CSV pickers and
+            # the explore setup all read these context properties; without them
+            # they raised ReferenceError and rendered nothing, so a case could
+            # not reach them. Production models rather than stand-ins because two
+            # back a ListView whose delegate declares `required property` per
+            # role -- a mirror that drifted would fail as the real thing passing.
+            # They persist under disposable test storage (see qml_test_context.h).
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/app_prefs.cpp
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/decoder_host.cpp
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/imported_files_model.cpp
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/json_store.cpp
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/saved_systems_model.cpp
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/session_args.cpp
             # The decode-chip flag mapping (src/ui/qt/decode_mode_flag.h) is the
             # production one, so the preset a chip sends is really under test. It
             # needs the CLI mapping behind it, and that translation unit is
@@ -2413,9 +2426,18 @@ if(DSD_ENABLE_QT_UI)
                 ${PROJECT_SOURCE_DIR}/include
                 ${PROJECT_SOURCE_DIR}/src/ui/qt
         )
+        # dsd-neo_core carries the dry-run CSV validation ImportedFilesModel runs
+        # on an import; dsd-neo_proto_dmr comes with it (same pairing as
+        # UI_QT_IMPORTED_FILES). Still nothing from the engine or app-control.
         target_link_libraries(
             dsd-neo_test_ui_qt_qml
-            PRIVATE Qt6::Gui Qt6::Qml Qt6::Quick Qt6::QuickTest
+            PRIVATE
+                Qt6::Gui
+                Qt6::Qml
+                Qt6::Quick
+                Qt6::QuickTest
+                dsd-neo_core
+                dsd-neo_proto_dmr
         )
         target_compile_definitions(
             dsd-neo_test_ui_qt_qml

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2268,6 +2268,35 @@ if(DSD_ENABLE_QT_UI)
     set_target_properties(dsd-neo_test_ui_qt_session_args PROPERTIES AUTOMOC ON)
     add_test(NAME UI_QT_SESSION_ARGS COMMAND dsd-neo_test_ui_qt_session_args)
 
+    # The imported-files layer behind the CSV pickers: DecoderHost's desktop
+    # importDocument() copy/unique-ify/replace semantics and the library model
+    # the wizard and the imports screen share.
+    add_executable(
+        dsd-neo_test_ui_qt_imported_files_model
+        ui/test_ui_qt_imported_files_model.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/decoder_host.cpp
+    )
+    target_include_directories(
+        dsd-neo_test_ui_qt_imported_files_model
+        PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/qt
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_qt_imported_files_model
+        PRIVATE Qt6::Core
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_qt_imported_files_model
+        PRIVATE QT_NO_KEYWORDS
+    )
+    set_target_properties(
+        dsd-neo_test_ui_qt_imported_files_model
+        PROPERTIES AUTOMOC ON
+    )
+    add_test(
+        NAME UI_QT_IMPORTED_FILES
+        COMMAND dsd-neo_test_ui_qt_imported_files_model
+    )
+
     # What the spectrum model does with the frames a producer hands it, and what
     # the waterfall does with the model: the frame-identity check that keeps a
     # re-read of an unreplaced frame from scrolling a duplicate row, the history

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2275,6 +2275,8 @@ if(DSD_ENABLE_QT_UI)
         dsd-neo_test_ui_qt_imported_files_model
         ui/test_ui_qt_imported_files_model.cpp
         ${PROJECT_SOURCE_DIR}/src/ui/qt/decoder_host.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/imported_files_model.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/json_store.cpp
     )
     target_include_directories(
         dsd-neo_test_ui_qt_imported_files_model
@@ -2282,7 +2284,7 @@ if(DSD_ENABLE_QT_UI)
     )
     target_link_libraries(
         dsd-neo_test_ui_qt_imported_files_model
-        PRIVATE Qt6::Core
+        PRIVATE Qt6::Core dsd-neo_core dsd-neo_proto_dmr
     )
     target_compile_definitions(
         dsd-neo_test_ui_qt_imported_files_model

--- a/tests/core/test_core_csv_validate.c
+++ b/tests/core/test_core_csv_validate.c
@@ -176,9 +176,141 @@ test_key_hex_counts_mixed_rows(void) {
     return failed;
 }
 
+/*
+ * A trailing empty line is filler, not a malformed row — editors and several
+ * exporters leave one behind, and counting it would tell the user a clean file
+ * had rows it could not read.
+ */
+static int
+test_blank_lines_are_not_rows(void) {
+    char tmpl[] = "dsd-neo-test-validate-blank-XXXXXX";
+    if (write_temp_csv(tmpl, "TG,Mode,Name\n"
+                             "101,D,Dispatch\n"
+                             "\n"
+                             "102,D,Fire\n"
+                             "   \n")
+        != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_group_file(tmpl, &v) != 0) {
+        DSD_FPRINTF(stderr, "group validate failed on file with blank lines\n");
+        failed = 1;
+    }
+    if (v.accepted != 2U || v.skipped != 0U || v.total != 2U) {
+        DSD_FPRINTF(stderr, "blank-line counts wrong: accepted=%u skipped=%u total=%u\n", v.accepted, v.skipped,
+                    v.total);
+        failed = 1;
+    }
+    (void)remove(tmpl);
+    return failed;
+}
+
+/*
+ * A key id that is not decimal normalizes to 0, so every such row would "store"
+ * onto slot 0 together. Reporting them as loaded is how a hex-id file passed off
+ * as decimal validates as "N keys" while exactly one key exists.
+ */
+static int
+test_key_dec_bad_id_is_skipped(void) {
+    char tmpl[] = "dsd-neo-test-validate-keyid-XXXXXX";
+    if (write_temp_csv(tmpl, "key id (dec),key value (dec)\n"
+                             "C197,1234\n"
+                             "C198,5678\n"
+                             "7,9012\n")
+        != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_key_file_dec(tmpl, &v) != 0) {
+        DSD_FPRINTF(stderr, "dec key validate failed on bad-id file\n");
+        failed = 1;
+    }
+    if (v.accepted != 1U || v.skipped != 2U || v.total != 3U) {
+        DSD_FPRINTF(stderr, "dec key bad-id counts wrong: accepted=%u skipped=%u total=%u\n", v.accepted, v.skipped,
+                    v.total);
+        failed = 1;
+    }
+    (void)remove(tmpl);
+    return failed;
+}
+
+/*
+ * A channel map row and a decimal key row are both `number,number`, and the
+ * header line is free text, so nothing in the file says which it is. Picking a
+ * key list as a channel map used to validate as "N channels" and load its
+ * values as frequencies -- the doc's own example row `2,70` became a channel at
+ * 70 Hz, which the trunking SM would then try to tune. The frequency column
+ * being a plausible RF frequency is what tells them apart.
+ */
+static int
+test_chan_rejects_a_key_list(void) {
+    char tmpl[] = "dsd-neo-test-validate-chan-keys-XXXXXX";
+    /* docs/csv-formats.md's own decimal key example, verbatim. */
+    if (write_temp_csv(tmpl, "key id or tg id (dec),key number or value (dec)\n"
+                             "2,70\n"
+                             "12,48713912656\n")
+        != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_chan_file(tmpl, &v) != 0) {
+        DSD_FPRINTF(stderr, "chan validate failed to open a key list\n");
+        failed = 1;
+    }
+    /* Nothing usable, which is what the imports screen reports as "no usable
+     * rows" and what svc_import_channel_map() refuses to adopt. */
+    if (v.accepted != 0U || v.skipped != 2U || v.total != 2U) {
+        DSD_FPRINTF(stderr, "key list read as a channel map: accepted=%u skipped=%u total=%u\n", v.accepted, v.skipped,
+                    v.total);
+        failed = 1;
+    }
+    (void)remove(tmpl);
+    return failed;
+}
+
+/* The bounds are generous on purpose -- they reject numbers that cannot be
+ * radio frequencies at all, not frequencies outside a band plan. */
+static int
+test_chan_frequency_bounds(void) {
+    char tmpl[] = "dsd-neo-test-validate-chan-bounds-XXXXXX";
+    if (write_temp_csv(tmpl, "channel_number,frequency_hz\n"
+                             "1,0\n"          /* a blank column parses to this */
+                             "2,99999\n"      /* just under the floor */
+                             "3,100000\n"     /* the floor itself: HF, kept */
+                             "4,6000000000\n" /* the ceiling: 6 GHz, kept */
+                             "5,6000000001\n" /* past any front end's reach */
+                             "6,851000000\n")
+        != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_chan_file(tmpl, &v) != 0) {
+        DSD_FPRINTF(stderr, "chan validate failed on the bounds file\n");
+        failed = 1;
+    }
+    if (v.accepted != 3U || v.skipped != 3U || v.total != 6U) {
+        DSD_FPRINTF(stderr, "chan bounds counts wrong: accepted=%u skipped=%u total=%u\n", v.accepted, v.skipped,
+                    v.total);
+        failed = 1;
+    }
+    (void)remove(tmpl);
+    return failed;
+}
+
 int
 main(void) {
     if (test_missing_file_fails() != 0) {
+        return 1;
+    }
+    if (test_chan_rejects_a_key_list() != 0) {
+        return 1;
+    }
+    if (test_chan_frequency_bounds() != 0) {
         return 1;
     }
     if (test_group_header_only() != 0) {
@@ -194,6 +326,12 @@ main(void) {
         return 1;
     }
     if (test_key_hex_counts_mixed_rows() != 0) {
+        return 1;
+    }
+    if (test_blank_lines_are_not_rows() != 0) {
+        return 1;
+    }
+    if (test_key_dec_bad_id_is_skipped() != 0) {
         return 1;
     }
     return 0;

--- a/tests/core/test_core_csv_validate.c
+++ b/tests/core/test_core_csv_validate.c
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/csv_validate.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/protocol/nxdn/nxdn_lfsr.h>
+#include <stdio.h>
+#include "dsd-neo/core/safe_api.h"
+
+void
+LFSRN(const char* BufferIn, char* BufferOut, dsd_state* state) {
+    (void)BufferIn;
+    (void)BufferOut;
+    (void)state;
+}
+
+static int
+write_temp_csv(char* tmpl, const char* contents) {
+    int fd = dsd_mkstemp(tmpl);
+    if (fd < 0) {
+        return -1;
+    }
+    (void)dsd_close(fd);
+    FILE* fp = dsd_fopen_private(tmpl, "w");
+    if (!fp) {
+        (void)remove(tmpl);
+        return -1;
+    }
+    DSD_FPRINTF(fp, "%s", contents);
+    fclose(fp);
+    return 0;
+}
+
+static int
+test_missing_file_fails(void) {
+    dsd_csv_validation v = {9U, 9U, 9U};
+    if (dsd_csv_validate_group_file("dsd-neo-test-validate-missing-dir/missing.csv", &v) == 0) {
+        DSD_FPRINTF(stderr, "group validate accepted a missing file\n");
+        return 1;
+    }
+    if (dsd_csv_validate_chan_file("dsd-neo-test-validate-missing-dir/missing.csv", &v) == 0) {
+        DSD_FPRINTF(stderr, "chan validate accepted a missing file\n");
+        return 1;
+    }
+    if (dsd_csv_validate_group_file(NULL, &v) == 0 || dsd_csv_validate_group_file("", &v) == 0) {
+        DSD_FPRINTF(stderr, "group validate accepted an empty path\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_group_header_only(void) {
+    char tmpl[] = "dsd-neo-test-validate-group-hdr-XXXXXX";
+    if (write_temp_csv(tmpl, "TG,Mode,Name\n") != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {9U, 9U, 9U};
+    int failed = 0;
+    if (dsd_csv_validate_group_file(tmpl, &v) != 0) {
+        DSD_FPRINTF(stderr, "group validate failed on header-only file\n");
+        failed = 1;
+    }
+    if (v.accepted != 0U || v.skipped != 0U || v.total != 0U) {
+        DSD_FPRINTF(stderr, "group header-only counts wrong: accepted=%u skipped=%u total=%u\n", v.accepted, v.skipped,
+                    v.total);
+        failed = 1;
+    }
+    (void)remove(tmpl);
+    return failed;
+}
+
+static int
+test_group_counts_mixed_rows(void) {
+    char tmpl[] = "dsd-neo-test-validate-group-mix-XXXXXX";
+    if (write_temp_csv(tmpl, "TG,Mode,Name\n"
+                             "101,D,Dispatch\n"
+                             "201-210,D,Ops Range\n"
+                             "bogus,D,Bad Id\n"
+                             "301\n")
+        != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_group_file(tmpl, &v) != 0) {
+        DSD_FPRINTF(stderr, "group validate failed on mixed file\n");
+        failed = 1;
+    }
+    if (v.accepted != 2U || v.skipped != 2U || v.total != 4U) {
+        DSD_FPRINTF(stderr, "group mixed counts wrong: accepted=%u skipped=%u total=%u\n", v.accepted, v.skipped,
+                    v.total);
+        failed = 1;
+    }
+    (void)remove(tmpl);
+    return failed;
+}
+
+static int
+test_chan_counts_mixed_rows(void) {
+    char tmpl[] = "dsd-neo-test-validate-chan-mix-XXXXXX";
+    if (write_temp_csv(tmpl, "channel_number,frequency_hz\n"
+                             "1,851000000\n"
+                             "2,notafreq\n"
+                             "notachan,852000000\n"
+                             "3,852500000\n"
+                             "4\n")
+        != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_chan_file(tmpl, &v) != 0) {
+        DSD_FPRINTF(stderr, "chan validate failed on mixed file\n");
+        failed = 1;
+    }
+    if (v.accepted != 2U || v.skipped != 3U || v.total != 5U) {
+        DSD_FPRINTF(stderr, "chan mixed counts wrong: accepted=%u skipped=%u total=%u\n", v.accepted, v.skipped,
+                    v.total);
+        failed = 1;
+    }
+    (void)remove(tmpl);
+    return failed;
+}
+
+static int
+test_key_dec_counts_mixed_rows(void) {
+    char tmpl[] = "dsd-neo-test-validate-keydec-XXXXXX";
+    if (write_temp_csv(tmpl, "key id (dec),key value (dec)\n"
+                             "2,70\n"
+                             "3,notanumber\n"
+                             "5\n")
+        != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_key_file_dec(tmpl, &v) != 0) {
+        DSD_FPRINTF(stderr, "dec key validate failed on mixed file\n");
+        failed = 1;
+    }
+    if (v.accepted != 1U || v.skipped != 2U || v.total != 3U) {
+        DSD_FPRINTF(stderr, "dec key mixed counts wrong: accepted=%u skipped=%u total=%u\n", v.accepted, v.skipped,
+                    v.total);
+        failed = 1;
+    }
+    (void)remove(tmpl);
+    return failed;
+}
+
+static int
+test_key_hex_counts_mixed_rows(void) {
+    char tmpl[] = "dsd-neo-test-validate-keyhex-XXXXXX";
+    if (write_temp_csv(tmpl, "key id (hex),key value (hex)\n"
+                             "C197,A753BC945DE5E0F1\n"
+                             "C198,nothexatall\n")
+        != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_key_file_hex(tmpl, &v) != 0) {
+        DSD_FPRINTF(stderr, "hex key validate failed on mixed file\n");
+        failed = 1;
+    }
+    if (v.accepted != 1U || v.skipped != 1U || v.total != 2U) {
+        DSD_FPRINTF(stderr, "hex key mixed counts wrong: accepted=%u skipped=%u total=%u\n", v.accepted, v.skipped,
+                    v.total);
+        failed = 1;
+    }
+    (void)remove(tmpl);
+    return failed;
+}
+
+int
+main(void) {
+    if (test_missing_file_fails() != 0) {
+        return 1;
+    }
+    if (test_group_header_only() != 0) {
+        return 1;
+    }
+    if (test_group_counts_mixed_rows() != 0) {
+        return 1;
+    }
+    if (test_chan_counts_mixed_rows() != 0) {
+        return 1;
+    }
+    if (test_key_dec_counts_mixed_rows() != 0) {
+        return 1;
+    }
+    if (test_key_hex_counts_mixed_rows() != 0) {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/ui/qml/tst_context_fixture.qml
+++ b/tests/ui/qml/tst_context_fixture.qml
@@ -17,6 +17,7 @@ TestCase {
         // in as a singleton and it reads prefs itself.
         var missing = testContext.missingContextKeys(
             ["HistoryScreen.qml", "MonitorScreen.qml", "SpectrumScreen.qml", "ExploreSetupScreen.qml", "RadioSheet.qml",
+             "ImportsScreen.qml", "WizardScreen.qml", "HomeScreen.qml", "SettingsScreen.qml", "Main.qml",
              "Theme.qml"])
 
         compare(missing.length, 0,

--- a/tests/ui/qml/tst_imports_screen_layout.qml
+++ b/tests/ui/qml/tst_imports_screen_layout.qml
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import QtTest
+
+// A ListView positions its own delegates: for a vertical list it writes the
+// item's x on every layout pass, which silently overwrites an `x` the delegate
+// declared. A card that subtracts the screen padding from its width but loses
+// the matching x still measures right — it just sits flush against the left
+// edge with the whole inset piled up on the right. Nothing in a C++ model test
+// sees that, and on a phone it reads as the whole library being off-centre.
+//
+// So the assertion is on the rendered geometry: each card's gap to the left
+// edge equals its gap to the right, and both equal the inset the Import file
+// button below the list already uses.
+Item {
+    id: root
+
+    width: 420
+    height: 900
+
+    Loader {
+        id: screenLoader
+
+        anchors.fill: parent
+        source: uiDir + "/ImportsScreen.qml"
+    }
+
+    TestCase {
+        id: tc
+
+        name: "ImportsScreenLayout"
+        when: windowShown
+
+        property var screen: null
+        property var list: null
+        property var importButton: null
+
+        function initTestCase() {
+            tc.screen = screenLoader.item
+            verify(tc.screen !== null, "ImportsScreen.qml failed to load")
+            tc.list = findChild(tc.screen, "importedFilesList")
+            verify(tc.list !== null, "the imported-files list is missing")
+            tc.importButton = findChild(tc.screen, "importFileButton")
+            verify(tc.importButton !== null, "the import button is missing")
+
+            // Two rows, because one card centred by accident on an empty model
+            // would prove nothing; the library copies and parses a real file, so
+            // the fixture has to be one.
+            var groups = testContext.writeFixtureCsv(
+                "groups.csv", "id,mode,name\n1001,A,Dispatch\n1002,A,Fireground\n")
+            verify(groups.length > 0, "could not write the talkgroup fixture")
+            var accepted = importedFiles.importFile(groups, "groups.csv", "group")
+            verify(accepted.ok, "the talkgroup fixture did not import")
+
+            var more = testContext.writeFixtureCsv(
+                "extra.csv", "id,mode,name\n2001,A,Public Works\n")
+            verify(more.length > 0, "could not write the second fixture")
+            verify(importedFiles.importFile(more, "extra.csv", "group").ok,
+                   "the second fixture did not import")
+
+            tryCompare(tc.list, "count", 2)
+            tc.waitForRendering(tc.list)
+        }
+
+        function cleanupTestCase() {
+            // The library is one model shared by every case in this suite and it
+            // persists; leaving rows behind would hand the next file a fixture
+            // it never asked for.
+            while (importedFiles.count > 0) {
+                importedFiles.remove(0)
+            }
+        }
+
+        function test_the_cards_sit_centred_between_the_screen_edges() {
+            var inset = tc.importButton.mapToItem(tc.screen, 0, 0).x
+            verify(inset > 0, "the import button is not inset from the edge")
+
+            for (var i = 0; i < tc.list.count; i++) {
+                var card = tc.list.itemAtIndex(i)
+                verify(card !== null, "row " + i + " has no delegate")
+
+                var left = card.mapToItem(tc.screen, 0, 0).x
+                var right = tc.screen.width - (left + card.width)
+                compare(left, inset, "row " + i + " does not start where the import button does")
+                compare(right, left, "row " + i + " is not centred between the screen edges")
+            }
+        }
+
+        // The empty-state sentence sits one step further in than the cards, and
+        // it measures itself against the view rather than the screen — so it
+        // moved with the inset and had to give up a step of its own.
+        function test_the_empty_message_stays_a_step_in_from_the_cards() {
+            var message = findChild(tc.screen, "importsEmptyMessage")
+            verify(message !== null, "the empty-state message is missing")
+
+            var inset = tc.importButton.mapToItem(tc.screen, 0, 0).x
+            var card = tc.list.itemAtIndex(0)
+            verify(card !== null, "the first row has no delegate")
+            compare(message.width, card.width - 2 * inset)
+        }
+    }
+}

--- a/tests/ui/qml/tst_main_overlay_layering.qml
+++ b/tests/ui/qml/tst_main_overlay_layering.qml
@@ -38,17 +38,21 @@ Item {
 
         property var app: null
         property var monitor: null
+        property var imports: null
 
         function initTestCase() {
             tc.app = appLoader.item
             verify(tc.app !== null, "Main.qml failed to load")
             tc.monitor = findChild(tc.app, "monitorScreen")
             verify(tc.monitor !== null, "the monitor screen is missing")
+            tc.imports = findChild(tc.app, "importsScreen")
+            verify(tc.imports !== null, "the imports screen is missing")
         }
 
         function init() {
             tc.app.spectrumOpen = false
             tc.app.wizardOpen = false
+            tc.app.importsOpen = false
         }
 
         // The baseline the other cases are measured against: with a live session
@@ -78,6 +82,29 @@ Item {
             tc.app.wizardOpen = false
             tryVerify(function () { return tc.monitor.enabled },
                       2000, "the monitor stayed inert after the wizard closed")
+        }
+
+        // The imports library goes the other way: it is reached from Settings
+        // rather than opened over a session, so the monitor keeps the screen and
+        // the library stands down. Either direction is fine — what is not is
+        // both being lit and enabled at once, and here the library's bottom
+        // "Import file" button sits exactly over "Stop listening".
+        function test_05_the_imports_library_stands_down_for_the_monitor() {
+            tc.app.importsOpen = true
+            // Waited out rather than tryVerify'd: `enabled` follows an animated
+            // opacity, so "it is inert" is true on the fade's first frame no
+            // matter what the binding says. What is under test is where the
+            // layer settles, which is only knowable after the 150ms fade.
+            wait(400)
+            verify(!tc.imports.enabled,
+                   "a tap on the imports library also reaches the monitor underneath")
+            verify(tc.monitor.enabled,
+                   "the monitor gave up its taps to a layer that is standing down")
+
+            // Both inert would leave a live session with nothing taking taps.
+            tc.app.importsOpen = false
+            tryVerify(function () { return tc.monitor.enabled },
+                      2000, "the monitor stayed inert after the imports library closed")
         }
 
         // The wizard opens over the spectrum ("Save as a system"), so both are up

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -499,6 +499,32 @@ class Setup : public QObject {
         return dsd_neo_qml_stub::spectrum_peak_hz();
     }
 
+    /**
+     * @brief Write @p contents to a disposable CSV and answer its path.
+     *
+     * The imports library only grows a row by copying a real file through
+     * DecoderHost::importDocument() and parsing what landed, and QML cannot
+     * create one. The file goes under the same disposable app data tree the
+     * library itself persists to, so a run leaves nothing behind.
+     */
+    Q_INVOKABLE QString
+    writeFixtureCsv(const QString& name, const QString& contents) const {
+        QDir dir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + QStringLiteral("/fixtures"));
+        if (!dir.mkpath(QStringLiteral("."))) {
+            return QString();
+        }
+        const QString path = dir.filePath(name);
+        QFile file(path);
+        if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            return QString();
+        }
+        if (file.write(contents.toUtf8()) < 0) {
+            return QString();
+        }
+        file.close();
+        return path;
+    }
+
     /** @brief Forget every recorded command. */
     Q_INVOKABLE void
     resetCommands() {

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -34,7 +34,9 @@
 #define DSD_NEO_TESTS_UI_QML_TEST_CONTEXT_H_
 
 #include <QAbstractListModel>
+#include <QCoreApplication>
 #include <QDateTime>
+#include <QDir>
 #include <QFile>
 #include <QFontDatabase>
 #include <QHash>
@@ -43,20 +45,58 @@
 #include <QQmlContext>
 #include <QQmlEngine>
 #include <QRegularExpression>
+#include <QStandardPaths>
 #include <QString>
 #include <QStringList>
 #include <QVariantMap>
 #include <QtQuickTest>
 
+#include "app_prefs.h"
 #include "call_history_filter.h"
 #include "call_history_model.h"
 #include "decode_mode_flag.h"
+#include "decoder_host.h"
+#include "imported_files_model.h"
 #include "qml_spectrum_stub.h"
+#include "saved_systems_model.h"
+#include "session_args.h"
 #include "spectrum_model.h"
 #include "spectrum_view_item.h"
 
 using dsd_qt::CallHistoryFilterModel;
 using dsd_qt::CallHistoryModel;
+
+/**
+ * @brief Minimal DecoderHost so ImportedFilesModel has one to copy through.
+ *
+ * Only importDocument() is exercised here, and that is DecoderHost's own
+ * non-virtual desktop implementation. The lifecycle members exist because the
+ * base class is abstract; the `decoderHost` the QML reads is still the plain map
+ * below, which is what keeps the screens' session bindings drivable from a case.
+ */
+class ImportOnlyHost : public dsd_qt::DecoderHost {
+    Q_OBJECT
+
+  public:
+    bool
+    isRunning() const override {
+        return false;
+    }
+
+    QString
+    statusText() const override {
+        return QString();
+    }
+
+    bool
+    start(const QStringList& argv) override {
+        Q_UNUSED(argv)
+        return false;
+    }
+
+    void
+    stop() override {}
+};
 
 /**
  * @brief Stand-in for CommandBridge that records instead of submitting.
@@ -573,6 +613,15 @@ class Setup : public QObject {
      */
     void
     applicationAvailable() {
+        /* The library and saved-systems models persist to the app data tree, so
+         * point that at disposable test storage before either is constructed --
+         * a run must not read or write a real profile (same arrangement as
+         * UI_QT_PERSISTENCE and UI_QT_IMPORTED_FILES). */
+        QCoreApplication::setOrganizationName(QStringLiteral("dsd-neo-test"));
+        QCoreApplication::setApplicationName(QStringLiteral("dsd-neo-qml-%1").arg(QCoreApplication::applicationPid()));
+        QStandardPaths::setTestModeEnabled(true);
+        QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)).removeRecursively();
+
         for (const QString& file :
              {QStringLiteral("IBMPlexSans-Regular.ttf"), QStringLiteral("IBMPlexSans-SemiBold.ttf"),
               QStringLiteral("IBMPlexSans-Bold.ttf"), QStringLiteral("IBMPlexMono-Regular.ttf"),
@@ -610,6 +659,23 @@ class Setup : public QObject {
         prefs[QStringLiteral("appearance")] = 2;
         prefs[QStringLiteral("onboardingDone")] = true;
         prefs[QStringLiteral("backgroundListening")] = false;
+        prefs[QStringLiteral("keepScreenAwake")] = false;
+        prefs[QStringLiteral("skipEncrypted")] = false;
+        /* The radio defaults the settings screen and the explore setup edit.
+         * AppPrefs' own defaults, so a case that reads one sees what a fresh
+         * install would. */
+        prefs[QStringLiteral("autoPpm")] = false;
+        prefs[QStringLiteral("gainDb")] = 30;
+        prefs[QStringLiteral("ppm")] = 0;
+        prefs[QStringLiteral("bandwidthKhz")] = 48;
+        prefs[QStringLiteral("biasTee")] = false;
+        prefs[QStringLiteral("extraArgs")] = QString();
+        /* Empty on purpose: it is what makes the explore setup's first tap ask
+         * for a source rather than start something that cannot tune. */
+        prefs[QStringLiteral("exploreSourceType")] = QString();
+        prefs[QStringLiteral("exploreHost")] = QString();
+        prefs[QStringLiteral("explorePort")] = 1234;
+        prefs[QStringLiteral("exploreFreqMhz")] = QString();
         m_prefs = prefs;
         ctx->setContextProperty(QStringLiteral("prefs"), prefs);
 
@@ -674,6 +740,15 @@ class Setup : public QObject {
         /* The spectrum view gates production on a live session, so the fixture
          * has to claim one or its frames would never start. */
         host[QStringLiteral("sessionActive")] = true;
+        /* Why the last session stopped, empty while nothing has failed. */
+        host[QStringLiteral("failureText")] = QString();
+        /* The Android-only capabilities the settings screen hides rows on: a
+         * desktop host brokers no USB device and cannot hold the screen awake,
+         * which is the arrangement this offscreen run matches. */
+        host[QStringLiteral("keepScreenAwakeSupported")] = false;
+        host[QStringLiteral("localDeviceBrokered")] = false;
+        host[QStringLiteral("localDeviceReady")] = false;
+        host[QStringLiteral("localDeviceStatus")] = QString();
         m_host = host;
         ctx->setContextProperty(QStringLiteral("decoderHost"), host);
 
@@ -686,6 +761,25 @@ class Setup : public QObject {
         m_commands = new CommandRecorder();
         m_commands->setParent(engine);
         ctx->setContextProperty(QStringLiteral("commands"), m_commands);
+
+        /* Production models, not stand-ins. Two of these back a ListView whose
+         * delegate declares `required property` per role, so a stand-in would
+         * have to mirror all nineteen roles exactly or the delegate would fail
+         * to instantiate -- and a mirror that drifted would fail as the real
+         * thing passing. They persist under the disposable app data tree set up
+         * in applicationAvailable(), and start empty there. Without them the
+         * home screen, the imports library, the wizard's pickers and the explore
+         * setup all raised ReferenceError and rendered nothing. */
+        m_import_host = new ImportOnlyHost();
+        m_import_host->setParent(engine);
+        auto* imported_files = new dsd_qt::ImportedFilesModel(m_import_host, engine);
+        auto* saved_systems = new dsd_qt::SavedSystemsModel(engine);
+        auto* app_prefs = new dsd_qt::AppPrefs(engine);
+        auto* session_args = new dsd_qt::SessionArgsBuilder(app_prefs, engine);
+        ctx->setContextProperty(QStringLiteral("importedFiles"), imported_files);
+        ctx->setContextProperty(QStringLiteral("savedSystems"), saved_systems);
+        ctx->setContextProperty(QStringLiteral("sessionArgs"), session_args);
+        ctx->setContextProperty(QStringLiteral("appVersionText"), QStringLiteral("0.0.0-test"));
     }
 
   private:
@@ -695,6 +789,7 @@ class Setup : public QObject {
     QQmlEngine* m_engine = nullptr;
     dsd_qt::SpectrumModel* m_spectrum = nullptr;
     CommandRecorder* m_commands = nullptr;
+    ImportOnlyHost* m_import_host = nullptr;
 };
 
 #endif /* DSD_NEO_TESTS_UI_QML_TEST_CONTEXT_H_ */

--- a/tests/ui/test_ui_menu_services.c
+++ b/tests/ui/test_ui_menu_services.c
@@ -140,11 +140,26 @@ openWavOutFileRaw(dsd_opts* opts, dsd_state* state) {
     (void)state;
 }
 
+/*
+ * Controllable importer stub: fills whichever state it is handed, the way the
+ * real importer does, so the service's replace-vs-append behavior is observable.
+ */
+static int g_chan_import_result = -1;
+static int g_chan_import_count = 0;
+static uint32_t g_chan_import_chan[4];
+static long int g_chan_import_freq[4];
+
 int
 csvChanImport(const dsd_opts* opts, dsd_state* state) {
     (void)opts;
-    (void)state;
-    return -1;
+    if (g_chan_import_result != 0 || !state) {
+        return g_chan_import_result;
+    }
+    for (int i = 0; i < g_chan_import_count; i++) {
+        dsd_state_set_trunk_chan_freq(state, g_chan_import_chan[i], g_chan_import_freq[i]);
+        state->trunk_lcn_freq[state->lcn_freq_count++] = g_chan_import_freq[i];
+    }
+    return 0;
 }
 
 int
@@ -704,6 +719,7 @@ test_file_network_and_import_failure_contracts(void) {
     rc |= expect_int("rigctl socket invalid after connect failure", opts.rigctl_sockfd, DSD_INVALID_SOCKET);
     rc |= expect_int("rigctl disabled after connect failure", opts.use_rigctl, 0);
 
+    g_chan_import_result = -1;
     rc |= expect_int("channel import failure", svc_import_channel_map(&opts, &state, "channels.csv"), -1);
     rc |= expect_str("channel import path stored", opts.chan_in_file, "channels.csv");
     rc |= expect_int("group import failure", svc_import_group_list(&opts, &state, "groups.csv"), -1);
@@ -712,6 +728,48 @@ test_file_network_and_import_failure_contracts(void) {
     rc |= expect_str("keys dec import path stored", opts.key_in_file, "keys.csv");
     rc |= expect_int("keys hex import failure", svc_import_keys_hex(&opts, &state, "keys.hex"), -1);
     rc |= expect_str("keys hex import path stored", opts.key_in_file, "keys.hex");
+
+    return rc;
+}
+
+static int
+test_channel_map_reimport_replaces_previous_map(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    g_chan_import_result = 0;
+    g_chan_import_count = 3;
+    g_chan_import_chan[0] = 101;
+    g_chan_import_freq[0] = 851000000L;
+    g_chan_import_chan[1] = 102;
+    g_chan_import_freq[1] = 852000000L;
+    g_chan_import_chan[2] = 103;
+    g_chan_import_freq[2] = 853000000L;
+    rc |= expect_int("chan map first import ok", svc_import_channel_map(&opts, &state, "a.csv"), 0);
+    rc |= expect_int("first import lcn count", state.lcn_freq_count, 3);
+    rc |= expect_int("first import chan applied", (int)state.trunk_chan_map[101], 851000000);
+    rc |= expect_int("first import used count", (int)state.trunk_chan_map_used_count, 3);
+
+    g_chan_import_count = 2;
+    g_chan_import_chan[0] = 201;
+    g_chan_import_freq[0] = 860000000L;
+    g_chan_import_chan[1] = 202;
+    g_chan_import_freq[1] = 861000000L;
+    rc |= expect_int("chan map reimport ok", svc_import_channel_map(&opts, &state, "b.csv"), 0);
+    rc |= expect_int("reimport replaces lcn count", state.lcn_freq_count, 2);
+    rc |= expect_int("reimport clears stale chan", (int)state.trunk_chan_map[101], 0);
+    rc |= expect_int("reimport applies new chan", (int)state.trunk_chan_map[201], 860000000);
+    rc |= expect_int("reimport replaces used count", (int)state.trunk_chan_map_used_count, 2);
+    rc |= expect_int("reimport replaces lcn list", (int)state.trunk_lcn_freq[0], 860000000);
+
+    g_chan_import_result = -1;
+    rc |= expect_int("failed reimport rc", svc_import_channel_map(&opts, &state, "bad.csv"), -1);
+    rc |= expect_int("failed reimport preserves lcn count", state.lcn_freq_count, 2);
+    rc |= expect_int("failed reimport preserves chan", (int)state.trunk_chan_map[201], 860000000);
+    rc |= expect_str("failed reimport still stores path", opts.chan_in_file, "bad.csv");
 
     return rc;
 }
@@ -728,5 +786,6 @@ main(void) {
     rc |= test_rtl_service_option_contracts();
 #endif
     rc |= test_file_network_and_import_failure_contracts();
+    rc |= test_channel_map_reimport_replaces_previous_map();
     return rc ? 1 : 0;
 }

--- a/tests/ui/test_ui_menu_services.c
+++ b/tests/ui/test_ui_menu_services.c
@@ -34,6 +34,7 @@
 #include "services.h"
 
 #include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_ext.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/io/rtl_stream_fwd.h"
 #include "dsd-neo/platform/sockets.h"
@@ -162,18 +163,20 @@ csvChanImport(const dsd_opts* opts, dsd_state* state) {
     return 0;
 }
 
+static int g_key_import_result = -1;
+
 int
 csvKeyImportDec(const dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    return -1;
+    return g_key_import_result;
 }
 
 int
 csvKeyImportHex(const dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    return -1;
+    return g_key_import_result;
 }
 
 int
@@ -181,6 +184,25 @@ dsd_tg_policy_reload_group_file(const dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
     return -1;
+}
+
+/* Counts calls rather than returning a canned value: what svc_clear_group_list()
+ * owes the caller is that the policy was asked to empty itself, and the emptying
+ * itself belongs to CORE_TALKGROUP_POLICY. */
+static int g_tg_policy_clear_calls = 0;
+
+int
+dsd_tg_policy_clear(dsd_state* state) {
+    (void)state;
+    g_tg_policy_clear_calls++;
+    return 0;
+}
+
+/* The throwaway import state may carry module extensions; nothing under test
+ * allocates one, so releasing it is a no-op here. */
+void
+dsd_state_ext_free_all(dsd_state* state) {
+    (void)state;
 }
 
 double
@@ -771,6 +793,128 @@ test_channel_map_reimport_replaces_previous_map(void) {
     rc |= expect_int("failed reimport preserves chan", (int)state.trunk_chan_map[201], 860000000);
     rc |= expect_str("failed reimport still stores path", opts.chan_in_file, "bad.csv");
 
+    // The importer reports success for any file it can open, so a mispicked CSV
+    // parses to an empty map. Adopting that would replace the live map with
+    // zeros; the service has to refuse instead.
+    g_chan_import_result = 0;
+    g_chan_import_count = 0;
+    rc |= expect_int("empty import refused", svc_import_channel_map(&opts, &state, "talkgroups.csv"), -1);
+    rc |= expect_int("empty import preserves chan", (int)state.trunk_chan_map[201], 860000000);
+    rc |= expect_int("empty import preserves lcn count", state.lcn_freq_count, 2);
+
+    // Trunk scan owns per-target maps; a global runtime import would wipe them.
+    opts.trunk_scan_enabled = 1;
+    g_chan_import_count = 1;
+    g_chan_import_chan[0] = 301;
+    g_chan_import_freq[0] = 870000000L;
+    rc |= expect_int("trunk-scan import refused", svc_import_channel_map(&opts, &state, "scan.csv"), -1);
+    rc |= expect_int("trunk-scan import preserves chan", (int)state.trunk_chan_map[201], 860000000);
+    opts.trunk_scan_enabled = 0;
+
+    // dmr_lcn_trust is provenance for the map, not a separate table: a stale
+    // "learned on the CC" byte would authorize an off-CC tune to a frequency
+    // only the new CSV asserts. lcn_freq_roll indexes the replaced LCN list.
+    state.dmr_lcn_trust[201] = 2;
+    state.lcn_freq_roll = 1;
+    g_chan_import_count = 1;
+    g_chan_import_chan[0] = 401;
+    g_chan_import_freq[0] = 880000000L;
+    rc |= expect_int("adopt ok", svc_import_channel_map(&opts, &state, "c.csv"), 0);
+    rc |= expect_int("adopt clears stale lcn trust", (int)state.dmr_lcn_trust[201], 0);
+    rc |= expect_int("adopt restarts the lcn roll", state.lcn_freq_roll, 0);
+
+    return rc;
+}
+
+/*
+ * Runtime key import has to arm the keyring the way -k/-K does: every consumer
+ * of rkey_array gates on keyloader, so without this the rows load and nothing
+ * ever uses them while the UI reports success.
+ */
+static int
+test_key_import_arms_keyloader(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    g_key_import_result = -1;
+    rc |= expect_int("dec key import failure rc", svc_import_keys_dec(&opts, &state, "keys.csv"), -1);
+    rc |= expect_int("failed dec key import leaves keyloader off", state.keyloader, 0);
+
+    g_key_import_result = 0;
+    rc |= expect_int("dec key import ok", svc_import_keys_dec(&opts, &state, "keys.csv"), 0);
+    rc |= expect_int("dec key import arms keyloader", state.keyloader, 1);
+
+    state.keyloader = 0;
+    rc |= expect_int("hex key import ok", svc_import_keys_hex(&opts, &state, "keys.hex"), 0);
+    rc |= expect_int("hex key import arms keyloader", state.keyloader, 1);
+
+    g_key_import_result = -1;
+    return rc;
+}
+
+/*
+ * Unloading. A frontend whose system can deselect a CSV needs a way to say
+ * "none": every importer takes a path and rejects an empty one, so without
+ * these the deselected file stays live for the rest of the session.
+ */
+static int
+test_clear_services_unload_what_the_importers_loaded(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    g_chan_import_result = 0;
+    g_chan_import_count = 2;
+    g_chan_import_chan[0] = 101;
+    g_chan_import_freq[0] = 851000000L;
+    g_chan_import_chan[1] = 102;
+    g_chan_import_freq[1] = 852000000L;
+    rc |= expect_int("clear: seed import ok", svc_import_channel_map(&opts, &state, "a.csv"), 0);
+    state.dmr_lcn_trust[101] = 2;
+    state.lcn_freq_roll = 1;
+    const unsigned int seq_before = state.trunk_chan_map_seq;
+
+    rc |= expect_int("chan map clear ok", svc_clear_channel_map(&opts, &state), 0);
+    rc |= expect_str("chan map clear forgets the path", opts.chan_in_file, "");
+    rc |= expect_int("chan map clear empties the map", (int)state.trunk_chan_map[101], 0);
+    rc |= expect_int("chan map clear empties used count", (int)state.trunk_chan_map_used_count, 0);
+    rc |= expect_int("chan map clear empties lcn list", state.lcn_freq_count, 0);
+    rc |= expect_int("chan map clear restarts the lcn roll", state.lcn_freq_roll, 0);
+    // Provenance goes with the map for the same reason it does on an adopt: a
+    // surviving trust byte authorizes an off-CC tune to a frequency now gone.
+    rc |= expect_int("chan map clear drops lcn trust", (int)state.dmr_lcn_trust[101], 0);
+    rc |= expect_int("chan map clear advances the map seq", (int)(state.trunk_chan_map_seq != seq_before), 1);
+
+    // Trunk scan owns per-target maps; emptying a global one is not this
+    // frontend's call, exactly as on the import side.
+    opts.trunk_scan_enabled = 1;
+    rc |= expect_int("trunk-scan chan map clear refused", svc_clear_channel_map(&opts, &state), -1);
+    opts.trunk_scan_enabled = 0;
+
+    DSD_SNPRINTF(opts.group_in_file, sizeof opts.group_in_file, "%s", "groups.csv");
+    const int clears_before = g_tg_policy_clear_calls;
+    rc |= expect_int("group list clear ok", svc_clear_group_list(&opts, &state), 0);
+    rc |= expect_str("group list clear forgets the path", opts.group_in_file, "");
+    rc |= expect_int("group list clear empties the policy", g_tg_policy_clear_calls - clears_before, 1);
+
+    g_key_import_result = 0;
+    rc |= expect_int("clear: seed key import ok", svc_import_keys_dec(&opts, &state, "keys.csv"), 0);
+    state.rkey_array[7] = 0x1234ULL;
+    state.rkey_array_loaded[7] = 1U;
+    rc |= expect_int("keys clear ok", svc_clear_keys(&opts, &state), 0);
+    rc |= expect_str("keys clear forgets the path", opts.key_in_file, "");
+    rc |= expect_int("keys clear empties the keyring", (int)state.rkey_array[7], 0);
+    rc |= expect_int("keys clear marks the slot unloaded", (int)state.rkey_array_loaded[7], 0);
+    // Disarmed, or every consumer keeps treating the zeroed array as loaded keys.
+    rc |= expect_int("keys clear disarms the keyloader", state.keyloader, 0);
+
+    g_chan_import_result = -1;
+    g_key_import_result = -1;
     return rc;
 }
 
@@ -787,5 +931,7 @@ main(void) {
 #endif
     rc |= test_file_network_and_import_failure_contracts();
     rc |= test_channel_map_reimport_replaces_previous_map();
+    rc |= test_key_import_arms_keyloader();
+    rc |= test_clear_services_unload_what_the_importers_loaded();
     return rc ? 1 : 0;
 }

--- a/tests/ui/test_ui_qt_imported_files_model.cpp
+++ b/tests/ui/test_ui_qt_imported_files_model.cpp
@@ -9,15 +9,19 @@
  * wizard and imports screen share. Registered only when the Qt frontend is
  * enabled (DSD_ENABLE_QT_UI), since these link Qt. */
 
+#include <QByteArray>
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
 #include <QIODevice>
+#include <QList>
+#include <QMap>
 #include <QStandardPaths>
 #include <QString>
 #include <QStringList>
 #include <QTemporaryDir>
 #include <QUrl>
+#include <QVariant>
 #include <QVariantList>
 #include <QVariantMap>
 #include <dsd-neo/core/state_fwd.h>

--- a/tests/ui/test_ui_qt_imported_files_model.cpp
+++ b/tests/ui/test_ui_qt_imported_files_model.cpp
@@ -123,6 +123,16 @@ test_import_document(void) {
     expect("replace returns the replaced path", replaced == imported);
     expect("replace updates the content", read_file(imported) == "channel,freq\n9,860000000\n");
 
+    /* A replace target inside the imports dir that no longer exists is still a
+     * write target: QFileInfo::canonicalPath() gives up on a missing leaf, and
+     * falling back to a fresh unique copy would strand a file no library row
+     * references while the update reports failure. */
+    expect("stored copy removable", QFile::remove(imported));
+    const QString recreated =
+        host.importDocument(QUrl::fromLocalFile(sourceC).toString(), QStringLiteral("updated.csv"), imported);
+    expect("missing replace target is recreated in place", recreated == imported);
+    expect("recreated copy has the source content", read_file(imported) == "channel,freq\n9,860000000\n");
+
     /* replacePath outside the imports dir is not a write target — treat it as
      * a fresh import instead of scribbling wherever the caller points. */
     const QString outside = sourceDir.filePath(QStringLiteral("outside.csv"));
@@ -234,6 +244,22 @@ test_imported_files_model(void) {
         expect("load drops rows for missing files", model.rowCount() == 1);
         expect("survivor is the header-only row",
                model.get(0).value(QStringLiteral("name")).toString() == QStringLiteral("header_only.csv"));
+
+        /* Pruning the row is only half the repair: a saved system still holding
+         * that path builds a `-G <missing>` argv and fails to start with a parse
+         * error naming the input settings, not the file. The owner reconciles
+         * that, so the path has to survive the prune long enough to be handed
+         * over — and exactly once, or a later caller would re-clear a path some
+         * system had legitimately re-selected. */
+        const QStringList pruned = model.takePrunedPaths();
+        expect("prune reports the vanished path", pruned == QStringList{storedGroupPath});
+        expect("prune is reported only once", model.takePrunedPaths().isEmpty());
+    }
+
+    {
+        /* Nothing missing: no reconciliation for the owner to do. */
+        dsd_qt::ImportedFilesModel model(&host);
+        expect("a clean load prunes nothing", model.takePrunedPaths().isEmpty());
     }
 }
 

--- a/tests/ui/test_ui_qt_imported_files_model.cpp
+++ b/tests/ui/test_ui_qt_imported_files_model.cpp
@@ -5,8 +5,9 @@
 
 /* Unit tests: the Qt frontend's imported-files layer — DecoderHost's desktop
  * importDocument() default (copy into the app's imports dir, unique-ify on
- * collision, atomic replace on update). Registered only when the Qt frontend
- * is enabled (DSD_ENABLE_QT_UI), since these link Qt. */
+ * collision, atomic replace on update) and the ImportedFilesModel library the
+ * wizard and imports screen share. Registered only when the Qt frontend is
+ * enabled (DSD_ENABLE_QT_UI), since these link Qt. */
 
 #include <QCoreApplication>
 #include <QDir>
@@ -17,10 +18,22 @@
 #include <QStringList>
 #include <QTemporaryDir>
 #include <QUrl>
+#include <QVariantList>
+#include <QVariantMap>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/protocol/nxdn/nxdn_lfsr.h>
 #include <stdio.h>
 
 #include "decoder_host.h"
 #include "dsd-neo/core/safe_api.h"
+#include "imported_files_model.h"
+
+void
+LFSRN(const char* BufferIn, char* BufferOut, dsd_state* state) {
+    (void)BufferIn;
+    (void)BufferOut;
+    (void)state;
+}
 
 namespace {
 
@@ -124,6 +137,106 @@ test_import_document(void) {
     expect("missing source returns empty", missing.isEmpty());
 }
 
+void
+test_imported_files_model(void) {
+    /* Fresh app-data tree: the imports directory is shared state, and copies
+     * left by the importDocument tests would unique-ify this test's names. */
+    QDir(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)).removeRecursively();
+
+    TestHost host;
+    QTemporaryDir sourceDir;
+    expect("model source dir created", sourceDir.isValid());
+
+    const QString groupSrc = sourceDir.filePath(QStringLiteral("county.csv"));
+    expect("group source written", write_file(groupSrc, "TG,Mode,Name\n101,D,Dispatch\n102,D,Fire\nbogus,D,Bad\n"));
+    const QString chanSrc = sourceDir.filePath(QStringLiteral("chan.csv"));
+    expect("chan source written", write_file(chanSrc, "channel,freq\n1,851000000\n"));
+    const QString emptySrc = sourceDir.filePath(QStringLiteral("header_only.csv"));
+    expect("empty source written", write_file(emptySrc, "TG,Mode,Name\n"));
+
+    QString storedGroupPath;
+    {
+        dsd_qt::ImportedFilesModel model(&host);
+        expect("model starts empty", model.rowCount() == 0);
+
+        const QVariantMap imported = model.importFile(QUrl::fromLocalFile(groupSrc).toString(),
+                                                      QStringLiteral("county.csv"), QStringLiteral("group"));
+        expect("group import ok", imported.value(QStringLiteral("ok")).toBool());
+        expect("group import counts accepted", imported.value(QStringLiteral("accepted")).toInt() == 2);
+        expect("group import counts skipped", imported.value(QStringLiteral("skipped")).toInt() == 1);
+        expect("group import has no error", imported.value(QStringLiteral("error")).toString().isEmpty());
+        storedGroupPath = imported.value(QStringLiteral("path")).toString();
+        expect("group import stores a path", !storedGroupPath.isEmpty() && QFile::exists(storedGroupPath));
+        expect("group import adds a row", model.rowCount() == 1);
+
+        const QVariantMap chan = model.importFile(QUrl::fromLocalFile(chanSrc).toString(), QStringLiteral("chan.csv"),
+                                                  QStringLiteral("chan"));
+        expect("chan import ok", chan.value(QStringLiteral("ok")).toBool());
+        expect("chan import counts accepted", chan.value(QStringLiteral("accepted")).toInt() == 1);
+
+        /* A parseable file with zero usable rows is kept — recoverable via
+         * update — but flagged so the UI can warn instead of silently storing
+         * a talkgroup list that names nothing. */
+        const QVariantMap empty = model.importFile(QUrl::fromLocalFile(emptySrc).toString(),
+                                                   QStringLiteral("header_only.csv"), QStringLiteral("group"));
+        expect("empty import kept", empty.value(QStringLiteral("ok")).toBool());
+        expect("empty import flagged", empty.value(QStringLiteral("error")).toString() == QStringLiteral("empty"));
+        expect("empty import accepted zero", empty.value(QStringLiteral("accepted")).toInt() == 0);
+
+        const QVariantMap bad = model.importFile(QUrl::fromLocalFile(sourceDir.filePath("absent.csv")).toString(),
+                                                 QStringLiteral("absent.csv"), QStringLiteral("group"));
+        expect("unreadable import rejected", !bad.value(QStringLiteral("ok")).toBool());
+        expect("unreadable import adds no row", model.rowCount() == 3);
+
+        const QVariantList groups = model.entriesForType(QStringLiteral("group"));
+        expect("type filter finds group rows", groups.size() == 2);
+        const QVariantList chans = model.entriesForType(QStringLiteral("chan"));
+        expect("type filter finds chan row",
+               chans.size() == 1
+                   && chans.at(0).toMap().value(QStringLiteral("name")).toString() == QStringLiteral("chan.csv"));
+
+        expect("rowForPath finds the stored file", model.rowForPath(storedGroupPath) == 0);
+        expect("rowForPath misses unknown path", model.rowForPath(QStringLiteral("/nope.csv")) == -1);
+    }
+
+    {
+        /* Fresh instance: the library must reload from disk. */
+        dsd_qt::ImportedFilesModel model(&host);
+        expect("library persists across instances", model.rowCount() == 3);
+        const QVariantMap row = model.get(0);
+        expect("persisted row keeps name",
+               row.value(QStringLiteral("name")).toString() == QStringLiteral("county.csv"));
+        expect("persisted row keeps type", row.value(QStringLiteral("type")).toString() == QStringLiteral("group"));
+        expect("persisted row keeps counts", row.value(QStringLiteral("accepted")).toInt() == 2);
+
+        /* Update in place: the stored path must not change, the counts must. */
+        const QString updatedSrc = sourceDir.filePath(QStringLiteral("updated.csv"));
+        expect("updated source written",
+               write_file(updatedSrc, "TG,Mode,Name\n201,D,PD\n202,D,FD\n203,D,EMS\n204,D,DPW\n"));
+        const QVariantMap updated =
+            model.updateFile(0, QUrl::fromLocalFile(updatedSrc).toString(), QStringLiteral("updated.csv"));
+        expect("update ok", updated.value(QStringLiteral("ok")).toBool());
+        expect("update keeps the stored path", updated.value(QStringLiteral("path")).toString() == storedGroupPath);
+        expect("update refreshes counts", model.get(0).value(QStringLiteral("accepted")).toInt() == 4);
+
+        /* Remove deletes the stored file with the row. */
+        const QString chanPath = model.get(1).value(QStringLiteral("path")).toString();
+        model.remove(1);
+        expect("remove drops the row", model.rowCount() == 2);
+        expect("remove deletes the file", !QFile::exists(chanPath));
+    }
+
+    {
+        /* A stored file deleted behind the app's back must not survive as a
+         * ghost row pointing nowhere. */
+        expect("stored group file removable", QFile::remove(storedGroupPath));
+        dsd_qt::ImportedFilesModel model(&host);
+        expect("load drops rows for missing files", model.rowCount() == 1);
+        expect("survivor is the header-only row",
+               model.get(0).value(QStringLiteral("name")).toString() == QStringLiteral("header_only.csv"));
+    }
+}
+
 } // namespace
 
 int
@@ -139,6 +252,7 @@ main(int argc, char** argv) {
     QDir(dataDir).removeRecursively();
 
     test_import_document();
+    test_imported_files_model();
 
     QDir(dataDir).removeRecursively();
     if (g_failures != 0) {

--- a/tests/ui/test_ui_qt_imported_files_model.cpp
+++ b/tests/ui/test_ui_qt_imported_files_model.cpp
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/* Unit tests: the Qt frontend's imported-files layer — DecoderHost's desktop
+ * importDocument() default (copy into the app's imports dir, unique-ify on
+ * collision, atomic replace on update). Registered only when the Qt frontend
+ * is enabled (DSD_ENABLE_QT_UI), since these link Qt. */
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QFile>
+#include <QIODevice>
+#include <QStandardPaths>
+#include <QString>
+#include <QStringList>
+#include <QTemporaryDir>
+#include <QUrl>
+#include <stdio.h>
+
+#include "decoder_host.h"
+#include "dsd-neo/core/safe_api.h"
+
+namespace {
+
+int g_failures = 0;
+
+void
+expect(const char* what, bool ok) {
+    if (!ok) {
+        DSD_FPRINTF(stderr, "FAIL: %s\n", what);
+        g_failures++;
+    }
+}
+
+class TestHost : public dsd_qt::DecoderHost {
+  public:
+    bool
+    isRunning() const override {
+        return false;
+    }
+
+    QString
+    statusText() const override {
+        return QString();
+    }
+
+    bool
+    start(const QStringList& argv) override {
+        (void)argv;
+        return false;
+    }
+
+    void
+    stop() override {}
+};
+
+bool
+write_file(const QString& path, const QByteArray& contents) {
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly)) {
+        return false;
+    }
+    file.write(contents);
+    return true;
+}
+
+QByteArray
+read_file(const QString& path) {
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return QByteArray();
+    }
+    return file.readAll();
+}
+
+void
+test_import_document(void) {
+    TestHost host;
+    QTemporaryDir sourceDir;
+    expect("source dir created", sourceDir.isValid());
+    const QString importsDir =
+        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + QStringLiteral("/imports");
+
+    const QString sourceA = sourceDir.filePath(QStringLiteral("chan.csv"));
+    expect("source A written", write_file(sourceA, "channel,freq\n1,851000000\n"));
+    const QString imported = host.importDocument(QUrl::fromLocalFile(sourceA).toString(), QStringLiteral("chan.csv"));
+    expect("import returns a path inside imports dir", imported.startsWith(importsDir));
+    expect("import keeps the display name", imported.endsWith(QStringLiteral("/chan.csv")));
+    expect("imported copy has the source content", read_file(imported) == "channel,freq\n1,851000000\n");
+
+    /* A different document with the same display name must not overwrite the
+     * first import — two agencies both ship a "chan.csv". */
+    const QString sourceB = sourceDir.filePath(QStringLiteral("other/chan.csv"));
+    expect("source B dir created", QDir(sourceDir.path()).mkpath(QStringLiteral("other")));
+    expect("source B written", write_file(sourceB, "channel,freq\n2,852000000\n"));
+    const QString importedB = host.importDocument(QUrl::fromLocalFile(sourceB).toString(), QStringLiteral("chan.csv"));
+    expect("collision returns a distinct path", !importedB.isEmpty() && importedB != imported);
+    expect("collision keeps the extension", importedB.endsWith(QStringLiteral(".csv")));
+    expect("first import untouched by collision", read_file(imported) == "channel,freq\n1,851000000\n");
+    expect("collision copy has its own content", read_file(importedB) == "channel,freq\n2,852000000\n");
+
+    /* Update-in-place: replacePath re-uses the stored file so saved systems
+     * keep pointing at the same path. */
+    const QString sourceC = sourceDir.filePath(QStringLiteral("updated.csv"));
+    expect("source C written", write_file(sourceC, "channel,freq\n9,860000000\n"));
+    const QString replaced =
+        host.importDocument(QUrl::fromLocalFile(sourceC).toString(), QStringLiteral("updated.csv"), imported);
+    expect("replace returns the replaced path", replaced == imported);
+    expect("replace updates the content", read_file(imported) == "channel,freq\n9,860000000\n");
+
+    /* replacePath outside the imports dir is not a write target — treat it as
+     * a fresh import instead of scribbling wherever the caller points. */
+    const QString outside = sourceDir.filePath(QStringLiteral("outside.csv"));
+    expect("outside target written", write_file(outside, "original\n"));
+    const QString redirected =
+        host.importDocument(QUrl::fromLocalFile(sourceC).toString(), QStringLiteral("updated.csv"), outside);
+    expect("outside replace lands in imports dir", redirected.startsWith(importsDir));
+    expect("outside file untouched", read_file(outside) == "original\n");
+
+    const QString missing = host.importDocument(QUrl::fromLocalFile(sourceDir.filePath("absent.csv")).toString(),
+                                                QStringLiteral("absent.csv"));
+    expect("missing source returns empty", missing.isEmpty());
+}
+
+} // namespace
+
+int
+main(int argc, char** argv) {
+    QCoreApplication app(argc, argv);
+    /* Isolated, disposable storage — nothing this test writes may touch a real
+     * profile (same arrangement as test_ui_qt_persistence). */
+    QCoreApplication::setOrganizationName(QStringLiteral("dsd-neo-test"));
+    QCoreApplication::setApplicationName(
+        QStringLiteral("dsd-neo-imported-files-%1").arg(QCoreApplication::applicationPid()));
+    QStandardPaths::setTestModeEnabled(true);
+    const QString dataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir(dataDir).removeRecursively();
+
+    test_import_document();
+
+    QDir(dataDir).removeRecursively();
+    if (g_failures != 0) {
+        DSD_FPRINTF(stderr, "%d failure(s)\n", g_failures);
+        return 1;
+    }
+    DSD_FPRINTF(stderr, "OK\n");
+    return 0;
+}

--- a/tests/ui/test_ui_qt_persistence.cpp
+++ b/tests/ui/test_ui_qt_persistence.cpp
@@ -191,6 +191,64 @@ test_saved_systems(void) {
 }
 
 void
+test_saved_systems_csv_fields(void) {
+    const QString groupPath = QStringLiteral("/data/imports/county.csv");
+    {
+        SavedSystemsModel model;
+        QVariantMap sys = full_system_map();
+        sys.insert(QStringLiteral("chanCsvPath"), QStringLiteral("/data/imports/chan map.csv"));
+        sys.insert(QStringLiteral("groupCsvPath"), groupPath);
+        sys.insert(QStringLiteral("keyCsvPath"), QStringLiteral("/data/imports/keys.csv"));
+        sys.insert(QStringLiteral("keyCsvHex"), true);
+        model.add(sys);
+
+        /* Legacy row: fields absent must read as no CSV, not junk. */
+        QVariantMap legacy;
+        legacy.insert(QStringLiteral("name"), QStringLiteral("Legacy"));
+        model.add(legacy);
+
+        QVariantMap second = full_system_map();
+        second.insert(QStringLiteral("name"), QStringLiteral("Butler Co DMR"));
+        second.insert(QStringLiteral("groupCsvPath"), groupPath);
+        model.add(second);
+    }
+
+    SavedSystemsModel model;
+    const QVariantMap got = model.get(0);
+    expect("csv fields round-trip",
+           got.value(QStringLiteral("chanCsvPath")).toString() == QStringLiteral("/data/imports/chan map.csv")
+               && got.value(QStringLiteral("groupCsvPath")).toString() == groupPath
+               && got.value(QStringLiteral("keyCsvPath")).toString() == QStringLiteral("/data/imports/keys.csv")
+               && got.value(QStringLiteral("keyCsvHex")).toBool());
+    expect("legacy row reads empty csv fields",
+           model.get(1).value(QStringLiteral("chanCsvPath")).toString().isEmpty()
+               && model.get(1).value(QStringLiteral("groupCsvPath")).toString().isEmpty()
+               && model.get(1).value(QStringLiteral("keyCsvPath")).toString().isEmpty()
+               && !model.get(1).value(QStringLiteral("keyCsvHex")).toBool());
+
+    /* The delete-with-in-use-warning flow: which systems reference a stored
+     * file, and clearing that reference everywhere when the file goes away. */
+    const QStringList users = model.systemsReferencingPath(groupPath);
+    expect("referencing systems are named", users.size() == 2 && users.contains(QStringLiteral("Hamilton Co P25"))
+                                                && users.contains(QStringLiteral("Butler Co DMR")));
+    expect("unreferenced path names nobody",
+           model.systemsReferencingPath(QStringLiteral("/data/imports/nope.csv")).isEmpty());
+
+    model.clearCsvPath(groupPath);
+    expect("clear blanks every matching field",
+           model.get(0).value(QStringLiteral("groupCsvPath")).toString().isEmpty()
+               && model.get(2).value(QStringLiteral("groupCsvPath")).toString().isEmpty());
+    expect("clear leaves other csv fields alone", model.get(0).value(QStringLiteral("chanCsvPath")).toString()
+                                                      == QStringLiteral("/data/imports/chan map.csv"));
+
+    SavedSystemsModel reloaded;
+    expect("clear persists", reloaded.get(0).value(QStringLiteral("groupCsvPath")).toString().isEmpty());
+    reloaded.remove(0);
+    reloaded.remove(0);
+    reloaded.remove(0);
+}
+
+void
 test_app_prefs(void) {
     {
         AppPrefs prefs;
@@ -267,6 +325,7 @@ main(int argc, char** argv) {
 
     test_json_store();
     test_saved_systems();
+    test_saved_systems_csv_fields();
     test_app_prefs();
 
     QDir(dataDir).removeRecursively();

--- a/tests/ui/test_ui_qt_qml_main.cpp
+++ b/tests/ui/test_ui_qt_qml_main.cpp
@@ -22,9 +22,11 @@
 
 /* Pulled in by the DMR library that backs the imports library's CSV validation.
  * Nothing here decodes anything, so the vocoder descrambler is a stub -- the
- * same arrangement UI_QT_IMPORTED_FILES uses. */
+ * same arrangement UI_QT_IMPORTED_FILES uses. External linkage is the point: the
+ * library's undefined reference is what this definition satisfies, so it cannot
+ * be made static. */
 void
-LFSRN(const char* BufferIn, char* BufferOut, dsd_state* state) {
+LFSRN(const char* BufferIn, char* BufferOut, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
     (void)BufferIn;
     (void)BufferOut;
     (void)state;

--- a/tests/ui/test_ui_qt_qml_main.cpp
+++ b/tests/ui/test_ui_qt_qml_main.cpp
@@ -16,7 +16,18 @@
  */
 
 #include <QtQuickTest>
+#include <dsd-neo/core/state_fwd.h>
 
 #include "qml_test_context.h"
+
+/* Pulled in by the DMR library that backs the imports library's CSV validation.
+ * Nothing here decodes anything, so the vocoder descrambler is a stub -- the
+ * same arrangement UI_QT_IMPORTED_FILES uses. */
+void
+LFSRN(const char* BufferIn, char* BufferOut, dsd_state* state) {
+    (void)BufferIn;
+    (void)BufferOut;
+    (void)state;
+}
 
 QUICK_TEST_MAIN_WITH_SETUP(dsd_neo_qml, Setup)

--- a/tests/ui/test_ui_qt_session_args.cpp
+++ b/tests/ui/test_ui_qt_session_args.cpp
@@ -147,6 +147,44 @@ test_defaults_and_overrides(void) {
 }
 
 void
+test_csv_args(void) {
+    SessionArgsError error = SessionArgsError::None;
+
+    /* CSV paths must be discrete argv elements: the extraArgs field is
+     * whitespace-split, so a path with a space can only survive here. */
+    QVariantMap sys = usb_system();
+    sys.insert(QStringLiteral("chanCsvPath"), QStringLiteral("/data/imports/chan map.csv"));
+    sys.insert(QStringLiteral("groupCsvPath"), QStringLiteral("/data/imports/county.csv"));
+    sys.insert(QStringLiteral("keyCsvPath"), QStringLiteral("/data/imports/keys.csv"));
+    sys.insert(QStringLiteral("keyCsvHex"), false);
+    sys.insert(QStringLiteral("extraArgs"), QStringLiteral("--wav-dir /tmp"));
+    const QStringList args = session_args_build(sys, SessionArgPrefs(), &error);
+    expect("csv build succeeds", error == SessionArgsError::None);
+    qsizetype at = args.indexOf(QStringLiteral("-C"));
+    expect("chan path follows -C intact",
+           at >= 0 && at + 1 < args.size() && args.at(at + 1) == QStringLiteral("/data/imports/chan map.csv"));
+    at = args.indexOf(QStringLiteral("-G"));
+    expect("group path follows -G",
+           at >= 0 && at + 1 < args.size() && args.at(at + 1) == QStringLiteral("/data/imports/county.csv"));
+    at = args.indexOf(QStringLiteral("-k"));
+    expect("dec keys use -k",
+           at >= 0 && at + 1 < args.size() && args.at(at + 1) == QStringLiteral("/data/imports/keys.csv"));
+    expect("dec keys never emit -K", !args.contains(QStringLiteral("-K")));
+    expect("csv args coexist with extra args", args.contains(QStringLiteral("--wav-dir")));
+
+    sys.insert(QStringLiteral("keyCsvHex"), true);
+    const QStringList hexArgs = session_args_build(sys, SessionArgPrefs(), &error);
+    expect("hex keys use -K", hexArgs.contains(QStringLiteral("-K")));
+    expect("hex keys never emit -k", !hexArgs.contains(QStringLiteral("-k")));
+
+    /* Absent or empty fields emit nothing — legacy systems keep their argv. */
+    const QStringList bare = session_args_build(usb_system(), SessionArgPrefs(), &error);
+    expect("no csv fields emit no csv flags",
+           !bare.contains(QStringLiteral("-C")) && !bare.contains(QStringLiteral("-G"))
+               && !bare.contains(QStringLiteral("-k")) && !bare.contains(QStringLiteral("-K")));
+}
+
+void
 test_ppm_shapes(void) {
     SessionArgsError error = SessionArgsError::None;
     QVariantMap sys = usb_system();
@@ -235,6 +273,7 @@ int
 main(void) {
     test_freq_validation();
     test_defaults_and_overrides();
+    test_csv_args();
     test_ppm_shapes();
     test_bias_tee_tristate();
     test_network_and_file_sources();

--- a/tests/ui/test_ui_qt_session_args.cpp
+++ b/tests/ui/test_ui_qt_session_args.cpp
@@ -96,13 +96,16 @@ test_explore_system(void) {
                                                             && !args.contains(QStringLiteral("-fs"))
                                                             && !args.contains(QStringLiteral("-ft")));
 
-    // Over rtl_tcp it is the same session with a different front end.
+    // Over rtl_tcp it is the same session with a different front end. The host
+    // lands in the ':'-delimited spec verbatim, so stray whitespace from the
+    // soft keyboard or a paste must be trimmed here — "10.0.2.2 " resolves to
+    // nothing and the start fails with an opaque input error.
     sys.insert(QStringLiteral("sourceType"), QStringLiteral("rtltcp"));
-    sys.insert(QStringLiteral("host"), QStringLiteral("10.0.2.2"));
+    sys.insert(QStringLiteral("host"), QStringLiteral("10.0.2.2  "));
     sys.insert(QStringLiteral("port"), 1234);
     const QStringList remote = session_args_build(sys, SessionArgPrefs(), &error);
     expect("explore builds over rtl_tcp", error == SessionArgsError::None);
-    expect("explore reaches the remote tuner",
+    expect("explore reaches the remote tuner, host trimmed",
            input_spec(remote) == QStringLiteral("rtltcp:10.0.2.2:1234:855.0000M:30:0:48:0:2"));
 
     // A frequency that never made it into the prefs must be refused here, the


### PR DESCRIPTION
## Summary

- Replaces the Android app's only CSV affordance — typing `-C chan.csv -G group.csv` into the free-text "Extra CLI args" field — with a real import UX for DMR/P25 trunking data: SAF file pickers, a persistent imported-files library, validation feedback, and live apply into a running session.
- **Core**: new dry-run validation API (`<dsd-neo/core/csv_validate.h>`, `dsd_csv_validate_{group,chan}_file` / `dsd_csv_validate_key_file_{dec,hex}`) reports accepted/skipped/total row counts by running the real import loops into throwaway heap state; public importer signatures unchanged.
- **Core/app_control**: runtime channel-map import is now an atomic reload (import into throwaway state, adopt on success) instead of additive — re-applying a map no longer appends duplicate LCN entries or leaves stale `trunk_chan_map` slots, and a failed import leaves the live map untouched.
- **Storage**: new `DecoderHost::importDocument()` seam materializes picked documents into durable app storage (`files/imports/` on Android via `AppSupport.importDocumentToFiles`, `QStandardPaths::AppDataLocation/imports` on desktop) — the previous cache-dir copy path is evictable and overwrote on display-name collisions. Collisions unique-ify (`chan.csv` → `chan (2).csv`); updates stage + rename so a half-copied CSV is never observable.
- **UI**: `ImportedFilesModel` (JSON-persisted library with per-file type + validation counts), a Settings → Imported files management screen (update-from-file, remove with used-by warning that clears referencing systems), and a wizard "Trunking data" panel with picker rows for channel map / talkgroups / encryption keys.
- **Session args**: saved systems gain first-class `chanCsvPath`/`groupCsvPath`/`keyCsvPath`/`keyCsvHex` fields emitted as discrete `-C`/`-G`/`-k`/`-K` argv elements (the extras field is whitespace-split, so paths with spaces only survive this way); absent fields in legacy stores read as none.
- **Live import**: `CommandBridge` exposes the existing `DSD_APP_CMD_IMPORT_*` runtime commands; long-pressing the running session's title on the monitor opens the edit wizard, and saving pushes its CSVs into the live engine.
- Validated end-to-end in the Android emulator per the documented rig (SAF import of every file type, counts, persistence across restart, unique-ify, wizard assignment, live apply confirmed via engine-thread log, in-use removal, dark/light themes). That pass surfaced and fixed three real bugs: the CSV MIME name filter greying out every `.csv` in the picker, untrimmed host text breaking the rtl_tcp input spec, and the live-apply path being unreachable while the tab shell is hidden during a session.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: **file input / parser** (CSV importers gained optional stats counters; open path policy unchanged — all reads still funnel through `dsd_path_fopen_user_read_file`).
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope (none added).
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — 525/525, including new `CORE_CSV_VALIDATE`, `HEADERS_PUBLIC_CORE_CSV_VALIDATE`, and the channel-map reload regression in `UI_MENU_SERVICES`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes (no workflow changes)
- [ ] `tools/osv_scan.sh` for dependency input changes (no dependency changes)
- [ ] `tools/check_secret_redaction.sh` etc. (no security-sensitive workflow/release changes)
- [x] Qt UI tests under `-DDSD_ENABLE_QT_UI=ON`: `UI_QT_PERSISTENCE`, `UI_QT_SESSION_ARGS`, new `UI_QT_IMPORTED_FILES`
- [x] Android emulator pass per `ANDROID_EMULATOR.md` (API 36, arm64 translation, fake rtl_tcp session)

## Risk

- Security/dependency impact: none new — SAF imports are copied through the existing content-resolver path into app-private storage; core file opens keep the `O_NOFOLLOW`/regular-file policy; no new permissions or dependencies.
- CLI/UI behavior impact: CLI unchanged. Android/Qt UI gains the imports library screen, wizard trunking-data pickers, and the monitor-header long-press; existing `extraArgs`-based `-C`/`-G` setups keep working. Runtime channel-map re-import now replaces instead of appending (behavior fix).
- Compatibility or packaging impact: saved-systems JSON gains four optional fields (absent = none, legacy stores load unchanged); new `imported_files.json` store; no packaging changes.
