### PR TITLE
macOS Curses discovery, plus the Release+tests build it exposed

### DIFF
--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -235,12 +235,26 @@ jobs:
       - name: Configure (Release preset)
         shell: bash
         run: |
+          # No curses overrides on purpose: this is the discovery path a user
+          # gets, and pinning it here is what kept issue #339 out of CI.
           cmake --preset dev-release -G Ninja \
             -DDSD_ENABLE_LTO=OFF -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -DDSD_REQUIRE_RTLSDR=ON -DDSD_REQUIRE_SOAPYSDR=ON \
-            -DBUILD_TESTING=OFF \
-            -DCURSES_LIBRARY="$HB_PREFIX/opt/ncurses/lib/libncursesw.dylib" \
-            -DCURSES_INCLUDE_PATH="$HB_PREFIX/opt/ncurses/include"
+            -DBUILD_TESTING=OFF
+
+      - name: Verify curses selection
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Discovery is unpinned here on purpose, so assert the outcome: the
+          # portable DMG is built against Homebrew's wide ncurses, and a silent
+          # downgrade to the SDK's narrow curses must not pass unnoticed.
+          lib=$(sed -n 's/^CURSES_NCURSES_LIBRARY:[A-Z]*=//p' build/dev-release/CMakeCache.txt)
+          echo "CURSES_NCURSES_LIBRARY=$lib"
+          case "$lib" in
+            *ncursesw*) ;;
+            *) echo "ERROR: expected a wide ncurses, got '$lib'" >&2; exit 1 ;;
+          esac
 
       - name: Build
         shell: bash
@@ -484,12 +498,26 @@ jobs:
       - name: Configure (Release preset)
         shell: bash
         run: |
+          # No curses overrides on purpose: this is the discovery path a user
+          # gets, and pinning it here is what kept issue #339 out of CI.
           cmake --preset dev-release -G Ninja \
             -DDSD_ENABLE_LTO=OFF -DCMAKE_OSX_ARCHITECTURES=arm64 \
             -DDSD_REQUIRE_RTLSDR=ON -DDSD_REQUIRE_SOAPYSDR=ON \
-            -DBUILD_TESTING=OFF \
-            -DCURSES_LIBRARY="$HB_PREFIX/opt/ncurses/lib/libncursesw.dylib" \
-            -DCURSES_INCLUDE_PATH="$HB_PREFIX/opt/ncurses/include"
+            -DBUILD_TESTING=OFF
+
+      - name: Verify curses selection
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Discovery is unpinned here on purpose, so assert the outcome: the
+          # portable DMG is built against Homebrew's wide ncurses, and a silent
+          # downgrade to the SDK's narrow curses must not pass unnoticed.
+          lib=$(sed -n 's/^CURSES_NCURSES_LIBRARY:[A-Z]*=//p' build/dev-release/CMakeCache.txt)
+          echo "CURSES_NCURSES_LIBRARY=$lib"
+          case "$lib" in
+            *ncursesw*) ;;
+            *) echo "ERROR: expected a wide ncurses, got '$lib'" >&2; exit 1 ;;
+          esac
 
       - name: Build
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,7 +817,75 @@ if(DSD_ENABLE_TERMINAL_UI)
             "PDCurses wide-character API: ${DSD_HAS_PDCURSES_WIDE_API}"
         )
     else()
