### PR TITLE
ui/qt: RadioReference import UX — reversible stages, keyed-build credentials

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -307,6 +307,30 @@ jobs:
         shell: bash
         run: ctest --preset dev-debug -R '^UI_QT_' --output-on-failure
 
+      # The baked RadioReference key is a compile-time constant, so the shipped
+      # configuration — a build that carries its own key and must ignore any
+      # stored override — is a branch no other job here can reach. The APK job
+      # builds it but cannot run tests; every other job is keyless.
+      #
+      # Reconfiguring the same tree costs a relink: DSD_RR_APP_KEY only feeds a
+      # generated one-line C file. The key below is a dummy that no request is
+      # ever made with — the transport in this test is faked — and it is
+      # deliberately NOT the repository secret, so this step stays meaningful on
+      # a fork with no secrets configured.
+      - name: Re-test the RadioReference model as a keyed build
+        shell: bash
+        env:
+          DSD_RR_APP_KEY: CI_DUMMY_KEY_not_a_real_credential
+        run: |
+          set -euxo pipefail
+          cmake --preset dev-debug \
+            -DDSD_ENABLE_QT_UI=ON \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --build --preset dev-debug -j \
+            --target dsd-neo_test_ui_qt_radio_reference_model
+          ctest --preset dev-debug -R '^UI_QT_RADIO_REFERENCE$' --output-on-failure
+
       - name: Show ccache stats
         shell: bash
         run: ccache --show-stats

--- a/docs/radioreference-import.md
+++ b/docs/radioreference-import.md
@@ -23,7 +23,11 @@ terminal UI can adopt it later; today the Qt Quick frontend is the only consumer
 ## The application key
 
 RadioReference issues one key per *application*, separately from your account. dsd-neo can carry a
-project key baked in at build time, and you can override it with your own.
+project key baked in at build time; a build that carries one never asks the user for a key — the
+key fields stay hidden, and sign-in is just the RadioReference username and password. In a build
+without a baked key, the import screen and Settings both offer the key field, and the entered key
+is stored. A stored key always takes precedence over the baked one; in a keyed build the Settings
+field only reappears while such an override is stored, so it can be seen and cleared.
 
 Baking one in:
 

