### PR TITLE
dmr: decode ARS records, fix MNIS payload length and endpoint labels

### DIFF
--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -480,12 +480,11 @@ jobs:
     # during LTO linking the full executable has to link, not just compile. Arch is used
     # because it tracks the GCC release the reports come from.
     #
-    # Deliberately non-required: -Wstringop-overflow is version- and vectorizer-sensitive,
-    # and the container is a rolling tag, so a GCC point release must not block unrelated
-    # PRs. Promote to required once it has been stable across a few releases.
+    # Required status check. -Wstringop-overflow is version- and vectorizer-sensitive and the
+    # container is a rolling tag, so a GCC point release can break this job on an unrelated PR;
+    # pin the image digest to the last good release when that happens rather than merging around it.
     name: gcc lto link (x86-64-v4)
     runs-on: ubuntu-latest
-    continue-on-error: true
     container:
       image: archlinux:base-devel@sha256:25074821d28e54a0bbbd87a88d392f1489be9bd815ee5c60744be6e57fd500d8
     defaults:

--- a/src/protocol/dmr/CMakeLists.txt
+++ b/src/protocol/dmr/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(
     dsd-neo_proto_dmr
     PRIVATE
         dmr_34_viterbi.c
+        dmr_ars.c
         dmr_block.c
         dmr_block_crypto.c
         dmr_bs.c

--- a/src/protocol/dmr/dmr_ars.c
+++ b/src/protocol/dmr/dmr_ars.c
@@ -7,62 +7,204 @@
  * @file
  * @brief Motorola MOTOTRBO Automatic Registration Service (ARS) message decode.
  *
- * ARS messages are length prefixed: a two octet message size (excluding the size octets)
- * followed by a header octet carrying Ext/Ack/Pri/Cntl flags in bits 7-4 and a PDU type in
- * bits 3-0, an optional second header octet when the Ext flag is set, and a PDU-specific
- * payload. Registrations carry length-value fields (device id, user id, password).
+ * Wire format follows the MOTOTRBO Application Developer Program "Development Specification -
+ * Automatic Registration Service" v02.00. A message is a two octet size prefix (excluding the
+ * size octets themselves) followed by a first header octet, zero or more extension header
+ * octets, and a PDU specific payload:
+ *
+ *   1st header: bit 7 Ext, bit 6 Ack, bit 5 Pri, bit 4 Cntl, bits 3-0 PDU type (spec 3.2).
+ *   Each header octet's Ext bit says another header octet follows.
+ *
+ * On an acknowledgement PDU the Ack bit is the verdict - clear is success, set is failure - and
+ * the optional second header carries a refresh/session timer on success or a reason code on
+ * failure. Registrations carry a length-value name field: device id, user id, password, each
+ * preceded by a one octet size that may be zero when the field is unused (spec 3.4.1, 3.4.7).
  */
 
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/string_utils.h>
 #include <dsd-neo/protocol/dmr/dmr_utf8_text.h>
 #include <stdio.h>
-#include <string.h>
 #include "dmr_ars.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
-#define DMR_ARS_HDR_EXT        0x80U
-#define DMR_ARS_TYPE_DEV_REG   0x00U
-#define DMR_ARS_TYPE_DEV_DEREG 0x01U
-#define DMR_ARS_TYPE_QUERY     0x04U
-#define DMR_ARS_TYPE_USER_REG  0x05U
-#define DMR_ARS_TYPE_REG_ACK   0x0FU
+#define DMR_ARS_HDR_EXT         0x80U
+#define DMR_ARS_HDR_ACK         0x40U
 
-static void
-dmr_ars_append(char* dst, size_t dstsz, const char* src) {
-    if (!dst || !src || dstsz == 0) {
-        return;
-    }
-    size_t len = strlen(dst);
-    if (len >= dstsz) {
-        return;
-    }
-    DSD_SNPRINTF(dst + len, dstsz - len, "%s", src);
-}
+#define DMR_ARS_TYPE_DEV_REG    0x00U
+#define DMR_ARS_TYPE_DEV_DEREG  0x01U
+#define DMR_ARS_TYPE_QUERY      0x04U
+#define DMR_ARS_TYPE_USER_REG   0x05U
+#define DMR_ARS_TYPE_USER_DEREG 0x06U
+#define DMR_ARS_TYPE_USER_ACK   0x07U
+#define DMR_ARS_TYPE_REG_ACK    0x0FU
 