+        # macOS ships no libncursesw, so CURSES_NEED_WIDE makes FindCurses miss
+        # the wide library, fall through to its plain-curses branch, and skip
+        # the header search there - configure then fails with a bare "Could NOT
+        # find Curses (missing: CURSES_INCLUDE_PATH)". Point it at a wide
+        # ncurses when the host has one - Homebrew keeps its keg-only, so that
+        # prefix is not on any default search path - and otherwise drop the
+        # requirement and take the SDK's unified libncurses. See
+        # cmake/macos_curses.cmake for the whole story.
+        set(_dsd_curses_saved_prefix_path "${CMAKE_PREFIX_PATH}")
+        if(APPLE AND CURSES_NEED_WIDE)
+            include(macos_curses)
+            find_library(DSD_NCURSESW_LIBRARY NAMES ncursesw)
+            mark_as_advanced(DSD_NCURSESW_LIBRARY)
+
+            set(_dsd_curses_prefixes "")
+            find_program(DSD_BREW_EXECUTABLE brew)
+            mark_as_advanced(DSD_BREW_EXECUTABLE)
+            if(DSD_BREW_EXECUTABLE)
+                # Reports the keg for a custom Homebrew prefix too, and prints
+                # the path a formula would take even when it is not installed,
+                # which the plan then rejects for having no headers.
+                execute_process(
+                    COMMAND "${DSD_BREW_EXECUTABLE}" --prefix ncurses
+                    OUTPUT_VARIABLE _dsd_brew_ncurses
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    ERROR_QUIET
+                )
+                if(_dsd_brew_ncurses)
+                    list(APPEND _dsd_curses_prefixes "${_dsd_brew_ncurses}")
+                endif()
+                unset(_dsd_brew_ncurses)
+            endif()
+            # brew is not always on PATH - IDE-driven and non-login shells lose
+            # it - so the standard prefixes are probed directly as well.
+            if(DEFINED ENV{HOMEBREW_PREFIX})
+                list(
+                    APPEND _dsd_curses_prefixes
+                    "$ENV{HOMEBREW_PREFIX}/opt/ncurses"
+                )
+            endif()
+            list(
+                APPEND _dsd_curses_prefixes
+                "/opt/homebrew/opt/ncurses"
+                "/usr/local/opt/ncurses"
+            )
+            list(REMOVE_DUPLICATES _dsd_curses_prefixes)
+
+            dsd_neo_macos_curses_plan(
+                NCURSESW_LIBRARY "${DSD_NCURSESW_LIBRARY}"
+                PREFIXES ${_dsd_curses_prefixes}
+                OUT_NEED_WIDE _dsd_curses_need_wide
+                OUT_PREFIX _dsd_curses_prefix
+                OUT_REASON _dsd_curses_reason
+            )
+            set(CURSES_NEED_WIDE ${_dsd_curses_need_wide})
+            if(_dsd_curses_prefix)
+                list(PREPEND CMAKE_PREFIX_PATH "${_dsd_curses_prefix}")
+            endif()
+            message(STATUS "Curses: ${_dsd_curses_reason}")
+            unset(_dsd_curses_prefixes)
+            unset(_dsd_curses_need_wide)
+            unset(_dsd_curses_prefix)
+            unset(_dsd_curses_reason)
+        endif()
         find_package(Curses REQUIRED)
+        # A keg-only prefix is for curses alone; leaving it on CMAKE_PREFIX_PATH
+        # would offer it to every find_package below.
+        set(CMAKE_PREFIX_PATH "${_dsd_curses_saved_prefix_path}")
+        unset(_dsd_curses_saved_prefix_path)
         # Some ncurses installs do not provide a top-level curses.h shim in the
         # include root. Our code includes <curses.h>, so add the ncursesw subdir
         # when needed.

--- a/cmake/macos_curses.cmake
+++ b/cmake/macos_curses.cmake
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# macOS curses flavour selection.
+#
+# CURSES_NEED_WIDE is set for every non-Windows target, but macOS ships no
+# libncursesw: its unified libncurses carries the wide entry points behind
+# _XOPEN_SOURCE_EXTENDED. FindCurses therefore misses the wide library, falls
+# through to its plain-curses branch, and skips the header search entirely -
+# that branch only probes for headers when the wide flag is off - so configure
+# dies with a bare "Could NOT find Curses (missing: CURSES_INCLUDE_PATH)" one
+# line after reporting the library it just found in the SDK.
+#
+# The decision of which curses to aim FindCurses at lives here, apart from the
+# probing, so it can be exercised by MACOS_CURSES_PLAN without a macOS host.
+
+# dsd_neo_macos_curses_plan(
+#     NCURSESW_LIBRARY <path>   # what find_library(ncursesw) returned, may be
+#                               # empty or a <var>-NOTFOUND string
+#     PREFIXES <dir>...         # keg-only prefixes to search, most specific first
+#     OUT_NEED_WIDE <var>       # TRUE to keep CURSES_NEED_WIDE, FALSE to drop it
+#     OUT_PREFIX <var>          # prefix to put on CMAKE_PREFIX_PATH, "" for none
+#     OUT_REASON <var>          # one line describing the choice, for message()
+# )
+#
+# A wide ncurses already on the search path is left alone: second-guessing it
+# would risk pairing one installation's headers with another's library. Homebrew
+# keeps its ncurses keg-only, so those prefixes have to be spelled out by the
+# caller. Failing both, the wide requirement is dropped and FindCurses takes the
+# SDK's unified libncurses, whose headers it locates through its own HINTS.
+# Nothing in the ncurses path calls the wide API - the only addwstr() sits
+# behind DSD_USE_PDCURSES in src/ui/terminal/ncurses_snr.c - so the narrow build
+# is complete.
+function(dsd_neo_macos_curses_plan)
+    set(_options "")
+    set(_one_value NCURSESW_LIBRARY OUT_NEED_WIDE OUT_PREFIX OUT_REASON)
+    set(_multi_value PREFIXES)
+    cmake_parse_arguments(
+        _MCP
+        "${_options}"
+        "${_one_value}"
+        "${_multi_value}"
+        ${ARGN}
+    )
+
+    foreach(_required IN ITEMS OUT_NEED_WIDE OUT_PREFIX OUT_REASON)
+        if(NOT _MCP_${_required})
+            message(
+                FATAL_ERROR
+                "dsd_neo_macos_curses_plan: ${_required} is required"
+            )
+        endif()
+    endforeach()
+    if(_MCP_UNPARSED_ARGUMENTS)
+        message(
+            FATAL_ERROR
+            "dsd_neo_macos_curses_plan: unexpected arguments: ${_MCP_UNPARSED_ARGUMENTS}"
+        )
+    endif()
+
+    # if() reads a value ending in -NOTFOUND as false, so an unfound cache entry
+    # needs no special casing here.
+    if(_MCP_NCURSESW_LIBRARY)
+        set(${_MCP_OUT_NEED_WIDE} TRUE PARENT_SCOPE)
+        set(${_MCP_OUT_PREFIX} "" PARENT_SCOPE)
+        set(${_MCP_OUT_REASON}
+            "wide ncurses already on the search path (${_MCP_NCURSESW_LIBRARY})"
+            PARENT_SCOPE
+        )
+        return()
+    endif()
+
+    foreach(_prefix IN LISTS _MCP_PREFIXES)
+        if(NOT _prefix)
+            continue()
+        endif()
+        if(NOT EXISTS "${_prefix}/include/ncursesw/curses.h")
+            continue()
+        endif()
+        # Homebrew ships libncursesw.dylib next to the versioned library, but a
+        # keg whose headers arrived without one would only send FindCurses back
+        # to the same failure, so both halves have to be there.
+        file(GLOB _libs "${_prefix}/lib/libncursesw*.dylib")
+        if(NOT _libs)
+            continue()
+        endif()
+        set(${_MCP_OUT_NEED_WIDE} TRUE PARENT_SCOPE)
+        set(${_MCP_OUT_PREFIX} "${_prefix}" PARENT_SCOPE)
+        set(${_MCP_OUT_REASON}
+            "using the keg-only ncursesw at ${_prefix}"
+            PARENT_SCOPE
+        )
+        return()
+    endforeach()
+
+    set(${_MCP_OUT_NEED_WIDE} FALSE PARENT_SCOPE)
+    set(${_MCP_OUT_PREFIX} "" PARENT_SCOPE)
+    set(${_MCP_OUT_REASON}
+        "no ncursesw on this host, using the system curses (narrow)"
+        PARENT_SCOPE
+    )
+endfunction()

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -13,7 +13,12 @@ Required dependencies are:
 - OpenSSL 3.x libcrypto
 - `mbe-neo` 2.x CMake package from mbelib-neo
 - libsndfile