--- a/docs/radioreference-import.md
+++ b/docs/radioreference-import.md
@@ -2,8 +2,9 @@
 
 The Android app can build a system's trunking data straight from the
 [RadioReference.com](https://www.radioreference.com/) database instead of asking you to hand-write
-CSVs: browse to a system by zip code, by country/state/county, or by its system ID, pick the site,
-and the app generates the talkgroup list and — where the protocol needs one — the channel map, in
+CSVs: browse to a system by zip code, by country/state/county, or by its system ID, pick the site
+(a trunked system with only one is picked for you), and the app generates the talkgroup list and —
+where the protocol needs one — the channel map, in
 the same formats `docs/csv-formats.md` describes. The generated files land in the imported-files
 library like any other import, and the add-system wizard opens with the frequency, the decode flag
 and both files already filled in.
@@ -23,11 +24,21 @@ terminal UI can adopt it later; today the Qt Quick frontend is the only consumer
 ## The application key
 
 RadioReference issues one key per *application*, separately from your account. dsd-neo can carry a
-project key baked in at build time; a build that carries one never asks the user for a key — the
-key fields stay hidden, and sign-in is just the RadioReference username and password. In a build
-without a baked key, the import screen and Settings both offer the key field, and the entered key
-is stored. A stored key always takes precedence over the baked one; in a keyed build the Settings
-field only reappears while such an override is stored, so it can be seen and cleared.
+project key baked in at build time, and **the baked key is authoritative**: a build that carries one
+never asks the user for a key and never lets one be substituted. The key fields stay hidden in both
+the import screen and Settings, sign-in is just the RadioReference username and password, and an
+auth failure names only those two as possible culprits.
+
+In a build without a baked key the import screen and Settings both offer the key field, and the
+entered key is stored in the app's settings.
+
+The two do not mix. A key stored under a keyless build is *ignored*, not merged, once a keyed build
+is installed over it — the app's settings are shared between builds, and a leftover override that
+outranked the working baked key would fail every request with no in-app way to reach it. It is left
+in place rather than erased, so a keyless build run later still finds it.
+
+The trade-off is deliberate: in a keyed build there is no in-app recovery if the project key is
+revoked or exhausts its quota. Recovering means shipping a build with a new key.
 
 Baking one in:
 
@@ -56,13 +67,25 @@ with their own premium credentials, is squarely the sanctioned case.
 
 ## Credentials
 
-- The **username** and an optional **application-key override** persist in the app's settings
-  (`Settings → RadioReference account`).
+- The **username** and, in a build without a baked key, the **application key** persist in the app's
+  settings (`Settings → RadioReference account`). The key row is offered only where the user is the
+  one who has to supply a key — see [The application key](#the-application-key).
 - The **password is held in memory only** and is asked for once per app session. It is never
   written to disk, never logged, and never reaches a status line or an error message.
 
 After the password is entered the app verifies the account once (`getUserData`) and reports an
 expired premium subscription as such, rather than letting it surface later as an opaque failure.
+
+## Finding a system
+
+The import screen is a drill-down with two stages, and shows one or the other, never both:
+
+- **Find** — the credentials form, the search controls (zip / browse / system ID) and the results
+  list. Searching again from here replaces the results.
+- **The system** — its sites, talkgroup summary, import options and preview. Loading a system
+  replaces the find stage; a `‹ All systems` row (`‹ Search` when no list was fetched) is the way
+  back to it. The results list survives that, so importing several systems from one search is a
+  tap each.
 
 ## What gets generated
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -95,6 +95,37 @@ ctest --preset dev-debug -L qml --output-on-failure
 It carries its own headless environment (offscreen platform, software renderer)
 in the CTest registration, so it needs no window server and no GPU.
 
+#### Build-time constants that gate a branch
+
+`DSD_RR_APP_KEY` bakes the RadioReference application key into a generated C
+source at configure time, so `dsd_rr_builtin_app_key()` is a compile-time
+constant and a test can only ever see the configuration it was built in. A
+keyless build — every developer machine and every CI job but one — cannot reach
+the shipped behaviour where the baked key is authoritative and a stored override
+is ignored.
+
+Two things close that, and both are needed:
+
+- `RadioReferenceModel::chooseAppKey(builtin, override)` is a static, public pure
+  function taking both candidates as arguments, so every combination is asserted
+  in any build. This is what catches a regression on a developer's machine.
+- The `qt-ui-tests` job reconfigures the same tree with a dummy
+  `DSD_RR_APP_KEY` and re-runs `UI_QT_RADIO_REFERENCE`. Only the generated
+  one-line key file recompiles, so it costs a relink. This is what proves the
+  chosen key reaches the SOAP envelope and the ignored override does not.
+
+The pattern generalises: when a build-time constant selects a branch, take the
+constant as a parameter somewhere testable rather than reading it in the code
+under test, and reconfigure in CI to prove the wiring. A case that reads the
+constant directly must assert *against* it (`hasAppKey() == baked`) rather than
+assume a configuration, or it passes only in the one it was written in.
+
+```sh
+DSD_RR_APP_KEY=CI_DUMMY_KEY_not_a_real_credential cmake --preset dev-debug -DDSD_ENABLE_QT_UI=ON
+cmake --build --preset dev-debug -j --target dsd-neo_test_ui_qt_radio_reference_model
+ctest --preset dev-debug -R '^UI_QT_RADIO_REFERENCE$' --output-on-failure
+```
+
 ## Continuous Integration
 
 GitHub Actions runs tests and quality checks on pull requests, primary-branch

--- a/include/dsd-neo/runtime/radioreference.h
+++ b/include/dsd-neo/runtime/radioreference.h
@@ -247,9 +247,12 @@ typedef struct {
     char sub_expire[64];
 } dsd_rr_user_info;
 
-/** Warnings surfaced in the import preview. One shape for every generator. */
+/** Warnings surfaced in the import preview. One shape for every generator.
+ *  Sized for the longest message a generator emits — the 241-byte P25
+ *  no-channel-identifiers explanation — since a bound that trims a real
+ *  sentence mid-word reads as a rendering bug, not a bound. */
 typedef struct {
-    char text[192];
+    char text[256];
 } dsd_rr_warning;
 
 typedef struct {

--- a/include/dsd-neo/runtime/radioreference.h
+++ b/include/dsd-neo/runtime/radioreference.h
@@ -247,12 +247,17 @@ typedef struct {
     char sub_expire[64];
 } dsd_rr_user_info;
 
-/** Warnings surfaced in the import preview. One shape for every generator.
- *  Sized for the longest message a generator emits — the 241-byte P25
- *  no-channel-identifiers explanation — since a bound that trims a real
- *  sentence mid-word reads as a rendering bug, not a bound. */
+/** Bytes in a warning, terminator included. Sized for the longest message a
+ *  generator emits — the 241-byte P25 no-channel-identifiers explanation —
+ *  since a bound that trims a real sentence mid-word reads as a rendering bug,
+ *  not a bound. Generators that build a warning with a format string must stage
+ *  it in a buffer of this size, or their own local would reimpose the older,
+ *  smaller bound before the text ever reaches a slot. */
+#define DSD_RR_WARNING_TEXT_MAX 256
+
+/** Warnings surfaced in the import preview. One shape for every generator. */
 typedef struct {
-    char text[256];
+    char text[DSD_RR_WARNING_TEXT_MAX];
 } dsd_rr_warning;
 
 typedef struct {

--- a/src/runtime/radioreference/rr_generate.c
+++ b/src/runtime/radioreference/rr_generate.c
@@ -619,7 +619,7 @@ rr_collect_rows(const dsd_rr_site* site, long min_chan, long max_chan, rr_chan_r
  */
 static void
 rr_warn_skips(const rr_skip_counts* skips, const char* label, const char* range, dsd_rr_warning_list* warnings) {
-    char msg[192];
+    char msg[DSD_RR_WARNING_TEXT_MAX];
     if (skips->no_freq > 0U) {
         (void)DSD_SNPRINTF(msg, sizeof(msg), "%zu site frequency/frequencies had no usable value and were skipped.",
                            skips->no_freq);
@@ -759,7 +759,7 @@ rr_chan_p25(const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warning
         return;
     }
 
-    char msg[192];
+    char msg[DSD_RR_WARNING_TEXT_MAX];
     if (skips.unusable > 0U) {
         (void)DSD_SNPRINTF(msg, sizeof(msg), "%zu site frequency/frequencies had no usable value and were skipped.",
                            skips.unusable);
@@ -939,7 +939,7 @@ rr_chan_edacs(const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warni
     }
 
     if (dropped > 0U) {
-        char msg[192];
+        char msg[DSD_RR_WARNING_TEXT_MAX];
         (void)DSD_SNPRINTF(msg, sizeof(msg), "%zu EDACS LCN(s) above 25 were dropped; only 25 are reachable.", dropped);
         rr_warn(warnings, msg);
     }
@@ -963,7 +963,7 @@ rr_chan_edacs(const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warni
         rr_text_chan_row(text, (long)lcn, by_lcn[lcn], NULL);
     }
     if (gaps > 0U) {
-        char msg[192];
+        char msg[DSD_RR_WARNING_TEXT_MAX];
         (void)DSD_SNPRINTF(msg, sizeof(msg),
                            "%zu EDACS LCN slot(s) have no frequency and were written as placeholders; the import "
                            "reports them as skipped rows, which keeps every later LCN in position.",
@@ -1019,7 +1019,7 @@ rr_chan_conventional(const dsd_rr_site* sites, size_t site_count, rr_text* text,
         count++;
     }
 
-    char msg[192];
+    char msg[DSD_RR_WARNING_TEXT_MAX];
     if (empty > 0U) {
         (void)DSD_SNPRINTF(msg, sizeof(msg), "%zu selected repeater(s) list no usable frequency and were skipped.",
                            empty);
@@ -1345,7 +1345,7 @@ rr_group_emit(rr_text* text, const dsd_rr_talkgroup* talkgroup, int partial_enc_
  */
 static void
 rr_group_warn(dsd_rr_warning_list* warnings, const rr_group_counts* counts) {
-    char msg[192];
+    char msg[DSD_RR_WARNING_TEXT_MAX];
     if (counts->duplicates > 0U) {
         (void)DSD_SNPRINTF(msg, sizeof(msg), "%zu duplicate talkgroup ID(s) were dropped; the first one wins.",
                            counts->duplicates);

--- a/src/ui/qt/qml/ImportsScreen.qml
+++ b/src/ui/qt/qml/ImportsScreen.qml
@@ -330,6 +330,10 @@ Item {
         anchors.margins: Theme.screenPadding
         anchors.bottomMargin: Theme.gap
         visible: radioReference.available
+        // Same gate as the refresh action below: both drive the one model and
+        // one system at a time, and opening the import screen resets it out
+        // from under a refresh this screen started.
+        enabled: !radioReference.busy
         text: qsTr("Import from RadioReference")
         onClicked: {
             screen.notice = ""

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -400,13 +400,17 @@ Window {
         system: mainRoot.sessionSystem
         opacity: mainRoot.monitorMode ? 1.0 : 0.0
         visible: opacity > 0.0
-        // The wizard ("Save as a system") and the spectrum both open over a
-        // running session, and TapHandlers never take exclusive grabs, so without
-        // this a tap on the layer above also lands on "Stop listening", which sits
-        // at exactly the same rect underneath both of them and ends the session.
+        // The wizard ("Save as a system"), the spectrum, and the RadioReference
+        // screen the wizard pushes from its tune step all open over a running
+        // session, and TapHandlers never take exclusive grabs, so without this a
+        // tap on the layer above also lands on "Stop listening", which sits at
+        // exactly the same rect underneath all three and ends the session.
         // That is what "Explore from here" — the one way out of view-only — did
-        // instead of offering to hand the tuner over.
+        // instead of offering to hand the tuner over. The RadioReference term is
+        // what lets that screen stay lit over the monitor rather than standing
+        // down into a three-layer deadlock.
         enabled: opacity > 0.9 && !mainRoot.wizardOpen && !mainRoot.spectrumOpen
+                 && !mainRoot.radioReferenceOpen
 
         Behavior on opacity {
             NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
@@ -503,6 +507,8 @@ Window {
     WizardScreen {
         id: wizard
 
+        objectName: "wizardScreen"
+
         anchors.fill: safeArea
         opacity: mainRoot.wizardOpen ? 1.0 : 0.0
         visible: opacity > 0.0
@@ -595,16 +601,23 @@ Window {
     // ---- RadioReference import (pushed from Settings, the library, or the
     // wizard) ----
     // Declared after the imports library because declaration order is z-order
-    // among siblings and this opens over it. It stands down for the monitor for
-    // the same reason the library does: two lit, enabled full-screen layers
-    // means one tap lands on both.
+    // among siblings and this opens over it.
+    //
+    // Unlike the library, this does NOT stand down for the monitor. The wizard
+    // opens over a running session ("Save as a system") and pushes this screen
+    // from its tune step, so a !monitorMode term here left all three layers
+    // inert at once — this one unlit and disabled, the wizard disabled by its
+    // own !radioReferenceOpen term, the monitor disabled by !wizardOpen — with
+    // no back key anywhere in the tree to escape it. It owns a full-bleed
+    // opaque Theme.bg backdrop, so it covers the session exactly as the wizard
+    // does; the monitor gives up its taps below instead.
     RadioReferenceScreen {
         id: radioReferenceScreen
 
         objectName: "radioReferenceScreen"
 
         anchors.fill: safeArea
-        opacity: mainRoot.radioReferenceOpen && !mainRoot.monitorMode ? 1.0 : 0.0
+        opacity: mainRoot.radioReferenceOpen ? 1.0 : 0.0
         visible: opacity > 0.0
         enabled: opacity > 0.9
 

--- a/src/ui/qt/qml/RadioReferenceScreen.qml
+++ b/src/ui/qt/qml/RadioReferenceScreen.qml
@@ -801,7 +801,7 @@ Item {
 
                             width: parent.width - zipGo.width - 10
                             mono: true
-                            placeholderText: qsTr("e.g. 52401")
+                            placeholderText: qsTr("e.g. 12345")
                             inputMethodHints: Qt.ImhDigitsOnly
                             // A leading-zero zip resolves correctly as an int, so
                             // the validator is only here to stop a stray letter

--- a/src/ui/qt/qml/RadioReferenceScreen.qml
+++ b/src/ui/qt/qml/RadioReferenceScreen.qml
@@ -88,6 +88,12 @@ Item {
         screen.selectedSites = []
         screen.simulcastOverride = -1
         screen.eskOverride = -1
+        // A single-site trunked system has exactly one right answer, so give
+        // it: the preview and the Import button light up without asking for a
+        // tap on the only row there is. Conventional lists stay untouched —
+        // "which repeaters can I hear" is a real question even with one entry.
+        if (!radioReference.conventional && screen.siteList.length === 1)
+            screen.selectedSites = [0]
         screen.refreshPlan()
     }
 
@@ -125,6 +131,12 @@ Item {
 
     /** Clear everything that belongs to one visit. */
     function reset() {
+        // A visit never starts mid-system: drop whatever the last visit — or a
+        // library refresh, which loads the system it re-fetches — left behind.
+        // The model keeps the results list across this on purpose, so "come
+        // back and import the next one" starts at the list, not at a search.
+        if (screen.rrLive())
+            radioReference.closeSystem()
         screen.sourceMode = 0
         zipField.text = ""
         sidField.text = ""
@@ -540,10 +552,15 @@ Item {
         anchors.leftMargin: Theme.screenPadding
         anchors.rightMargin: Theme.screenPadding
         visible: text.length > 0
+        // The auth wording names only what the user can fix here: a build that
+        // bakes the application key (with no override stored) leaves username
+        // and password as the two possible culprits.
         text: radioReference.errorIsSubscription
               ? qsTr("This account's RadioReference premium subscription has expired.")
               : radioReference.errorIsAuth
-                ? qsTr("RadioReference did not accept that username, password or application key.")
+                ? (radioReference.buildHasAppKey && prefs.rrAppKey.length === 0
+                   ? qsTr("RadioReference did not accept that username or password.")
+                   : qsTr("RadioReference did not accept that username, password or application key."))
                 : radioReference.errorText.length > 0 ? radioReference.errorText : screen.notice
         font.family: Theme.sans
         font.pixelSize: 13
@@ -585,12 +602,17 @@ Item {
             // Every user authenticates with their own RadioReference account and
             // needs their own premium subscription; nothing is pooled, and the
             // password is never written anywhere.
+            //
+            // Username and password lead, the way every sign-in form does. The
+            // application key comes last and only in a build that bakes none in
+            // (buildHasAppKey, not hasAppKey: a stored override must not hide
+            // the field that edits it).
             UiPanel {
                 // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
                 objectName: "radioReferenceCredentials"
 
                 width: parent.width
-                visible: !radioReference.hasAppKey || !radioReference.credentialsReady
+                visible: !radioReference.credentialsReady
                 height: credentialsColumn.height + 2 * Theme.cardPadding
 
                 Column {
@@ -604,45 +626,6 @@ Item {
 
                     MicroLabel {
                         text: qsTr("RadioReference account")
-                    }
-
-                    Text {
-                        width: parent.width
-                        visible: !radioReference.hasAppKey
-                        text: qsTr("Application key")
-                        font.family: Theme.sans
-                        font.pixelSize: 13
-                        color: Theme.textSecondary
-                    }
-
-                    PlexTextField {
-                        id: appKeyField
-
-                        // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
-                        objectName: "radioReferenceAppKeyField"
-
-                        width: parent.width
-                        visible: !radioReference.hasAppKey
-                        mono: true
-                        text: prefs.rrAppKey
-                        placeholderText: qsTr("application key")
-                        inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
-                        // Commit on Enter or focus loss, not per keystroke: every
-                        // write lands in QSettings (disk on Android).
-                        onEditingFinished: prefs.rrAppKey = text
-                    }
-
-                    Text {
-                        width: parent.width
-                        visible: !radioReference.hasAppKey
-                        text: qsTr("This build carries no application key. Request one at <a href=\"https://www.radioreference.com/account/api/apply\">radioreference.com/account/api/apply</a>.")
-                        textFormat: Text.StyledText
-                        linkColor: Theme.cyan
-                        font.family: Theme.sans
-                        font.pixelSize: 12
-                        color: Theme.textSubdued
-                        wrapMode: Text.Wrap
-                        onLinkActivated: function (link) { Qt.openUrlExternally(link) }
                     }
 
                     Text {
@@ -706,6 +689,50 @@ Item {
                         wrapMode: Text.Wrap
                     }
 
+                    Text {
+                        width: parent.width
+                        visible: !radioReference.buildHasAppKey
+                        text: qsTr("Application key")
+                        font.family: Theme.sans
+                        font.pixelSize: 13
+                        color: Theme.textSecondary
+                    }
+
+                    PlexTextField {
+                        id: appKeyField
+
+                        // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
+                        objectName: "radioReferenceAppKeyField"
+
+                        width: parent.width
+                        visible: !radioReference.buildHasAppKey
+                        mono: true
+                        text: prefs.rrAppKey
+                        placeholderText: qsTr("application key")
+                        inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
+                        // Commit on Enter or focus loss, not per keystroke: every
+                        // write lands in QSettings (disk on Android). The account
+                        // check fires the same way the password field's does, so
+                        // whichever field is answered last completes the form.
+                        onEditingFinished: {
+                            prefs.rrAppKey = text
+                            screen.verifyAccount()
+                        }
+                    }
+
+                    Text {
+                        width: parent.width
+                        visible: !radioReference.buildHasAppKey
+                        text: qsTr("This build carries no application key. Request one at <a href=\"https://www.radioreference.com/account/api/apply\">radioreference.com/account/api/apply</a>.")
+                        textFormat: Text.StyledText
+                        linkColor: Theme.cyan
+                        font.family: Theme.sans
+                        font.pixelSize: 12
+                        color: Theme.textSubdued
+                        wrapMode: Text.Wrap
+                        onLinkActivated: function (link) { Qt.openUrlExternally(link) }
+                    }
+
                     OutlineButton {
                         // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
                         objectName: "radioReferenceCheckAccountButton"
@@ -719,12 +746,16 @@ Item {
             }
 
             // ---- Where to look ----
+            // Hidden while a system is loaded: the screen is a drill-down, and
+            // showing the search controls above a system being configured made
+            // it read as two screens at once — searching from there fetched a
+            // results list that stayed invisible behind the loaded system.
             UiPanel {
                 // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
                 objectName: "radioReferenceSourcePanel"
 
                 width: parent.width
-                visible: radioReference.credentialsReady
+                visible: radioReference.credentialsReady && !screen.systemLoaded
                 height: sourceColumn.height + 2 * Theme.cardPadding
 
                 Column {
@@ -909,6 +940,55 @@ Item {
                             tapEnabled: !radioReference.busy
                             onTapped: screen.openSystem(systemRow.modelData.sid)
                         }
+                    }
+                }
+            }
+
+            // ---- Back to the find stage ----
+            // The drill-down's way out: a loaded system replaces the find panel
+            // and the results list, and this row is what puts them back. The
+            // model keeps the results across closeSystem(), so "back, pick the
+            // next one" is one tap — the loop for importing several systems
+            // from one search.
+            Item {
+                // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
+                objectName: "radioReferenceBackToResults"
+
+                width: parent.width
+                height: 40
+                visible: screen.systemLoaded
+                opacity: radioReference.busy ? 0.5 : 1.0
+
+                Row {
+                    anchors.left: parent.left
+                    anchors.verticalCenter: parent.verticalCenter
+                    spacing: 8
+
+                    Text {
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: "‹"
+                        font.pixelSize: 22
+                        color: Theme.cyan
+                    }
+
+                    Text {
+                        anchors.verticalCenter: parent.verticalCenter
+                        // Named after where it lands: the results list when one
+                        // is in hand, otherwise the find-a-system panel.
+                        text: radioReference.systems.length > 0 ? qsTr("All systems") : qsTr("Search")
+                        font.family: Theme.sans
+                        font.pixelSize: 14
+                        font.weight: Font.DemiBold
+                        color: Theme.cyan
+                    }
+                }
+
+                TapHandler {
+                    enabled: !radioReference.busy
+                    onTapped: {
+                        screen.clearNotice()
+                        if (screen.rrLive())
+                            radioReference.closeSystem()
                     }
                 }
             }

--- a/src/ui/qt/qml/RadioReferenceScreen.qml
+++ b/src/ui/qt/qml/RadioReferenceScreen.qml
@@ -612,7 +612,13 @@ Item {
                 objectName: "radioReferenceCredentials"
 
                 width: parent.width
-                visible: !radioReference.credentialsReady
+                // credentialsReady means the fields are FILLED, not accepted —
+                // so an account failure reopens the form, or the session-only
+                // password would have nowhere left to be retyped. Both account
+                // errors qualify: auth wants a correction, an expired
+                // subscription wants a different account.
+                visible: !radioReference.credentialsReady || radioReference.errorIsAuth
+                         || radioReference.errorIsSubscription
                 height: credentialsColumn.height + 2 * Theme.cardPadding
 
                 Column {

--- a/src/ui/qt/qml/RadioReferenceScreen.qml
+++ b/src/ui/qt/qml/RadioReferenceScreen.qml
@@ -69,6 +69,13 @@ Item {
     readonly property bool systemLoaded: radioReference.systemDetails.sid !== undefined
                                          && radioReference.systemDetails.sid > 0
 
+    // Whether the application key is the user's to supply — and so whether this
+    // screen offers a field for it and names it as a possible culprit. A build
+    // that bakes a key in answers no to both: fillAuth() ignores any stored
+    // override there, so the key is neither editable nor a credential in play.
+    // Same rule as the Settings row.
+    readonly property bool offersAppKey: !radioReference.buildHasAppKey
+
     // The resolved RadioReference type name, which is what decides whether the
     // simulcast and ESK toggles mean anything here. Matching the name rather
     // than the protocol enum keeps QML out of the business of tracking C
@@ -85,15 +92,24 @@ Item {
     readonly property var siteList: radioReference.sites
 
     onSiteListChanged: {
-        screen.selectedSites = []
         screen.simulcastOverride = -1
         screen.eskOverride = -1
+        // Belongs to the system in hand like the two overrides do, not to the
+        // screen: the back row makes "system A, back, system B" one visit, and
+        // A's answer would otherwise be written into B's import provenance.
+        screen.partialEncAsDe = true
         // A single-site trunked system has exactly one right answer, so give
         // it: the preview and the Import button light up without asking for a
         // tap on the only row there is. Conventional lists stay untouched —
         // "which repeaters can I hear" is a real question even with one entry.
-        if (!radioReference.conventional && screen.siteList.length === 1)
-            screen.selectedSites = [0]
+        //
+        // `trunked`, not `!conventional`: a system type this build cannot import
+        // is neither, and reading it as trunked selected and lit up the one row
+        // of an LTR or MPT-1327 system whose plan can never be built.
+        //
+        // Assigned once rather than cleared and then filled: every write to
+        // selectedSites runs refreshPlan(), and that builds both CSVs.
+        screen.selectedSites = (radioReference.trunked && screen.siteList.length === 1) ? [0] : []
         screen.refreshPlan()
     }
 
@@ -135,7 +151,13 @@ Item {
         // library refresh, which loads the system it re-fetches — left behind.
         // The model keeps the results list across this on purpose, so "come
         // back and import the next one" starts at the list, not at a search.
-        if (screen.rrLive())
+        //
+        // Only when there is a system to drop, or a fetch still on its way to
+        // becoming one: closeSystem() retires the model's error along with it,
+        // and a rejected sign-in is the one error that must outlive a visit —
+        // it is what holds the credentials form open for the retype, and the
+        // password lives nowhere else. An idle visit that ended on one keeps it.
+        if (screen.rrLive() && (screen.systemLoaded || radioReference.busy))
             radioReference.closeSystem()
         screen.sourceMode = 0
         zipField.text = ""
@@ -247,6 +269,27 @@ Item {
     function verifyAccount() {
         if (screen.rrLive() && radioReference.credentialsReady)
             radioReference.checkAccount()
+    }
+
+    /**
+     * The "Check account" button, which is not the same gesture as finishing a
+     * field.
+     *
+     * Nothing on this screen takes keyboard focus — every control is a
+     * TapHandler — so a text field only emits editingFinished on Enter or when
+     * another field is tapped. Tapping the button leaves the field the user
+     * just filled uncommitted, and its answer never reaches prefs or the model.
+     * Move focus off first, which commits it, then check what the form holds.
+     */
+    function checkAccountTapped() {
+        credentialsColumn.forceActiveFocus()
+        if (screen.rrLive() && !radioReference.credentialsReady) {
+            screen.notice = qsTr("Fill in every field above first.")
+            screen.noticeIsProblem = true
+            return
+        }
+        screen.clearNotice()
+        screen.verifyAccount()
     }
 
     function findByZip() {
@@ -552,15 +595,16 @@ Item {
         anchors.leftMargin: Theme.screenPadding
         anchors.rightMargin: Theme.screenPadding
         visible: text.length > 0
-        // The auth wording names only what the user can fix here: a build that
-        // bakes the application key (with no override stored) leaves username
-        // and password as the two possible culprits.
+        // The auth wording names only what the user can fix here, which is the
+        // same set the form offers: a build that bakes the application key in,
+        // with no override stored, leaves username and password as the two
+        // possible culprits.
         text: radioReference.errorIsSubscription
               ? qsTr("This account's RadioReference premium subscription has expired.")
               : radioReference.errorIsAuth
-                ? (radioReference.buildHasAppKey && prefs.rrAppKey.length === 0
-                   ? qsTr("RadioReference did not accept that username or password.")
-                   : qsTr("RadioReference did not accept that username, password or application key."))
+                ? (screen.offersAppKey
+                   ? qsTr("RadioReference did not accept that username, password or application key.")
+                   : qsTr("RadioReference did not accept that username or password."))
                 : radioReference.errorText.length > 0 ? radioReference.errorText : screen.notice
         font.family: Theme.sans
         font.pixelSize: 13
@@ -604,9 +648,8 @@ Item {
             // password is never written anywhere.
             //
             // Username and password lead, the way every sign-in form does. The
-            // application key comes last and only in a build that bakes none in
-            // (buildHasAppKey, not hasAppKey: a stored override must not hide
-            // the field that edits it).
+            // application key comes last and only where the user is the one who
+            // supplies it — see offersAppKey.
             UiPanel {
                 // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
                 objectName: "radioReferenceCredentials"
@@ -697,7 +740,7 @@ Item {
 
                     Text {
                         width: parent.width
-                        visible: !radioReference.buildHasAppKey
+                        visible: screen.offersAppKey
                         text: qsTr("Application key")
                         font.family: Theme.sans
                         font.pixelSize: 13
@@ -711,7 +754,7 @@ Item {
                         objectName: "radioReferenceAppKeyField"
 
                         width: parent.width
-                        visible: !radioReference.buildHasAppKey
+                        visible: screen.offersAppKey
                         mono: true
                         text: prefs.rrAppKey
                         placeholderText: qsTr("application key")
@@ -744,9 +787,15 @@ Item {
                         objectName: "radioReferenceCheckAccountButton"
 
                         width: parent.width
-                        enabled: !radioReference.busy && radioReference.credentialsReady
+                        // Deliberately not gated on credentialsReady. The fields
+                        // commit on Enter or focus loss, and a TapHandler takes
+                        // no focus — so the field the user is still typing in
+                        // has not committed when they reach for this button, and
+                        // gating on the committed state greys it out exactly
+                        // when the last answer is the one still sitting in it.
+                        enabled: !radioReference.busy
                         text: qsTr("Check account")
-                        onClicked: screen.verifyAccount()
+                        onClicked: screen.checkAccountTapped()
                     }
                 }
             }

--- a/src/ui/qt/qml/SettingsScreen.qml
+++ b/src/ui/qt/qml/SettingsScreen.qml
@@ -314,7 +314,12 @@ Item {
 
                     DisclosureRow {
                         title: qsTr("Import a system")
-                        subtitle: qsTr("Talkgroups and channel maps from the online database")
+                        // Not "talkgroups and channel maps": that framing reads
+                        // as trunked-only, and the import serves conventional
+                        // systems just as well. Same line as the wizard's entry
+                        // row on purpose — one action, one description — and
+                        // anything longer elides on a phone-width row.
+                        subtitle: qsTr("Fills in the frequency, decode mode and talkgroups")
                         showDivider: true
                         onTapped: screen.openRadioReference()
                     }

--- a/src/ui/qt/qml/SettingsScreen.qml
+++ b/src/ui/qt/qml/SettingsScreen.qml
@@ -358,17 +358,17 @@ Item {
 
                     // A build that bakes the application key in does not ask for
                     // one: this row sat right under Username looking like a
-                    // password box, and anything typed here becomes a stored
-                    // override that outranks the working baked key. It stays
-                    // visible while an override IS stored — the field is the
-                    // only way to see and clear it, and clearing re-hides it.
+                    // password box. Nor does it show a stored override left over
+                    // from a keyless build — fillAuth() ignores it there, so it
+                    // is not a credential in play and a field for it would only
+                    // invite editing a key this build does not use.
                     Item {
                         // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
                         objectName: "settingsRrAppKeyRow"
 
                         width: parent.width
                         height: 76
-                        visible: !radioReference.buildHasAppKey || prefs.rrAppKey.length > 0
+                        visible: !radioReference.buildHasAppKey
 
                         Text {
                             id: rrKeyLabel
@@ -391,11 +391,10 @@ Item {
                             height: 38
                             mono: true
                             text: prefs.rrAppKey
-                            // "Leave empty" is only true when there is a build
-                            // key to fall back to.
-                            placeholderText: radioReference.buildHasAppKey
-                                             ? qsTr("leave empty to use this build's key")
-                                             : qsTr("application key")
+                            // No "leave empty to use this build's key" branch:
+                            // the row is shown only where this build has no key
+                            // to fall back to.
+                            placeholderText: qsTr("application key")
                             inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
                             onEditingFinished: prefs.rrAppKey = text
                         }

--- a/src/ui/qt/qml/SettingsScreen.qml
+++ b/src/ui/qt/qml/SettingsScreen.qml
@@ -351,9 +351,19 @@ Item {
                         }
                     }
 
+                    // A build that bakes the application key in does not ask for
+                    // one: this row sat right under Username looking like a
+                    // password box, and anything typed here becomes a stored
+                    // override that outranks the working baked key. It stays
+                    // visible while an override IS stored — the field is the
+                    // only way to see and clear it, and clearing re-hides it.
                     Item {
+                        // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
+                        objectName: "settingsRrAppKeyRow"
+
                         width: parent.width
                         height: 76
+                        visible: !radioReference.buildHasAppKey || prefs.rrAppKey.length > 0
 
                         Text {
                             id: rrKeyLabel
@@ -376,7 +386,11 @@ Item {
                             height: 38
                             mono: true
                             text: prefs.rrAppKey
-                            placeholderText: qsTr("leave empty to use this build's key")
+                            // "Leave empty" is only true when there is a build
+                            // key to fall back to.
+                            placeholderText: radioReference.buildHasAppKey
+                                             ? qsTr("leave empty to use this build's key")
+                                             : qsTr("application key")
                             inputMethodHints: Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText
                             onEditingFinished: prefs.rrAppKey = text
                         }

--- a/src/ui/qt/qml/Util.js
+++ b/src/ui/qt/qml/Util.js
@@ -92,11 +92,17 @@ var LEGACY_DECODE_LABELS = {
 // bottom edge, so the first screen of waterfall usually has something on it.
 // `low`/`high` also bound the sweep — it wraps inside the band it began in rather
 // than walking off into spectrum nobody asked about.
+// `trunked` marks the bands where a bare carrier is far more often a trunked
+// control channel than a conventional voice channel: 700 and 800 are where the
+// statewide and county P25 systems the decode chips are pitched at live, and
+// 851.375 — the wizard's own frequency prefill — is one. VHF and UHF stay out
+// because conventional repeater pairs are at least as common there, so neither
+// answer would be a safe suggestion. See suggestsTrunking().
 var BANDS = [
     { label: "VHF", low: 136.0e6, high: 174.0e6, start: 154.0e6 },
     { label: "UHF", low: 380.0e6, high: 470.0e6, start: 453.0e6 },
-    { label: "700", low: 763.0e6, high: 806.0e6, start: 770.0e6 },
-    { label: "800", low: 806.0e6, high: 869.0e6, start: 855.0e6 }
+    { label: "700", low: 763.0e6, high: 806.0e6, start: 770.0e6, trunked: true },
+    { label: "800", low: 806.0e6, high: 869.0e6, start: 855.0e6, trunked: true }
 ]
 
 // The tuner's usable range. R820T/R828D — the tuner in essentially every RTL
@@ -137,33 +143,60 @@ function fmtMhz(hz) {
     return mhzText(hz) + " MHz"
 }
 
-function decodeLabel(flag) {
+// The catalog entry a chip flag names, or null. One lookup for every question
+// asked of the catalog, so a flag that has to be matched some other way — the
+// importer's composite forms are already the reason LEGACY_DECODE_LABELS exists
+// — is taught here once rather than in each accessor.
+function findDecodeMode(flag) {
     for (var i = 0; i < DECODE_MODES.length; i++) {
         if (DECODE_MODES[i].flag === flag)
-            return DECODE_MODES[i].short
+            return DECODE_MODES[i]
     }
+    return null
+}
+
+function decodeLabel(flag) {
+    var mode = findDecodeMode(flag)
+    if (mode !== null)
+        return mode.short
     if (LEGACY_DECODE_LABELS[flag] !== undefined)
         return LEGACY_DECODE_LABELS[flag]
     return "Auto"
 }
 
 function decodeHint(flag) {
-    for (var i = 0; i < DECODE_MODES.length; i++) {
-        if (DECODE_MODES[i].flag === flag)
-            return DECODE_MODES[i].hint
-    }
-    return ""
+    var mode = findDecodeMode(flag)
+    return mode !== null ? mode.hint : ""
 }
 
-// Whether picking this chip should suggest turning trunking on. Flags outside
-// the catalog (the RadioReference import's composite forms) never reach this:
-// the import carries the database's own trunking answer instead.
-function decodeSuggestsTrunking(flag) {
-    for (var i = 0; i < DECODE_MODES.length; i++) {
-        if (DECODE_MODES[i].flag === flag)
-            return DECODE_MODES[i].trunked === true
-    }
-    return false
+// Whether the wizard should suggest turning call-following on, for a user who
+// has not answered "is it trunked?" themselves.
+//
+// The chip is the stronger signal and answers alone whenever it names a system
+// type. The Auto chip names none, so the frequency is all there is to go on —
+// and that case is not academic: Auto is the default selection, so a user who
+// accepts the wizard's own 851.375 prefill never taps a chip at all. Reading
+// that as "not trunked" hands the decoder a control channel with call-following
+// off, which locks on and plays nothing, with no error to explain the silence.
+//
+// @a hz may be NaN (an empty or half-typed field); bandFor() returns null for
+// it, so the answer is simply "no suggestion".
+//
+// Flags outside the catalog (the RadioReference import's composite forms) never
+// reach this: the import carries the database's own trunking answer instead.
+function suggestsTrunking(flag, hz) {
+    var mode = findDecodeMode(flag)
+    if (mode === null)
+        return false
+    if (mode.trunked === true)
+        return true
+    // An explicit system type that does not carry `trunked` has answered for
+    // itself — DMR and NXDN trunk too, but conventional use is common enough
+    // there that the band must not override the user's own pick.
+    if (mode.flag !== "")
+        return false
+    var band = bandFor(hz)
+    return band !== null && band.trunked === true
 }
 
 // The one-line mono meta under a saved system's name: "851.375 MHz · P25 trunked"

--- a/src/ui/qt/qml/Util.js
+++ b/src/ui/qt/qml/Util.js
@@ -18,13 +18,17 @@ var DECODE_MODES = [
         // commonly Phase 2, and -f1 sets frame_p25p2=0 — every Phase 2 voice
         // grant would tune and stay permanently mute. -ft keeps the P25p1
         // control channel plus both voice phases.
-        label: "P25", short: "P25", flag: "-ft",
+        // trunked: an explicit P25 pick almost certainly means a trunked
+        // system, so the wizard suggests turning call-following on. Only these
+        // two chips carry it — DMR and NXDN trunk too, but conventional use is
+        // common enough there that neither answer is a safe suggestion.
+        label: "P25", short: "P25", flag: "-ft", trunked: true,
         hint: "Standard P25 — most statewide and county digital systems."
     },
     {
         // -mq alone, not -f1 -mq: QPSK is what LSM needs, and the engine's default
         // decode set already covers both P25 Phase 1 and Phase 2.
-        label: "P25 Simulcast", short: "P25 LSM", flag: "-mq",
+        label: "P25 Simulcast", short: "P25 LSM", flag: "-mq", trunked: true,
         hint: "Simulcast P25 (LSM) — pick this when standard P25 never locks or sounds garbled."
     },
     {
@@ -149,6 +153,17 @@ function decodeHint(flag) {
             return DECODE_MODES[i].hint
     }
     return ""
+}
+
+// Whether picking this chip should suggest turning trunking on. Flags outside
+// the catalog (the RadioReference import's composite forms) never reach this:
+// the import carries the database's own trunking answer instead.
+function decodeSuggestsTrunking(flag) {
+    for (var i = 0; i < DECODE_MODES.length; i++) {
+        if (DECODE_MODES[i].flag === flag)
+            return DECODE_MODES[i].trunked === true
+    }
+    return false
 }
 
 // The one-line mono meta under a saved system's name: "851.375 MHz · P25 trunked"

--- a/src/ui/qt/qml/WizardScreen.qml
+++ b/src/ui/qt/qml/WizardScreen.qml
@@ -95,8 +95,10 @@ Item {
         fileField.text = ""
         freqField.text = "851.375"
         decodeFlag = ""
-        trunking = false
         trunkingAnswered = false
+        // After the field and the chip, never before: the prefill is an 800 MHz
+        // control channel, so this is what keeps the shipped defaults decoding.
+        refreshTrunkingSuggestion()
         advancedOpen = false
         gainField.text = ""
         ppmField.text = ""
@@ -130,8 +132,11 @@ Item {
         fileField.text = ""
         freqField.text = freqMhz
         decodeFlag = ""
-        trunking = false
         trunkingAnswered = false
+        // The frequency a user "found" while exploring 700/800 is most often a
+        // constant-carrier control channel — that is what stands out on a
+        // waterfall — so the same suggestion applies, and more strongly.
+        refreshTrunkingSuggestion()
         advancedOpen = false
         gainField.text = ""
         ppmField.text = ""
@@ -157,10 +162,9 @@ Item {
         fileField.text = sys.filePath
         freqField.text = sys.freqMhz
         decodeFlag = sys.decodeFlag
-        trunking = sys.trunking
         // The saved system already answered the question; a chip tap during
         // the edit must not silently flip what the card was doing yesterday.
-        trunkingAnswered = true
+        answerTrunking(sys.trunking)
         advancedOpen = false
         gainField.text = sys.gainDb >= 0 ? String(sys.gainDb) : ""
         ppmField.text = sys.ppm
@@ -194,8 +198,24 @@ Item {
      */
     function pickDecodeFlag(flag) {
         decodeFlag = flag
-        if (!trunkingAnswered)
-            trunking = Util.decodeSuggestsTrunking(flag)
+        refreshTrunkingSuggestion()
+    }
+
+    /**
+     * Re-derive the unanswered trunking switch from the chip and the frequency.
+     *
+     * Called on every chip pick and on every frequency edit, not just the pick:
+     * Auto is the default chip and carries no system type, so a user who accepts
+     * the prefills taps no chip at all and the suggestion would otherwise never
+     * run. An explicit answer — the toggle, an import, an edit's saved state —
+     * stops this for good, which is what trunkingAnswered is for.
+     */
+    function refreshTrunkingSuggestion() {
+        if (trunkingAnswered)
+            return
+        // parseFloat("") and a half-typed "8." are NaN, which suggestsTrunking()
+        // reads as "no band, no suggestion" rather than as 0 Hz.
+        trunking = Util.suggestsTrunking(decodeFlag, parseFloat(freqField.text) * 1.0e6)
     }
 
     /** The user's own toggle: an answer, which no later chip pick may undo. */
@@ -314,8 +334,7 @@ Item {
         wizard.decodeFlag = result.decodeFlag
         // The database's answer, and an answer: a chip tap after the import
         // must not second-guess what the record says the system is.
-        wizard.trunking = result.trunking
-        wizard.trunkingAnswered = true
+        wizard.answerTrunking(result.trunking)
         // Only when the wizard has no name yet: an edit already has one the user
         // chose, and RadioReference's is a database title, not their label.
         if (nameField.text.trim().length === 0 && result.name)
@@ -609,9 +628,14 @@ Item {
                 UiPanel {
                     width: parent.width
                     visible: radioReference.available
-                    height: 66
+                    // From the row rather than a copy of its height: DisclosureRow
+                    // is shared, and a card that restated its 58 would clip it the
+                    // day that number moves.
+                    height: rrEntryRow.height + 8
 
                     DisclosureRow {
+                        id: rrEntryRow
+
                         // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
                         objectName: "wizardRadioReferenceRow"
 
@@ -648,6 +672,14 @@ Item {
 
                             width: parent.width
                             text: "851.375"
+                            // Not editingFinished: every control on this screen
+                            // is TapHandler-based and TapHandler takes no focus,
+                            // so a user who types a frequency and taps Continue
+                            // never commits the field. The hint text under this
+                            // one already follows `trunking` live, so the switch
+                            // moving as the band is entered is visible, not a
+                            // surprise sprung at the end.
+                            onTextChanged: wizard.refreshTrunkingSuggestion()
                         }
 
                         Text {

--- a/src/ui/qt/qml/WizardScreen.qml
+++ b/src/ui/qt/qml/WizardScreen.qml
@@ -566,6 +566,29 @@ Item {
                 visible: wizard.step === 1
                 spacing: Theme.gap
 
+                // The database can answer this whole step — frequency, decode
+                // mode, trunking, files — and it covers conventional systems as
+                // much as trunked ones. So the entry leads the step instead of
+                // trailing the file pickers, where it read as a trunked-only
+                // CSV utility discovered only after answering everything by
+                // hand. A Column collapses an invisible child, so nothing
+                // moves where the feature is absent.
+                UiPanel {
+                    width: parent.width
+                    visible: radioReference.available
+                    height: 66
+
+                    DisclosureRow {
+                        // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
+                        objectName: "wizardRadioReferenceRow"
+
+                        anchors.verticalCenter: parent.verticalCenter
+                        title: qsTr("Import from RadioReference…")
+                        subtitle: qsTr("Fills in the frequency, decode mode and talkgroups")
+                        onTapped: wizard.openRadioReference()
+                    }
+                }
+
                 UiPanel {
                     width: parent.width
                     visible: wizard.radioSource
@@ -596,7 +619,12 @@ Item {
 
                         Text {
                             width: parent.width
-                            text: qsTr("Tune to the system's control channel — find it on RadioReference.")
+                            // Only a build without the importer sends the user
+                            // to the website; with it, the entry above IS the
+                            // way to look the frequency up.
+                            text: radioReference.available
+                                  ? qsTr("Tune to the system's control channel.")
+                                  : qsTr("Tune to the system's control channel — find it on RadioReference.")
                             font.family: Theme.sans
                             font.pixelSize: 13
                             color: Theme.textSubdued
@@ -720,22 +748,6 @@ Item {
                             title: qsTr("Encryption keys")
                             target: "keys"
                             path: wizard.keyCsvPath
-                            showDivider: radioReference.available
-                        }
-
-                        // A DisclosureRow rather than a CsvPickerRow: that wrapper
-                        // always opens the file-picker sheet. A Column collapses
-                        // an invisible child, so nothing moves where the feature
-                        // is absent.
-                        DisclosureRow {
-                            // Named so UI_QT_QML_CALL_LISTS can reach it with findChild().
-                            objectName: "wizardRadioReferenceRow"
-
-                            visible: radioReference.available
-                            title: qsTr("Import from RadioReference…")
-                            subtitle: qsTr("Generates both files from the online database")
-                            showDivider: true
-                            onTapped: wizard.openRadioReference()
                         }
 
                         Text {

--- a/src/ui/qt/qml/WizardScreen.qml
+++ b/src/ui/qt/qml/WizardScreen.qml
@@ -29,7 +29,12 @@ Item {
     // Step 2 state
     property alias freqText: freqField.text
     property string decodeFlag: ""
-    property bool trunking: true
+    property bool trunking: false
+    // Whether the trunking question has been answered — by the user's own
+    // toggle, a RadioReference import, or a saved system being edited. Until
+    // then the decode chip pick suggests it (see pickDecodeFlag), and an
+    // explicit answer must survive every later chip change.
+    property bool trunkingAnswered: false
     property bool advancedOpen: false
     property alias gainText: gainField.text
     property alias ppmText: ppmField.text
@@ -90,7 +95,8 @@ Item {
         fileField.text = ""
         freqField.text = "851.375"
         decodeFlag = ""
-        trunking = true
+        trunking = false
+        trunkingAnswered = false
         advancedOpen = false
         gainField.text = ""
         ppmField.text = ""
@@ -124,7 +130,8 @@ Item {
         fileField.text = ""
         freqField.text = freqMhz
         decodeFlag = ""
-        trunking = true
+        trunking = false
+        trunkingAnswered = false
         advancedOpen = false
         gainField.text = ""
         ppmField.text = ""
@@ -151,6 +158,9 @@ Item {
         freqField.text = sys.freqMhz
         decodeFlag = sys.decodeFlag
         trunking = sys.trunking
+        // The saved system already answered the question; a chip tap during
+        // the edit must not silently flip what the card was doing yesterday.
+        trunkingAnswered = true
         advancedOpen = false
         gainField.text = sys.gainDb >= 0 ? String(sys.gainDb) : ""
         ppmField.text = sys.ppm
@@ -172,6 +182,26 @@ Item {
             return qsTr("None")
         var row = importedFiles.rowForPath(path)
         return row >= 0 ? importedFiles.get(row).name : path.substring(path.lastIndexOf('/') + 1)
+    }
+
+    /**
+     * Take a decode chip pick, suggesting the trunking answer with it.
+     *
+     * A new system starts with trunking off, and most users cannot answer
+     * "is it trunked?" cold — but an explicit P25 pick almost certainly means
+     * a trunked system, so the switch follows the chip until the user (or a
+     * RadioReference import, or an edit's saved state) answers it for real.
+     */
+    function pickDecodeFlag(flag) {
+        decodeFlag = flag
+        if (!trunkingAnswered)
+            trunking = Util.decodeSuggestsTrunking(flag)
+    }
+
+    /** The user's own toggle: an answer, which no later chip pick may undo. */
+    function answerTrunking(state) {
+        trunking = state
+        trunkingAnswered = true
     }
 
     // parseInt alone lets a hardware-keyboard "abc" become NaN, which QVariant
@@ -282,7 +312,10 @@ Item {
         if (result.freqMhz && result.freqMhz.length > 0)
             freqField.text = result.freqMhz
         wizard.decodeFlag = result.decodeFlag
+        // The database's answer, and an answer: a chip tap after the import
+        // must not second-guess what the record says the system is.
         wizard.trunking = result.trunking
+        wizard.trunkingAnswered = true
         // Only when the wizard has no name yet: an edit already has one the user
         // chose, and RadioReference's is a database title, not their label.
         if (nameField.text.trim().length === 0 && result.name)
@@ -619,12 +652,19 @@ Item {
 
                         Text {
                             width: parent.width
-                            // Only a build without the importer sends the user
-                            // to the website; with it, the entry above IS the
-                            // way to look the frequency up.
-                            text: radioReference.available
-                                  ? qsTr("Tune to the system's control channel.")
-                                  : qsTr("Tune to the system's control channel — find it on RadioReference.")
+                            // "Control channel" only while the trunking answer
+                            // below says there is one — a conventional system
+                            // has no control channel, and the line follows the
+                            // switch as it changes. Only a build without the
+                            // importer sends the user to the website; with it,
+                            // the entry above IS the way to look this up.
+                            text: wizard.trunking
+                                  ? (radioReference.available
+                                     ? qsTr("Tune to the system's control channel.")
+                                     : qsTr("Tune to the system's control channel — find it on RadioReference."))
+                                  : (radioReference.available
+                                     ? qsTr("Tune to the frequency you want to hear.")
+                                     : qsTr("Tune to the frequency you want to hear — find it on RadioReference."))
                             font.family: Theme.sans
                             font.pixelSize: 13
                             color: Theme.textSubdued
@@ -653,7 +693,7 @@ Item {
 
                             text: modelData.label
                             selected: wizard.decodeFlag === modelData.flag
-                            onClicked: wizard.decodeFlag = modelData.flag
+                            onClicked: wizard.pickDecodeFlag(modelData.flag)
                         }
                     }
                 }
@@ -681,7 +721,10 @@ Item {
 
                         Text {
                             width: parent.width
-                            text: qsTr("Follow calls across channels")
+                            // The term, not a description: this audience knows
+                            // trunking by name, and the subtitle carries the
+                            // decision rule for anyone who does not.
+                            text: qsTr("Trunking")
                             font.family: Theme.sans
                             font.pixelSize: 15
                             font.weight: Font.DemiBold
@@ -691,7 +734,13 @@ Item {
 
                         Text {
                             width: parent.width
-                            text: qsTr("Trunking — recommended for public safety")
+                            // The decision rule, not the audience: a trunked
+                            // utility system wants this on, a conventional fire
+                            // channel wants it off. "Control channel" rather
+                            // than "trunked" — the title and the card below
+                            // already carry the term, and it is the thing the
+                            // user actually tuned.
+                            text: qsTr("On when the system uses a control channel")
                             font.family: Theme.sans
                             font.pixelSize: 13
                             color: Theme.textSubdued
@@ -705,7 +754,7 @@ Item {
                         anchors.rightMargin: Theme.cardPadding
                         anchors.verticalCenter: parent.verticalCenter
                         checked: wizard.trunking
-                        onToggled: function (state) { wizard.trunking = state }
+                        onToggled: function (state) { wizard.answerTrunking(state) }
                     }
                 }
 

--- a/src/ui/qt/radio_reference_model.cpp
+++ b/src/ui/qt/radio_reference_model.cpp
@@ -467,19 +467,26 @@ RadioReferenceModel::available() const {
 }
 
 bool
-RadioReferenceModel::hasAppKey() const {
-    if (m_prefs != nullptr && !m_prefs->rrAppKey().isEmpty()) {
-        return true;
-    }
-    const char* builtin = dsd_rr_builtin_app_key();
-    return builtin != nullptr && builtin[0] != '\0';
-}
-
-bool
 // cppcheck-suppress functionStatic -- a Q_PROPERTY READ accessor cannot be static
 RadioReferenceModel::buildHasAppKey() const {
     const char* builtin = dsd_rr_builtin_app_key();
     return builtin != nullptr && builtin[0] != '\0';
+}
+
+QByteArray
+RadioReferenceModel::chooseAppKey(const char* builtin, const QString& override) {
+    if (builtin != nullptr && builtin[0] != '\0') {
+        return QByteArray(builtin);
+    }
+    return override.isEmpty() ? QByteArray() : override.toUtf8();
+}
+
+bool
+RadioReferenceModel::hasAppKey() const {
+    /* Asked through the same choice fillAuth() sends, so "is there a key" and
+     * "which key" can never answer from different rules. */
+    const QString override = (m_prefs != nullptr) ? m_prefs->rrAppKey() : QString();
+    return !chooseAppKey(dsd_rr_builtin_app_key(), override).isEmpty();
 }
 
 bool
@@ -519,8 +526,13 @@ RadioReferenceModel::fillAuth(dsd_rr_auth* auth) const {
      * it came from it can genuinely be overwritten - and it holds the password
      * in cleartext until it is. */
     QByteArray password = m_password.toUtf8();
-    const QString override = m_prefs->rrAppKey();
-    const QByteArray key = override.isEmpty() ? QByteArray(dsd_rr_builtin_app_key()) : override.toUtf8();
+    /* The baked key wins wherever there is one - see chooseAppKey(). Hiding the
+     * field alone left a stored override still outranking the key, which made a
+     * stale one - entered under a keyless build, still in the shared QSettings
+     * after a keyed one is installed over it - break every request with no way
+     * to reach it. Ignored rather than erased, so a keyless build run later
+     * still finds the user's own key where they left it. */
+    const QByteArray key = chooseAppKey(dsd_rr_builtin_app_key(), m_prefs->rrAppKey());
 
     const bool fits = static_cast<size_t>(user.size()) < sizeof(auth->username)
                       && static_cast<size_t>(password.size()) < sizeof(auth->password)
@@ -614,7 +626,13 @@ RadioReferenceModel::beginFetch(Fetch kind) {
     request->generation = m_generation;
     if (!fillAuth(&request->auth)) {
         delete request;
-        setError(ConfigError, tr("Enter your RadioReference username, password and application key first."));
+        /* Names only what can actually be missing. A key in force - baked in
+         * or stored as an override - is never the gap, and a keyed build
+         * offers no field to supply one, so naming it sends the user hunting
+         * for something they cannot enter. */
+        setError(ConfigError, hasAppKey()
+                                  ? tr("Enter your RadioReference username and password first.")
+                                  : tr("Enter your RadioReference username, password and application key first."));
         return nullptr;
     }
     return request;
@@ -659,14 +677,20 @@ RadioReferenceModel::cancel() {
 
 void
 RadioReferenceModel::closeSystem() {
+    /* A load still in flight carries the live generation, so its replies would
+     * land after this and finishSystemLoad() would republish the system with
+     * the sid clearSystem() just zeroed - a fully populated system no view can
+     * show, because the screen's stage predicate is sid > 0. cancel() is the
+     * retirement the rest of this class uses: it drops the replies, settles
+     * busy, and answers a library refresh riding on the same batch instead of
+     * leaving it waiting for a finishSystemLoad() that must not run. */
+    if (m_systemPending > 0) {
+        cancel();
+    }
     clearSystem();
     /* The retired error described the system just closed; keeping it would put
      * a stale failure over the results list the user went back to. */
-    if (m_errorKind != NoError || !m_errorText.isEmpty()) {
-        m_errorKind = NoError;
-        m_errorText.clear();
-        Q_EMIT statusChanged();
-    }
+    setError(NoError, QString());
 }
 
 /* ------------------------------------------------------------------------- */
@@ -1346,7 +1370,13 @@ RadioReferenceModel::refreshRow(int row) {
         return false;
     }
     if (!credentialsReady()) {
-        setError(ConfigError, tr("Enter your RadioReference username, password and application key first."));
+        /* Names only what can actually be missing. A key in force - baked in
+         * or stored as an override - is never the gap, and a keyed build
+         * offers no field to supply one, so naming it sends the user hunting
+         * for something they cannot enter. */
+        setError(ConfigError, hasAppKey()
+                                  ? tr("Enter your RadioReference username and password first.")
+                                  : tr("Enter your RadioReference username, password and application key first."));
         return false;
     }
 

--- a/src/ui/qt/radio_reference_model.cpp
+++ b/src/ui/qt/radio_reference_model.cpp
@@ -476,6 +476,13 @@ RadioReferenceModel::hasAppKey() const {
 }
 
 bool
+// cppcheck-suppress functionStatic -- a Q_PROPERTY READ accessor cannot be static
+RadioReferenceModel::buildHasAppKey() const {
+    const char* builtin = dsd_rr_builtin_app_key();
+    return builtin != nullptr && builtin[0] != '\0';
+}
+
+bool
 RadioReferenceModel::credentialsReady() const {
     const bool haveUser = (m_prefs != nullptr) && !m_prefs->rrUsername().isEmpty();
     return haveUser && !m_password.isEmpty() && hasAppKey();
@@ -648,6 +655,18 @@ RadioReferenceModel::cancel() {
      * reply, so finishSystemLoad() - and with it completeRefresh() - can never
      * run for this batch. Without this the library caller waits forever. */
     abandonRefresh();
+}
+
+void
+RadioReferenceModel::closeSystem() {
+    clearSystem();
+    /* The retired error described the system just closed; keeping it would put
+     * a stale failure over the results list the user went back to. */
+    if (m_errorKind != NoError || !m_errorText.isEmpty()) {
+        m_errorKind = NoError;
+        m_errorText.clear();
+        Q_EMIT statusChanged();
+    }
 }
 
 /* ------------------------------------------------------------------------- */
@@ -831,7 +850,16 @@ RadioReferenceModel::applyListReply(const Reply& reply) {
         case FetchCountries: m_countries = reply.list; break;
         case FetchStates: m_states = reply.list; break;
         case FetchCounties: m_counties = reply.list; break;
-        case FetchSystems: m_systems = reply.list; break;
+        case FetchSystems:
+            /* A fresh results list retires the loaded system: the screen shows
+             * one stage or the other, and the user who just searched asked for
+             * the list. Without this the results landed invisibly behind the
+             * stale system. */
+            if (m_sid != 0 || !m_systemDetails.isEmpty()) {
+                clearSystem();
+            }
+            m_systems = reply.list;
+            break;
         default: return false;
     }
     Q_EMIT listsChanged();

--- a/src/ui/qt/radio_reference_model.h
+++ b/src/ui/qt/radio_reference_model.h
@@ -74,8 +74,14 @@ class RadioReferenceModel : public QObject {
     Q_PROPERTY(QVariantMap systemDetails READ systemDetails NOTIFY systemChanged)
     Q_PROPERTY(QVariantMap talkgroupSummary READ talkgroupSummary NOTIFY systemChanged)
     /* So the site list can switch between single- and multi-select without
-     * knowing the protocol enum, for the same reason errorIsAuth exists. */
+     * knowing the protocol enum, for the same reason errorIsAuth exists.
+     *
+     * Both, not one and its negation: an unresolved protocol is neither, so
+     * `!conventional` does not mean "trunked". A system type this build cannot
+     * import answers false to both, which is what keeps its site list from
+     * auto-selecting a row that could never be imported. */
     Q_PROPERTY(bool conventional READ conventional NOTIFY systemChanged)
+    Q_PROPERTY(bool trunked READ trunked NOTIFY systemChanged)
 
   public:
     /** @brief What went wrong, as QML-agnostic integers. */
@@ -100,6 +106,25 @@ class RadioReferenceModel : public QObject {
     bool hasAppKey() const;
     bool buildHasAppKey() const;
     bool credentialsReady() const;
+
+    /**
+     * @brief Which application key a request carries, given the two candidates.
+     *
+     * @param builtin  The key baked in at build time; NULL or empty for none.
+     * @param override The key stored in the app's settings; empty for none.
+     * @return The chosen key, or empty when there is none to send.
+     *
+     * The baked key wins wherever there is one: a build that ships a key is not
+     * asking the user for one, so it must not be substitutable either. Without
+     * a baked key the stored key is the only key there is.
+     *
+     * Static and public so both branches can be tested from either build. The
+     * baked value is a compile-time constant, so a test that could only reach
+     * this through fillAuth() would exercise whichever single branch the build
+     * it ran in was configured for - and the branch that matters most is the one
+     * a developer's keyless build can never take.
+     */
+    static QByteArray chooseAppKey(const char* builtin, const QString& override);
 
     bool
     busy() const {
@@ -171,6 +196,11 @@ class RadioReferenceModel : public QObject {
         return dsd_rr_protocol_is_conventional(m_protocol) != 0;
     }
 
+    bool
+    trunked() const {
+        return dsd_rr_protocol_is_trunked(m_protocol) != 0;
+    }
+
     /** @brief Hold the account password for this process only. Never persisted. */
     Q_INVOKABLE void setPassword(const QString& password);
 
@@ -202,9 +232,12 @@ class RadioReferenceModel : public QObject {
      * @brief Drop the loaded system, returning the screen to its results stage.
      *
      * The systems list survives — "back to the list, pick another" is the whole
-     * point. Any lingering error is retired with the system it described. The
-     * screen only offers this while the model is idle (the busy overlay covers
-     * it otherwise), so nothing in flight needs cancelling here.
+     * point. Any lingering error is retired with the system it described.
+     *
+     * A system load still in flight is retired too. The back row only offers
+     * this while the model is idle, but reset() calls it on every visit, and a
+     * reply that landed afterwards would rebuild the system around the sid this
+     * just zeroed — a system the screen can never show again.
      */
     Q_INVOKABLE void closeSystem();
 

--- a/src/ui/qt/radio_reference_model.h
+++ b/src/ui/qt/radio_reference_model.h
@@ -52,6 +52,10 @@ class RadioReferenceModel : public QObject {
      * this is false. */
     Q_PROPERTY(bool available READ available CONSTANT)
     Q_PROPERTY(bool hasAppKey READ hasAppKey NOTIFY credentialsChanged)
+    /* Whether THIS BUILD carries a baked-in application key, ignoring the prefs
+     * override — the predicate for "must the user supply a key at all". CONSTANT
+     * because it is decided at compile time. */
+    Q_PROPERTY(bool buildHasAppKey READ buildHasAppKey CONSTANT)
     Q_PROPERTY(bool credentialsReady READ credentialsReady NOTIFY credentialsChanged)
     Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
     Q_PROPERTY(QString statusText READ statusText NOTIFY statusChanged)
@@ -94,6 +98,7 @@ class RadioReferenceModel : public QObject {
 
     bool available() const;
     bool hasAppKey() const;
+    bool buildHasAppKey() const;
     bool credentialsReady() const;
 
     bool
@@ -192,6 +197,16 @@ class RadioReferenceModel : public QObject {
 
     /** @brief Best-effort cancel of everything in flight. */
     Q_INVOKABLE void cancel();
+
+    /**
+     * @brief Drop the loaded system, returning the screen to its results stage.
+     *
+     * The systems list survives — "back to the list, pick another" is the whole
+     * point. Any lingering error is retired with the system it described. The
+     * screen only offers this while the model is idle (the busy overlay covers
+     * it otherwise), so nothing in flight needs cancelling here.
+     */
+    Q_INVOKABLE void closeSystem();
 
     /**
      * @brief Preview an import. Pure: no network, no files.

--- a/src/ui/qt/saved_systems_model.h
+++ b/src/ui/qt/saved_systems_model.h
@@ -113,7 +113,14 @@ class SavedSystemsModel : public QAbstractListModel {
         int port = 0;
         QString freqMhz;
         QString decodeFlag;
-        bool trunking = true;
+        /* False, like every other layer reads an absent key: session_args'
+         * `system.value("trunking").toBool()` appends -T only for a present
+         * true, and the wizard starts a new system with it off. A default of
+         * true here meant a map that never mentioned trunking - a hand-edited
+         * or partially restored systems.json row, or a future caller that
+         * simply forgot the key - was stored as call-following ON while every
+         * reader of that same map said OFF. */
+        bool trunking = false;
         int gainDb = -1;
         QString ppm;
         int bandwidthKhz = -1;

--- a/tests/runtime/test_runtime_rr_generate.c
+++ b/tests/runtime/test_runtime_rr_generate.c
@@ -752,6 +752,9 @@ test_chan_p25_fixture(void) {
                           "1,851050000\n", 12U)
                       == 0);
     expect("p25 fixture placeholder warned", warned(&warnings, "placeholder"));
+    /* The whole sentence must reach the screen: a 192-byte warning slot used to
+     * cut this, the longest generator message, off mid-word at "...half is u". */
+    expect("p25 fixture placeholder warning not truncated", warned(&warnings, "broadcasts its band plan."));
     expect("p25 fixture control freq", dsd_rr_site_control_freq_hz(&sites.items[0]) == 851050000LL);
 
     dsd_csv_validation counts;

--- a/tests/ui/qml/tst_main_overlay_layering.qml
+++ b/tests/ui/qml/tst_main_overlay_layering.qml
@@ -40,6 +40,7 @@ Item {
         property var monitor: null
         property var imports: null
         property var radioReference: null
+        property var wizard: null
 
         function initTestCase() {
             tc.app = appLoader.item
@@ -50,6 +51,8 @@ Item {
             verify(tc.imports !== null, "the imports screen is missing")
             tc.radioReference = findChild(tc.app, "radioReferenceScreen")
             verify(tc.radioReference !== null, "the RadioReference screen is missing")
+            tc.wizard = findChild(tc.app, "wizardScreen")
+            verify(tc.wizard !== null, "the wizard screen is missing")
         }
 
         function init() {
@@ -111,24 +114,53 @@ Item {
                       2000, "the monitor stayed inert after the imports library closed")
         }
 
-        // The RadioReference import screen is reached the same way the library
-        // is — from Settings, or from the library itself — so it stands down for
-        // the monitor too. Its bottom "Import this system" button sits at the
-        // same rect as "Stop listening".
-        function test_06_the_radioreference_screen_stands_down_for_the_monitor() {
+        // The RadioReference import screen goes the wizard's way, not the
+        // library's: the wizard opens over a running session ("Save as a
+        // system") and pushes this screen from its tune step, so it has to stay
+        // lit over the monitor and take the taps itself. Its bottom "Import this
+        // system" button sits at the same rect as "Stop listening", so the
+        // monitor is what stands down.
+        function test_06_the_radioreference_screen_takes_taps_over_the_monitor() {
             tc.app.radioReferenceOpen = true
             // Waited out rather than tryVerify'd, for the reason test_05 gives:
-            // `enabled` follows a 150ms animated opacity, so "it is inert" is
-            // true on the fade's first frame regardless of the binding.
+            // `enabled` follows a 150ms animated opacity, so a reading taken on
+            // the fade's first frame says nothing about what the binding settles
+            // on either way.
             wait(400)
-            verify(!tc.radioReference.enabled,
+            verify(tc.radioReference.enabled,
+                   "the RadioReference screen stood down and cannot be operated")
+            verify(!tc.monitor.enabled,
                    "a tap on the RadioReference screen also reaches the monitor underneath")
-            verify(tc.monitor.enabled,
-                   "the monitor gave up its taps to a layer that is standing down")
 
             tc.app.radioReferenceOpen = false
             tryVerify(function () { return tc.monitor.enabled },
                       2000, "the monitor stayed inert after the RadioReference screen closed")
+        }
+
+        // The deadlock this layering exists to prevent. "Save as a system" from
+        // a live session opens the wizard over the monitor (openForFound sets
+        // step = 1), and the tune step leads with the RadioReference row — so
+        // all three layers are up at once over an active session. Each one is
+        // disabled by the layer above it, and there is no Keys.onBackPressed or
+        // Shortcut anywhere in the QML tree, so if the top layer also stands
+        // down nothing on screen takes a tap and the app cannot be recovered
+        // short of killing the process.
+        function test_07_the_wizard_pushing_radioreference_leaves_a_live_layer() {
+            tc.app.wizardOpen = true
+            tc.app.radioReferenceOpen = true
+            wait(400)
+
+            verify(tc.monitor.enabled || tc.wizard.enabled || tc.radioReference.enabled,
+                   "monitor, wizard and RadioReference screen are all inert at once: "
+                   + "the session is unrecoverable with no back key to escape it")
+            // And specifically the top layer is the live one — anything else
+            // means taps are landing on a screen the user cannot see.
+            verify(tc.radioReference.enabled,
+                   "the top layer is not the one taking taps")
+
+            tc.app.radioReferenceOpen = false
+            tryVerify(function () { return tc.wizard.enabled },
+                      2000, "the wizard stayed inert after the RadioReference screen closed")
         }
 
         // The wizard opens over the spectrum ("Save as a system"), so both are up

--- a/tests/ui/qml/tst_radioreference_screen.qml
+++ b/tests/ui/qml/tst_radioreference_screen.qml
@@ -68,7 +68,12 @@ Item {
             testContext.setRadioReference("hasAppKey", false)
             testContext.setRadioReference("buildHasAppKey", false)
             testContext.setRadioReference("credentialsReady", false)
+            // Set independently, because the real model does: a system type this
+            // build cannot import answers false to BOTH, so neither reading can
+            // be derived from the other. The pair below is an ordinary trunked
+            // system, which is what most cases here load.
             testContext.setRadioReference("conventional", false)
+            testContext.setRadioReference("trunked", true)
             testContext.setRadioReference("busy", false)
             testContext.setRadioReference("sites", [])
             testContext.setRadioReference("systems", [])
@@ -80,6 +85,10 @@ Item {
             testContext.setRadioReference("errorText", "")
             testContext.setRadioReference("errorIsAuth", false)
             testContext.setRadioReference("errorIsSubscription", false)
+            // The other shared map. The Settings case below stores a key
+            // override, and the auth wording here reads prefs.rrAppKey — which
+            // would make this case's result depend on TestCase running order.
+            testContext.setPrefs("rrAppKey", "")
             tc.screen.reset()
         }
 
@@ -183,6 +192,7 @@ Item {
             testContext.setRadioReference("hasAppKey", true)
             testContext.setRadioReference("credentialsReady", true)
             testContext.setRadioReference("conventional", true)
+            testContext.setRadioReference("trunked", false)
             testContext.setRadioReference("systemDetails", {
                                               "sid": 9340,
                                               "name": "Users Group",
@@ -402,6 +412,7 @@ Item {
                       2000, "a two-site system had a site answered for the user")
 
             testContext.setRadioReference("conventional", true)
+            testContext.setRadioReference("trunked", false)
             testContext.setRadioReference("sites", [
                                               { "siteNumber": 310011, "descr": "Zeta", "freqCount": 1,
                                                 "controlFreqMhz": "", "simulcast": false,
@@ -409,6 +420,21 @@ Item {
                                           ])
             tryVerify(function () { return tc.screen.selectedSites.length === 0 },
                       2000, "a lone conventional repeater was selected uninvited")
+
+            // The third state, and the reason this reads `trunked` rather than
+            // `!conventional`: an LTR, MPT-1327 or Motorola Type II system has
+            // no protocol row, so it is neither conventional NOR trunked.
+            // buildImportPlan() refuses it outright, so selecting and lighting
+            // up its one row promises an import that cannot happen.
+            testContext.setRadioReference("conventional", false)
+            testContext.setRadioReference("trunked", false)
+            testContext.setRadioReference("sites", [
+                                              { "siteNumber": 1, "descr": "Solo", "freqCount": 5,
+                                                "controlFreqMhz": "851.0125", "simulcast": false,
+                                                "freqMhz": "851.0125", "colorCode": "" }
+                                          ])
+            tryVerify(function () { return tc.screen.selectedSites.length === 0 },
+                      2000, "an unimportable system had its only site selected for the user")
         }
 
         // In a keyed build the user has no application key to fix, so an auth
@@ -456,6 +482,56 @@ Item {
                       2000, "the form stayed up after the failure was resolved")
         }
 
+        // Nothing on this screen takes keyboard focus — every control is a
+        // TapHandler — so a field only commits on Enter or when another field is
+        // tapped. The button has to move focus itself, and it cannot be gated on
+        // the committed state: that greys it out exactly when the last answer is
+        // the one still sitting uncommitted in the field.
+        function test_13_check_account_commits_the_field_still_being_typed_in() {
+            var key = findChild(tc.screen, "radioReferenceAppKeyField")
+            var button = findChild(tc.screen, "radioReferenceCheckAccountButton")
+            tryVerify(function () { return key.visible && button.visible },
+                      2000, "the keyless form did not offer a key field and a button")
+            verify(button.enabled, "the button was dead with the form not yet committed")
+
+            var commits = 0
+            key.editingFinished.connect(function () { commits++ })
+            key.input.forceActiveFocus()
+            verify(key.input.activeFocus, "the key field did not take focus")
+
+            // clicked() rather than a synthetic tap: OutlineButton's TapHandler
+            // is covered where the component is, and what matters here is what
+            // the screen's handler does once it fires.
+            button.clicked()
+            tryVerify(function () { return commits === 1 },
+                      2000, "tapping Check account left the typed key uncommitted")
+        }
+
+        // A keyed build's key is not the user's to change, and fillAuth() makes
+        // that true rather than merely unoffered: the baked key wins even when a
+        // stored override is sitting in QSettings from a keyless build installed
+        // over it. So the field stays hidden and the notice keeps naming only
+        // username and password, override or no override.
+        function test_14_a_keyed_build_ignores_a_stored_override() {
+            testContext.setRadioReference("buildHasAppKey", true)
+            var key = findChild(tc.screen, "radioReferenceAppKeyField")
+            tryVerify(function () { return !key.visible },
+                      2000, "a keyed build with no override still asked for a key")
+
+            testContext.setPrefs("rrAppKey", "OVERRIDE_KEY_1a2")
+            // Waited out rather than tryVerify'd: the assertion is that nothing
+            // changes, which is true on the first frame however the binding is
+            // written. Only a settled reading distinguishes the two.
+            wait(200)
+            verify(!key.visible,
+                   "a stored override reopened a field this build does not let the user change")
+
+            var notice = findChild(tc.screen, "radioReferenceNotice")
+            testContext.setRadioReference("errorText", "Invalid Username or Password")
+            testContext.setRadioReference("errorIsAuth", true)
+            tryVerify(function () { return notice.visible && notice.text.indexOf("application key") < 0 },
+                      2000, "the notice blamed a key this build ignores: " + notice.text)
+        }
     }
 
     // "Refresh from RadioReference" is offered on a row this app generated and on
@@ -559,19 +635,22 @@ Item {
             tryVerify(function () { return row.visible },
                       2000, "a keyless build hid the application-key row")
 
-            // A keyed build asks for nothing.
+            // A keyed build asks for nothing — and keeps asking for nothing with
+            // an override stored. fillAuth() ignores it there, so it is not a
+            // credential in play, and a row for it would only invite editing a
+            // key this build never sends.
             testContext.setRadioReference("buildHasAppKey", true)
             tryVerify(function () { return !row.visible },
                       2000, "a keyed build still offered the application-key row")
 
-            // ...unless an override is stored, which must stay visible to stay
-            // clearable — and clearing it re-hides the row.
             testContext.setPrefs("rrAppKey", "OVERRIDE_KEY_1a2")
-            tryVerify(function () { return row.visible },
-                      2000, "a stored override was invisible and uneditable")
+            // Waited out rather than tryVerify'd: what is asserted is that
+            // nothing changes, which is trivially true on the fade's first
+            // frame however the binding is written.
+            wait(200)
+            verify(!row.visible, "a keyed build offered a row for a key it does not use")
+
             testContext.setPrefs("rrAppKey", "")
-            tryVerify(function () { return !row.visible },
-                      2000, "clearing the override did not re-hide the row")
         }
     }
 }

--- a/tests/ui/qml/tst_radioreference_screen.qml
+++ b/tests/ui/qml/tst_radioreference_screen.qml
@@ -38,6 +38,16 @@ Item {
         source: uiDir + "/ImportsScreen.qml"
     }
 
+    // The stored-credentials rows live in Settings; the key row's gate is what
+    // the last case below pins.
+    Loader {
+        id: settingsLoader
+
+        anchors.fill: parent
+        active: false
+        source: uiDir + "/SettingsScreen.qml"
+    }
+
     TestCase {
         id: tc
 
@@ -483,6 +493,58 @@ Item {
 
             sheet.visible = false
             refreshCase.screen.actionRow = -1
+        }
+    }
+
+    // The Settings application-key row exists for builds that need a key from
+    // the user. In a keyed build it hides — it sat right under Username reading
+    // as a password box, and anything typed there becomes a stored override
+    // that outranks the working baked key — except while an override IS stored:
+    // the field is the only place to see and clear one.
+    TestCase {
+        id: settingsCase
+
+        name: "SettingsRadioReferenceKeyRow"
+        when: windowShown
+
+        property var screen: null
+
+        function initTestCase() {
+            testContext.setRadioReference("available", true)
+            settingsLoader.active = true
+            settingsCase.screen = settingsLoader.item
+            verify(settingsCase.screen !== null, "SettingsScreen.qml failed to load")
+        }
+
+        function cleanupTestCase() {
+            testContext.setRadioReference("available", false)
+            testContext.setRadioReference("buildHasAppKey", false)
+            testContext.setPrefs("rrAppKey", "")
+        }
+
+        function test_01_the_key_row_follows_what_this_build_needs() {
+            var row = findChild(settingsCase.screen, "settingsRrAppKeyRow")
+            verify(row !== null, "the application-key row is missing")
+
+            // A keyless build needs the user's key, so the row is offered.
+            testContext.setRadioReference("buildHasAppKey", false)
+            testContext.setPrefs("rrAppKey", "")
+            tryVerify(function () { return row.visible },
+                      2000, "a keyless build hid the application-key row")
+
+            // A keyed build asks for nothing.
+            testContext.setRadioReference("buildHasAppKey", true)
+            tryVerify(function () { return !row.visible },
+                      2000, "a keyed build still offered the application-key row")
+
+            // ...unless an override is stored, which must stay visible to stay
+            // clearable — and clearing it re-hides the row.
+            testContext.setPrefs("rrAppKey", "OVERRIDE_KEY_1a2")
+            tryVerify(function () { return row.visible },
+                      2000, "a stored override was invisible and uneditable")
+            testContext.setPrefs("rrAppKey", "")
+            tryVerify(function () { return !row.visible },
+                      2000, "clearing the override did not re-hide the row")
         }
     }
 }

--- a/tests/ui/qml/tst_radioreference_screen.qml
+++ b/tests/ui/qml/tst_radioreference_screen.qml
@@ -56,6 +56,7 @@ Item {
         // loaded would hand the next one a screen it never set up.
         function init() {
             testContext.setRadioReference("hasAppKey", false)
+            testContext.setRadioReference("buildHasAppKey", false)
             testContext.setRadioReference("credentialsReady", false)
             testContext.setRadioReference("conventional", false)
             testContext.setRadioReference("busy", false)
@@ -295,6 +296,129 @@ Item {
             verify(county !== null, "the county sheet is missing")
             compare(county.rowCount, 0, "an unfetched level did not read as empty")
         }
+
+        // A build that bakes the application key in never asks for one: the
+        // field would sit under the password box looking like a second secret,
+        // and anything typed there becomes a stored override that breaks the
+        // working key.
+        function test_08_a_keyed_build_never_asks_for_an_application_key() {
+            testContext.setRadioReference("buildHasAppKey", true)
+
+            var credentials = findChild(tc.screen, "radioReferenceCredentials")
+            tryVerify(function () { return credentials.visible },
+                      2000, "the credentials gate is missing for a keyed build")
+
+            var appKey = findChild(tc.screen, "radioReferenceAppKeyField")
+            verify(!appKey.visible, "a build with a baked key still asked for one")
+
+            var username = findChild(tc.screen, "radioReferenceUsernameField")
+            verify(username.visible, "the username field went missing with the key hidden")
+            var password = findChild(tc.screen, "radioReferencePasswordField")
+            verify(password.visible, "the password field went missing with the key hidden")
+        }
+
+        // The screen is a drill-down: find/results, or the loaded system —
+        // never both. A loaded system swaps the search controls for a back row,
+        // and closing it (simulated here by the model answering closeSystem()
+        // with cleared readings) puts the results list back.
+        function test_09_a_loaded_system_swaps_the_find_stage_for_a_back_row() {
+            testContext.setRadioReference("credentialsReady", true)
+            testContext.setRadioReference("systems", [
+                                              { "sid": 6673, "name": "SARA Network", "city": "" },
+                                              { "sid": 8734, "name": "ISICS", "city": "" }
+                                          ])
+
+            var sourcePanel = findChild(tc.screen, "radioReferenceSourcePanel")
+            var systemList = findChild(tc.screen, "radioReferenceSystemList")
+            var backRow = findChild(tc.screen, "radioReferenceBackToResults")
+            verify(backRow !== null, "the back row is missing")
+            tryVerify(function () { return systemList.visible },
+                      2000, "the results list did not appear")
+            verify(sourcePanel.visible, "the find panel went missing on the results stage")
+            verify(!backRow.visible, "the back row appeared with nothing to go back from")
+
+            testContext.setRadioReference("systemDetails", {
+                                              "sid": 6673,
+                                              "name": "SARA Network",
+                                              "typeDescr": "Project 25",
+                                              "flavorDescr": "Phase II"
+                                          })
+            tryVerify(function () { return !sourcePanel.visible },
+                      2000, "the find panel stayed up over a loaded system")
+            verify(!systemList.visible, "the results list stayed up over a loaded system")
+            verify(backRow.visible, "a loaded system offered no way back")
+
+            // The model keeps the results list across closeSystem(); with the
+            // system gone the screen must land back on it.
+            testContext.setRadioReference("systemDetails", {})
+            testContext.setRadioReference("sites", [])
+            tryVerify(function () { return systemList.visible },
+                      2000, "closing the system did not bring the results back")
+            verify(sourcePanel.visible, "closing the system did not bring the find panel back")
+            verify(!backRow.visible, "the back row outlived the system it went back from")
+        }
+
+        // One trunked site is not a choice: the screen answers it, so the
+        // preview and the Import button light up without a tap on the only row.
+        // A conventional single repeater stays a question — "which repeaters
+        // can I hear" has a real no-selection answer.
+        function test_10_a_single_trunked_site_selects_itself() {
+            testContext.setRadioReference("credentialsReady", true)
+            testContext.setRadioReference("systemDetails", {
+                                              "sid": 6673,
+                                              "name": "Test System",
+                                              "typeDescr": "Project 25",
+                                              "flavorDescr": "Phase II"
+                                          })
+            testContext.setRadioReference("sites", [
+                                              { "siteNumber": 1, "descr": "Alpha", "freqCount": 11,
+                                                "controlFreqMhz": "851.0125", "simulcast": true,
+                                                "freqMhz": "851.0125", "colorCode": "" }
+                                          ])
+            tryVerify(function () { return tc.screen.selectedSites.length === 1 },
+                      2000, "the only site of a trunked system was not selected")
+            compare(tc.screen.selectedSites[0], 0, "the wrong site index was selected")
+
+            // Two sites are a real choice, so nothing is answered for the user.
+            testContext.setRadioReference("sites", [
+                                              { "siteNumber": 1, "descr": "Alpha", "freqCount": 11,
+                                                "controlFreqMhz": "851.0125", "simulcast": true,
+                                                "freqMhz": "851.0125", "colorCode": "" },
+                                              { "siteNumber": 2, "descr": "Bravo", "freqCount": 13,
+                                                "controlFreqMhz": "852.5", "simulcast": false,
+                                                "freqMhz": "852.5", "colorCode": "" }
+                                          ])
+            tryVerify(function () { return tc.screen.selectedSites.length === 0 },
+                      2000, "a two-site system had a site answered for the user")
+
+            testContext.setRadioReference("conventional", true)
+            testContext.setRadioReference("sites", [
+                                              { "siteNumber": 310011, "descr": "Zeta", "freqCount": 1,
+                                                "controlFreqMhz": "", "simulcast": false,
+                                                "freqMhz": "444.525", "colorCode": "1" }
+                                          ])
+            tryVerify(function () { return tc.screen.selectedSites.length === 0 },
+                      2000, "a lone conventional repeater was selected uninvited")
+        }
+
+        // In a keyed build the user has no application key to fix, so an auth
+        // failure must not send them hunting for one.
+        function test_11_auth_wording_matches_what_this_build_asks_for() {
+            var notice = findChild(tc.screen, "radioReferenceNotice")
+            testContext.setRadioReference("errorText", "Invalid Username or Password")
+            testContext.setRadioReference("errorIsAuth", true)
+
+            testContext.setRadioReference("buildHasAppKey", true)
+            tryVerify(function () { return notice.visible && notice.text.indexOf("application key") < 0 },
+                      2000, "a keyed build blamed an application key the user cannot fix: " + notice.text)
+            verify(notice.text.indexOf("username or password") >= 0,
+                   "a keyed build's auth failure did not name the two real culprits: " + notice.text)
+
+            testContext.setRadioReference("buildHasAppKey", false)
+            tryVerify(function () { return notice.text.indexOf("application key") >= 0 },
+                      2000, "a keyless build's auth failure stopped naming the key: " + notice.text)
+        }
+
     }
 
     // "Refresh from RadioReference" is offered on a row this app generated and on

--- a/tests/ui/qml/tst_radioreference_screen.qml
+++ b/tests/ui/qml/tst_radioreference_screen.qml
@@ -429,6 +429,33 @@ Item {
                       2000, "a keyless build's auth failure stopped naming the key: " + notice.text)
         }
 
+        // credentialsReady only says the fields are filled. When the account
+        // check comes back rejected, the form must reopen — the password lives
+        // nowhere but this screen, so a hidden form would leave no way to
+        // retype it short of restarting the app.
+        function test_12_a_rejected_account_reopens_the_credentials_form() {
+            testContext.setRadioReference("credentialsReady", true)
+
+            var credentials = findChild(tc.screen, "radioReferenceCredentials")
+            tryVerify(function () { return !credentials.visible },
+                      2000, "the form stayed up with the fields filled and no failure")
+
+            testContext.setRadioReference("errorText", "Invalid Username or Password")
+            testContext.setRadioReference("errorIsAuth", true)
+            tryVerify(function () { return credentials.visible },
+                      2000, "a rejected password left nowhere to retype it")
+
+            testContext.setRadioReference("errorIsAuth", false)
+            testContext.setRadioReference("errorIsSubscription", true)
+            tryVerify(function () { return credentials.visible },
+                      2000, "an expired subscription left nowhere to switch accounts")
+
+            testContext.setRadioReference("errorIsSubscription", false)
+            testContext.setRadioReference("errorText", "")
+            tryVerify(function () { return !credentials.visible },
+                      2000, "the form stayed up after the failure was resolved")
+        }
+
     }
 
     // "Refresh from RadioReference" is offered on a row this app generated and on

--- a/tests/ui/qml/tst_shared_row_components.qml
+++ b/tests/ui/qml/tst_shared_row_components.qml
@@ -69,16 +69,38 @@ Item {
             verify(wizardLoader.item !== null, "WizardScreen.qml failed to load")
         }
 
-        // The wizard reaches its RadioReference entry point through a
-        // DisclosureRow now; findChild is how UI_QT_QML_CALL_LISTS addresses it,
-        // so the objectName has to survive the extraction.
+        // The wizard's RadioReference entry is a card of its own at the top of
+        // the tune step, not a row inside the trunking-data card: it answers
+        // the whole step (frequency, decode mode, talkgroups), so it must not
+        // read as a trunked-only file-picker detail. findChild is how
+        // UI_QT_QML_CALL_LISTS addresses it, so the objectName has to survive
+        // the move.
         function test_03_the_wizard_radioreference_row_is_still_addressable() {
             wizardLoader.active = true
             tryVerify(function () { return wizardLoader.item !== null }, 4000,
                       "WizardScreen.qml failed to load")
             var row = findChild(wizardLoader.item, "wizardRadioReferenceRow")
             verify(row !== null, "the wizard's RadioReference row is missing")
-            compare(row.showDivider, true, "the wizard's RadioReference row lost its divider")
+            compare(row.showDivider, false,
+                    "the row is alone in its own panel now — a divider would underline nothing")
+
+            // The entry appears only in builds that carry the feature, and only
+            // on the tune step, which is where the answers it fills in live.
+            wizardLoader.item.step = 1
+            testContext.setRadioReference("available", true)
+            tryVerify(function () { return row.visible }, 4000,
+                      "the row must appear once the feature reports available")
+            testContext.setRadioReference("available", false)
+            tryVerify(function () { return !row.visible }, 4000,
+                      "the row must hide in a build without the feature")
+            wizardLoader.item.step = 0
+
+            // The row IS the entry point: a tap must still ask Main.qml to push
+            // the RadioReference screen.
+            var opens = 0
+            wizardLoader.item.openRadioReference.connect(function () { opens++ })
+            row.tapped()
+            compare(opens, 1, "tapping the row no longer opens the RadioReference screen")
         }
 
         function test_04_disclosure_row_reports_taps_only_when_enabled() {

--- a/tests/ui/qml/tst_wizard_trunking.qml
+++ b/tests/ui/qml/tst_wizard_trunking.qml
@@ -4,11 +4,17 @@
 import QtQuick
 import QtTest
 
-// The wizard's trunking answer: a new system starts with it off, and until the
-// user answers the switch themselves the decode chip pick suggests it — the
-// P25 chips are almost always trunked systems, the others usually are not. An
-// explicit answer survives every later chip change, whether it came from the
-// user's own toggle, a RadioReference import, or a saved system being edited.
+// The wizard's trunking answer. Until the user answers the switch themselves it
+// is a suggestion, drawn from the decode chip when the chip names a system type
+// — the P25 chips are almost always trunked systems — and from the frequency's
+// band when it does not. The band matters because Auto IS the default chip: a
+// user who accepts the wizard's own 851.375 prefill taps no chip at all, so a
+// chip-only suggestion never runs and the shipped defaults produce a decoder
+// locked to a control channel with call-following off, playing nothing.
+//
+// An explicit answer ends the guessing for good, and survives every later chip
+// pick and frequency edit, whether it came from the user's own toggle, a
+// RadioReference import, or a saved system being edited.
 Item {
     id: root
 
@@ -29,30 +35,81 @@ Item {
         when: windowShown
 
         readonly property var wizard: wizardLoader.item
+        // savedSystems is the production model on shared test storage, so a row
+        // a case adds has to go again whatever happens — a compare() that fails
+        // throws, and a row left behind would follow every later file in the
+        // same binary. Recorded here, dropped in cleanup().
+        property int savedRow: -1
 
         function init() {
             verify(tc.wizard !== null, "WizardScreen.qml failed to load")
             tc.wizard.openForAdd(false)
         }
 
-        function test_01_a_new_system_starts_with_trunking_off() {
-            compare(tc.wizard.trunking, false, "openForAdd must not presume a trunked system")
-            tc.wizard.openForFound(null, "851.375")
-            compare(tc.wizard.trunking, false, "a system found while exploring is not presumed trunked either")
+        function cleanup() {
+            if (tc.savedRow >= 0) {
+                savedSystems.remove(tc.savedRow)
+                tc.savedRow = -1
+            }
         }
 
-        function test_02_the_chip_pick_suggests_the_answer() {
+        // The shipped defaults have to decode. openForAdd() prefills 851.375 —
+        // an 800 MHz P25 control channel, which is why it is the prefill — and
+        // leaves Auto selected, so nothing else in the flow ever answers the
+        // trunking question for a user who accepts them.
+        function test_01_the_prefilled_control_channel_suggests_trunking() {
+            compare(tc.wizard.trunking, true,
+                    "the 800 MHz prefill plus the Auto chip produced a silent session")
+
+            // Worse for a found system, not better: a carrier that stands out on
+            // a 700/800 waterfall is most often a constant control channel.
+            tc.wizard.openForFound(null, "851.375")
+            compare(tc.wizard.trunking, true,
+                    "a control channel found while exploring is presumed conventional")
+        }
+
+        // The suggestion is the band's, not a blanket default. VHF and UHF carry
+        // conventional repeater pairs at least as often as trunked sites, so
+        // there the switch stays off until something answers it.
+        function test_02_only_the_trunked_bands_suggest_it() {
+            tc.wizard.freqText = "154.0"
+            compare(tc.wizard.trunking, false, "VHF must not be presumed trunked")
+            tc.wizard.freqText = "453.0"
+            compare(tc.wizard.trunking, false, "UHF must not be presumed trunked")
+            tc.wizard.freqText = "770.0"
+            compare(tc.wizard.trunking, true, "700 MHz is a trunked band")
+
+            // An empty or half-typed field parses to NaN, which must read as
+            // "no band, no suggestion" rather than as 0 Hz.
+            tc.wizard.freqText = ""
+            compare(tc.wizard.trunking, false, "an empty frequency suggested something")
+            tc.wizard.freqText = "8."
+            compare(tc.wizard.trunking, false, "a half-typed frequency suggested something")
+        }
+
+        // A chip that names a system type has said more than the band can, in
+        // both directions.
+        function test_03_the_chip_pick_outranks_the_band() {
             tc.wizard.pickDecodeFlag("-ft")
             compare(tc.wizard.trunking, true, "picking P25 must suggest trunking on")
             tc.wizard.pickDecodeFlag("-fs")
-            compare(tc.wizard.trunking, false, "picking DMR must drop the unanswered suggestion")
+            compare(tc.wizard.trunking, false,
+                    "an explicit DMR pick must outrank the 800 MHz band")
             tc.wizard.pickDecodeFlag("-mq")
             compare(tc.wizard.trunking, true, "picking P25 Simulcast must suggest trunking on")
             tc.wizard.pickDecodeFlag("")
-            compare(tc.wizard.trunking, false, "the Auto chip is not an explicit P25 pick")
+            compare(tc.wizard.trunking, true,
+                    "returning to Auto must fall back to the band, not to off")
+
+            // And a P25 pick is trunked wherever it is tuned — the band only
+            // speaks for the chip that names no system type.
+            tc.wizard.freqText = "154.0"
+            tc.wizard.pickDecodeFlag("-ft")
+            compare(tc.wizard.trunking, true,
+                    "an explicit P25 pick must hold outside the trunked bands")
         }
 
-        function test_03_the_users_own_answer_survives_chip_changes() {
+        function test_04_the_users_own_answer_survives_everything() {
             tc.wizard.answerTrunking(true)
             tc.wizard.pickDecodeFlag("-fs")
             compare(tc.wizard.trunking, true, "an explicit on must survive a DMR pick")
@@ -62,9 +119,15 @@ Item {
             tc.wizard.answerTrunking(false)
             tc.wizard.pickDecodeFlag("-mq")
             compare(tc.wizard.trunking, false, "an explicit off must survive a P25 pick")
+
+            // Now that the field feeds the suggestion, an answer has to survive
+            // retuning as well as re-chipping.
+            tc.wizard.freqText = "851.375"
+            compare(tc.wizard.trunking, false,
+                    "an explicit off must survive retuning into a trunked band")
         }
 
-        function test_04_a_radioreference_import_is_the_answer() {
+        function test_05_a_radioreference_import_is_the_answer() {
             tc.wizard.applyRadioReference({
                                               "name": "Imported System",
                                               "freqMhz": "853.0625",
@@ -74,22 +137,39 @@ Item {
             compare(tc.wizard.trunking, true, "the import must carry the database's trunking answer")
             tc.wizard.pickDecodeFlag("-fy")
             compare(tc.wizard.trunking, true, "a chip pick must not second-guess the imported answer")
+
+            // The ordering that makes this fragile: applyRadioReference() writes
+            // the frequency field before it answers, so the write fires the band
+            // suggestion. A conventional system in a trunked band is the case
+            // where the two disagree, and the database has to win.
+            tc.wizard.openForAdd(false)
+            tc.wizard.applyRadioReference({
+                                              "name": "Imported Conventional",
+                                              "freqMhz": "853.0625",
+                                              "decodeFlag": "-fs",
+                                              "trunking": false
+                                          })
+            compare(tc.wizard.trunking, false,
+                    "the 800 MHz band overrode a conventional system's own record")
         }
 
-        function test_05_editing_keeps_the_saved_answer() {
+        function test_06_editing_keeps_the_saved_answer() {
+            // Deliberately a conventional system on an 800 MHz frequency: the
+            // band suggests trunking, the saved row says otherwise, and
+            // openForEdit() writes the frequency field before it restores the
+            // answer. Yesterday's card must not change what it does.
             savedSystems.add({
-                                 "name": "Saved Trunked", "sourceType": "usb", "host": "", "port": 0,
-                                 "freqMhz": "851.375", "decodeFlag": "-fs", "trunking": true,
+                                 "name": "Saved Conventional", "sourceType": "usb", "host": "", "port": 0,
+                                 "freqMhz": "851.375", "decodeFlag": "-fs", "trunking": false,
                                  "gainDb": -1, "ppm": "", "bandwidthKhz": -1, "biasTee": -1,
                                  "extraArgs": "", "filePath": "", "chanCsvPath": "",
                                  "groupCsvPath": "", "keyCsvPath": "", "keyCsvHex": false
                              })
-            var row = savedSystems.count - 1
-            tc.wizard.openForEdit(row)
-            compare(tc.wizard.trunking, true, "the edit must show the saved answer")
-            tc.wizard.pickDecodeFlag("-fy")
-            compare(tc.wizard.trunking, true, "a chip pick must not flip a saved system's answer")
-            savedSystems.remove(row)
+            tc.savedRow = savedSystems.count - 1
+            tc.wizard.openForEdit(tc.savedRow)
+            compare(tc.wizard.trunking, false, "the edit must show the saved answer, not the band's")
+            tc.wizard.pickDecodeFlag("-ft")
+            compare(tc.wizard.trunking, false, "a chip pick must not flip a saved system's answer")
         }
     }
 }

--- a/tests/ui/qml/tst_wizard_trunking.qml
+++ b/tests/ui/qml/tst_wizard_trunking.qml
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import QtTest
+
+// The wizard's trunking answer: a new system starts with it off, and until the
+// user answers the switch themselves the decode chip pick suggests it — the
+// P25 chips are almost always trunked systems, the others usually are not. An
+// explicit answer survives every later chip change, whether it came from the
+// user's own toggle, a RadioReference import, or a saved system being edited.
+Item {
+    id: root
+
+    width: 420
+    height: 900
+
+    Loader {
+        id: wizardLoader
+
+        anchors.fill: parent
+        source: uiDir + "/WizardScreen.qml"
+    }
+
+    TestCase {
+        id: tc
+
+        name: "WizardTrunking"
+        when: windowShown
+
+        readonly property var wizard: wizardLoader.item
+
+        function init() {
+            verify(tc.wizard !== null, "WizardScreen.qml failed to load")
+            tc.wizard.openForAdd(false)
+        }
+
+        function test_01_a_new_system_starts_with_trunking_off() {
+            compare(tc.wizard.trunking, false, "openForAdd must not presume a trunked system")
+            tc.wizard.openForFound(null, "851.375")
+            compare(tc.wizard.trunking, false, "a system found while exploring is not presumed trunked either")
+        }
+
+        function test_02_the_chip_pick_suggests_the_answer() {
+            tc.wizard.pickDecodeFlag("-ft")
+            compare(tc.wizard.trunking, true, "picking P25 must suggest trunking on")
+            tc.wizard.pickDecodeFlag("-fs")
+            compare(tc.wizard.trunking, false, "picking DMR must drop the unanswered suggestion")
+            tc.wizard.pickDecodeFlag("-mq")
+            compare(tc.wizard.trunking, true, "picking P25 Simulcast must suggest trunking on")
+            tc.wizard.pickDecodeFlag("")
+            compare(tc.wizard.trunking, false, "the Auto chip is not an explicit P25 pick")
+        }
+
+        function test_03_the_users_own_answer_survives_chip_changes() {
+            tc.wizard.answerTrunking(true)
+            tc.wizard.pickDecodeFlag("-fs")
+            compare(tc.wizard.trunking, true, "an explicit on must survive a DMR pick")
+
+            tc.wizard.openForAdd(false)
+            tc.wizard.pickDecodeFlag("-ft")
+            tc.wizard.answerTrunking(false)
+            tc.wizard.pickDecodeFlag("-mq")
+            compare(tc.wizard.trunking, false, "an explicit off must survive a P25 pick")
+        }
+
+        function test_04_a_radioreference_import_is_the_answer() {
+            tc.wizard.applyRadioReference({
+                                              "name": "Imported System",
+                                              "freqMhz": "853.0625",
+                                              "decodeFlag": "-fs",
+                                              "trunking": true
+                                          })
+            compare(tc.wizard.trunking, true, "the import must carry the database's trunking answer")
+            tc.wizard.pickDecodeFlag("-fy")
+            compare(tc.wizard.trunking, true, "a chip pick must not second-guess the imported answer")
+        }
+
+        function test_05_editing_keeps_the_saved_answer() {
+            savedSystems.add({
+                                 "name": "Saved Trunked", "sourceType": "usb", "host": "", "port": 0,
+                                 "freqMhz": "851.375", "decodeFlag": "-fs", "trunking": true,
+                                 "gainDb": -1, "ppm": "", "bandwidthKhz": -1, "biasTee": -1,
+                                 "extraArgs": "", "filePath": "", "chanCsvPath": "",
+                                 "groupCsvPath": "", "keyCsvPath": "", "keyCsvHex": false
+                             })
+            var row = savedSystems.count - 1
+            tc.wizard.openForEdit(row)
+            compare(tc.wizard.trunking, true, "the edit must show the saved answer")
+            tc.wizard.pickDecodeFlag("-fy")
+            compare(tc.wizard.trunking, true, "a chip pick must not flip a saved system's answer")
+            savedSystems.remove(row)
+        }
+    }
+}

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -836,7 +836,11 @@ class Setup : public QObject {
         rr[QStringLiteral("errorKind")] = 0;
         rr[QStringLiteral("errorIsAuth")] = false;
         rr[QStringLiteral("errorIsSubscription")] = false;
+        /* Both, and independently: the real model answers false to both for a
+         * system type it cannot import, so a fixture that derived one from the
+         * other could not express the case that mis-selects. */
         rr[QStringLiteral("conventional")] = false;
+        rr[QStringLiteral("trunked")] = true;
         rr[QStringLiteral("countries")] = QVariantList();
         rr[QStringLiteral("states")] = QVariantList();
         rr[QStringLiteral("counties")] = QVariantList();

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -494,6 +494,22 @@ class Setup : public QObject {
     }
 
     /**
+     * @brief Set one prefs key, for the same reason setRadioReference() exists.
+     *
+     * The fixture prefs are a plain map too, so a screen that gates on a stored
+     * preference (the Settings application-key row reads prefs.rrAppKey) could
+     * otherwise only ever be tested at the fixture's defaults. Reads only, like
+     * the rest of the map: a QML write to prefs.* still no-ops here.
+     */
+    Q_INVOKABLE void
+    setPrefs(const QString& key, const QVariant& value) {
+        m_prefs[key] = value;
+        if (m_engine != nullptr) {
+            m_engine->rootContext()->setContextProperty(QStringLiteral("prefs"), m_prefs);
+        }
+    }
+
+    /**
      * @brief Reads in @p qmlFiles that name a context-property key the fixture lacks.
      *
      * Returns "metrics.someReading" style entries, empty when the maps below cover

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -810,6 +810,9 @@ class Setup : public QObject {
         QVariantMap rr;
         rr[QStringLiteral("available")] = false;
         rr[QStringLiteral("hasAppKey")] = false;
+        /* Whether the binary bakes an application key in. False, like a source
+         * build with DSD_RR_APP_KEY unset, so the key field is offered. */
+        rr[QStringLiteral("buildHasAppKey")] = false;
         rr[QStringLiteral("credentialsReady")] = false;
         rr[QStringLiteral("busy")] = false;
         rr[QStringLiteral("statusText")] = QString();

--- a/tests/ui/test_ui_qt_persistence.cpp
+++ b/tests/ui/test_ui_qt_persistence.cpp
@@ -137,8 +137,13 @@ test_saved_systems(void) {
                sparseGot.value(QStringLiteral("gainDb")).toInt() == -1
                    && sparseGot.value(QStringLiteral("bandwidthKhz")).toInt() == -1
                    && sparseGot.value(QStringLiteral("biasTee")).toInt() == -1
-                   && sparseGot.value(QStringLiteral("trunking")).toBool()
                    && sparseGot.value(QStringLiteral("lastHeard")).toLongLong() == 0);
+        /* Absent trunking is OFF, the same reading session_args gives it - it
+         * appends -T only for a present true. The store defaulting it ON meant a
+         * map that never mentioned trunking was saved as call-following on while
+         * the args built from that same map left it off. */
+        expect("an absent trunking key reads as off, as it does everywhere else",
+               !sparseGot.value(QStringLiteral("trunking")).toBool());
 
         /* A partial update must not blank fields it does not mention. */
         QVariantMap rename;

--- a/tests/ui/test_ui_qt_radio_reference_model.cpp
+++ b/tests/ui/test_ui_qt_radio_reference_model.cpp
@@ -367,12 +367,18 @@ test_credentials_gate(void) {
     dsd_qt::ImportedFilesModel library(&host);
     dsd_qt::RadioReferenceModel model(&prefs, &library, &host);
 
-    /* This build bakes no application key, so a fresh install has neither. */
-    expect("no app key on a fresh install", !model.hasAppKey());
-    expect("credentials are not ready without a key", !model.credentialsReady());
+    /* Whether a fresh install already has a key is this build's answer, not a
+     * constant: a keyed build ships one, a keyless build waits for the user to
+     * supply it. Asserted against the build rather than assuming keyless, or
+     * this case reads as a pass only in the configuration it happened to be
+     * written in. */
+    const char* builtin = dsd_rr_builtin_app_key();
+    const bool baked = builtin != nullptr && builtin[0] != '\0';
+    expect("a fresh install has a key only where one is baked in", model.hasAppKey() == baked);
+    expect("credentials are never ready on a fresh install", !model.credentialsReady());
 
     prefs.setRrAppKey(kAppKey);
-    expect("a user-supplied key counts", model.hasAppKey());
+    expect("a key is in hand once one is stored", model.hasAppKey());
     expect("credentials still need a username", !model.credentialsReady());
 
     prefs.setRrUsername(kUsername);
@@ -924,12 +930,47 @@ test_results_and_loaded_system_stay_exclusive(void) {
     /* buildHasAppKey reports the baked key and only the baked key: the harness
      * stores a prefs override, which must not count. */
     const char* builtin = dsd_rr_builtin_app_key();
-    expect("buildHasAppKey answers for the baked key alone",
-           h.model.buildHasAppKey() == (builtin != nullptr && builtin[0] != '\0'));
+    const bool baked = builtin != nullptr && builtin[0] != '\0';
+    expect("buildHasAppKey answers for the baked key alone", h.model.buildHasAppKey() == baked);
+
+    /* Which key a request carries. Asserted through chooseAppKey() rather than
+     * only through the model, because the baked value is a compile-time
+     * constant: a test that could reach this only via hasAppKey()/fillAuth()
+     * would exercise whichever single branch this build was configured for, and
+     * the branch that matters most - a shipped key refusing to be displaced by
+     * a stale override - is the one a keyless developer build can never take. */
+    const QByteArray bakedKey("BAKED_KEY_9f4");
+    const QString stored = QStringLiteral("OVERRIDE_KEY_1a2");
+    expect("a baked key is authoritative",
+           dsd_qt::RadioReferenceModel::chooseAppKey(bakedKey.constData(), stored) == bakedKey);
+    expect("a baked key stands alone when nothing is stored",
+           dsd_qt::RadioReferenceModel::chooseAppKey(bakedKey.constData(), QString()) == bakedKey);
+    expect("without a baked key the stored key is the key",
+           dsd_qt::RadioReferenceModel::chooseAppKey("", stored) == stored.toUtf8());
+    expect("a NULL builtin counts as no baked key",
+           dsd_qt::RadioReferenceModel::chooseAppKey(nullptr, stored) == stored.toUtf8());
+    expect("neither candidate leaves no key to send",
+           dsd_qt::RadioReferenceModel::chooseAppKey("", QString()).isEmpty());
+
+    /* And that the model asks the same question the same way. */
+    h.prefs.setRrAppKey(QString());
+    expect("a keyed build needs no stored key; a keyless one has none yet", h.model.hasAppKey() == baked);
+    h.prefs.setRrAppKey(stored);
+    expect("a stored key completes a keyless build", h.model.hasAppKey());
 
     h.model.loadSystem(6673);
     pump(h.model);
     expect("a system is loaded", !h.model.systemDetails().isEmpty());
+
+    /* The choice is not merely reported but sent. This assertion is meaningful
+     * in both configurations, which is what makes the CI step that reconfigures
+     * this build with a baked key worth its seconds: there it flips to proving
+     * the shipped key goes on the wire and the stale override does not. */
+    expect("the envelope carries the chosen application key",
+           h.fake.lastRequest.contains(dsd_qt::RadioReferenceModel::chooseAppKey(builtin, stored)));
+    if (baked) {
+        expect("the envelope does not carry the ignored override", !h.fake.lastRequest.contains(stored.toUtf8()));
+    }
 
     /* A fresh search must land on a visible results stage: the screen shows the
      * list only while no system is loaded, so the reply retires the system. */
@@ -962,6 +1003,26 @@ test_results_and_loaded_system_stay_exclusive(void) {
     h.model.closeSystem();
     expect_int("closing the system retires the error", h.model.errorKind(), dsd_qt::RadioReferenceModel::NoError);
     expect("closing the system clears the error text", h.model.errorText().isEmpty());
+
+    /* And mid-load, which is what reset() does when the screen is reopened over
+     * a fetch that is still running. The replies carry the live generation, so
+     * without retiring the batch they land afterwards and finishSystemLoad()
+     * rebuilds the system around the sid clearSystem() just zeroed - details and
+     * sites fully populated with sid 0, which the screen's stage predicate
+     * (sid > 0) can never show. */
+    h.model.closeSystem();
+    h.model.loadSystem(6673);
+    h.model.closeSystem();
+    pump(h.model);
+    expect("a system closed mid-load stays closed", h.model.systemDetails().isEmpty());
+    expect("a system closed mid-load leaves no sites", h.model.sites().isEmpty());
+    expect("a system closed mid-load leaves no talkgroups", h.model.talkgroupSummary().isEmpty());
+    expect("a system closed mid-load leaves the model idle", !h.model.busy());
+    /* And the screen can still open it again afterwards. */
+    h.model.loadSystem(6673);
+    pump(h.model);
+    expect_int("reopening after a mid-load close works", h.model.systemDetails().value(QStringLiteral("sid")).toInt(),
+               6673);
 }
 
 void

--- a/tests/ui/test_ui_qt_radio_reference_model.cpp
+++ b/tests/ui/test_ui_qt_radio_reference_model.cpp
@@ -918,6 +918,53 @@ test_error_and_cancel(void) {
 }
 
 void
+test_results_and_loaded_system_stay_exclusive(void) {
+    Harness h;
+
+    /* buildHasAppKey reports the baked key and only the baked key: the harness
+     * stores a prefs override, which must not count. */
+    const char* builtin = dsd_rr_builtin_app_key();
+    expect("buildHasAppKey answers for the baked key alone",
+           h.model.buildHasAppKey() == (builtin != nullptr && builtin[0] != '\0'));
+
+    h.model.loadSystem(6673);
+    pump(h.model);
+    expect("a system is loaded", !h.model.systemDetails().isEmpty());
+
+    /* A fresh search must land on a visible results stage: the screen shows the
+     * list only while no system is loaded, so the reply retires the system. */
+    h.model.loadCountySystems(841);
+    pump(h.model);
+    expect_int("the county's systems arrived", h.model.systems().size(), 24);
+    expect("the results retired the loaded system", h.model.systemDetails().isEmpty());
+    expect("the results retired the site list", h.model.sites().isEmpty());
+
+    /* closeSystem() is the screen's back affordance: the system goes, the
+     * results stay, and a stale error goes with the system it described. */
+    h.model.loadSystem(6673);
+    pump(h.model);
+    int systemChanges = 0;
+    QObject::connect(&h.model, &dsd_qt::RadioReferenceModel::systemChanged, &h.model,
+                     [&systemChanges]() { systemChanges++; });
+    h.model.closeSystem();
+    expect("closing the system clears its details", h.model.systemDetails().isEmpty());
+    expect("closing the system clears its sites", h.model.sites().isEmpty());
+    expect("closing the system clears its talkgroups", h.model.talkgroupSummary().isEmpty());
+    expect("closing the system keeps the results list", h.model.systems().size() == 24);
+    expect("closing the system announced itself", systemChanges > 0);
+
+    /* And with an error up: back means the failure is acknowledged. */
+    h.fake.serveFault = true;
+    h.model.loadSystem(6673);
+    pump(h.model);
+    expect("the fault landed as an error", h.model.errorKind() != dsd_qt::RadioReferenceModel::NoError);
+    h.fake.serveFault = false;
+    h.model.closeSystem();
+    expect_int("closing the system retires the error", h.model.errorKind(), dsd_qt::RadioReferenceModel::NoError);
+    expect("closing the system clears the error text", h.model.errorText().isEmpty());
+}
+
+void
 test_destroy_with_requests_in_flight(void) {
     /* The client is destroyed first in ~RadioReferenceModel, which joins the
      * worker before any member it might read goes away. Under ASan this case is
@@ -958,6 +1005,7 @@ main(int argc, char** argv) {
     test_refresh_uses_the_recorded_tower();
     test_site_without_a_marked_control_channel();
     test_error_and_cancel();
+    test_results_and_loaded_system_stay_exclusive();
     test_destroy_with_requests_in_flight();
 
     QDir(dataDir).removeRecursively();


### PR DESCRIPTION
## Problems

Two reported after using #335 on Android, two more found while fixing them:

1. **Stuck on the imported system.** The found-systems list is hidden whenever a system is
   loaded, nothing ever cleared the loaded system, and `reset()` only cleared screen-local
   state — so a second search fetched a list that landed invisibly behind the stale system,
   and re-entering the screen after an import dropped you back on the old system with no way
   out. There was no back affordance from a loaded system at all.
2. **Application-key box shown in keyed builds.** Settings rendered the key field
   unconditionally, directly under Username — reading like a password box. Anything typed
   there becomes a persisted override that outranks the working baked key, with nothing but
   an auth banner to show for it.
3. The find panel stayed visible above a loaded system, so the screen read as two modes at
   once (half of why it felt stuck).
4. The credentials form hides when the fields are *filled*, not *accepted* — a mistyped
   password produced the auth error with the form already gone, and the session-only password
   had nowhere left to be retyped short of an app restart.

## What changed

- **Model invariants** (`radio_reference_model`): a fresh `FetchSystems` reply retires the
  loaded system; new `closeSystem()` invokable drops the system and its stale error while
  keeping the results list; new `buildHasAppKey` CONSTANT property — whether *this build*
  bakes a key, ignoring the prefs override.
- **Import screen** is now an explicit drill-down: sign-in → find/results → system, with a
  "‹ All systems" back row between the last two and `reset()` closing any leftover system on
  every visit. The results list survives going back on purpose — importing several systems
  from one search is the loop this exists for.
- **Credentials**: username/password lead, the application key comes last and only in keyless
  builds; the key field's commit fires the account check like the password's; an auth failure
  in a keyed build stops naming a key the user cannot fix; the form reopens while the last
  failure is an auth/subscription rejection.
- **Settings**: the key row is gated on `buildHasAppKey`, staying visible only while an
  override is stored (the field is the only way to see and clear one; clearing re-hides it).
  Placeholder no longer promises a build key that keyless builds don't have.
- A single-site trunked system selects its only site automatically.
- `docs/radioreference-import.md` states the keyed/keyless UI behaviour.

## Tests

- `UI_QT_RADIO_REFERENCE`: new case pinning results/system exclusivity, `closeSystem()`
  semantics (incl. error retirement), and `buildHasAppKey` vs the baked key.
- `UI_QT_QML_CALL_LISTS`: five new cases — keyed-build gate, drill-down staging, single-site
  auto-select, per-build auth wording, form-reopen on rejection — plus a Settings key-row
  suite driven through a new `setPrefs` fixture invokable. 110 QML assertions, all 12 `UI_QT`
  binaries green; `tools/preflight_ci.sh` clean.

## Emulator validation (API 36, headless)

Both flavors driven end to end short of a real sign-in: keyless (key fields present with the
request link), and keyed via `DSD_RR_APP_KEY` (key confirmed in the generated source and via
`strings` on the shipped `.so`; no key boxes anywhere; live auth failure reads
"RadioReference did not accept that username or password" with the form still up for a
retype). The online search→import→back→import-another loop is covered by the QML staging
tests; driving it live needs a premium account.