-// Registration payloads are length-value encoded and start with the device identifier:
-// <id size> <id octets>. Returns 0 when the field does not fit the record or the identifier
-// is not printable ASCII, so the caller can fall back to a raw dump instead of a bogus id.
-static uint8_t
-dmr_ars_lv_device_id(const uint8_t* rec, uint16_t rec_len, uint16_t pos, char* out, size_t out_sz) {
-    if (pos >= rec_len) {
-        return 0;
+// Upper bound on the raw fallback dump. The record length already keeps the dump inside the
+// received bytes, but an ARS record can be as long as a whole reassembled data PDU and
+// utf8_to_text emits one unbuffered stderr write per byte; the two call sites this replaced
+// capped the dump at 10 and 15 bytes, so keep a diagnostic-sized ceiling.
+#define DMR_ARS_MAX_DUMP        64U
+
+// Longest name field rendered. Device and user identifiers are short strings (the spec's own
+// examples are a radio id and a nine digit user id); anything longer is not worth a log line.
+#define DMR_ARS_ID_MAX          32U
+
+typedef enum {
+    DMR_ARS_LV_ERR = -1,  // field does not fit the record; stop walking
+    DMR_ARS_LV_EMPTY = 0, // zero length or unrenderable, `*pos` still advanced
+    DMR_ARS_LV_OK = 1     // `out` holds the decoded field
+} dmr_ars_lv_result;
+
+// Reads one length-value name field at `*pos` and advances `*pos` past it. A zero length is legal
+// for any of the three fields, and a field that is not printable text is skipped rather than
+// abandoned, so that one binary field cannot hide the ones after it.
+static dmr_ars_lv_result
+dmr_ars_lv_next(const uint8_t* rec, uint16_t rec_len, uint16_t* pos, char* out, size_t out_sz) {
+    out[0] = '\0';
+    if (*pos >= rec_len) {
+        return DMR_ARS_LV_ERR;
     }
 
-    uint8_t id_len = rec[pos];
-    if (id_len == 0 || (uint16_t)(pos + 1U + id_len) > rec_len || (size_t)id_len + 1U > out_sz) {
-        return 0;
+    uint8_t id_len = rec[*pos];
+    // Compare in the promoted type: narrowing the sum back to uint16_t would wrap it past the
+    // bound this check exists to enforce as the walk reaches the later fields.
+    if ((uint32_t)*pos + 1U + id_len > rec_len) {
+        return DMR_ARS_LV_ERR;
+    }
+
+    uint16_t value_pos = (uint16_t)(*pos + 1U);
+    *pos = (uint16_t)(value_pos + id_len);
+    if (id_len == 0U || (size_t)id_len + 1U > out_sz) {
+        return DMR_ARS_LV_EMPTY;
     }
 
     for (uint8_t i = 0; i < id_len; i++) {
-        uint8_t c = rec[pos + 1U + i];
+        uint8_t c = rec[value_pos + i];
         if (c < 0x20U || c >= 0x7FU) {
-            return 0;
+            out[0] = '\0';
+            return DMR_ARS_LV_EMPTY;
         }
         out[i] = (char)c;
     }
     out[id_len] = '\0';
-    return 1;
+    return DMR_ARS_LV_OK;
+}
+
+// Renders a device or user registration. The name field is device id, user id, password in that
+// order; a user registration is about the user that signed in, so that identifier leads and the
+// device it signed in from follows. Passwords are credentials, so only their presence is noted.
+static void
+dmr_ars_format_registration(const uint8_t* rec, uint16_t rec_len, uint16_t pos, uint8_t is_user, char* out,
+                            size_t out_sz) {
+    char dev_id[DMR_ARS_ID_MAX];
+    char user_id[DMR_ARS_ID_MAX];
+    char password[DMR_ARS_ID_MAX];
+    uint8_t have_dev = (dmr_ars_lv_next(rec, rec_len, &pos, dev_id, sizeof(dev_id)) == DMR_ARS_LV_OK);
+    uint8_t have_user = (dmr_ars_lv_next(rec, rec_len, &pos, user_id, sizeof(user_id)) == DMR_ARS_LV_OK);
+    uint8_t have_pw = (dmr_ars_lv_next(rec, rec_len, &pos, password, sizeof(password)) == DMR_ARS_LV_OK);
+
+    out[0] = '\0';
+    if (!have_dev && !have_user) {
+        // Nothing renderable in the name field: let the caller fall back to the raw dump, which
+        // is more diagnostic than a bare label.
+        return;
+    }
+
+    if (is_user) {
+        DSD_SNPRINTF(out, out_sz, "ARS User Reg: %s; ", have_user ? user_id : "?");
+        if (have_dev) {
+            char dev_str[DMR_ARS_ID_MAX + 8U];
+            DSD_SNPRINTF(dev_str, sizeof(dev_str), "DEV: %s; ", dev_id);
+            dsd_strncat_s(out, out_sz, dev_str, sizeof(dev_str));
+        }
+    } else {
+        DSD_SNPRINTF(out, out_sz, "ARS Reg: %s; ", have_dev ? dev_id : "?");
+    }
+
+    if (have_pw) {
+        dsd_strncat_s(out, out_sz, "PW set; ", 8U);
+    }
+}
+
+// Reason codes for a failed acknowledgement (spec 3.4.3 for the device ack, 3.4.9 for the user
+// ack). Only these are defined; anything else is reported numerically.
+static void
+dmr_ars_fail_reason(uint8_t is_user, uint8_t code, char* out, size_t out_sz) {
+    if (is_user && code == 0x01U) {
+        DSD_SNPRINTF(out, out_sz, "%s", "user validation failed");
+    } else if (is_user && code == 0x02U) {
+        DSD_SNPRINTF(out, out_sz, "%s", "user validation timeout");
+    } else if (is_user) {
+        DSD_SNPRINTF(out, out_sz, "%s", "transmission failure");
+    } else if (code == 0x00U) {
+        DSD_SNPRINTF(out, out_sz, "%s", "device not authorized");
+    } else {
+        DSD_SNPRINTF(out, out_sz, "reason %02X", code);
+    }
+}
+
+// Renders a registration acknowledgement. Bit 6 of the first header is the verdict, so a refused
+// registration and a successful one differ by one bit and must not print the same line.
+static void
+dmr_ars_format_ack(const uint8_t* rec, uint16_t rec_len, uint8_t is_user, char* out, size_t out_sz) {
+    const char* label = is_user ? "ARS User Ack" : "ARS Ack";
+    uint8_t hdr = rec[0];
+    // The timer/reason lives in the second header. Without it the spec pins the refresh timer to
+    // zero (disabled) and the session to "until power cycle", which is what a 0 renders as.
+    uint8_t have_ext = (uint8_t)(((hdr & DMR_ARS_HDR_EXT) != 0U) && rec_len > 1U);
+    uint8_t value = have_ext ? (uint8_t)(rec[1] & 0x7FU) : 0U;
+
+    if ((hdr & DMR_ARS_HDR_ACK) != 0U) {
+        char reason[32];
+        dmr_ars_fail_reason(is_user, value, reason, sizeof(reason));
+        DSD_SNPRINTF(out, out_sz, "%s: FAIL - %s; ", label, reason);
+    } else if (is_user) {
+        if (value == 0U) {
+            DSD_SNPRINTF(out, out_sz, "%s: OK; session until power cycle; ", label);
+        } else {
+            DSD_SNPRINTF(out, out_sz, "%s: OK; session %u; ", label, (unsigned)value);
+        }
+    } else if (value == 0U) {
+        DSD_SNPRINTF(out, out_sz, "%s: OK; refresh off; ", label);
+    } else {
+        // One unit is 30 minutes, range 1-63 (spec 3.4.2).
+        DSD_SNPRINTF(out, out_sz, "%s: OK; refresh %u min; ", label, (unsigned)value * 30U);
+    }
+}
+
+// Walks the header extension chain and returns the offset of the payload within the record.
+static uint16_t
+dmr_ars_payload_pos(const uint8_t* rec, uint16_t rec_len) {
+    uint16_t pos = 1U;
+    while ((uint16_t)(pos - 1U) < rec_len && (rec[pos - 1U] & DMR_ARS_HDR_EXT) != 0U) {
+        pos++;
+    }
+    return pos;
+}
+
+static void
+dmr_ars_format(const uint8_t* rec, uint16_t rec_len, char* out, size_t out_sz) {
+    // The Cntl bit namespaces the type values, but ARS defines no user messages (spec 3.4), and a
+    // decoder is better off reading a non-conformant transmitter than dropping it, so the type
+    // nibble is taken at face value.
+    uint8_t pdu_type = rec[0] & 0x0FU;
+    uint16_t payload_pos = dmr_ars_payload_pos(rec, rec_len);
+
+    out[0] = '\0';
+    switch (pdu_type) {
+        case DMR_ARS_TYPE_DEV_REG:
+        case DMR_ARS_TYPE_USER_REG:
+            dmr_ars_format_registration(rec, rec_len, payload_pos, (uint8_t)(pdu_type == DMR_ARS_TYPE_USER_REG), out,
+                                        out_sz);
+            break;
+        case DMR_ARS_TYPE_DEV_DEREG: DSD_SNPRINTF(out, out_sz, "ARS Dereg; "); break;
+        case DMR_ARS_TYPE_USER_DEREG: DSD_SNPRINTF(out, out_sz, "ARS User Dereg; "); break;
+        case DMR_ARS_TYPE_QUERY: DSD_SNPRINTF(out, out_sz, "ARS Query; "); break;
+        case DMR_ARS_TYPE_USER_ACK: dmr_ars_format_ack(rec, rec_len, 1U, out, out_sz); break;
+        case DMR_ARS_TYPE_REG_ACK: dmr_ars_format_ack(rec, rec_len, 0U, out, out_sz); break;
+        default: break;
+    }
 }
 
 // Print an ARS message. `msg` points at the two octet size prefix; `len` is the number of
@@ -70,14 +212,13 @@ dmr_ars_lv_device_id(const uint8_t* rec, uint16_t rec_len, uint16_t pos, char* o
 // never run past the record into block trailer or padding bytes.
 void
 dmr_ars_print_message(dsd_state* state, const uint8_t* msg, uint16_t len) {
-    uint8_t slot = state->currentslot & 1;
-    char summary[64];
-    char dev_id[32];
+    char summary[128];
 
-    if (msg == NULL || len < 3U) {
+    if (state == NULL || msg == NULL || len < 3U) {
         return;
     }
 
+    uint8_t slot = state->currentslot & 1;
     uint16_t rec_len = (uint16_t)(((uint16_t)msg[0] << 8) | msg[1]);
     uint16_t avail = (uint16_t)(len - 2U);
     if (rec_len > avail) {
@@ -88,29 +229,16 @@ dmr_ars_print_message(dsd_state* state, const uint8_t* msg, uint16_t len) {
     }
 
     const uint8_t* rec = msg + 2;
-    uint8_t hdr = rec[0];
-    uint8_t pdu_type = hdr & 0x0FU;
-    // The second header octet (encoding or refresh timer) is only present with the Ext flag.
-    uint16_t payload_pos = (hdr & DMR_ARS_HDR_EXT) ? 2U : 1U;
-
-    summary[0] = '\0';
-    if ((pdu_type == DMR_ARS_TYPE_DEV_REG || pdu_type == DMR_ARS_TYPE_USER_REG)
-        && dmr_ars_lv_device_id(rec, rec_len, payload_pos, dev_id, sizeof(dev_id))) {
-        DSD_SNPRINTF(summary, sizeof(summary), "ARS %sReg: %s; ", pdu_type == DMR_ARS_TYPE_USER_REG ? "User " : "",
-                     dev_id);
-    } else if (pdu_type == DMR_ARS_TYPE_DEV_DEREG) {
-        DSD_SNPRINTF(summary, sizeof(summary), "ARS Dereg; ");
-    } else if (pdu_type == DMR_ARS_TYPE_QUERY) {
-        DSD_SNPRINTF(summary, sizeof(summary), "ARS Query; ");
-    } else if (pdu_type == DMR_ARS_TYPE_REG_ACK) {
-        DSD_SNPRINTF(summary, sizeof(summary), "ARS Ack; ");
-    }
+    dmr_ars_format(rec, rec_len, summary, sizeof(summary));
 
     if (summary[0] != '\0') {
         DSD_FPRINTF(stderr, "\n %s", summary);
-        dmr_ars_append(state->dmr_lrrp_gps[slot], sizeof(state->dmr_lrrp_gps[slot]), summary);
+        dsd_strncat_s(state->dmr_lrrp_gps[slot], sizeof(state->dmr_lrrp_gps[slot]), summary, sizeof(summary));
         return;
     }
 
+    if (rec_len > DMR_ARS_MAX_DUMP) {
+        rec_len = DMR_ARS_MAX_DUMP;
+    }
     utf8_to_text(state, 0, rec_len, rec);
 }

--- a/src/protocol/dmr/dmr_ars.c
+++ b/src/protocol/dmr/dmr_ars.c
@@ -168,7 +168,8 @@ dmr_ars_format_ack(const uint8_t* rec, uint16_t rec_len, uint8_t is_user, char* 
     } else if (value == 0U) {
         DSD_SNPRINTF(out, out_sz, "%s: OK; refresh off; ", label);
     } else {
-        // One unit is 30 minutes, range 1-63 (spec 3.4.2).
+        // One unit is 30 minutes over the 7 bit field, range 1-127: 30 minutes to ~2.5 days
+        // (spec 3.4.2).
         DSD_SNPRINTF(out, out_sz, "%s: OK; refresh %u min; ", label, (unsigned)value * 30U);
     }
 }

--- a/src/protocol/dmr/dmr_ars.c
+++ b/src/protocol/dmr/dmr_ars.c
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Motorola MOTOTRBO Automatic Registration Service (ARS) message decode.
+ *
+ * ARS messages are length prefixed: a two octet message size (excluding the size octets)
+ * followed by a header octet carrying Ext/Ack/Pri/Cntl flags in bits 7-4 and a PDU type in
+ * bits 3-0, an optional second header octet when the Ext flag is set, and a PDU-specific
+ * payload. Registrations carry length-value fields (device id, user id, password).
+ */
+
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/dmr/dmr_utf8_text.h>
+#include <stdio.h>
+#include <string.h>
+#include "dmr_ars.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#define DMR_ARS_HDR_EXT        0x80U
+#define DMR_ARS_TYPE_DEV_REG   0x00U
+#define DMR_ARS_TYPE_DEV_DEREG 0x01U
+#define DMR_ARS_TYPE_QUERY     0x04U
+#define DMR_ARS_TYPE_USER_REG  0x05U
+#define DMR_ARS_TYPE_REG_ACK   0x0FU
+
+static void
+dmr_ars_append(char* dst, size_t dstsz, const char* src) {
+    if (!dst || !src || dstsz == 0) {
+        return;
+    }
+    size_t len = strlen(dst);
+    if (len >= dstsz) {
+        return;
+    }
+    DSD_SNPRINTF(dst + len, dstsz - len, "%s", src);
+}
+
+// Registration payloads are length-value encoded and start with the device identifier:
+// <id size> <id octets>. Returns 0 when the field does not fit the record or the identifier
+// is not printable ASCII, so the caller can fall back to a raw dump instead of a bogus id.
+static uint8_t
+dmr_ars_lv_device_id(const uint8_t* rec, uint16_t rec_len, uint16_t pos, char* out, size_t out_sz) {
+    if (pos >= rec_len) {
+        return 0;
+    }
+
+    uint8_t id_len = rec[pos];
+    if (id_len == 0 || (uint16_t)(pos + 1U + id_len) > rec_len || (size_t)id_len + 1U > out_sz) {
+        return 0;
+    }
+
+    for (uint8_t i = 0; i < id_len; i++) {
+        uint8_t c = rec[pos + 1U + i];
+        if (c < 0x20U || c >= 0x7FU) {
+            return 0;
+        }
+        out[i] = (char)c;
+    }
+    out[id_len] = '\0';
+    return 1;
+}
+
+// Print an ARS message. `msg` points at the two octet size prefix; `len` is the number of
+// received octets available from there. The size prefix bounds every read, so a dump can
+// never run past the record into block trailer or padding bytes.
+void
+dmr_ars_print_message(dsd_state* state, const uint8_t* msg, uint16_t len) {
+    uint8_t slot = state->currentslot & 1;
+    char summary[64];
+    char dev_id[32];
+
+    if (msg == NULL || len < 3U) {
+        return;
+    }
+
+    uint16_t rec_len = (uint16_t)(((uint16_t)msg[0] << 8) | msg[1]);
+    uint16_t avail = (uint16_t)(len - 2U);
+    if (rec_len > avail) {
+        rec_len = avail;
+    }
+    if (rec_len == 0U) {
+        return;
+    }
+
+    const uint8_t* rec = msg + 2;
+    uint8_t hdr = rec[0];
+    uint8_t pdu_type = hdr & 0x0FU;
+    // The second header octet (encoding or refresh timer) is only present with the Ext flag.
+    uint16_t payload_pos = (hdr & DMR_ARS_HDR_EXT) ? 2U : 1U;
+
+    summary[0] = '\0';
+    if ((pdu_type == DMR_ARS_TYPE_DEV_REG || pdu_type == DMR_ARS_TYPE_USER_REG)
+        && dmr_ars_lv_device_id(rec, rec_len, payload_pos, dev_id, sizeof(dev_id))) {
+        DSD_SNPRINTF(summary, sizeof(summary), "ARS %sReg: %s; ", pdu_type == DMR_ARS_TYPE_USER_REG ? "User " : "",
+                     dev_id);
+    } else if (pdu_type == DMR_ARS_TYPE_DEV_DEREG) {
+        DSD_SNPRINTF(summary, sizeof(summary), "ARS Dereg; ");
+    } else if (pdu_type == DMR_ARS_TYPE_QUERY) {
+        DSD_SNPRINTF(summary, sizeof(summary), "ARS Query; ");
+    } else if (pdu_type == DMR_ARS_TYPE_REG_ACK) {
+        DSD_SNPRINTF(summary, sizeof(summary), "ARS Ack; ");
+    }
+
+    if (summary[0] != '\0') {
+        DSD_FPRINTF(stderr, "\n %s", summary);
+        dmr_ars_append(state->dmr_lrrp_gps[slot], sizeof(state->dmr_lrrp_gps[slot]), summary);
+        return;
+    }
+
+    utf8_to_text(state, 0, rec_len, rec);
+}

--- a/src/protocol/dmr/dmr_ars.h
+++ b/src/protocol/dmr/dmr_ars.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Motorola MOTOTRBO Automatic Registration Service (ARS) message decode.
+ */
+
+#ifndef DSD_NEO_SRC_PROTOCOL_DMR_DMR_ARS_H_
+#define DSD_NEO_SRC_PROTOCOL_DMR_DMR_ARS_H_
+
+#include <dsd-neo/core/state_fwd.h>
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void dmr_ars_print_message(dsd_state* state, const uint8_t* msg, uint16_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_SRC_PROTOCOL_DMR_DMR_ARS_H_ */

--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include "dmr_ars.h"
 #include "dmr_block_crypto.h"
 #include "dmr_pdu_internal.h"
 #include "dsd-neo/core/opts_fwd.h"
@@ -1250,7 +1251,9 @@ dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, 
         uint8_t pdu_crc_ok = dmr_block_type1_lrrp_crc_ok(ctx->state, ctx->slot);
         dmr_lrrp(ctx->opts, ctx->state, len, msrc, mdst, ctx->state->dmr_pdu_sf[ctx->slot] + 7, pdu_crc_ok);
     } else if (mnis_type == 0x33) {
-        utf8_to_text(ctx->state, 0, 15, ctx->state->dmr_pdu_sf[ctx->slot] + 7);
+        // ARS records are length prefixed; a fixed dump window would run past the record
+        // into the block trailer and render it as random-looking text.
+        dmr_ars_print_message(ctx->state, ctx->state->dmr_pdu_sf[ctx->slot] + 7, len);
     } else if (mnis_type == 0x01) {
         utf8_to_text(ctx->state, 0, len - offset, ctx->state->dmr_pdu_sf[ctx->slot] + 7);
         dmr_locn(ctx->opts, ctx->state, len, ctx->state->dmr_pdu_sf[ctx->slot] + 7);
@@ -1287,7 +1290,10 @@ static void
 dmr_block_type1_handle_mnis(dmr_block_assembler_ctx* ctx, int offset) {
     uint16_t byte_count = ctx->state->data_byte_ctr[ctx->slot];
     uint8_t poc = ctx->state->data_block_poc[ctx->slot];
-    uint16_t len = byte_count - poc - 4 - 7;
+    // A short PDU would wrap this subtraction to ~65k and then clamp to 150, handing the
+    // payload handlers a length far past the received bytes. Treat it as empty instead.
+    uint16_t overhead = (uint16_t)(poc + 4 + 7);
+    uint16_t len = (byte_count > overhead) ? (uint16_t)(byte_count - overhead) : 0;
     uint32_t msrc = ctx->state->dmr_lrrp_source[ctx->slot];
     uint32_t mdst = ctx->state->dmr_lrrp_target[ctx->slot];
     uint8_t mnis_type = ctx->state->dmr_pdu_sf[ctx->slot][4];

--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -1191,7 +1191,7 @@ dmr_block_type1_handle_encrypted_notice(dmr_block_assembler_ctx* ctx) {
 
     DSD_MEMSET(enc_str, 0, sizeof(enc_str));
     DSD_SNPRINTF(enc_str, sizeof(enc_str), "DATA TGT: %lld; SRC: %lld; ENC PDU; ALG: %02X; KID: %02X;",
-                 ctx->state->dmr_lrrp_source[ctx->slot], ctx->state->dmr_lrrp_target[ctx->slot], alg, kid);
+                 ctx->state->dmr_lrrp_target[ctx->slot], ctx->state->dmr_lrrp_source[ctx->slot], alg, kid);
     DSD_SNPRINTF(ctx->state->dmr_lrrp_gps[ctx->slot], sizeof(ctx->state->dmr_lrrp_gps[ctx->slot]), "%s", enc_str);
     const dsd_call_observation observation =
         dsd_call_observation_data(ctx->state->lastsynctype, ctx->slot, (uint64_t)ctx->state->dmr_lrrp_source[ctx->slot],
@@ -1245,8 +1245,8 @@ dmr_block_type1_mnis_event_category(uint8_t mnis_type) {
 }
 
 static void
-dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, uint8_t mnis_type, int offset,
-                                    uint32_t msrc, uint32_t mdst) {
+dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, uint8_t mnis_type, uint32_t msrc,
+                                    uint32_t mdst) {
     if (mnis_type == 0x11) {
         uint8_t pdu_crc_ok = dmr_block_type1_lrrp_crc_ok(ctx->state, ctx->slot);
         dmr_lrrp(ctx->opts, ctx->state, len, msrc, mdst, ctx->state->dmr_pdu_sf[ctx->slot] + 7, pdu_crc_ok);
@@ -1255,7 +1255,11 @@ dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, 
         // into the block trailer and render it as random-looking text.
         dmr_ars_print_message(ctx->state, ctx->state->dmr_pdu_sf[ctx->slot] + 7, len);
     } else if (mnis_type == 0x01) {
-        utf8_to_text(ctx->state, 0, len - offset, ctx->state->dmr_pdu_sf[ctx->slot] + 7);
+        // `len` already counts only the octets available at +7, so nothing further comes off it.
+        // Upstream subtracted the CRC32 bit-reordering loop's `offset` here, which is a constant
+        // for locating confirmed-data DBSN octets and has no bearing on a text length; the
+        // dmr_locn() call on the next line passes the same pointer with the unadjusted length.
+        utf8_to_text(ctx->state, 0, len, ctx->state->dmr_pdu_sf[ctx->slot] + 7);
         dmr_locn(ctx->opts, ctx->state, len, ctx->state->dmr_pdu_sf[ctx->slot] + 7);
         dsd_event_history_transaction transaction;
         dsd_event_history_transaction_begin(ctx->state, &transaction);
@@ -1268,14 +1272,18 @@ dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, 
 
     if (mnis_type != 0x11 && mnis_type != 0x01) {
         char mnis_str[200];
-        DSD_MEMSET(mnis_str, 200, sizeof(mnis_str));
-        DSD_SNPRINTF(mnis_str, sizeof(mnis_str), "MNIS TGT: %lld; SRC: %lld;", ctx->state->dmr_lrrp_source[ctx->slot],
-                     ctx->state->dmr_lrrp_target[ctx->slot]);
+        DSD_MEMSET(mnis_str, 0, sizeof(mnis_str));
+        DSD_SNPRINTF(mnis_str, sizeof(mnis_str), "MNIS TGT: %lld; SRC: %lld;", ctx->state->dmr_lrrp_target[ctx->slot],
+                     ctx->state->dmr_lrrp_source[ctx->slot]);
         const dsd_call_observation observation = dsd_call_observation_data(
             ctx->state->lastsynctype, ctx->slot, (uint64_t)ctx->state->dmr_lrrp_source[ctx->slot],
             (uint64_t)ctx->state->dmr_lrrp_target[ctx->slot]);
+        // ARS decodes append their summary to dmr_lrrp_gps, which already carries the same
+        // endpoints; emit that so the decoded registration reaches the history row and not just
+        // the live slot pane. Other MNIS types have nothing extra to say, so keep mnis_str.
+        const char* notice = (mnis_type == 0x33) ? ctx->state->dmr_lrrp_gps[ctx->slot] : mnis_str;
         (void)dsd_event_emit_data_notice_classified(ctx->opts, ctx->state, ctx->slot, &observation,
-                                                    dmr_block_type1_mnis_event_category(mnis_type), mnis_str);
+                                                    dmr_block_type1_mnis_event_category(mnis_type), notice);
     } else if (mnis_type == 0x11 || mnis_type == 0x01) {
         const dsd_call_observation observation = dsd_call_observation_data(
             ctx->state->lastsynctype, ctx->slot, (uint64_t)ctx->state->dmr_lrrp_source[ctx->slot],
@@ -1287,13 +1295,18 @@ dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, 
 }
 
 static void
-dmr_block_type1_handle_mnis(dmr_block_assembler_ctx* ctx, int offset) {
+dmr_block_type1_handle_mnis(dmr_block_assembler_ctx* ctx) {
     uint16_t byte_count = ctx->state->data_byte_ctr[ctx->slot];
     uint8_t poc = ctx->state->data_block_poc[ctx->slot];
-    // A short PDU would wrap this subtraction to ~65k and then clamp to 150, handing the
-    // payload handlers a length far past the received bytes. Treat it as empty instead.
-    uint16_t overhead = (uint16_t)(poc + 4 + 7);
-    uint16_t len = (byte_count > overhead) ? (uint16_t)(byte_count - overhead) : 0;
+    // The payload starts at octet 7 of the stored proprietary header and the CRC32 trailer sits
+    // at the end, so 11 octets are never payload. A short PDU would wrap this subtraction to
+    // ~65k and then clamp to 150, handing the payload handlers a length far past the received
+    // bytes; treat it as empty instead.
+    uint16_t avail = (byte_count > 11U) ? (uint16_t)(byte_count - 11U) : 0U;
+    // MNIS PDUs are accepted with a failed CRC32 (see dmr_block_type1_update_crc), so the pad
+    // octet count is unverified. Trust the octets that actually arrived over a pad count that
+    // claims more of them than exist.
+    uint16_t len = (poc <= avail) ? (uint16_t)(avail - poc) : avail;
     uint32_t msrc = ctx->state->dmr_lrrp_source[ctx->slot];
     uint32_t mdst = ctx->state->dmr_lrrp_target[ctx->slot];
     uint8_t mnis_type = ctx->state->dmr_pdu_sf[ctx->slot][4];
@@ -1309,7 +1322,7 @@ dmr_block_type1_handle_mnis(dmr_block_assembler_ctx* ctx, int offset) {
     DSD_FPRINTF(stderr, " ???: %04X", mnis_unk);
     DSD_SNPRINTF(ctx->state->dmr_lrrp_gps[ctx->slot], sizeof(ctx->state->dmr_lrrp_gps[ctx->slot]),
                  "MNIS SRC: %d; DST: %d; ", msrc, mdst);
-    dmr_block_type1_handle_mnis_payload(ctx, len, mnis_type, offset, msrc, mdst);
+    dmr_block_type1_handle_mnis_payload(ctx, len, mnis_type, msrc, mdst);
 }
 
 static void
@@ -1322,15 +1335,15 @@ dmr_block_type1_handle_unknown_pdu(dmr_block_assembler_ctx* ctx) {
         source = ctx->state->dmr_lrrp_source[safe_slot];
         target = ctx->state->dmr_lrrp_target[safe_slot];
     }
-    DSD_MEMSET(unk_str, 200, sizeof(unk_str));
-    DSD_SNPRINTF(unk_str, sizeof(unk_str), "DATA TGT: %lld; SRC: %lld; Unknown PDU Format;", source, target);
+    DSD_MEMSET(unk_str, 0, sizeof(unk_str));
+    DSD_SNPRINTF(unk_str, sizeof(unk_str), "DATA TGT: %lld; SRC: %lld; Unknown PDU Format;", target, source);
     const dsd_call_observation observation =
         dsd_call_observation_data(ctx->state->lastsynctype, (uint8_t)safe_slot, source, target);
     (void)dsd_event_emit_data_notice(ctx->opts, ctx->state, (uint8_t)safe_slot, &observation, unk_str);
 }
 
 static void
-dmr_block_type1_handle_sap(dmr_block_assembler_ctx* ctx, int offset) {
+dmr_block_type1_handle_sap(dmr_block_assembler_ctx* ctx) {
     if (ctx->slot > 1) {
         dmr_block_type1_handle_unknown_pdu(ctx);
         return;
@@ -1347,14 +1360,14 @@ dmr_block_type1_handle_sap(dmr_block_assembler_ctx* ctx, int offset) {
     } else if (sap == 2 || sap == 3) {
         dmr_udp_comp_pdu(ctx->opts, ctx->state, len, ctx->state->dmr_pdu_sf[ctx->slot]);
     } else if (sap == 1 && ctx->state->dmr_pdu_sf[ctx->slot][1] == 0x10) {
-        dmr_block_type1_handle_mnis(ctx, offset);
+        dmr_block_type1_handle_mnis(ctx);
     } else {
         dmr_block_type1_handle_unknown_pdu(ctx);
     }
 }
 
 static void
-dmr_block_type1_process_payload(dmr_block_assembler_ctx* ctx, int offset) {
+dmr_block_type1_process_payload(dmr_block_assembler_ctx* ctx) {
     uint8_t enc_check = dmr_block_type1_encryption_required(ctx);
     uint8_t decrypted_pdu = enc_check ? 0 : 1;
 
@@ -1364,7 +1377,7 @@ dmr_block_type1_process_payload(dmr_block_assembler_ctx* ctx, int offset) {
     if (enc_check == 1 && decrypted_pdu == 0) {
         dmr_block_type1_handle_encrypted_notice(ctx);
     } else if (ctx->crc_correct || ctx->opts->aggressive_framesync == 0 || ctx->opts->dmr_crc_relaxed_default) {
-        dmr_block_type1_handle_sap(ctx, offset);
+        dmr_block_type1_handle_sap(ctx);
     }
 }
 
@@ -1405,6 +1418,8 @@ dmr_block_type1_clear_header_state(dmr_block_assembler_ctx* ctx) {
 static void
 dmr_block_assembler_handle_type1(dmr_block_assembler_ctx* ctx) {
     uint16_t ctr = 0;
+    // Only the CRC32 bit-reordering walk needs this: it locates the confirmed-data DBSN octets
+    // past the 12 octet proprietary header.
     int offset = dmr_block_type1_offset(ctx);
 
     dmr_block_type1_append_bytes(ctx, &ctr);
@@ -1412,7 +1427,7 @@ dmr_block_assembler_handle_type1(dmr_block_assembler_ctx* ctx) {
         return;
     }
     dmr_block_type1_update_crc(ctx, ctr, offset);
-    dmr_block_type1_process_payload(ctx, offset);
+    dmr_block_type1_process_payload(ctx);
     dmr_block_type1_log_crc_and_payload(ctx);
     dmr_block_type1_clear_header_state(ctx);
 }

--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "dmr_ars.h"
 #include "dmr_pdu_internal.h"
 #include "dmr_text.h"
 #include "dsd-neo/core/opts_fwd.h"
@@ -674,8 +675,7 @@ decode_ip_pdu_handle_udp_service_core(dsd_opts* opts, dsd_state* state, uint8_t 
             DSD_FPRINTF(stderr, "ARS;");
             DSD_SNPRINTF(state->dmr_lrrp_gps[slot], sizeof(state->dmr_lrrp_gps[slot]), "ARS SRC: %d; DST: %d; ", src24,
                          dst24);
-            uint16_t ars_len = (payload_len < 10) ? payload_len : 10;
-            utf8_to_text(state, 0, ars_len, payload);
+            dmr_ars_print_message(state, payload, payload_len);
             return 1;
         }
         case 4007: decode_ip_pdu_handle_udp_tms(opts, state, slot, src24, dst24, payload_len, payload); return 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6439,6 +6439,7 @@ add_test(NAME DMR_BLOCK_CRYPTO COMMAND dsd-neo_test_dmr_block_crypto)
 add_executable(
     dsd-neo_test_dmr_relaxed_header_ip
     protocol/dmr/test_dmr_relaxed_header_ip.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_block.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_block_crypto.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_utils.c
@@ -6468,6 +6469,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_time_fallback
     protocol/dmr/test_dmr_lrrp_time_fallback.c
     test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
@@ -6494,6 +6496,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_time_valid
     protocol/dmr/test_dmr_lrrp_time_valid.c
     test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
@@ -6517,6 +6520,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_token_alignment
     protocol/dmr/test_dmr_lrrp_token_alignment.c
     test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
@@ -6542,6 +6546,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_response_token_lengths
     protocol/dmr/test_dmr_lrrp_response_token_lengths.c
     test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
@@ -6567,6 +6572,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_resync_prefix
     protocol/dmr/test_dmr_lrrp_resync_prefix.c
     test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
@@ -6592,6 +6598,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_position_token_precedence
     protocol/dmr/test_dmr_lrrp_position_token_precedence.c
     test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
@@ -6618,6 +6625,7 @@ add_executable(
     dsd-neo_test_dmr_lrrp_crc_gating
     protocol/dmr/test_dmr_lrrp_crc_gating.c
     test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
@@ -6640,6 +6648,7 @@ add_test(NAME DMR_LRRP_CRC_GATING COMMAND dsd-neo_test_dmr_lrrp_crc_gating)
 add_executable(
     dsd-neo_test_dmr_lrrp_ip_udp_lengths
     protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )
@@ -6684,6 +6693,7 @@ add_executable(
     dsd-neo_test_dmr_locn_time_fallback
     protocol/dmr/test_dmr_locn_time_fallback.c
     test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
 )

--- a/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
@@ -745,7 +745,9 @@ main(void) {
     // registered device identifier instead of dumping the record as raw text (issue #337).
     {
         reset_spies();
-        const uint8_t ars_reg[] = {0x00, 0x09, 0xF0, 0x20, 0x04, '1', '2', '3', '4', 0x00, 0x00};
+        // The four octets after the declared 9 byte record stand in for the block trailer the old
+        // fixed window used to run into; the decode must stop at the record length, not payload_len.
+        const uint8_t ars_reg[] = {0x00, 0x09, 0xF0, 0x20, 0x04, '1', '2', '3', '4', 0x00, 0x00, 0x5E, 0x6C, 0xA7};
         size_t plen = build_ipv4_udp_payload(pkt, sizeof pkt, 4005U, ars_reg, sizeof(ars_reg));
         st.currentslot = 0;
         st.dmr_lrrp_gps[0][0] = '\0';

--- a/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
@@ -741,6 +741,18 @@ main(void) {
         }
     }
 
+    // Case 13b: UDP/4005 ARS device registration honours the record length and reports the
+    // registered device identifier instead of dumping the record as raw text (issue #337).
+    {
+        reset_spies();
+        const uint8_t ars_reg[] = {0x00, 0x09, 0xF0, 0x20, 0x04, '1', '2', '3', '4', 0x00, 0x00};
+        size_t plen = build_ipv4_udp_payload(pkt, sizeof pkt, 4005U, ars_reg, sizeof(ars_reg));
+        st.currentslot = 0;
+        st.dmr_lrrp_gps[0][0] = '\0';
+        decode_ip_pdu(&opts, &st, (uint16_t)plen, pkt);
+        rc |= expect_has_substr(st.dmr_lrrp_gps[0], "ARS Reg: 1234;", "ars registration device id");
+    }
+
     // Case 14: UDP/4007 TMS acknowledgment and UTF-16 text take distinct state paths.
     {
         reset_spies();

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include "dmr_ars.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -813,6 +814,208 @@ test_type1_mnis_classifies_decoded_service(void) {
     }
 }
 
+// Drives a two-block MNIS PDU through the assembler with stderr captured. The first block is
+// seeded directly so the second one completes the PDU; aggressive_framesync stays off so the
+// captured trailer does not gate the payload path.
+static int
+run_type1_mnis_pdu_captured(const uint8_t pdu[24], uint8_t poc, const char* cap_tag, char* output, size_t output_sz) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    dsd_test_capture_stderr cap;
+    uint8_t block[12];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+
+    opts.aggressive_framesync = 0;
+    state.event_history_s = history;
+    state.currentslot = 0;
+    state.data_header_valid[0] = 1;
+    state.data_header_blocks[0] = 2;
+    state.data_block_counter[0] = 2;
+    state.data_header_format[0] = 2;
+    state.data_header_sap[0] = 1;
+    state.data_block_poc[0] = poc;
+
+    DSD_MEMCPY(state.dmr_pdu_sf[0], pdu, 12);
+    state.data_byte_ctr[0] = 12;
+    DSD_MEMCPY(block, pdu + 12, sizeof(block));
+
+    reset_datacall_spy();
+
+    if (dsd_test_capture_stderr_begin(&cap, cap_tag) != 0) {
+        return 1;
+    }
+    dmr_block_assembler(&opts, &state, block, (uint8_t)sizeof(block), 0, 1);
+    if (dsd_test_capture_stderr_end(&cap) != 0 || read_file_to_buffer(cap.path, output, output_sz) != 0) {
+        (void)remove(cap.path);
+        return 1;
+    }
+    (void)remove(cap.path);
+    return 0;
+}
+
+// Off-air MNIS ARS device registration (issue #337), device identifier replaced with "1234".
+// The ARS record is length prefixed: 00 09 covers F0 20 04 "1234" 00 00, and the bytes after it
+// belong to the block trailer. The old fixed 15-byte window ran into that trailer and printed
+// the whole thing as a "UTF8 Text" line that looked like a corrupted text message.
+static int
+test_type1_mnis_ars_registration_prints_device_id(void) {
+    static const uint8_t pdu[24] = {0x1F, 0x10, 0x02, 0x01, 0x33, 0x84, 0xD4, 0x00, 0x09, 0xF0, 0x20, 0x04,
+                                    0x31, 0x32, 0x33, 0x34, 0x00, 0x00, 0x5E, 0x6C, 0xA7, 0x5C, 0x00, 0x00};
+    char output[2048];
+    int rc = 0;
+
+    if (run_type1_mnis_pdu_captured(pdu, 0U, "dmr_mnis_ars_reg", output, sizeof(output)) != 0) {
+        return 1;
+    }
+
+    rc |= expect_contains("ars-device-id", output, "ARS Reg: 1234;");
+    if (g_utf8_calls != 0U) {
+        DSD_FPRINTF(stderr, "ars-device-id: ARS registration still rendered as text (%u utf8 calls, len %u)\n",
+                    g_utf8_calls, g_utf8_last_len);
+        rc = 1;
+    }
+    return rc;
+}
+
+// An ARS record that does not match a known PDU shape still gets the raw text dump, but bounded
+// by the record length instead of the old fixed 15-byte window.
+static int
+test_type1_mnis_ars_fallback_dump_is_bounded(void) {
+    static const uint8_t pdu[24] = {0x1F, 0x10, 0x02, 0x01, 0x33, 0x84, 0xD4, 0x00, 0x05, 0x33, 0x41, 0x42,
+                                    0x43, 0x44, 0x00, 0x00, 0x5E, 0x6C, 0xA7, 0x5C, 0x00, 0x00, 0x00, 0x00};
+    char output[2048];
+    int rc = 0;
+
+    if (run_type1_mnis_pdu_captured(pdu, 0U, "dmr_mnis_ars_fallback", output, sizeof(output)) != 0) {
+        return 1;
+    }
+
+    if (g_utf8_calls != 1U || g_utf8_last_len != 5U || g_utf8_first_byte != 0x33U) {
+        DSD_FPRINTF(stderr,
+                    "ars-fallback-bound: expected one 5-byte dump of the record, got %u calls len %u first %02X\n",
+                    g_utf8_calls, g_utf8_last_len, g_utf8_first_byte);
+        rc = 1;
+    }
+    return rc;
+}
+
+// The other ARS PDU types are label-only or carry the same length-value identifier fields as a
+// device registration. Each must print its own label instead of a "UTF8 Text" dump.
+static int
+run_ars_message_captured(const uint8_t* msg, uint16_t len, const char* cap_tag, char* output, size_t output_sz) {
+    static dsd_state state;
+    dsd_test_capture_stderr cap;
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.currentslot = 0;
+    reset_datacall_spy();
+
+    if (dsd_test_capture_stderr_begin(&cap, cap_tag) != 0) {
+        return -1;
+    }
+    dmr_ars_print_message(&state, msg, len);
+    if (dsd_test_capture_stderr_end(&cap) != 0 || read_file_to_buffer(cap.path, output, output_sz) != 0) {
+        (void)remove(cap.path);
+        return -1;
+    }
+    (void)remove(cap.path);
+    return 0;
+}
+
+static int
+test_ars_message_type_labels(void) {
+    static const uint8_t dereg[] = {0x00, 0x01, 0x71};
+    static const uint8_t query[] = {0x00, 0x01, 0x04};
+    static const uint8_t ack[] = {0x00, 0x02, 0xBF, 0x02};
+    static const uint8_t user_reg[] = {0x00, 0x0C, 0xF5, 0x20, 0x04, 0x31, 0x32, 0x33, 0x34, 0x02, 0x6A, 0x70, 0x00};
+    static const uint8_t empty[] = {0x00, 0x00};
+    char output[512];
+    int rc = 0;
+
+    if (run_ars_message_captured(dereg, (uint16_t)sizeof(dereg), "ars_dereg", output, sizeof(output)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("ars-dereg", output, "ARS Dereg;");
+
+    if (run_ars_message_captured(query, (uint16_t)sizeof(query), "ars_query", output, sizeof(output)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("ars-query", output, "ARS Query;");
+
+    if (run_ars_message_captured(ack, (uint16_t)sizeof(ack), "ars_ack", output, sizeof(output)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("ars-ack", output, "ARS Ack;");
+
+    if (run_ars_message_captured(user_reg, (uint16_t)sizeof(user_reg), "ars_user_reg", output, sizeof(output)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("ars-user-reg", output, "ARS User Reg: 1234;");
+
+    if (g_utf8_calls != 0U) {
+        DSD_FPRINTF(stderr, "ars-labels: known ARS types still fell back to a text dump (%u calls)\n", g_utf8_calls);
+        rc = 1;
+    }
+
+    if (run_ars_message_captured(empty, (uint16_t)sizeof(empty), "ars_empty", output, sizeof(output)) != 0) {
+        return 1;
+    }
+    if (output[0] != '\0' || g_utf8_calls != 0U) {
+        DSD_FPRINTF(stderr, "ars-empty: truncated message still printed something: '%s'\n", output);
+        rc = 1;
+    }
+    return rc;
+}
+
+// A short PDU used to wrap `byte_count - poc - 4 - 7` in uint16_t to ~65k, clamp to 150, and hand
+// the payload handlers a length far past the received bytes. It must be treated as empty instead.
+static int
+test_type1_mnis_short_pdu_length_underflow_guard(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    uint8_t block[12] = {0x1F, 0x10, 0x02, 0x01, 0x01, 0x84, 0xD4, 0x00, 0x00, 0x00, 0x00, 0x00};
+    dsd_test_capture_stderr cap;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+
+    opts.aggressive_framesync = 0;
+    state.event_history_s = history;
+    state.currentslot = 0;
+    state.data_header_valid[0] = 1;
+    state.data_header_blocks[0] = 1;
+    state.data_block_counter[0] = 1;
+    state.data_header_format[0] = 2;
+    state.data_header_sap[0] = 1;
+    state.data_block_poc[0] = 4; // 12 received bytes < poc + CRC32 + MNIS header
+
+    reset_datacall_spy();
+
+    if (dsd_test_capture_stderr_begin(&cap, "dmr_mnis_short_pdu") != 0) {
+        return 1;
+    }
+    dmr_block_assembler(&opts, &state, block, (uint8_t)sizeof(block), 0, 1);
+    if (dsd_test_capture_stderr_end(&cap) != 0) {
+        (void)remove(cap.path);
+        return 1;
+    }
+    (void)remove(cap.path);
+
+    if (g_utf8_calls != 0U && g_utf8_last_len != 0U) {
+        DSD_FPRINTF(stderr, "mnis-short-pdu: underflowed length reached the payload handler (len %u)\n",
+                    g_utf8_last_len);
+        rc = 1;
+    }
+    return rc;
+}
+
 static void
 test_crc_valid_type1_pdu_dispatches_short_data_and_udp_saps(void) {
     uint8_t block[12] = {0x83, 0x10, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0, 0, 0, 0};
@@ -1278,6 +1481,10 @@ main(int argc, char** argv) {
     test_type1_encrypted_notice_reports_missing_key();
     test_type2_rejects_out_of_bounds_aggregate_length();
     int rc = test_data_header_prints_fsn_and_final_flag();
+    rc |= test_type1_mnis_ars_registration_prints_device_id();
+    rc |= test_type1_mnis_ars_fallback_dump_is_bounded();
+    rc |= test_ars_message_type_labels();
+    rc |= test_type1_mnis_short_pdu_length_underflow_guard();
     test_irrecoverable_header_resets_data_state();
     rc |= test_response_headers_emit_control_events();
     test_response_header_event_acceptance_gates();

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -873,6 +873,9 @@ test_type1_mnis_ars_registration_prints_device_id(void) {
     }
 
     rc |= expect_contains("ars-device-id", output, "ARS Reg: 1234;");
+    // The decoded identifier has to reach the emitted notice too, not just the live slot pane:
+    // the history row is what survives past the next PDU.
+    rc |= expect_contains("ars-device-id-notice", g_datacall_last_text, "ARS Reg: 1234;");
     if (g_utf8_calls != 0U) {
         DSD_FPRINTF(stderr, "ars-device-id: ARS registration still rendered as text (%u utf8 calls, len %u)\n",
                     g_utf8_calls, g_utf8_last_len);
@@ -906,7 +909,8 @@ test_type1_mnis_ars_fallback_dump_is_bounded(void) {
 // The other ARS PDU types are label-only or carry the same length-value identifier fields as a
 // device registration. Each must print its own label instead of a "UTF8 Text" dump.
 static int
-run_ars_message_captured(const uint8_t* msg, uint16_t len, const char* cap_tag, char* output, size_t output_sz) {
+run_ars_message_captured(const uint8_t* msg, uint16_t len, const char* cap_tag, char* output, size_t output_sz,
+                         char* gps, size_t gps_sz) {
     static dsd_state state;
     dsd_test_capture_stderr cap;
 
@@ -915,56 +919,95 @@ run_ars_message_captured(const uint8_t* msg, uint16_t len, const char* cap_tag, 
     reset_datacall_spy();
 
     if (dsd_test_capture_stderr_begin(&cap, cap_tag) != 0) {
-        return -1;
+        return 1;
     }
     dmr_ars_print_message(&state, msg, len);
     if (dsd_test_capture_stderr_end(&cap) != 0 || read_file_to_buffer(cap.path, output, output_sz) != 0) {
         (void)remove(cap.path);
-        return -1;
+        return 1;
     }
     (void)remove(cap.path);
+    // Hand back the slot string too: appending the summary there is the only persistent effect
+    // this function has, and it is what the UI renders and what the IP path emits as the notice.
+    DSD_SNPRINTF(gps, gps_sz, "%s", state.dmr_lrrp_gps[0]);
     return 0;
+}
+
+// The helper resets the spy on every message, so the "no text dump" check has to be made per
+// message; asserting once at the end would only ever cover the last one.
+static int
+expect_no_text_dump(const char* tag) {
+    if (g_utf8_calls != 0U) {
+        DSD_FPRINTF(stderr, "%s: known ARS type still fell back to a text dump (%u calls, len %u)\n", tag, g_utf8_calls,
+                    g_utf8_last_len);
+        return 1;
+    }
+    return 0;
+}
+
+// Asserts one ARS record renders `expect` on stderr, appends the same text to the slot string,
+// and does not fall back to the raw text dump.
+static int
+expect_ars_label(const uint8_t* msg, uint16_t len, const char* tag, const char* expect) {
+    char output[512];
+    char gps[512];
+    int rc = 0;
+
+    if (run_ars_message_captured(msg, len, tag, output, sizeof(output), gps, sizeof(gps)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains(tag, output, expect);
+    rc |= expect_contains(tag, gps, expect);
+    rc |= expect_no_text_dump(tag);
+    return rc;
 }
 
 static int
 test_ars_message_type_labels(void) {
-    static const uint8_t dereg[] = {0x00, 0x01, 0x71};
-    static const uint8_t query[] = {0x00, 0x01, 0x04};
-    static const uint8_t ack[] = {0x00, 0x02, 0xBF, 0x02};
-    static const uint8_t user_reg[] = {0x00, 0x0C, 0xF5, 0x20, 0x04, 0x31, 0x32, 0x33, 0x34, 0x02, 0x6A, 0x70, 0x00};
+    // Header octets carry Pri|Cntl on every real ARS message; these values are the ones seen in
+    // MOTOTRBO captures (dereg 0x31, query 0x74, query/registration ack 0x3F or 0xBF).
+    static const uint8_t dereg[] = {0x00, 0x01, 0x31};
+    static const uint8_t query[] = {0x00, 0x01, 0x74};
+    static const uint8_t user_dereg[] = {0x00, 0x01, 0x76};
+    // 0xBF: Ext set, Ack clear, so a successful registration; 0x02 is two 30 minute refresh units.
+    static const uint8_t ack_ok[] = {0x00, 0x02, 0xBF, 0x02};
+    // 0xFF: Ext set with Ack set, so the same PDU type refusing the registration. Reason 0x00 is
+    // "device not authorized"; it must not render like the success above.
+    static const uint8_t ack_fail[] = {0x00, 0x02, 0xFF, 0x00};
+    // A bare acknowledgement with no extension header: the spec pins the refresh timer to zero.
+    static const uint8_t ack_bare[] = {0x00, 0x01, 0x3F};
+    // 0x07 is the user registration acknowledgement; 0x01 is "user validation failed".
+    static const uint8_t user_ack_fail[] = {0x00, 0x02, 0xC7, 0x01};
+    // 0x000B: hdr F5, ext 20, device id 04 "1234", user id 02 "jp", password 00 is 11 octets. The
+    // prefix has to match or the record is silently clamped and the fixture stops being well formed.
+    static const uint8_t user_reg[] = {0x00, 0x0B, 0xF5, 0x20, 0x04, 0x31, 0x32, 0x33, 0x34, 0x02, 0x6A, 0x70, 0x00};
+    // Device registration as a radio sends it: 0xF0 with Event 0x20 (initial), device id only.
+    static const uint8_t dev_reg[] = {0x00, 0x09, 0xF0, 0x20, 0x04, 0x31, 0x32, 0x33, 0x34, 0x00, 0x00};
     static const uint8_t empty[] = {0x00, 0x00};
     char output[512];
+    char gps[512];
     int rc = 0;
 
-    if (run_ars_message_captured(dereg, (uint16_t)sizeof(dereg), "ars_dereg", output, sizeof(output)) != 0) {
+    rc |= expect_ars_label(dereg, (uint16_t)sizeof(dereg), "ars-dereg", "ARS Dereg;");
+    rc |= expect_ars_label(query, (uint16_t)sizeof(query), "ars-query", "ARS Query;");
+    rc |= expect_ars_label(user_dereg, (uint16_t)sizeof(user_dereg), "ars-user-dereg", "ARS User Dereg;");
+    rc |= expect_ars_label(ack_ok, (uint16_t)sizeof(ack_ok), "ars-ack-ok", "ARS Ack: OK; refresh 60 min;");
+    rc |= expect_ars_label(ack_fail, (uint16_t)sizeof(ack_fail), "ars-ack-fail",
+                           "ARS Ack: FAIL - device not authorized;");
+    rc |= expect_ars_label(ack_bare, (uint16_t)sizeof(ack_bare), "ars-ack-bare", "ARS Ack: OK; refresh off;");
+    rc |= expect_ars_label(user_ack_fail, (uint16_t)sizeof(user_ack_fail), "ars-user-ack-fail",
+                           "ARS User Ack: FAIL - user validation failed;");
+    rc |= expect_ars_label(dev_reg, (uint16_t)sizeof(dev_reg), "ars-dev-reg", "ARS Reg: 1234;");
+    // A user registration is about the user that signed in, so the user identifier leads and the
+    // device it signed in from follows. Reporting the device under a "User Reg" label loses the
+    // only identity the message exists to carry.
+    rc |= expect_ars_label(user_reg, (uint16_t)sizeof(user_reg), "ars-user-reg", "ARS User Reg: jp; DEV: 1234;");
+
+    if (run_ars_message_captured(empty, (uint16_t)sizeof(empty), "ars_empty", output, sizeof(output), gps, sizeof(gps))
+        != 0) {
         return 1;
     }
-    rc |= expect_contains("ars-dereg", output, "ARS Dereg;");
-
-    if (run_ars_message_captured(query, (uint16_t)sizeof(query), "ars_query", output, sizeof(output)) != 0) {
-        return 1;
-    }
-    rc |= expect_contains("ars-query", output, "ARS Query;");
-
-    if (run_ars_message_captured(ack, (uint16_t)sizeof(ack), "ars_ack", output, sizeof(output)) != 0) {
-        return 1;
-    }
-    rc |= expect_contains("ars-ack", output, "ARS Ack;");
-
-    if (run_ars_message_captured(user_reg, (uint16_t)sizeof(user_reg), "ars_user_reg", output, sizeof(output)) != 0) {
-        return 1;
-    }
-    rc |= expect_contains("ars-user-reg", output, "ARS User Reg: 1234;");
-
-    if (g_utf8_calls != 0U) {
-        DSD_FPRINTF(stderr, "ars-labels: known ARS types still fell back to a text dump (%u calls)\n", g_utf8_calls);
-        rc = 1;
-    }
-
-    if (run_ars_message_captured(empty, (uint16_t)sizeof(empty), "ars_empty", output, sizeof(output)) != 0) {
-        return 1;
-    }
-    if (output[0] != '\0' || g_utf8_calls != 0U) {
+    if (output[0] != '\0' || gps[0] != '\0' || g_utf8_calls != 0U) {
         DSD_FPRINTF(stderr, "ars-empty: truncated message still printed something: '%s'\n", output);
         rc = 1;
     }
@@ -972,7 +1015,8 @@ test_ars_message_type_labels(void) {
 }
 
 // A short PDU used to wrap `byte_count - poc - 4 - 7` in uint16_t to ~65k, clamp to 150, and hand
-// the payload handlers a length far past the received bytes. It must be treated as empty instead.
+// the payload handlers a length far past the received bytes. Whatever length the MNIS branch
+// settles on, it can never exceed the octets that actually arrived after the +7 payload offset.
 static int
 test_type1_mnis_short_pdu_length_underflow_guard(void) {
     static dsd_opts opts;
@@ -995,6 +1039,9 @@ test_type1_mnis_short_pdu_length_underflow_guard(void) {
     state.data_header_format[0] = 2;
     state.data_header_sap[0] = 1;
     state.data_block_poc[0] = 4; // 12 received bytes < poc + CRC32 + MNIS header
+    // Real MNIS always arrives behind a Motorola proprietary header, so keep data_p_head set: it
+    // is the state every MNIS PDU decodes under.
+    state.data_p_head[0] = 1;
 
     reset_datacall_spy();
 
@@ -1008,9 +1055,126 @@ test_type1_mnis_short_pdu_length_underflow_guard(void) {
     }
     (void)remove(cap.path);
 
-    if (g_utf8_calls != 0U && g_utf8_last_len != 0U) {
-        DSD_FPRINTF(stderr, "mnis-short-pdu: underflowed length reached the payload handler (len %u)\n",
+    // 12 octets arrived and the payload starts at +7, so 5 is the most that can ever be readable.
+    const uint16_t max_readable = (uint16_t)(sizeof(block) - 7U);
+    if (g_utf8_calls == 0U || g_utf8_last_len > max_readable) {
+        DSD_FPRINTF(stderr, "mnis-short-pdu: payload handler got len %u, more than the %u octets received\n",
+                    g_utf8_last_len, max_readable);
+        rc = 1;
+    }
+    return rc;
+}
+
+// The LOCN branch used to subtract the CRC32 bit-reordering walk's `offset` - 12 whenever a
+// proprietary header is present, which is every real MNIS PDU - from a length that already
+// counted only the payload octets, silently truncating the tail of every location report. The
+// dmr_locn() call beside it always passed the same pointer with the unadjusted length.
+static int
+test_type1_mnis_locn_length_is_not_offset_adjusted(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    static const uint8_t pdu[24] = {0x1F, 0x10, 0x02, 0x01, 0x01, 0x84, 0xD4, 0x41, 0x42, 0x43, 0x44, 0x45,
+                                    0x46, 0x47, 0x48, 0x49, 0x4A, 0x4B, 0x4C, 0x4D, 0x5E, 0x6C, 0xA7, 0x5C};
+    uint8_t block[12];
+    dsd_test_capture_stderr cap;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+
+    opts.aggressive_framesync = 0;
+    state.event_history_s = history;
+    state.currentslot = 0;
+    state.data_header_valid[0] = 1;
+    state.data_header_blocks[0] = 2;
+    state.data_block_counter[0] = 2;
+    state.data_header_format[0] = 2;
+    state.data_header_sap[0] = 1;
+    state.data_block_poc[0] = 0;
+    state.data_p_head[0] = 1;
+
+    DSD_MEMCPY(state.dmr_pdu_sf[0], pdu, 12);
+    state.data_byte_ctr[0] = 12;
+    DSD_MEMCPY(block, pdu + 12, sizeof(block));
+
+    reset_datacall_spy();
+
+    if (dsd_test_capture_stderr_begin(&cap, "dmr_mnis_locn_len") != 0) {
+        return 1;
+    }
+    dmr_block_assembler(&opts, &state, block, (uint8_t)sizeof(block), 0, 1);
+    if (dsd_test_capture_stderr_end(&cap) != 0) {
+        (void)remove(cap.path);
+        return 1;
+    }
+    (void)remove(cap.path);
+
+    // 24 octets assembled, the payload starts at +7, the CRC32 trailer is 4 and there are no pad
+    // octets, so all 13 remaining octets are readable. The old code handed over 1.
+    if (g_utf8_calls != 1U || g_utf8_last_len != 13U) {
+        DSD_FPRINTF(stderr, "mnis-locn-len: expected one 13 octet text call, got %u calls len %u\n", g_utf8_calls,
                     g_utf8_last_len);
+        rc = 1;
+    }
+    if (g_utf8_first_byte != 0x41U) {
+        DSD_FPRINTF(stderr, "mnis-locn-len: text started at %02X, not at the +7 payload offset\n", g_utf8_first_byte);
+        rc = 1;
+    }
+    return rc;
+}
+
+// The MNIS notice used to label the two radio IDs backwards - "MNIS TGT:" was fed the source and
+// "SRC:" the target - while the observation attached to the same event had them the right way
+// round, so the rendered text and the machine readable IDs disagreed about who registered.
+static int
+test_type1_mnis_notice_labels_match_observation(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I history[2];
+    static const uint8_t pdu[24] = {0x1F, 0x10, 0x02, 0x01, 0x88, 0x84, 0xD4, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5E, 0x6C, 0xA7, 0x5C};
+    uint8_t block[12];
+    dsd_test_capture_stderr cap;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(history, 0, sizeof(history));
+
+    opts.aggressive_framesync = 0;
+    state.event_history_s = history;
+    state.currentslot = 0;
+    state.data_header_valid[0] = 1;
+    state.data_header_blocks[0] = 2;
+    state.data_block_counter[0] = 2;
+    state.data_header_format[0] = 2;
+    state.data_header_sap[0] = 1;
+    state.data_p_head[0] = 1;
+    state.dmr_lrrp_source[0] = 1234567;
+    state.dmr_lrrp_target[0] = 7654321;
+
+    DSD_MEMCPY(state.dmr_pdu_sf[0], pdu, 12);
+    state.data_byte_ctr[0] = 12;
+    DSD_MEMCPY(block, pdu + 12, sizeof(block));
+
+    reset_datacall_spy();
+
+    if (dsd_test_capture_stderr_begin(&cap, "dmr_mnis_labels") != 0) {
+        return 1;
+    }
+    dmr_block_assembler(&opts, &state, block, (uint8_t)sizeof(block), 0, 1);
+    if (dsd_test_capture_stderr_end(&cap) != 0) {
+        (void)remove(cap.path);
+        return 1;
+    }
+    (void)remove(cap.path);
+
+    rc |= expect_contains("mnis-labels", g_datacall_last_text, "MNIS TGT: 7654321; SRC: 1234567;");
+    if (g_datacall_last_src != 1234567U || g_datacall_last_dst != 7654321U) {
+        DSD_FPRINTF(stderr, "mnis-labels: observation carried src %u dst %u\n", (unsigned)g_datacall_last_src,
+                    (unsigned)g_datacall_last_dst);
         rc = 1;
     }
     return rc;
@@ -1485,6 +1649,8 @@ main(int argc, char** argv) {
     rc |= test_type1_mnis_ars_fallback_dump_is_bounded();
     rc |= test_ars_message_type_labels();
     rc |= test_type1_mnis_short_pdu_length_underflow_guard();
+    rc |= test_type1_mnis_locn_length_is_not_offset_adjusted();
+    rc |= test_type1_mnis_notice_labels_match_observation();
     test_irrecoverable_header_resets_data_state();
     rc |= test_response_headers_emit_control_events();
     test_response_header_event_acceptance_gates();


### PR DESCRIPTION
Fixes #337.

## Problem

Two call sites rendered Motorola ARS (Automatic Registration Service) records as raw text with a fixed dump window:

- MNIS type 0x33 payloads went through `utf8_to_text()` with a hard-coded 15-byte window (`dmr_block.c`). ARS messages are length prefixed, so the dump ran past the record into the block trailer, and every ARS device registration printed as a `UTF8 Text` line with a random-looking tail.
- The UDP/4005 service path (`dmr_pdu.c`) had the same defect with a 10-byte window.

Chasing that turned up four more defects on the same MNIS payload path, three of them inherited from upstream DSD-FME:

- `dmr_block_type1_handle_mnis()` computed `len = byte_count - poc - 4 - 7` in `uint16_t`; a short PDU wrapped that to ~65k, which then clamped to 150 and handed the payload handlers a length far past the received bytes.
- The LOCN branch called `utf8_to_text(state, 0, len - offset, sf + 7)`. `offset` is the CRC32 bit-reordering walk's constant for locating confirmed-data DBSN octets — 12 whenever a proprietary header is present, which is every real MNIS PDU — and `len` already counted only the payload octets. Every location report long enough to have them lost 12 octets off the tail, while the `dmr_locn()` call on the very next line passed the same pointer with the unadjusted length.
- `"MNIS TGT:"` was fed the source and `"SRC:"` the target, so the rendered text disagreed with the `dsd_call_observation_data()` attached to the same event about which radio did what. The two `"DATA TGT:"` notices had the same swap.
- A User Registration reported the device identifier under a `User Reg` label and discarded the user that had actually signed in.

## Fix

### ARS decoder (`src/protocol/dmr/dmr_ars.c`, new, shared by both call sites)

Honours the two-octet message size and parses the header per the specification: Ext/Ack/Pri/Cntl flags in bits 7–4, a 4-bit PDU type in bits 3–0, walking the full header extension chain rather than assuming at most one extension octet.

- **Registrations** decode the length-value name field as the three fields it is — device id, user id, password. A device registration prints `ARS Reg: 1234;`; a user registration leads with the identity the message exists to carry, `ARS User Reg: jp; DEV: 1234;`. A zero-length field is legal and skips to the next one; a non-printable field is omitted rather than hiding the fields behind it; a password is reported as present but never printed into a log line.
- **Acknowledgements** decode the verdict. Bit 6 of the first header is success (clear) or failure (set), and the optional second header carries the refresh timer, session time, or reason code: `ARS Ack: OK; refresh 60 min;`, `ARS Ack: FAIL - device not authorized;`, `ARS User Ack: FAIL - user validation failed;`. Previously all of these collapsed to a bare `ARS Ack;`.
- **All seven PDU types** are handled: 0x00 device registration, 0x01 device de-registration, 0x04 query, 0x05 user registration, 0x06 user de-registration, 0x07 user registration acknowledgement, 0x0F registration acknowledgement.
- Records that do not match a known shape still fall back to the raw dump, now bounded both by the record length and by a 64-byte ceiling — the UDP path can otherwise hand `utf8_to_text()` ~3000 bytes, one unbuffered `stderr` write each.
- The decoded summary reaches the emitted event notice, not just the live slot pane, so the registration survives in the history row past the next PDU.

For the off-air PDU from the issue (`00 09 | F0 20 04 "1234" 00 00 | trailer…`), the output is now `ARS Reg: 1234;` instead of ``UTF8 Text: _-- -1234__^l-\``.

### MNIS payload path (`src/protocol/dmr/dmr_block.c`)

- Dropped the spurious `- offset` from the LOCN text length, and stopped threading `offset` through the payload path entirely; it survives only in `dmr_block_type1_update_crc()`, where it belongs.
- Corrected the `TGT:`/`SRC:` label order on all three notices so the text agrees with the observation IDs on the same event.
- Guarded the `uint16_t` underflow. MNIS PDUs are force-accepted with a failed CRC32, so the pad octet count is unverified: it is now ignored when it claims more octets than were received, rather than being allowed to zero out a payload that did arrive.
- Fixed two transposed `DSD_MEMSET()` value/size arguments.

## Sources

Implemented against the MOTOTRBO Application Developer Program *Development Specification — Automatic Registration Service* v02.00 (§3.1 PDU structure, §3.2 header bits, §3.4.1–3.4.11 per-PDU formats), cross-checked against two independent implementations: SDRTrunk's `io.github.dsheirer.module.decode.ip.mototrbo.ars` package, and the captured byte dumps in KD8EYF/TRBO-NET's `ARS.pm`. All three agree on the header layout and PDU type values; the fixture header octets in the tests are the values those captures show real radios sending (`0x31` de-register, `0x74` query, `0x3F`/`0xBF` acknowledge) rather than synthetic ones.

## Testing

Seven regression test entry points, each watched failing against the pre-fix code:

- the captured registration PDU prints the device id with no text dump, and reaches the emitted notice;
- fallback dumps are bounded by the record length;
- ten ARS records covering every PDU type, both acknowledgement verdicts, a bare acknowledgement with no extension header, and the truncated-message no-op;
- the short-PDU length guard, asserting the invariant that the length handed to a payload handler never exceeds the octets received;
- the LOCN length is not offset-adjusted (fails with `len 1` against the old code, passes at 13);
- the MNIS notice labels match the observation IDs (fails with `MNIS TGT: 1234567; SRC: 7654321;` against the old code);
- the UDP/4005 registration path.

Full suite 533/533 (`ctest --preset dev-debug`); `tools/preflight_ci.sh` clean; both DMR test binaries clean under ASan/UBSan.

Reported-by: @japigr, whose byte-level analysis in #337 this confirms.