-- curses backend: ncursesw/PDCurses
+- curses backend: ncursesw/PDCurses. macOS ships no `libncursesw` — its unified
+  `libncurses` carries the wide entry points behind `_XOPEN_SOURCE_EXTENDED` —
+  so configure prefers a wide ncurses when the host has one (including
+  Homebrew's keg-only `ncurses`, which is on no default search path) and
+  otherwise falls back to the SDK's curses, reporting which it took. Nothing in
+  the ncurses path calls the wide API, so the fallback is a complete build.
 - audio backend: PulseAudio by default on Unix-like systems, PortAudio on
   Windows
 

--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -59,7 +59,10 @@ convert_hex_to_dec(uint16_t input) {
 static void DSD_ATTR_USED
 utf16_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input) {
     uint8_t slot = state->currentslot;
-    dsd_event_history_transaction transaction;
+    // Only opened when wr says so, and closed under the same condition a loop
+    // later. A zeroed guard makes the close a no-op instead of a read of an
+    // indeterminate pointer if those two ever drift apart.
+    dsd_event_history_transaction transaction = {0};
     if (wr == 1) {
         dsd_event_history_transaction_begin(state, &transaction);
         DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].text_message,
@@ -119,7 +122,9 @@ utf8_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input) {
     uint8_t slot = state->currentslot;
     DSD_FPRINTF(stderr, "\n UTF8 Text: ");
 
-    dsd_event_history_transaction transaction;
+    // Zeroed for the same reason as utf16_to_text above: the open and the close
+    // sit on either side of a loop, both behind wr.
+    dsd_event_history_transaction transaction = {0};
     if (wr == 1) {
         dsd_event_history_transaction_begin(state, &transaction);
         DSD_SNPRINTF(state->event_history_s[slot].Event_History_Items[0].text_message,

--- a/src/ui/terminal/ncurses_p25_display.c
+++ b/src/ui/terminal/ncurses_p25_display.c
@@ -760,8 +760,11 @@ ui_print_p25_sm_tags(const dsd_state* state) {
 
 static int
 ui_append_sm_path_symbol(char* path, size_t path_len, int wrote, char sym) {
-    int m = (int)strlen(path);
-    if (m + 3 >= (int)path_len) {
+    size_t m = strlen(path);
+    // Three bytes of arrow once something is already there, the symbol, and the
+    // terminator: all of it has to fit, terminator included.
+    size_t need = (wrote > 0 ? 3U : 0U) + 2U;
+    if (m + need > path_len) {
         return wrote;
     }
     if (wrote > 0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,21 @@ set(_DSD_NEO_RR_FIXTURE_DIR
     "${PROJECT_SOURCE_DIR}/tests/fixtures/radioreference"
 )
 
-link_libraries(dsd-neo_warnings)
+# Release-style configurations put -DNDEBUG on the command line, and nearly
+# every test here carries its logic inside assert(). Left alone, a Release or
+# RelWithDebInfo build with BUILD_TESTING=ON - a plain `cmake ..`, or the
+# perf-bench preset - either fails to compile, where the now-unused parameters
+# trip -Werror, or builds a suite that passes while checking nothing. Test code
+# keeps its assertions in every configuration; production targets are untouched,
+# and the ban on assert() in src/ is enforced separately by semgrep.
+add_library(dsd-neo_test_assertions INTERFACE)
+if(MSVC)
+    target_compile_options(dsd-neo_test_assertions INTERFACE /UNDEBUG)
+else()
+    target_compile_options(dsd-neo_test_assertions INTERFACE -UNDEBUG)
+endif()
+
+link_libraries(dsd-neo_warnings dsd-neo_test_assertions)
 
 add_library(dsd-neo_test_support INTERFACE)
 target_include_directories(
@@ -158,6 +172,15 @@ add_test(
         "-DDSD_TEST_WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/macos_curses_plan" -P
         ${PROJECT_SOURCE_DIR}/tests/cmake/MacosCursesPlan.cmake
 )
+
+# Compiling this at all is most of the check; running it shows assert() still
+# evaluates what it is given.
+add_executable(dsd-neo_test_assertions_enabled build/test_assertions_enabled.c)
+target_include_directories(
+    dsd-neo_test_assertions_enabled
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+add_test(NAME ASSERTIONS_ENABLED COMMAND dsd-neo_test_assertions_enabled)
 
 set(_DSD_PUBLIC_HEADER_TEST_DIR
     "${CMAKE_CURRENT_BINARY_DIR}/public_header_smoke"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -149,6 +149,16 @@ add_test(
         ${PROJECT_SOURCE_DIR}/cmake/vcpkg_dependency_contract.cmake
 )
 
+# Runs everywhere: the macOS curses decision takes fabricated prefix trees, so
+# hosts that can never reach the real code path still guard it.
+add_test(
+    NAME MACOS_CURSES_PLAN
+    COMMAND
+        ${CMAKE_COMMAND}
+        "-DDSD_TEST_WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/macos_curses_plan" -P
+        ${PROJECT_SOURCE_DIR}/tests/cmake/MacosCursesPlan.cmake
+)
+
 set(_DSD_PUBLIC_HEADER_TEST_DIR
     "${CMAKE_CURRENT_BINARY_DIR}/public_header_smoke"
 )

--- a/tests/build/test_assertions_enabled.c
+++ b/tests/build/test_assertions_enabled.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Guards the test suite against being compiled with its assertions disabled.
+ *
+ * Most tests here carry their logic inside assert(), so a configuration that
+ * defines NDEBUG - a plain `cmake ..`, which defaults to Release with testing
+ * on, or the perf-bench preset - turns the suite into a set of programs that
+ * exit 0 without checking anything, when it compiles at all: parameters and
+ * locals that only the assertions read then trip -Werror=unused-parameter.
+ * tests/CMakeLists.txt keeps assertions on for test code; this fails the build
+ * the moment that stops being true.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include "dsd-neo/core/safe_api.h"
+
+#ifdef NDEBUG
+#error "test code must be built with assertions enabled (see dsd-neo_test_assertions)"
+#endif
+
+static int g_evaluations = 0;
+
+static int
+observe(void) {
+    g_evaluations++;
+    return 1;
+}
+
+int
+main(void) {
+    /* NOLINTNEXTLINE(bugprone-assert-side-effect): the side effect is the
+       subject of the test - it is what shows assert() still evaluates its
+       expression rather than having been compiled away. */
+    assert(observe());
+
+    if (g_evaluations != 1) {
+        DSD_FPRINTF(stderr, "assert() did not evaluate its expression (%d evaluations)\n", g_evaluations);
+        return 1;
+    }
+    return 0;
+}

--- a/tests/cmake/MacosCursesPlan.cmake
+++ b/tests/cmake/MacosCursesPlan.cmake
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Exercises dsd_neo_macos_curses_plan() from cmake/macos_curses.cmake.
+#
+# The function decides which curses FindCurses is aimed at on macOS, where the
+# wrong answer is a configure failure on a stock host. Its inputs are a library
+# path and a list of prefixes, so the decision can be checked against fabricated
+# prefix trees from any platform.
+#
+# Usage:
+#   cmake -DDSD_TEST_WORK_DIR=<dir> -P tests/cmake/MacosCursesPlan.cmake
+
+cmake_minimum_required(VERSION 3.20)
+
+if(NOT DEFINED CMAKE_SCRIPT_MODE_FILE)
+    message(
+        FATAL_ERROR
+        "MACOS_CURSES_PLAN: must be run via 'cmake -P <script>'"
+    )
+endif()
+if(NOT DSD_TEST_WORK_DIR)
+    message(FATAL_ERROR "MACOS_CURSES_PLAN: DSD_TEST_WORK_DIR is required")
+endif()
+
+get_filename_component(_MCPT_SCRIPT_DIR "${CMAKE_SCRIPT_MODE_FILE}" DIRECTORY)
+get_filename_component(_MCPT_TESTS_DIR "${_MCPT_SCRIPT_DIR}" DIRECTORY)
+get_filename_component(_MCPT_ROOT_DIR "${_MCPT_TESTS_DIR}" DIRECTORY)
+
+include("${_MCPT_ROOT_DIR}/cmake/macos_curses.cmake")
+
+set(_MCPT_FAILURES "")
+
+function(_mcpt_expect what actual expected)
+    if(NOT "${actual}" STREQUAL "${expected}")
+        set(_MCPT_FAILURES
+            "${_MCPT_FAILURES}\n  - ${what}: expected '${expected}', got '${actual}'"
+            PARENT_SCOPE
+        )
+    endif()
+endfunction()
+
+# A keg-only prefix as Homebrew lays one out: wide headers in their own subdir,
+# versioned library plus the unversioned symlink beside it.
+function(_mcpt_make_keg dir)
+    file(MAKE_DIRECTORY "${dir}/include/ncursesw")
+    file(MAKE_DIRECTORY "${dir}/lib")
+    file(WRITE "${dir}/include/ncursesw/curses.h" "/* fixture */\n")
+    file(WRITE "${dir}/include/curses.h" "/* fixture */\n")
+    file(WRITE "${dir}/lib/libncursesw.6.dylib" "fixture\n")
+    file(WRITE "${dir}/lib/libncursesw.dylib" "fixture\n")
+endfunction()
+
+set(_MCPT_WORK "${DSD_TEST_WORK_DIR}")
+file(REMOVE_RECURSE "${_MCPT_WORK}")
+file(MAKE_DIRECTORY "${_MCPT_WORK}")
+
+set(_MCPT_KEG "${_MCPT_WORK}/homebrew/opt/ncurses")
+set(_MCPT_KEG_ALT "${_MCPT_WORK}/homebrew-alt/opt/ncurses")
+_mcpt_make_keg("${_MCPT_KEG}")
+_mcpt_make_keg("${_MCPT_KEG_ALT}")
+
+# A keg whose headers arrived without the library, and one with neither.
+set(_MCPT_KEG_HEADERS_ONLY "${_MCPT_WORK}/broken/opt/ncurses")
+file(MAKE_DIRECTORY "${_MCPT_KEG_HEADERS_ONLY}/include/ncursesw")
+file(MAKE_DIRECTORY "${_MCPT_KEG_HEADERS_ONLY}/lib")
+file(
+    WRITE "${_MCPT_KEG_HEADERS_ONLY}/include/ncursesw/curses.h"
+    "/* fixture */\n"
+)
+set(_MCPT_KEG_ABSENT "${_MCPT_WORK}/absent/opt/ncurses")
+
+# ---------------------------------------------------------------------------
+# A wide ncurses on the default search path is used as found, prefixes ignored.
+# ---------------------------------------------------------------------------
+dsd_neo_macos_curses_plan(
+    NCURSESW_LIBRARY "/opt/local/lib/libncursesw.dylib"
+    PREFIXES "${_MCPT_KEG}"
+    OUT_NEED_WIDE _need_wide
+    OUT_PREFIX _prefix
+    OUT_REASON _reason
+)
+_mcpt_expect("found ncursesw: need wide" "${_need_wide}" "TRUE")
+_mcpt_expect("found ncursesw: prefix" "${_prefix}" "")
+
+# ---------------------------------------------------------------------------
+# An unfound cache entry reads as absent, not as a path.
+# ---------------------------------------------------------------------------
+dsd_neo_macos_curses_plan(
+    NCURSESW_LIBRARY "DSD_NCURSESW_LIBRARY-NOTFOUND"
+    PREFIXES "${_MCPT_KEG}"
+    OUT_NEED_WIDE _need_wide
+    OUT_PREFIX _prefix
+    OUT_REASON _reason
+)
+_mcpt_expect("NOTFOUND library: need wide" "${_need_wide}" "TRUE")
+_mcpt_expect("NOTFOUND library: prefix" "${_prefix}" "${_MCPT_KEG}")
+
+# ---------------------------------------------------------------------------
+# No ncursesw anywhere: drop the wide requirement rather than fail the configure.
+# ---------------------------------------------------------------------------
+dsd_neo_macos_curses_plan(
+    NCURSESW_LIBRARY ""
+    PREFIXES "${_MCPT_KEG_ABSENT}" "${_MCPT_KEG_HEADERS_ONLY}"
+    OUT_NEED_WIDE _need_wide
+    OUT_PREFIX _prefix
+    OUT_REASON _reason
+)
+_mcpt_expect("no ncursesw: need wide" "${_need_wide}" "FALSE")
+_mcpt_expect("no ncursesw: prefix" "${_prefix}" "")
+
+# ---------------------------------------------------------------------------
+# No prefixes at all is the same answer, and no error.
+# ---------------------------------------------------------------------------
+dsd_neo_macos_curses_plan(
+    NCURSESW_LIBRARY ""
+    OUT_NEED_WIDE _need_wide
+    OUT_PREFIX _prefix
+    OUT_REASON _reason
+)
+_mcpt_expect("no prefixes: need wide" "${_need_wide}" "FALSE")
+_mcpt_expect("no prefixes: prefix" "${_prefix}" "")
+
+# ---------------------------------------------------------------------------
+# Prefixes are searched in order, so the caller's precedence is what decides
+# between two usable kegs, and an empty entry does not end the search.
+# ---------------------------------------------------------------------------
+dsd_neo_macos_curses_plan(
+    NCURSESW_LIBRARY ""
+    PREFIXES
+        ""
+        "${_MCPT_KEG_HEADERS_ONLY}"
+        "${_MCPT_KEG_ALT}"
+        "${_MCPT_KEG}"
+    OUT_NEED_WIDE _need_wide
+    OUT_PREFIX _prefix
+    OUT_REASON _reason
+)
+_mcpt_expect("ordered prefixes: need wide" "${_need_wide}" "TRUE")
+_mcpt_expect("ordered prefixes: prefix" "${_prefix}" "${_MCPT_KEG_ALT}")
+
+# The reason is what a user reads on the configure line, so it has to name the
+# prefix that was chosen.
+if(NOT _reason MATCHES "${_MCPT_KEG_ALT}")
+    set(_MCPT_FAILURES
+        "${_MCPT_FAILURES}\n  - ordered prefixes: reason '${_reason}' does not name ${_MCPT_KEG_ALT}"
+    )
+endif()
+
+file(REMOVE_RECURSE "${_MCPT_WORK}")
+
+if(_MCPT_FAILURES)
+    message(FATAL_ERROR "MACOS_CURSES_PLAN failed:${_MCPT_FAILURES}")
+endif()
+
+message(STATUS "MACOS_CURSES_PLAN: ok")

--- a/tests/core/test_core_talkgroup_policy.c
+++ b/tests/core/test_core_talkgroup_policy.c
@@ -447,8 +447,10 @@ read_file_lines(const char* path, char* l1, size_t l1sz, char* l2, size_t l2sz, 
         fclose(fp);
         return -1;
     }
-    if (l3) {
-        (void)fgets(l3, (int)l3sz, fp);
+    if (l3 && fgets(l3, (int)l3sz, fp) == NULL) {
+        // The third line is optional, and a cast to void does not settle the
+        // warn_unused_result that _FORTIFY_SOURCE puts on fgets.
+        l3[0] = '\0';
     }
     fclose(fp);
     return 0;

--- a/tests/protocol/dmr/test_dmr_locn_time_fallback.c
+++ b/tests/protocol/dmr/test_dmr_locn_time_fallback.c
@@ -196,7 +196,16 @@ main(void) {
         remove(outtmpl);
         return 102;
     }
-    fread(buf, 1, psz, f);
+    // The buffer is calloc'd one byte longer than the file and therefore
+    // already terminated; what the read owes is the count, since
+    // _FORTIFY_SOURCE declares fread __wur and a short read here means the
+    // capture never landed.
+    if (fread(buf, 1, psz, f) != psz) {
+        fclose(f);
+        free(buf);
+        remove(outtmpl);
+        return 103;
+    }
     fclose(f);
 
     rc |= expect_nonempty(buf, "LOCN LRRP file non-empty");

--- a/tests/protocol/dmr/test_dmr_lrrp_time_fallback.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_time_fallback.c
@@ -188,7 +188,15 @@ main(void) {
         fclose(ef);
         return 105;
     }
-    fread(ebuf, 1, pesize, ef);
+    // The buffer is calloc'd one byte longer than the file and therefore
+    // already terminated; what the read owes is the count, since
+    // _FORTIFY_SOURCE declares fread __wur and a short read here means the
+    // capture never landed.
+    if (fread(ebuf, 1, pesize, ef) != pesize) {
+        fclose(ef);
+        free(ebuf);
+        return 107;
+    }
     fclose(ef);
 
     // Ensure decoded time was NOT printed (fallback path)
@@ -212,7 +220,11 @@ main(void) {
         fclose(of);
         return 106;
     }
-    fread(obuf, 1, posize, of);
+    if (fread(obuf, 1, posize, of) != posize) {
+        fclose(of);
+        free(obuf);
+        return 108;
+    }
     fclose(of);
 
     // Ensure the file has some content and does not contain the bogus decoded year "2038/"

--- a/tests/protocol/dmr/test_dmr_lrrp_time_valid.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_time_valid.c
@@ -180,7 +180,15 @@ main(void) {
         fclose(ef);
         return 105;
     }
-    fread(ebuf, 1, pesz, ef);
+    // The buffer is calloc'd one byte longer than the file and therefore
+    // already terminated; what the read owes is the count, since
+    // _FORTIFY_SOURCE declares fread __wur and a short read here means the
+    // capture never landed.
+    if (fread(ebuf, 1, pesz, ef) != pesz) {
+        fclose(ef);
+        free(ebuf);
+        return 107;
+    }
     fclose(ef);
     rc |= expect_has_substr(ebuf, " Time: 2024.12.01 23:59:58", "stderr has decoded Time");
     free(ebuf);
@@ -202,7 +210,11 @@ main(void) {
         fclose(of);
         return 106;
     }
-    fread(obuf, 1, posz, of);
+    if (fread(obuf, 1, posz, of) != posz) {
+        fclose(of);
+        free(obuf);
+        return 108;
+    }
     fclose(of);
     rc |= expect_has_substr(obuf, "1999/01/02\t11:22:33\t", "LRRP uses system timestamp");
     rc |= expect_no_substr(obuf, "2024/12/01\t23:59:58\t", "LRRP not using decoded timestamp in file");

--- a/tests/protocol/p25/test_p25_p1_mbtx_clamp.c
+++ b/tests/protocol/p25/test_p25_p1_mbtx_clamp.c
@@ -140,7 +140,15 @@ main(void) {
         fclose(rf);
         return 104;
     }
-    (void)fread(buf, 1, alloc - 1, rf);
+    // The buffer is calloc'd one byte longer than the file and therefore
+    // already terminated; what the read owes is the count, since
+    // _FORTIFY_SOURCE declares fread __wur and a short read here means the
+    // capture never landed.
+    if (fread(buf, 1, alloc - 1, rf) != alloc - 1) {
+        fclose(rf);
+        free(buf);
+        return 105;
+    }
     fclose(rf);
 
     // Clamp expectations: cc should remain 0 (no retune), and diagnostic text present

--- a/tests/protocol/p25/test_p25_p2_vpdu_core.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_core.c
@@ -201,7 +201,15 @@ expect_file_contains(const char* tag, const char* path, const char* needle) {
         fclose(f);
         return 1;
     }
-    (void)fread(buf, 1, (size_t)sz, f);
+    // The buffer is calloc'd one byte longer than the file and therefore
+    // already terminated; what the read owes is the count, since
+    // _FORTIFY_SOURCE declares fread __wur and a short read here means the
+    // capture never landed.
+    if (fread(buf, 1, (size_t)sz, f) != (size_t)sz) {
+        fclose(f);
+        free(buf);
+        return 1;
+    }
     fclose(f);
 
     int rc = expect_contains(tag, buf, needle);

--- a/tests/protocol/p25/test_p25_p2_vpdu_sequence.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_sequence.c
@@ -132,7 +132,15 @@ main(void) {
         fclose(rf);
         return 103;
     }
-    (void)fread(buf, 1, alloc - 1, rf);
+    // The buffer is calloc'd one byte longer than the file and therefore
+    // already terminated; what the read owes is the count, since
+    // _FORTIFY_SOURCE declares fread __wur and a short read here means the
+    // capture never landed.
+    if (fread(buf, 1, alloc - 1, rf) != alloc - 1) {
+        fclose(rf);
+        free(buf);
+        return 105;
+    }
     fclose(rf);
 
     // Order check: first occurrence indices must be increasing

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -62,11 +62,17 @@ close_parse_outputs(dsd_opts* opts) {
 
 static void
 test_redirect_stdout_to_null(void) {
+    // A cast to void does not settle warn_unused_result, which _FORTIFY_SOURCE
+    // puts on freopen. Losing the redirect only makes the run noisy, so say so
+    // on stderr and carry on.
 #if defined(_WIN32)
-    (void)freopen("NUL", "w", stdout);
+    FILE* redirected = freopen("NUL", "w", stdout);
 #else
-    (void)freopen("/dev/null", "w", stdout);
+    FILE* redirected = freopen("/dev/null", "w", stdout);
 #endif
+    if (redirected == NULL) {
+        DSD_FPRINTF(stderr, "note: could not redirect stdout; test output will be noisy\n");
+    }
 }
 
 static int

--- a/tests/ui/test_ui_ncurses_p25_display_helpers.c
+++ b/tests/ui/test_ui_ncurses_p25_display_helpers.c
@@ -538,6 +538,39 @@ run_trunk_sm_helper_cases(void) {
     assert(ui_append_sm_path_symbol(full, sizeof(full), 1, 'Z') == 1);
     assert(strcmp(full, "ABC") == 0);
 
+    // An empty buffer with room for the three-byte arrow and the symbol but not
+    // for the terminator: the append has to be refused. The guard used to count
+    // only the four payload bytes and then wrote a fifth, one past the end - a
+    // stack overflow the 64-byte production buffer escapes only because the tag
+    // count is capped. The canary catches the write; ASan would not, the buffer
+    // being a member rather than a whole object.
+    struct {
+        char buf[4];
+        char canary[4];
+    } tight;
+
+    DSD_MEMSET(&tight, 0, sizeof(tight));
+    DSD_MEMSET(tight.canary, '#', sizeof(tight.canary));
+    assert(ui_append_sm_path_symbol(tight.buf, sizeof(tight.buf), 1, 'Z') == 1);
+    assert(tight.buf[0] == '\0');
+    for (size_t i = 0; i < sizeof(tight.canary); i++) {
+        assert(tight.canary[i] == '#');
+    }
+
+    // One more byte is all it takes, and then the append goes through.
+    struct {
+        char buf[5];
+        char canary[4];
+    } room;
+
+    DSD_MEMSET(&room, 0, sizeof(room));
+    DSD_MEMSET(room.canary, '#', sizeof(room.canary));
+    assert(ui_append_sm_path_symbol(room.buf, sizeof(room.buf), 1, 'Z') == 2);
+    assert(strcmp(room.buf, "\xE2\x86\x92Z") == 0);
+    for (size_t i = 0; i < sizeof(room.canary); i++) {
+        assert(room.canary[i] == '#');
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
Fixes #339, reported by @japigr with a diagnosis and a patch that this follows.

## macOS: configure fails on every stock host

`CURSES_NEED_WIDE` is set for all non-Windows targets, but macOS ships no
`libncursesw` - its unified `libncurses` carries the wide entry points behind
`_XOPEN_SOURCE_EXTENDED`. `FindCurses` misses the wide library, falls through to
its plain-curses branch, and that branch probes for headers only when the wide
flag is off, so `CURSES_INCLUDE_PATH` stays unset and `REQUIRED` fails one line
after reporting the library it found in the SDK.

Reproduced against the real `FindCurses` with a sysroot that has `libcurses`
(exporting `wsyncup`) and no `ncursesw` - same error, same preceding line - and
both halves of the fix verified the same way: dropping the wide requirement
resolves the SDK's curses, and a keg prefix on `CMAKE_PREFIX_PATH` resolves the
wide one.

Configure now prefers a wide ncurses when the host has one (unaided on the
default search path, or from Homebrew's keg-only prefix via `brew` or the
standard prefixes) and drops the requirement otherwise. Nothing in the ncurses
path calls the wide API, so the fallback is a complete build. Guarded by
`APPLE`. The decision lives in `cmake/macos_curses.cmake` so `MACOS_CURSES_PLAN`
can drive it over fabricated prefix trees from any host.

**macos-ci never saw this** because it configured with `-DCURSES_LIBRARY` and
`-DCURSES_INCLUDE_PATH` pinned at the Homebrew keg - precisely the two variables
`find_package_handle_standard_args` checks, so discovery never ran. Those are
gone; a step after configure asserts a wide ncurses was selected instead.

## Release + BUILD_TESTING=ON, and what it turned up

Also reported in #339: a plain `cmake ..` defaults to Release with testing on
and does not build. The root cause is broader than the one file - `-DNDEBUG`
disables the `assert()` calls that carry the logic of 146 test sources, so the
suite either fails to compile on now-unused parameters or passes while checking
nothing. `perf-bench` (RelWithDebInfo + `BUILD_TESTING=ON`) has the same
problem. Test code now keeps its assertions in every configuration, guarded by
`ASSERTIONS_ENABLED`.

Building that configuration for the first time surfaced two production defects,
both fixed here with regression coverage:

- **`ui_append_sm_path_symbol()` wrote one byte past its buffer.** The guard
  counted the arrow and the symbol but not the terminator. ASan calls it a
  stack-buffer-overflow; the production caller escapes it only because the tag
  count is capped well below the buffer size.
- **DMR event-history guards were read uninitialized.** `utf16_to_text()` and
  `utf8_to_text()` open a transaction under `wr` and close it under `wr` on the
  far side of the decode loop, with the guard indeterminate in between.

Ten `fread`/`fgets`/`freopen` results in tests were also discarded, which only
fails under `_FORTIFY_SOURCE` (optimized builds); they are checked now.

## Verification

- `ctest` green in both configurations: 535/535 dev-debug, 535/535 Release with
  `BUILD_TESTING=ON` and `-Werror` - the configuration that did not build before.
- `tools/preflight_ci.sh` clean (clang-format, gersemi, clang-tidy, cppcheck,
  IWYU, `-fanalyzer`, semgrep, actionlint, zizmor, lizard).
- The macOS paths themselves are unverifiable from Linux; macos-ci on this PR is
  the real check, which is why the pins had to go.