### PR TITLE
p25p2: stop an encryption-locked-out companion call disturbing the clear call

### DIFF
--- a/src/core/audio/dsd_audio2.c
+++ b/src/core/audio/dsd_audio2.c
@@ -875,6 +875,23 @@ dsd_p25p2_flush_partial_audio_slot(dsd_opts* opts, dsd_state* state, int slot) {
         return;
     }
 
+    // The tail is only worth emitting while the slot's crypto classification
+    // still permits audio (every caller flushes before resetting it). A
+    // lockout- or classification-muted slot can hold stale pre-mute samples;
+    // emitting them would play audio the gate refused and wedge extra blocks
+    // into the audible companion's output stream. Drop the tail instead --
+    // downstream consumers treat a muted channel's buffers as blank, so the
+    // zeroing here just makes that assumption true immediately.
+    if (!p25_crypto_audio_permitted(opts, state, slot)) {
+        if (slot == 0) {
+            DSD_MEMSET(state->s_l4, 0, sizeof(state->s_l4));
+        } else {
+            DSD_MEMSET(state->s_r4, 0, sizeof(state->s_r4));
+        }
+        state->voice_counter[slot] = 0;
+        return;
+    }
+
     short saved_other[18][160];
     int saved_other_counter = state->voice_counter[other];
     int saved_other_allowed = state->p25_p2_audio_allowed[other];

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -5831,6 +5831,13 @@ p25_sm_tick_tuned_wait_voice(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state
     if (timeout_start_m <= 0.0) {
         return;
     }
+    // Deliberately no companion hold here: the carrier's stay is the shorter
+    // of the companion's hangtime bridge and a pending assignment's own
+    // acquisition window. When that window closes with nothing followed, the
+    // visit ends even inside the companion's gap -- pinned by the
+    // pending-companion and lockout-reprobe grant-timeout tests. The
+    // crypto-classification tick differs: classification is evidence a call
+    // may still resolve clear, so its timeout defers to the companion.
     if ((now_m - timeout_start_m) >= grant_timeout) {
         do_release(ctx, opts, state, "grant-timeout", 0);
     }
@@ -5900,13 +5907,23 @@ p25_sm_block_expired_crypto_slot(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
     return 0;
 }
 
+// The companion holds the carrier while it is active *or* while its own
+// conversation gap is still inside the hangtime window -- the same bridge the
+// enc-lockout release honors. The expired slot's classification is dismantled
+// either way; only the whole-carrier release is deferred to the hangtime tick.
 static int
-p25_sm_expired_slot_has_active_companion(const p25_sm_ctx_t* ctx, const dsd_state* state, const int expired[2]) {
+p25_sm_expired_slot_has_active_companion(const p25_sm_ctx_t* ctx, const dsd_state* state, const int expired[2],
+                                         double now_m) {
     if (!ctx->vc_is_tdma) {
         return 0;
     }
     for (int slot = 0; slot < 2; slot++) {
-        if (expired[slot] && p25_voice_other_slot_active(ctx, state, slot ^ 1)) {
+        if (!expired[slot]) {
+            continue;
+        }
+        const int other = slot ^ 1;
+        if (p25_voice_other_slot_active(ctx, state, other)
+            || p25_voice_companion_gap_within_hangtime(ctx, state, other, now_m)) {
             return 1;
         }
     }
@@ -5972,7 +5989,9 @@ p25_sm_tick_crypto_classification(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* 
     if (!expired_any) {
         return 0;
     }
-    if (p25_sm_expired_slot_has_active_companion(ctx, state, expired)) {
+    if (p25_sm_expired_slot_has_active_companion(ctx, state, expired, now_m)) {
+        p25_sm_diagf(opts, state, ctx, "crypto_timeout_companion_hold", "expired=%d/%d", expired[0], expired[1]);
+        sm_log(opts, state, "crypto-timeout-companion-hold");
         return 0;
     }
 

--- a/src/protocol/p25/phase2/p25p2_frame.c
+++ b/src/protocol/p25/phase2/p25p2_frame.c
@@ -1704,6 +1704,24 @@ p25p2_duid_post_timeslot(dsd_opts* opts, dsd_state* state, int timeslot_index, i
     }
 }
 
+// A slot still occupies the carrier when its gate is open, it holds buffered
+// audio, or its MAC signaling is fresh inside the hold window. The audio gate
+// alone cannot say "idle": an encryption-lockout-suppressed transmission
+// keeps its gate closed for its whole life while MAC_PTT/ACTIVE repeats prove
+// the site is still transmitting on the slot -- the same signals the LCCH
+// pending-release check consumes. Latching p25_sm_force_release on a slot the
+// SM is deliberately holding (classification in flight, companion bridging)
+// would bypass every guard the SM applies, because the forced-release tick
+// runs unguarded.
+static int
+p25p2_frame_slot_recently_occupied(const dsd_state* state, int slot, double mac_hold_s) {
+    if (state->p25_p2_audio_allowed[slot] || state->p25_p2_audio_ring_count[slot] > 0) {
+        return 1;
+    }
+    return (state->p25_p2_last_mac_active_m[slot] > 0.0)
+           && (dsd_time_now_monotonic_s() - state->p25_p2_last_mac_active_m[slot]) <= mac_hold_s;
+}
+
 static void DSD_ATTR_USED
 p25p2_duid_fallback_release(dsd_opts* opts, dsd_state* state) {
     if (opts->trunk_enable != 1 || opts->trunk_is_tuned != 1) {
@@ -1712,7 +1730,9 @@ p25p2_duid_fallback_release(dsd_opts* opts, dsd_state* state) {
 
     time_t now2 = time(NULL);
     int no_recent_voice = (state->last_vc_sync_time != 0) && ((now2 - state->last_vc_sync_time) > opts->trunk_hangtime);
-    int both_slots_idle = (state->p25_p2_audio_allowed[0] == 0 && state->p25_p2_audio_allowed[1] == 0);
+    double mac_hold = p25p2_frame_mac_hold_s(0.75);
+    int both_slots_idle = !p25p2_frame_slot_recently_occupied(state, 0, mac_hold)
+                          && !p25p2_frame_slot_recently_occupied(state, 1, mac_hold);
     double dt_since_tune = (state->p25_last_vc_tune_time != 0) ? (double)(now2 - state->p25_last_vc_tune_time) : 1e9;
     double vc_grace = p25p2_frame_vc_grace_s(0.75);
     if (no_recent_voice && both_slots_idle && dt_since_tune >= vc_grace) {

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -971,6 +971,23 @@ p25p2_vpdu_other_slot_audio_with_history(const dsd_state* state, int slot, doubl
            || recent_voice;
 }
 
+// Whether either logical slot still looks occupied: gated or buffered audio,
+// MAC activity inside the hold window, or recent voice on the carrier. A
+// Deny/Queued response heard in a voice channel's signaling answers some
+// unit's request; releasing the carrier over one while a call -- or the
+// hangtime gap the SM promises to bridge -- still occupies a slot tears down
+// audible traffic, so the voice hold is stretched to the trunking hangtime.
+static int
+p25p2_vpdu_carrier_occupied_for_response(const dsd_opts* opts, const dsd_state* state) {
+    double mac_hold = p25p2_vpdu_cfg_mac_hold_s(0.75);
+    double voice_hold = p25p2_vpdu_cfg_voice_hold_s(0.75);
+    if (opts != NULL && (double)opts->trunk_hangtime > voice_hold) {
+        voice_hold = (double)opts->trunk_hangtime;
+    }
+    return p25p2_vpdu_other_slot_audio_with_history(state, 0, mac_hold, voice_hold)
+           || p25p2_vpdu_other_slot_audio_with_history(state, 1, mac_hold, voice_hold);
+}
+
 static int
 p25p2_vpdu_force_release_after_grace(dsd_opts* opts, dsd_state* state) {
     double vc_grace = p25p2_vpdu_cfg_vc_grace_s(0.75);
@@ -4258,14 +4275,17 @@ p25p2_vpdu_iter_block_57(p25p2_vpdu_ctx* ctx) {
                                          target_addr, reason_str);
         }
 
-        // Notify the trunking state machine.
+        // Notify the trunking state machine. An occupied carrier keeps its
+        // calls; the acquisition watchdog owns cleaning up a granted-then-
+        // denied assignment that never produces voice.
         if (opts) {
             if (is_deny) {
                 state->p25_sm_deny_count++;
-                p25_sm_release(p25_sm_get_ctx(), opts, state, "deny-rsp");
             } else {
                 state->p25_sm_queued_count++;
-                p25_sm_release(p25_sm_get_ctx(), opts, state, "queued-rsp");
+            }
+            if (!p25p2_vpdu_carrier_occupied_for_response(opts, state)) {
+                p25_sm_release(p25_sm_get_ctx(), opts, state, is_deny ? "deny-rsp" : "queued-rsp");
             }
         }
     }
@@ -4762,13 +4782,15 @@ p25p2_vpdu_handle_motorola_queued_deny(p25p2_vpdu_ctx* ctx, int is_deny) {
     }
     DSD_FPRINTF(stderr, " Target [%d]", target_addr);
 
+    // Same occupancy rule as the standard Deny/Queued handler above.
     if (opts) {
         if (is_deny) {
             state->p25_sm_deny_count++;
-            p25_sm_release(p25_sm_get_ctx(), opts, state, "deny-rsp");
         } else {
             state->p25_sm_queued_count++;
-            p25_sm_release(p25_sm_get_ctx(), opts, state, "queued-rsp");
+        }
+        if (!p25p2_vpdu_carrier_occupied_for_response(opts, state)) {
+            p25_sm_release(p25_sm_get_ctx(), opts, state, is_deny ? "deny-rsp" : "queued-rsp");
         }
     }
 }

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -759,6 +759,14 @@ p25p2_vpdu_print_svc_no_state(const dsd_opts* opts, int svc) {
     p25p2_vpdu_print_svc_payload(opts, svc);
 }
 
+// Per-slot service options feed p25p2_prepare_voice_crypto(), where an
+// encrypted service bit flips the slot to ENCRYPTED_PENDING and, under
+// encryption lockout, closes its audio gate. Only voice-channel-user MCOs,
+// which describe the decode slot's own call, may store here: a channel-grant
+// announcement heard in this carrier's MAC signaling describes a call on some
+// other channel or slot, and writing its bits onto the decode slot mutes a
+// clear call whenever an encrypted call is announced nearby. Grant service
+// options reach classification through the SM grant event's svc_bits instead.
 static void
 p25p2_vpdu_store_slot_svc(dsd_state* state, int slot, int svc) {
     if ((slot & 1) == 0) {
@@ -1010,7 +1018,6 @@ typedef struct {
     int group;
     int source;
     int set_packet_bit;
-    int store_slot_svc;
     p25_sm_grant_provenance_e provenance;
     const char* label;
 } p25p2_group_explicit_grant;
@@ -1036,9 +1043,6 @@ p25p2_vpdu_handle_group_explicit_grant(dsd_opts* opts, dsd_state* state, int slo
     freq_t = process_channel_to_freq(opts, state, grant->channelt);
     if (p25p2_vpdu_channel_is_valid(grant->channelr)) {
         (void)process_channel_to_freq(opts, state, grant->channelr);
-    }
-    if (grant->store_slot_svc) {
-        p25p2_vpdu_store_slot_svc(state, slot_idx, grant->svc);
     }
     p25p2_vpdu_set_active_group_single(state, grant->channelt, grant->group, grant->svc);
     p25p2_vpdu_print_group_label(state, (uint32_t)grant->group);
@@ -1116,7 +1120,6 @@ p25p2_vpdu_iter_block_01(p25p2_vpdu_ctx* ctx) {
 
         //add active channel to string for ncurses display
         p25_set_mfid90_active_channel_single(state, channel, sgroup, svc);
-        p25p2_vpdu_store_slot_svc(state, slot_idx, svc);
 
         p25p2_vpdu_print_group_label(state, (uint32_t)sgroup);
 
@@ -1174,7 +1177,6 @@ p25p2_vpdu_iter_block_02(p25p2_vpdu_ctx* ctx) {
 
         //add active channel to string for ncurses display
         p25_set_mfid90_active_channel_single(state, channel, sgroup, svc);
-        p25p2_vpdu_store_slot_svc(state, slot_idx, svc);
 
         p25p2_vpdu_print_group_label(state, (uint32_t)sgroup);
 
@@ -1289,7 +1291,6 @@ p25p2_vpdu_iter_block_04(p25p2_vpdu_ctx* ctx) {
         DSD_FPRINTF(stderr, " Group Voice Channel Grant");
         DSD_FPRINTF(stderr, "\n  SVC [%02X] CHAN [%04X] Group [%d] Source [%d]", svc, channel, group, src);
         freq = process_channel_to_freq(opts, state, channel);
-        p25p2_vpdu_store_slot_svc(state, slot_idx, svc);
         p25p2_vpdu_set_active_group_single(state, channel, group, svc);
         p25p2_vpdu_print_group_label(state, (uint32_t)group);
 
@@ -1347,7 +1348,6 @@ p25p2_vpdu_iter_block_05(p25p2_vpdu_ctx* ctx) {
         DSD_FPRINTF(stderr, (MAC[1 + len_a] & 0x80) ? " Explicit" : " Implicit");
         DSD_FPRINTF(stderr, "\n  CHAN: %04X; Timer: %f Seconds; Target: %d;", channel, (float)timer * 0.1f, target);
         freq = process_channel_to_freq(opts, state, channel);
-        p25p2_vpdu_store_slot_svc(state, slot_idx, svc);
 
         if (p25p2_vpdu_channel_is_valid(channel)) {
             char suffix[32];
@@ -1699,7 +1699,6 @@ p25p2_vpdu_iter_block_10(p25p2_vpdu_ctx* ctx) {
             .group = group,
             .source = 0,
             .set_packet_bit = 0,
-            .store_slot_svc = 0,
             .provenance = P25_SM_GRANT_PROVENANCE_UPDATE,
             .label = "Group Voice Channel Grant Update - Explicit",
         };
@@ -1720,7 +1719,6 @@ p25p2_vpdu_iter_block_10(p25p2_vpdu_ctx* ctx) {
             .group = group,
             .source = source,
             .set_packet_bit = 1,
-            .store_slot_svc = 1,
             .provenance = P25_SM_GRANT_PROVENANCE_ASSIGNMENT,
             .label = "Group Voice Channel Grant - Explicit",
         };
@@ -1740,7 +1738,6 @@ p25p2_vpdu_iter_block_10(p25p2_vpdu_ctx* ctx) {
             .group = group,
             .source = 0,
             .set_packet_bit = 0,
-            .store_slot_svc = 0,
             .provenance = P25_SM_GRANT_PROVENANCE_UPDATE,
             .label = "Group Voice Channel Grant Update - Explicit",
         };
@@ -2076,7 +2073,6 @@ p25p2_vpdu_iter_block_17(p25p2_vpdu_ctx* ctx) {
         p25p2_vpdu_publish_activityf(state, (uint8_t)slot, DSD_CALL_KIND_GROUP_VOICE, (uint64_t)sg, 0U,
                                      (uint16_t)channel, freq, (uint16_t)svc, "MFID90 GRG VCH Upd: %04X%s SG: %d; ",
                                      channel, suf, sg);
-        p25p2_vpdu_store_slot_svc(state, slot_idx, svc);
         DSD_FPRINTF(stderr, "\n");
         // Route through SM for tuning consideration
         if (channel != 0 && p25p2_vpdu_can_dispatch_grant(opts, state, freq)) {

--- a/src/ui/terminal/dsd-neo/ui/ncurses_internal.h
+++ b/src/ui/terminal/dsd-neo/ui/ncurses_internal.h
@@ -126,6 +126,21 @@ ui_burst_is_active_call(int burst) {
     return burst == 16 || ui_burst_is_active_p25_call(burst);
 }
 
+/* A lockout-suppressed P25p2 companion transmission keeps repeating
+   MAC_PTT/MAC_ACTIVE (burst hints 20/21) and ESS crypto metadata after
+   encryption lockout ended its canonical call, so the raw decoder fields
+   would render a live keyed voice call with a blank identity. Such a slot
+   must render idle: lockout active, no ACTIVE canonical call on the slot,
+   the slot's crypto classification suppressed (pending or blocked), and a
+   burst hint that would otherwise claim call/crypto context. */
+static inline int
+ui_p25p2_lockout_suppressed_slot(int lockout_active, int call_active, int crypto_suppressed, int burst) {
+    if (!lockout_active || call_active || !crypto_suppressed) {
+        return 0;
+    }
+    return ui_burst_has_p25_crypto_metadata(burst);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -31,6 +31,7 @@
 #include <dsd-neo/protocol/edacs/edacs_afs.h>
 #include <dsd-neo/protocol/m17/m17_parse.h>
 #include <dsd-neo/protocol/p25/p25_callsign.h>
+#include <dsd-neo/protocol/p25/p25_crypto.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/ui/menu_core.h>
 #include <dsd-neo/ui/ncurses.h>
@@ -2546,7 +2547,7 @@ ui_apply_canonical_call_slot(ui_slot_view* slot, const dsd_call_snapshot* call) 
 }
 
 static ui_slot_view
-ui_build_slot_view(const dsd_state* state, int slot_idx) {
+ui_build_slot_view(const dsd_opts* opts, const dsd_state* state, int slot_idx) {
     ui_slot_view slot;
     DSD_MEMSET(&slot, 0, sizeof(slot));
     ui_fill_slot_decoder_state(state, slot_idx, &slot);
@@ -2557,6 +2558,20 @@ ui_build_slot_view(const dsd_state* state, int slot_idx) {
         if (call->phase == DSD_CALL_PHASE_ACTIVE) {
             ui_apply_canonical_call_slot(&slot, call);
         }
+    }
+    const int p25p2_context = DSD_SYNC_IS_P25P2(state->synctype) || DSD_SYNC_IS_P25P2(state->lastsynctype);
+    const int lockout_active = opts != NULL && opts->trunk_enable == 1 && opts->trunk_tune_enc_calls == 0;
+    if (p25p2_context
+        && ui_p25p2_lockout_suppressed_slot(lockout_active, slot.call.phase == DSD_CALL_PHASE_ACTIVE,
+                                            p25_crypto_companion_suppressed(state, slot_idx), slot.burst)) {
+        // The locked-out call's identity still reaches the operator through
+        // the lockout event-history row and the active-channel list; the
+        // slot row must not dress its MAC/ESS repeats up as a live keyed
+        // call with a blank identity.
+        slot.burst = 24;
+        slot.payload_algid = 0;
+        slot.payload_keyid = 0;
+        slot.payload_mi_p25 = 0;
     }
     return slot;
 }
@@ -3043,8 +3058,8 @@ ui_render_call_info_p25_dmr(const dsd_opts* opts, dsd_state* state) {
     ui_render_p25_dmr_header(opts, state);
     printw("\n");
 
-    ui_slot_view left = ui_build_slot_view(state, 0);
-    ui_slot_view right = ui_build_slot_view(state, 1);
+    ui_slot_view left = ui_build_slot_view(opts, state, 0);
+    ui_slot_view right = ui_build_slot_view(opts, state, 1);
     ui_render_p25_dmr_slot_block(opts, state, &left);
     ui_render_p25_dmr_slot_block(opts, state, &right);
     ui_render_p25_dmr_active_channels_line(opts, state);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5074,6 +5074,27 @@ add_test(
     COMMAND dsd-neo_test_p25_p2_vpdu_foreign_grant_svc
 )
 
+# P25 P2 tuned-tick timeouts must bridge the companion conversation's
+# hangtime gap instead of releasing the shared TDMA carrier mid-conversation
+add_executable(
+    dsd-neo_test_p25_p2_tick_companion_hold
+    protocol/p25/test_p25_p2_tick_companion_hold.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p2_tick_companion_hold
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/tests/protocol/p25
+)
+target_link_libraries(
+    dsd-neo_test_p25_p2_tick_companion_hold
+    PRIVATE dsd-neo_proto_p25
+)
+add_test(
+    NAME P25_P2_TICK_COMPANION_HOLD
+    COMMAND dsd-neo_test_p25_p2_tick_companion_hold
+)
+
 # P25 CC cache loading (read-only behavior and identity/RFSS/SITE scoping)
 add_executable(
     dsd-neo_test_p25_cc_cache_path

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5053,6 +5053,27 @@ target_link_libraries(
 )
 add_test(NAME P25_P2_VPDU_ENC_FLUSH COMMAND dsd-neo_test_p25_p2_vpdu_enc_flush)
 
+# P25 P2 VPDU foreign channel-grant announcements must not rewrite the decode
+# slot's own service options (feeds the clear-call encrypted-pending mute)
+add_executable(
+    dsd-neo_test_p25_p2_vpdu_foreign_grant_svc
+    protocol/p25/test_p25_p2_vpdu_foreign_grant_svc.c
+)
+target_include_directories(
+    dsd-neo_test_p25_p2_vpdu_foreign_grant_svc
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/tests/protocol/p25
+)
+target_link_libraries(
+    dsd-neo_test_p25_p2_vpdu_foreign_grant_svc
+    PRIVATE dsd-neo_proto_p25
+)
+add_test(
+    NAME P25_P2_VPDU_FOREIGN_GRANT_SVC
+    COMMAND dsd-neo_test_p25_p2_vpdu_foreign_grant_svc
+)
+
 # P25 CC cache loading (read-only behavior and identity/RFSS/SITE scoping)
 add_executable(
     dsd-neo_test_p25_cc_cache_path

--- a/tests/protocol/p25/test_p25_p2_tick_companion_hold.c
+++ b/tests/protocol/p25/test_p25_p2_tick_companion_hold.c
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * A lapsed crypto classification on one slot of a shared TDMA carrier must
+ * not tear the channel down while the other slot's conversation sits inside
+ * its hangtime gap: the retains-carrier signals (voice_active, audio gate,
+ * ring) all read a talker gap as inactive, but the gap is exactly what the
+ * hangtime window promises to bridge, and classification is itself evidence
+ * a call may still resolve clear. The hold mirrors the hangtime bridge the
+ * enc-lockout release path already honors; the hangtime tick still owns the
+ * release once the gap outlives the window. The plain pending-voice-grant
+ * timeout keeps its immediate release by design (the carrier's stay is the
+ * shorter of the companion bridge and the assignment's acquisition window),
+ * which the idle-companion case below exercises.
+ */
+
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static int g_return_to_cc_called = 0;
+
+static dsd_trunk_tune_result
+return_to_cc(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
+    (void)request_id;
+    (void)opts;
+    (void)state;
+    g_return_to_cc_called++;
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static void
+install_trunk_tuning_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.return_to_cc_request = return_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static int
+expect_eq(const char* tag, long got, long want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %ld want %ld\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+// Tuned TDMA carrier whose slot-0 conversation just went quiet: the talker
+// un-keyed a moment ago, so voice_active, the audio gate, and the ring are all
+// clear, but the stop is fresh inside the hangtime window the SM promises to
+// bridge.
+static void
+setup_clear_gap_on_slot0(dsd_opts* opts, dsd_state* state, p25_sm_ctx_t** out_ctx, double now_m) {
+    DSD_MEMSET(opts, 0, sizeof *opts);
+    DSD_MEMSET(state, 0, sizeof *state);
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->trunk_tune_enc_calls = 0;
+    opts->trunk_tune_group_calls = 1;
+    opts->trunk_hangtime = 2.0f;
+    state->currentslot = 0;
+    state->synctype = DSD_SYNC_P25P2_POS;
+    state->lastsynctype = DSD_SYNC_P25P2_POS;
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    p25_sm_init_ctx(ctx, opts, state);
+    *out_ctx = ctx;
+    ctx->state = P25_SM_TUNED;
+    ctx->vc_is_tdma = 1;
+    ctx->vc_freq_hz = 851500000;
+    ctx->config.hangtime_s = 2.0;
+    ctx->config.grant_timeout_s = 3.0;
+    ctx->t_tune_m = now_m - 60.0;
+    ctx->vc_activity_seen = 1;
+
+    p25_sm_slot_ctx_t* clear_slot = &ctx->slots[0];
+    clear_slot->grant_active = 0;
+    clear_slot->voice_active = 0;
+    clear_slot->is_group = 1;
+    clear_slot->ota_tg = 1234;
+    clear_slot->target_id = 1234;
+    clear_slot->last_grant_m = now_m - 10.0;
+    clear_slot->last_start_m = now_m - 8.0;
+    clear_slot->last_stop_m = now_m - 0.3;
+    clear_slot->last_followed_m = now_m - 0.3;
+}
+
+static void
+age_clear_gap_past_hangtime(p25_sm_ctx_t* ctx, double now_m) {
+    const double past_m = now_m - (ctx->config.hangtime_s + 1.0);
+    ctx->slots[0].last_stop_m = past_m;
+    ctx->slots[0].last_followed_m = past_m;
+    ctx->slots[0].last_start_m = past_m - 1.0;
+    ctx->slots[0].last_grant_m = past_m - 1.0;
+}
+
+// Crypto-classification timeout: slot 1's encryption classification never
+// resolved (no FEC-accepted ESS) and its budget lapses inside slot 0's gap.
+static int
+test_crypto_timeout_holds_through_companion_gap(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    const double now_m = dsd_time_now_monotonic_s();
+    int rc = 0;
+
+    setup_clear_gap_on_slot0(&opts, &state, &ctx, now_m);
+    p25_sm_slot_ctx_t* classifying_slot = &ctx->slots[1];
+    classifying_slot->grant_active = 1;
+    classifying_slot->is_group = 1;
+    classifying_slot->ota_tg = 30601;
+    classifying_slot->target_id = 30601;
+    classifying_slot->last_grant_m = now_m - (ctx->config.grant_timeout_s + 0.5);
+    classifying_slot->crypto_attempt_m = now_m - (ctx->config.grant_timeout_s + 0.5);
+    state.p25_crypto_state[1] = DSD_P25_CRYPTO_ENCRYPTED_PENDING;
+    g_return_to_cc_called = 0;
+
+    p25_sm_tick_ctx(ctx, &opts, &state);
+
+    rc |= expect_eq("crypto timeout in gap: no cc return", g_return_to_cc_called, 0);
+    rc |= expect_eq("crypto timeout in gap: still tuned", ctx->state == P25_SM_TUNED, 1);
+    rc |= expect_eq("crypto timeout in gap: classification dismantled", state.p25_crypto_state[1],
+                    DSD_P25_CRYPTO_UNKNOWN);
+    rc |= expect_eq("crypto timeout in gap: stale assignment cleared", ctx->slots[1].grant_active, 0);
+
+    age_clear_gap_past_hangtime(ctx, dsd_time_now_monotonic_s());
+    p25_sm_tick_ctx(ctx, &opts, &state);
+    rc |= expect_eq("crypto timeout past gap: released to cc", g_return_to_cc_called, 1);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+// With no companion history at all (the other slot never carried a call), both
+// timeouts keep their immediate release: nothing is waiting out a gap.
+static int
+test_timeouts_still_release_without_companion_history(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    p25_sm_ctx_t* ctx = NULL;
+    const double now_m = dsd_time_now_monotonic_s();
+    int rc = 0;
+
+    setup_clear_gap_on_slot0(&opts, &state, &ctx, now_m);
+    // Erase slot 0's conversation history: idle companion.
+    ctx->slots[0].last_grant_m = 0.0;
+    ctx->slots[0].last_start_m = 0.0;
+    ctx->slots[0].last_stop_m = 0.0;
+    ctx->slots[0].last_followed_m = 0.0;
+    ctx->slots[0].ota_tg = 0;
+    ctx->slots[0].target_id = 0;
+
+    p25_sm_slot_ctx_t* pending_slot = &ctx->slots[1];
+    pending_slot->grant_active = 1;
+    pending_slot->is_group = 1;
+    pending_slot->ota_tg = 30601;
+    pending_slot->target_id = 30601;
+    pending_slot->last_grant_m = now_m - (ctx->config.grant_timeout_s + 0.5);
+    g_return_to_cc_called = 0;
+
+    p25_sm_tick_ctx(ctx, &opts, &state);
+    rc |= expect_eq("idle companion: released to cc", g_return_to_cc_called, 1);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+int
+main(void) {
+    install_trunk_tuning_hooks();
+
+    int rc = 0;
+    rc |= test_crypto_timeout_holds_through_companion_gap();
+    rc |= test_timeouts_still_release_without_companion_history();
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "P25 P2 TICK COMPANION HOLD: OK\n");
+    }
+    return rc;
+}

--- a/tests/protocol/p25/test_p25_p2_vpdu_enc_flush.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_enc_flush.c
@@ -337,6 +337,35 @@ main(void) {
     rc |= expect_eq("MAC Release follow-up reopens call", released_call.phase, DSD_CALL_PHASE_ACTIVE);
     rc |= expect_eq("MAC Release follow-up starts new epoch", released_call.epoch == released_epoch + 1U, 1);
 
+    // Scenario 6: a MAC Release for a slot whose crypto classification refuses
+    // audio (encryption lockout) must not emit the slot's stale buffered tail:
+    // those samples predate the mute, and playing them would both surface
+    // refused audio and wedge extra blocks into the audible companion's output
+    // stream. The tail is dropped, the buffer blanked, and the companion keeps
+    // the carrier.
+    DSD_MEMSET(MAC, 0, sizeof MAC);
+    MAC[1] = 0x31;
+    opts.trunk_tune_enc_calls = 0;
+    st.currentslot = 0;
+    st.p25_crypto_state[0] = DSD_P25_CRYPTO_BLOCKED;
+    st.p25_crypto_state[1] = DSD_P25_CRYPTO_CLEAR;
+    st.p25_p2_audio_allowed[0] = 0;
+    st.p25_p2_audio_allowed[1] = 1;
+    st.p25_p2_last_mac_active[1] = time(NULL);
+    st.p25_p2_last_mac_active_m[1] = dsd_time_now_monotonic_s();
+    st.voice_counter[0] = 1;
+    st.s_l4[0][0] = 321;
+    g_return_to_cc_called = 0;
+    reset_audio_capture();
+
+    process_MAC_VPDU(&opts, &st, 0, P25_MAC_PDU_ACTIVE, MAC);
+
+    rc |= expect_eq("lockout MAC Release emits no tail", g_audio_capture_calls, 0);
+    rc |= expect_eq("lockout MAC Release blanks stale tail", st.s_l4[0][0], 0);
+    rc |= expect_eq("lockout MAC Release resets stale counter", st.voice_counter[0], 0);
+    rc |= expect_eq("lockout MAC Release keeps companion tuned", g_return_to_cc_called, 0);
+    rc |= expect_eq("lockout MAC Release keeps companion gate", st.p25_p2_audio_allowed[1], 1);
+
     dsd_udp_audio_hooks_set((dsd_udp_audio_hooks){0});
     dsd_state_ext_free_all(&st);
     return rc;

--- a/tests/protocol/p25/test_p25_p2_vpdu_foreign_grant_svc.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_foreign_grant_svc.c
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * A channel-grant announcement heard in a voice channel's MAC signaling
+ * describes a call on some other channel or slot. It must not overwrite the
+ * decode slot's own per-slot service options (dmr_so / dmr_soR): those bits
+ * feed p25p2_prepare_voice_crypto(), where a foreign grant's encrypted service
+ * bit flips a clear call to ENCRYPTED_PENDING mid-transmission and, under
+ * encryption lockout, closes its audio gate. Only the voice-channel-user MCOs,
+ * which describe the decode slot's own call, may store service options.
+ */
+
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/protocol/p25/p25_vpdu.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+// Stubs to satisfy external references
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+apx_embedded_alias_header_phase2(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)lc_bits;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+apx_embedded_alias_blocks_phase2(dsd_opts* opts, dsd_state* state, uint8_t slot, uint8_t* lc_bits) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)lc_bits;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+l3h_embedded_alias_decode(dsd_opts* opts, dsd_state* state, uint8_t slot, int16_t len, uint8_t* input) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+    (void)len;
+    (void)input;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+nmea_harris(dsd_opts* opts, dsd_state* state, uint8_t* input, uint32_t src, int slot) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)src;
+    (void)slot;
+}
+
+static dsd_trunk_tune_result
+return_to_cc(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
+    (void)request_id;
+    (void)opts;
+    (void)state;
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static void
+install_trunk_tuning_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.return_to_cc_request = return_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static int
+expect_eq(const char* tag, long got, long want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %ld want %ld\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+seed_call(dsd_state* state, uint8_t slot, uint64_t target) {
+    const dsd_call_observation observation = {
+        .protocol = DSD_SYNC_P25P2_POS,
+        .slot = slot,
+        .kind = DSD_CALL_KIND_GROUP_VOICE,
+        .ota_target_id = target,
+        .policy_target_id = target,
+        .observed_m = 1.0,
+    };
+    return dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) > 0;
+}
+
+// Tuned TDMA carrier with a clear group call decoding on each slot. Slot 0's
+// own service options are 0x00, slot 1's 0x20 (duplex, both clear).
+static void
+setup_dual_clear_calls(dsd_opts* opts, dsd_state* state) {
+    DSD_MEMSET(opts, 0, sizeof *opts);
+    DSD_MEMSET(state, 0, sizeof *state);
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->trunk_tune_enc_calls = 0;
+    opts->trunk_tune_group_calls = 1;
+    state->currentslot = 0;
+    state->synctype = DSD_SYNC_P25P2_POS;
+    state->lastsynctype = DSD_SYNC_P25P2_POS;
+    state->dmr_so = 0x00U;
+    state->dmr_soR = 0x20U;
+    state->p25_crypto_state[0] = DSD_P25_CRYPTO_CLEAR;
+    state->p25_crypto_state[1] = DSD_P25_CRYPTO_CLEAR;
+    state->p25_p2_audio_allowed[0] = 1;
+    state->p25_p2_audio_allowed[1] = 1;
+    (void)seed_call(state, 0U, 1234);
+    (void)seed_call(state, 1U, 2345);
+
+    p25_sm_ctx_t* sm = p25_sm_get_ctx();
+    p25_sm_init_ctx(sm, opts, state);
+    sm->state = P25_SM_TUNED;
+    sm->vc_is_tdma = 1;
+    sm->vc_freq_hz = 851500000;
+    for (int slot = 0; slot < 2; slot++) {
+        sm->slots[slot].grant_active = 1;
+        sm->slots[slot].freq_hz = sm->vc_freq_hz;
+        sm->slots[slot].target_id = slot == 0 ? 1234 : 2345;
+        sm->slots[slot].ota_tg = sm->slots[slot].target_id;
+        sm->slots[slot].is_group = 1;
+        sm->slots[slot].voice_active = 1;
+    }
+}
+
+typedef struct {
+    const char* name;
+    unsigned long long mac[24];
+} foreign_announcement;
+
+// Every announcement below names TG 0x7788 with encrypted service (0x44) on
+// channel 0x100A -- a call that is not on either of this carrier's slots. The
+// channel is deliberately absent from the iden/chan tables so the grant is
+// undispatchable and the store is the only observable side effect.
+static const foreign_announcement k_foreign_announcements[] = {
+    {
+        .name = "0x40 group voice channel grant",
+        .mac = {0, 0x40, 0x44, 0x10, 0x0A, 0x77, 0x88, 0x0A, 0x0B, 0x0C},
+    },
+    {
+        .name = "0xC0 group voice channel grant explicit",
+        .mac = {0, 0xC0, 0x44, 0x10, 0x0A, 0x10, 0x0B, 0x77, 0x88, 0x0A, 0x0B, 0x0C},
+    },
+    {
+        .name = "0xA3 mfid90 regroup channel grant implicit",
+        .mac = {0, 0xA3, 0x90, 0x00, 0x44, 0x10, 0x0A, 0x77, 0x88, 0x0A, 0x0B, 0x0C},
+    },
+    {
+        .name = "0xA4 mfid90 regroup channel grant explicit",
+        .mac = {0, 0xA4, 0x90, 0x00, 0x44, 0x10, 0x0A, 0x10, 0x0B, 0x77, 0x88, 0x0A, 0x0B, 0x0C},
+    },
+    {
+        .name = "0x83 mfid90 regroup voice channel update",
+        .mac = {0, 0x83, 0x90, 0x44, 0x77, 0x88, 0x10, 0x0A},
+    },
+    {
+        .name = "0x48 telephone interconnect voice channel grant",
+        .mac = {0, 0x48, 0x00, 0x44, 0x10, 0x0A, 0x00, 0x64, 0x0A, 0x0B, 0x0C},
+    },
+};
+
+static int
+test_foreign_announcements_do_not_rewrite_slot_svc(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    const size_t count = sizeof(k_foreign_announcements) / sizeof(k_foreign_announcements[0]);
+    for (size_t i = 0; i < count; i++) {
+        const foreign_announcement* fa = &k_foreign_announcements[i];
+        char tag[128];
+
+        // FACCH while decoding slot 0: the announcement rides the clear call's
+        // own signaling.
+        setup_dual_clear_calls(&opts, &state);
+        unsigned long long mac[24];
+        DSD_MEMCPY(mac, fa->mac, sizeof mac);
+        process_MAC_VPDU(&opts, &state, /*type FACCH*/ 0, P25_MAC_PDU_ACTIVE, mac);
+
+        DSD_SNPRINTF(tag, sizeof tag, "%s: facch slot0 svc preserved", fa->name);
+        rc |= expect_eq(tag, (long)state.dmr_so, 0x00);
+        DSD_SNPRINTF(tag, sizeof tag, "%s: facch slot1 svc preserved", fa->name);
+        rc |= expect_eq(tag, (long)state.dmr_soR, 0x20);
+        dsd_state_ext_free_all(&state);
+
+        // SACCH decoded in physical slot 1 maps to voice slot 0: the inverted
+        // attribution must not contaminate slot 0 either.
+        setup_dual_clear_calls(&opts, &state);
+        state.currentslot = 1;
+        DSD_MEMCPY(mac, fa->mac, sizeof mac);
+        process_MAC_VPDU(&opts, &state, /*type SACCH*/ 1, P25_MAC_PDU_ACTIVE, mac);
+
+        DSD_SNPRINTF(tag, sizeof tag, "%s: sacch slot0 svc preserved", fa->name);
+        rc |= expect_eq(tag, (long)state.dmr_so, 0x00);
+        DSD_SNPRINTF(tag, sizeof tag, "%s: sacch slot1 svc preserved", fa->name);
+        rc |= expect_eq(tag, (long)state.dmr_soR, 0x20);
+        dsd_state_ext_free_all(&state);
+    }
+
+    return rc;
+}
+
+// The voice-channel-user MCO describes the decode slot's own call and must
+// keep storing its service options -- the guard above must not overcorrect.
+static int
+test_own_voice_channel_user_still_stores_svc(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    setup_dual_clear_calls(&opts, &state);
+    unsigned long long mac[24] = {0};
+    mac[1] = 0x01; // Group Voice Channel User, abbreviated
+    mac[2] = 0x24; // Duplex, priority 4, clear
+    mac[3] = 0x04;
+    mac[4] = 0xD2; // TG 1234 (slot 0's own call)
+    mac[5] = 0x00;
+    mac[6] = 0x00;
+    mac[7] = 0x2A;
+    process_MAC_VPDU(&opts, &state, /*type FACCH*/ 0, P25_MAC_PDU_ACTIVE, mac);
+
+    rc |= expect_eq("own voice user: slot0 svc stored", (long)state.dmr_so, 0x24);
+    rc |= expect_eq("own voice user: slot1 svc preserved", (long)state.dmr_soR, 0x20);
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+int
+main(void) {
+    install_trunk_tuning_hooks();
+
+    int rc = 0;
+    rc |= test_foreign_announcements_do_not_rewrite_slot_svc();
+    rc |= test_own_voice_channel_user_still_stores_svc();
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "P25 P2 VPDU FOREIGN GRANT SVC: OK\n");
+    }
+    return rc;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif

--- a/tests/protocol/p25/test_p25_p2_vpdu_grants.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_grants.c
@@ -1127,6 +1127,10 @@ main(void) {
         rc |= expect_eq_long("0xA4 capture tg", ctx->slots[0].ota_tg, 0x4567);
         rc |= expect_eq_long("0xA4 capture src", ctx->vc_src, 0x0A0B0C);
         rc |= expect_eq_long("0xA4 CHAN-R cache", state.trunk_chan_map[0x100B], 851137500);
+        // Dispatched: the accepted assignment commits its service options to
+        // the granted slot through the SM identity path. Undispatchable
+        // announcements must leave per-slot service options alone (covered by
+        // P25_P2_VPDU_FOREIGN_GRANT_SVC).
         rc |= expect_eq_long("0xA4 stored service options", state.dmr_so, 0x23);
     }
 
@@ -1160,6 +1164,8 @@ main(void) {
         rc |= expect_eq_long("0x83 capture svc", ctx->slots[0].svc_bits, 0x81);
         rc |= expect_eq_long("0x83 capture tg", ctx->slots[0].ota_tg, 0x5566);
         rc |= expect_eq_long("0x83 capture src", ctx->vc_src, 0);
+        // Dispatched, same as 0xA4: the SM identity commit stores the granted
+        // slot's service options.
         rc |= expect_eq_long("0x83 stored service options", state.dmr_so, 0x81);
     }
 

--- a/tests/protocol/p25/test_p25_queued_deny_response.c
+++ b/tests/protocol/p25/test_p25_queued_deny_response.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/protocol/p25/p25_vpdu.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -33,6 +34,21 @@ static void
 reset_test_state(void) {
     dsd_state_ext_free_all(&st);
     DSD_MEMSET(&st, 0, sizeof st);
+}
+
+static dsd_trunk_tune_result
+test_return_to_cc(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
+    (void)request_id;
+    (void)opts;
+    (void)state;
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static void
+install_trunk_tuning_hooks(void) {
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.return_to_cc_request = test_return_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
 }
 
 static const char*
@@ -570,6 +586,89 @@ test_sm_deny_counter_increments(void) {
 }
 
 /* ============================================================================
+ * Test: Deny/Queued heard on an occupied carrier must not release it
+ * ============================================================================ */
+
+static int
+test_deny_holds_occupied_carrier(void) {
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    reset_test_state();
+    opts.trunk_hangtime = 2.0f;
+    opts.trunk_is_tuned = 1;
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    DSD_MEMSET(ctx, 0, sizeof(*ctx));
+    ctx->state = P25_SM_TUNED;
+    ctx->initialized = 1;
+
+    /* The companion slot is audibly carrying a call. */
+    st.p25_p2_audio_allowed[1] = 1;
+
+    unsigned long long MAC[24];
+    build_que_deny_mac(MAC, 1, 0x02, 0x60, 0, 424242);
+    process_MAC_VPDU(&opts, &st, 0, P25_MAC_PDU_ACTIVE, MAC);
+
+    int rc = 0;
+    if (st.p25_sm_deny_count != 1) {
+        DSD_FPRINTF(stderr, "FAIL: test_deny_holds_occupied_carrier: counter expected 1, got %u\n",
+                    st.p25_sm_deny_count);
+        rc = 1;
+    }
+    if (ctx->state != P25_SM_TUNED) {
+        DSD_FPRINTF(stderr, "FAIL: test_deny_holds_occupied_carrier: released an occupied carrier\n");
+        rc = 1;
+    }
+
+    /* Once nothing occupies either slot, the same deny releases as before. */
+    st.p25_p2_audio_allowed[1] = 0;
+    process_MAC_VPDU(&opts, &st, 0, P25_MAC_PDU_ACTIVE, MAC);
+    if (st.p25_sm_deny_count != 2) {
+        DSD_FPRINTF(stderr, "FAIL: test_deny_holds_occupied_carrier: counter expected 2, got %u\n",
+                    st.p25_sm_deny_count);
+        rc = 1;
+    }
+    if (ctx->state == P25_SM_TUNED) {
+        DSD_FPRINTF(stderr, "FAIL: test_deny_holds_occupied_carrier: idle carrier did not release\n");
+        rc = 1;
+    }
+
+    return rc;
+}
+
+static int
+test_motorola_queued_holds_occupied_carrier(void) {
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    reset_test_state();
+    opts.trunk_hangtime = 2.0f;
+    opts.trunk_is_tuned = 1;
+
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    DSD_MEMSET(ctx, 0, sizeof(*ctx));
+    ctx->state = P25_SM_TUNED;
+    ctx->initialized = 1;
+
+    st.p25_p2_audio_allowed[0] = 1;
+
+    unsigned long long MAC[24];
+    build_moto_que_deny_mac(MAC, 0, 0x15, 0x42, 0, 0xABCDEF, 0);
+    process_MAC_VPDU(&opts, &st, 0, P25_MAC_PDU_ACTIVE, MAC);
+
+    int rc = 0;
+    if (st.p25_sm_queued_count != 1) {
+        DSD_FPRINTF(stderr, "FAIL: test_motorola_queued_holds_occupied_carrier: counter expected 1, got %u\n",
+                    st.p25_sm_queued_count);
+        rc = 1;
+    }
+    if (ctx->state != P25_SM_TUNED) {
+        DSD_FPRINTF(stderr, "FAIL: test_motorola_queued_holds_occupied_carrier: released an occupied carrier\n");
+        rc = 1;
+    }
+    return rc;
+}
+
+/* ============================================================================
  * Test: Active channel display contains "QUE" and target
  * ============================================================================ */
 
@@ -710,6 +809,7 @@ int
 main(void) {
     int rc = 0;
 
+    install_trunk_tuning_hooks();
     rc |= test_que_rsp_field_extraction_known_payload();
     rc |= test_deny_rsp_field_extraction_known_payload();
     rc |= test_que_reason_code_lookup_all_known();
@@ -722,6 +822,8 @@ main(void) {
     rc |= test_sm_deny_noop_when_on_cc();
     rc |= test_sm_queued_counter_increments();
     rc |= test_sm_deny_counter_increments();
+    rc |= test_deny_holds_occupied_carrier();
+    rc |= test_motorola_queued_holds_occupied_carrier();
     rc |= test_active_channel_que_format();
     rc |= test_active_channel_deny_format();
     rc |= test_additional_info_indicator_controls_display();

--- a/tests/ui/test_ui_burst_active_call.c
+++ b/tests/ui/test_ui_burst_active_call.c
@@ -57,6 +57,20 @@ main(void) {
     assert(ui_burst_has_p25_crypto_metadata(30) == 0);
     assert(ui_burst_has_p25_crypto_metadata(31) == 0);
 
+    /* A lockout-suppressed companion (no ACTIVE canonical call, crypto
+       suppressed) with a call-claiming burst hint renders idle. */
+    assert(ui_p25p2_lockout_suppressed_slot(1, 0, 1, 20) == 1); /* MAC_PTT repeat */
+    assert(ui_p25p2_lockout_suppressed_slot(1, 0, 1, 21) == 1); /* MAC_ACTIVE repeat */
+    assert(ui_p25p2_lockout_suppressed_slot(1, 0, 1, 22) == 1); /* MAC_HANGTIME */
+
+    /* Follow mode, an ACTIVE canonical call, an unsuppressed classification,
+       or a hint with no call/crypto claim all render as-is. */
+    assert(ui_p25p2_lockout_suppressed_slot(0, 0, 1, 21) == 0); /* lockout off */
+    assert(ui_p25p2_lockout_suppressed_slot(1, 1, 1, 21) == 0); /* call active */
+    assert(ui_p25p2_lockout_suppressed_slot(1, 0, 0, 21) == 0); /* crypto clear/unknown */
+    assert(ui_p25p2_lockout_suppressed_slot(1, 0, 1, 23) == 0); /* PTT END */
+    assert(ui_p25p2_lockout_suppressed_slot(1, 0, 1, 24) == 0); /* already idle */
+
     printf("UI_BURST_ACTIVE_CALL: OK\n");
     return 0;
 }

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -1026,7 +1026,7 @@ test_patch_and_slot_helpers(void) {
     };
     assert(dsd_call_state_update_crypto(&state, 1U, &crypto) == 1);
 
-    ui_slot_view right = ui_build_slot_view(&state, 1);
+    ui_slot_view right = ui_build_slot_view(&(dsd_opts){0}, &state, 1);
     assert(right.slot_no == 2);
     assert(right.burst == 21);
     assert(right.target == 202);
@@ -1098,7 +1098,7 @@ test_canonical_p25_slot_and_recent_activity(void) {
     crypto.observed_m = 1.1;
     assert(dsd_call_state_update_crypto(state, 0U, &crypto) == 1);
 
-    ui_slot_view slot = ui_build_slot_view(state, 0);
+    ui_slot_view slot = ui_build_slot_view(&(dsd_opts){0}, state, 0);
     assert(slot.canonical_p25 == 1);
     assert(slot.burst == 21);
     assert(slot.target == 1201);
@@ -1118,7 +1118,7 @@ test_canonical_p25_slot_and_recent_activity(void) {
     assert_capture_contains(" | VOICE");
 
     state->dmrburstR = 21;
-    ui_slot_view idle_companion = ui_build_slot_view(state, 1);
+    ui_slot_view idle_companion = ui_build_slot_view(&(dsd_opts){0}, state, 1);
     assert(idle_companion.canonical_p25 == 0);
     assert(idle_companion.call.phase == DSD_CALL_PHASE_IDLE);
     reset_printw_capture();
@@ -1151,13 +1151,13 @@ test_canonical_p25_slot_and_recent_activity(void) {
     data_observation.policy_target_id = 2202U;
     data_observation.observed_m = 1.5;
     assert(dsd_call_state_observe(state, &data_observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
-    slot = ui_build_slot_view(state, 0);
+    slot = ui_build_slot_view(&(dsd_opts){0}, state, 0);
     assert(slot.canonical_p25 == 1);
     assert(slot.burst == 6);
     assert(strcmp(slot.call_banner, " Data") == 0);
 
     assert(dsd_call_state_end(state, 0U, 2.0) == 1);
-    slot = ui_build_slot_view(state, 0);
+    slot = ui_build_slot_view(&(dsd_opts){0}, state, 0);
     assert(slot.call.phase == DSD_CALL_PHASE_ENDED);
     reset_printw_capture();
     ui_render_p25_dmr_slot_block(&(dsd_opts){0}, state, &slot);
@@ -1168,7 +1168,7 @@ test_canonical_p25_slot_and_recent_activity(void) {
     state->payload_algid = 0x84;
     state->payload_keyid = 0x2468;
     state->payload_miP = 0x1122334455667788ULL;
-    slot = ui_build_slot_view(state, 0);
+    slot = ui_build_slot_view(&(dsd_opts){0}, state, 0);
     assert(slot.canonical_p25 == 0);
     assert(slot.call.phase == DSD_CALL_PHASE_ENDED);
     reset_printw_capture();
@@ -1196,7 +1196,7 @@ test_canonical_p25_slot_and_recent_activity(void) {
     observation.frequency_hz = 0;
     observation.observed_m = 3.0;
     assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
-    slot = ui_build_slot_view(state, 0);
+    slot = ui_build_slot_view(&(dsd_opts){0}, state, 0);
     assert(slot.canonical_p25 == 0);
     assert(slot.target == 4321);
     assert(slot.source == 8765);
@@ -1220,7 +1220,7 @@ capture_burst_separator_offset(void) {
 
 static void
 capture_slot_header_line(dsd_state* state, int slot_index) {
-    ui_slot_view slot = ui_build_slot_view(state, slot_index);
+    ui_slot_view slot = ui_build_slot_view(&(dsd_opts){0}, state, slot_index);
     ui_slot_render_flags flags = {0};
     reset_printw_capture();
     ui_render_slot_header_line(state, &slot, &flags);
@@ -1306,7 +1306,7 @@ test_slot_header_id_highlight_is_balanced(void) {
     assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
 
     // Voice burst: IDs are not highlighted, but the section colour is still restored.
-    ui_slot_view slot = ui_build_slot_view(state, 0);
+    ui_slot_view slot = ui_build_slot_view(&(dsd_opts){0}, state, 0);
     assert(slot.burst == 21);
     ui_slot_render_flags flags = {0};
     reset_color_trace();
@@ -1320,7 +1320,7 @@ test_slot_header_id_highlight_is_balanced(void) {
     data_observation.policy_target_id = 2202U;
     data_observation.observed_m = 2.0;
     assert(dsd_call_state_observe(state, &data_observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
-    slot = ui_build_slot_view(state, 0);
+    slot = ui_build_slot_view(&(dsd_opts){0}, state, 0);
     assert(slot.burst == 6);
     reset_color_trace();
     ui_render_slot_header_line(state, &slot, &flags);
@@ -1396,6 +1396,58 @@ test_live_protocol_panels_ignore_ended_call_identity(void) {
     free(state);
 }
 
+/* An encryption-lockout-suppressed P25p2 companion (canonical call ended by
+   lockout, crypto BLOCKED, MAC repeats keeping the raw burst hint on
+   MAC_ACTIVE and ESS repeats keeping ALG/KID/MI current) renders as an idle
+   slot: no VOICE status, no crypto line, blank identity. Follow mode keeps
+   the raw rendering. */
+static void
+test_lockout_suppressed_companion_slot_renders_idle(void) {
+    static dsd_opts lockout_opts;
+    dsd_state* state = (dsd_state*)calloc(1U, sizeof(*state));
+    assert(state != NULL);
+    DSD_MEMSET(&lockout_opts, 0, sizeof(lockout_opts));
+    lockout_opts.trunk_enable = 1;
+    lockout_opts.trunk_tune_enc_calls = 0;
+
+    state->synctype = DSD_SYNC_P25P2_POS;
+    state->lastsynctype = DSD_SYNC_P25P2_POS;
+    state->carrier = 1;
+    state->dmrburstR = 21; /* MAC_ACTIVE repeat after lockout ended the call */
+    state->payload_algidR = 0x84;
+    state->payload_keyidR = 0x026C;
+    state->payload_miN = 0x1122334455667788ULL;
+    state->p25_crypto_state[1] = DSD_P25_CRYPTO_BLOCKED;
+
+    ui_slot_view slot = ui_build_slot_view(&lockout_opts, state, 1);
+    assert(slot.burst == 24);
+    assert(slot.payload_algid == 0);
+    reset_printw_capture();
+    ui_render_p25_dmr_slot_block(&lockout_opts, state, &slot);
+    assert(strstr(g_printw_capture, "VOICE") == NULL);
+    assert(strstr(g_printw_capture, "ALG:") == NULL);
+    assert(strstr(g_printw_capture, "0x84") == NULL);
+    assert_capture_contains("TGT: [        ] SRC: [        ]");
+    assert_capture_contains("IDLE");
+
+    /* Follow mode (or non-trunked decode) keeps showing what the slot
+       carries. */
+    static dsd_opts follow_opts;
+    DSD_MEMSET(&follow_opts, 0, sizeof(follow_opts));
+    follow_opts.trunk_enable = 1;
+    follow_opts.trunk_tune_enc_calls = 1;
+    slot = ui_build_slot_view(&follow_opts, state, 1);
+    assert(slot.burst == 21);
+    assert(slot.payload_algid == 0x84);
+    reset_printw_capture();
+    ui_render_p25_dmr_slot_block(&follow_opts, state, &slot);
+    assert_capture_contains("VOICE");
+    assert_capture_contains("ALG: 0x84");
+
+    dsd_state_ext_free_all(state);
+    free(state);
+}
+
 int
 main(void) {
     test_input_source_helpers();
@@ -1417,6 +1469,7 @@ main(void) {
     test_slot_header_burst_column_is_fixed();
     test_slot_header_id_highlight_is_balanced();
     test_live_protocol_panels_ignore_ended_call_identity();
+    test_lockout_suppressed_companion_slot_renders_idle();
     return 0;
 }
 


### PR DESCRIPTION
## Problem

With encryption lockout enabled, the mere presence of an encrypted P25p2 call on the opposite logical slot of a shared TDMA voice channel intermittently disturbed the clear call: audio chopped in and out, sometimes the whole channel dropped mid-conversation, and the locked-out slot kept rendering as a live keyed call (`VOICE` + ALG/KID/MI with a blank TGT). Several earlier PRs (#294, #306, #308, #329) hardened the mixer, burst-hint consumers, and SM release timing; paths kept surfacing because the primary defect was upstream of all of them.

## Root cause

Channel-grant announcement MCOs decoded in a voice channel's MAC signaling — Group Voice Channel Grant 0x40/0xC0, MFID90 regroup grants 0xA3/0xA4, MFID90 voice channel update 0x83, telephone interconnect grants — describe a call on some *other* channel or slot, but stored that call's service options into `dmr_so`/`dmr_soR` indexed by the slot the PDU happened to be decoded on. Those per-slot bits feed `p25p2_prepare_voice_crypto()`, so an encrypted call announced anywhere nearby planted its `0x40` service bit on the clear call's slot and flipped it CLEAR → ENCRYPTED_PENDING mid-transmission. Under lockout, PENDING closes the audio gate, purges buffered voice, and clears the slot's SM activity:

- the clear call chops until its next FEC-accepted ESS re-resolves clear (~one superframe, longer in fades), and
- a streak of missed ESS lets the 3 s classification window lapse and release the whole carrier mid-conversation.

Follow mode leaves the gate open for PENDING, which is exactly why the symptom only appeared with lockout enabled. The existing frame-lockout tests already pinned the downstream behavior (`dmr_so = 0x40` on a clear slot ⇒ pending + mute) — the corruption was the announcements manufacturing that state.

## Changes

1. **`p25p2`: announcement MCOs no longer write per-slot service options** (root cause). Accepted assignments already carry svc into the granted slot through the SM identity commit, and the voice-channel-user MCOs — which describe the decode slot's own call and are gated on `observe_voice` — keep storing as before.
2. **`p25`: the crypto-classification timeout defers to the companion's hangtime gap**, mirroring the guard `p25_enc_lockout_release_or_hold()` gained in #308. The expired slot's classification is dismantled either way; the hangtime tick keeps owning the release once the gap outlives the window. The plain pending-voice-grant timeout deliberately keeps its immediate release (the carrier's stay is the shorter of the companion bridge and a pending assignment's own acquisition window, as the pending-companion and lockout-reprobe grant-timeout tests pin — a code comment now records why no hold belongs there).
3. **`ui/terminal`: a lockout-suppressed companion slot renders idle** — no `VOICE` status, no ALG/KID/MI — instead of dressing its MAC/ESS repeats up as a live keyed call with a blank identity. The locked-out call still reaches the operator through the lockout event row and the active-channel list. Follow mode and the Qt frontend are unchanged.
4. **`p25p2`: residual occupied-carrier releases and muted-slot flushes**: Deny/Queued responses (standard and Motorola) release only an unoccupied carrier; the end-of-superframe DUID fallback release now reads per-slot gate/ring/MAC-recency instead of the audio gates alone (and stops arming the unguarded forced-release tick while a suppressed transmission still occupies a slot); `dsd_p25p2_flush_partial_audio_slot()` drops and blanks a tail whose classification refuses audio instead of emitting it. The teardown/release flushes keep their buffer-presence gate on purpose — at those points MAC_END has often already reset a legitimately clear call's classification.

## Testing

- New: `P25_P2_VPDU_FOREIGN_GRANT_SVC` (replays every announcement MCO in both FACCH and SACCH slot mappings over a dual-slot clear-call carrier; failed on all 12 assertions pre-fix), `P25_P2_TICK_COMPANION_HOLD` (classification lapse in a fresh gap holds, aged gap releases, idle companion releases immediately).
- Extended: `P25_QUEUED_DENY_RESPONSE` (occupied-carrier deny/queued holds, idle releases), `P25_P2_VPDU_ENC_FLUSH` (MAC_RELEASE under lockout emits no tail, blanks the buffer, keeps the companion), `UI_BURST_ACTIVE_CALL` + `UI_NCURSES_PRINTER_HELPERS` (suppressed-slot decision table and end-to-end rendering, with the follow-mode counterexample).
- Full suite 535/535 on dev-debug, affected tests also pass under `asan-ubsan-debug`, `tools/preflight_ci.sh` clean.

On air, the expected differences: no more chop/mute of the clear call when the encrypted companion appears, the companion slot row goes quiet instead of showing VOICE + AES key info, and `--p25-sm-log` shows no `channel_release` with `reason=deny-rsp`/`p2-duid-timeout`/`grant-timeout` while a conversation or its hangtime gap occupies a slot.
