### PR TITLE
dmr: emit real newlines in payload, USBD, and PDU ALG dumps

### DIFF
--- a/docs/code-quality-guardrails.md
+++ b/docs/code-quality-guardrails.md
@@ -44,6 +44,7 @@ Run the smallest useful set before opening a PR, then broaden it when the change
 The repository intentionally blocks or flags patterns that are easy to reintroduce during large edits:
 
 - Use the project safe API wrappers instead of raw C memory/string/formatting APIs in project-owned code.
+- Write real control characters in format strings. `"\\n"` prints a literal `\` followed by `n` rather than breaking the line; this is easy to reintroduce when rewriting `fprintf` call sites in bulk, and has silently broken DMR console and structured-output dumps more than once. If a literal escape sequence is genuinely intended, emit it outside a format string or annotate the line with a narrow `nosemgrep` comment explaining why.
 - Do not execute shells or spawn processes from project-owned C/C++ without explicit design review.
 - Do not include bundled third-party headers directly outside approved wrappers and integration points.
 - Keep workflow scripts defensive: pass untrusted context through environment variables or action inputs, not direct expression interpolation in `run:` blocks.

--- a/semgrep/dsd-neo.yml
+++ b/semgrep/dsd-neo.yml
@@ -283,6 +283,39 @@ rules:
               }
           - pattern: DSD_SNPRINTF($DST, sizeof($DST), ...)
 
+  - id: dsd-neo.no-escaped-control-char-in-format-string
+    languages: [c, cpp]
+    severity: ERROR
+    message: >-
+      Format string emits a literal backslash escape instead of the control character. "\\n" prints the two
+      characters '\' and 'n', gluing the next output onto the current line; write "\n" for a real newline
+      (likewise "\t" and "\r"). This is refactor fallout from mechanically rewriting fprintf call sites, and
+      it has silently regressed DMR console and structured-output dumps more than once. If a literal escape
+      sequence really is intended, emit it outside a format string or annotate the line with a narrow
+      nosemgrep comment explaining why.
+    paths:
+      include:
+        - /android/**
+        - /apps/**
+        - /include/**
+        - /src/**
+      exclude:
+        - /android/third_party/**
+        - /src/third_party/**
+    patterns:
+      - pattern-either:
+          - pattern: DSD_FPRINTF($STREAM, $FMT, ...)
+          - pattern: DSD_SNPRINTF($DST, $SZ, $FMT, ...)
+          - pattern: DSD_VSNPRINTF($DST, $SZ, $FMT, $AP)
+          - pattern: LOG_ERROR($FMT, ...)
+          - pattern: LOG_WARN($FMT, ...)
+          - pattern: LOG_INFO($FMT, ...)
+          - pattern: LOG_DEBUG($FMT, ...)
+          - pattern: printf($FMT, ...)
+      - metavariable-regex:
+          metavariable: $FMT
+          regex: '.*\\\\[ntr].*'
+
   - id: dsd-neo.no-unbounded-byte-to-bit-unpack
     languages: [c, cpp]
     severity: ERROR

--- a/src/protocol/dmr/dmr_block_crypto.c
+++ b/src/protocol/dmr/dmr_block_crypto.c
@@ -163,7 +163,7 @@ dmr_block_crypto_print_info(const dmr_block_crypto_ctx* ctx, int show_keys) {
         return;
     }
 
-    DSD_FPRINTF(stderr, "\\n PDU ALG: %02X; Key ID: %02X;", ctx->alg, ctx->kid);
+    DSD_FPRINTF(stderr, "\n PDU ALG: %02X; Key ID: %02X;", ctx->alg, ctx->kid);
     if (ctx->alg != 0 && ctx->mi != 0ULL) {
         DSD_FPRINTF(stderr, " MI(32): %08llX;", ctx->mi);
     }

--- a/src/protocol/dmr/dmr_dburst.c
+++ b/src/protocol/dmr/dmr_dburst.c
@@ -216,13 +216,13 @@ dmr_dburst_print_header_and_dump(dmr_data_burst_ctx* ctx) {
         FILE* pfile = dsd_fopen_private(ctx->opts->dsp_out_file, "a");
         if (pfile != NULL) {
             uint32_t i;
-            DSD_FPRINTF(pfile, "\\n%d 98 ", ctx->slot + 1);
+            DSD_FPRINTF(pfile, "\n%d 98 ", ctx->slot + 1);
             for (i = 0; i < 6; i++) {
                 int cach_byte = (ctx->state->dmr_stereo_payload[((size_t)i * 2)] << 2)
                                 | ctx->state->dmr_stereo_payload[((size_t)i * 2) + 1];
                 DSD_FPRINTF(pfile, "%X", cach_byte);
             }
-            DSD_FPRINTF(pfile, "\\n%d %02X ", ctx->slot + 1, ctx->databurst);
+            DSD_FPRINTF(pfile, "\n%d %02X ", ctx->slot + 1, ctx->databurst);
             for (i = 6; i < 72; i++) {
                 int dsp_byte = (ctx->state->dmr_stereo_payload[((size_t)i * 2)] << 2)
                                | ctx->state->dmr_stereo_payload[((size_t)i * 2) + 1];
@@ -707,7 +707,7 @@ dmr_dburst_handle_usbd(dmr_data_burst_ctx* ctx) {
     uint8_t pl_bytes[11];
 
     ctx->usbd_st = (uint8_t)convert_bits_into_output(&ctx->dmr_pdu_bits[0], 4);
-    DSD_FPRINTF(stderr, "%s\\n", KYEL);
+    DSD_FPRINTF(stderr, "%s\n", KYEL);
     DSD_FPRINTF(stderr, " USBD - Service: %s (%u)", dmr_dburst_usbd_service_name(ctx->usbd_st), ctx->usbd_st);
 
     DSD_MEMSET(pl_bytes, 0, sizeof(pl_bytes));
@@ -799,7 +799,7 @@ dmr_dburst_finalize_status(dmr_data_burst_ctx* ctx) {
     }
 
     if (ctx->opts->payload == 1 && ctx->databurst != 0x09) {
-        DSD_FPRINTF(stderr, "\\n");
+        DSD_FPRINTF(stderr, "\n");
         DSD_FPRINTF(stderr, "%s", KCYN);
         DSD_FPRINTF(stderr, " DMR PDU Payload ");
         for (uint32_t i = 0; i < ctx->pdu_len; i++) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6186,6 +6186,10 @@ target_include_directories(
     dsd-neo_test_dmr_dburst_profile
     PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/dmr
 )
+target_link_libraries(
+    dsd-neo_test_dmr_dburst_profile
+    PRIVATE dsd-neo_test_support
+)
 add_test(NAME DMR_DBURST_PROFILE COMMAND dsd-neo_test_dmr_dburst_profile)
 
 add_executable(

--- a/tests/protocol/dmr/test_dmr_block_crypto.c
+++ b/tests/protocol/dmr/test_dmr_block_crypto.c
@@ -178,6 +178,29 @@ test_print_info_reveals_full_aes256_key_when_first_segment_zero(void) {
 }
 
 static int
+test_print_info_starts_on_its_own_line(void) {
+    static dsd_state state;
+    dmr_block_crypto_ctx ctx;
+    char output[256];
+    const uint8_t slot = 0;
+    const int kid = 0x23;
+    int rc = 0;
+
+    seed_window(&state, slot, 0, 28);
+    state.payload_algid = 4;
+    state.payload_keyid = kid;
+    seed_key_array(&state, kid, 0x0123456789ABCDEFULL, 0ULL, 0xDEADBEEFDEADBEEFULL, 0ULL);
+
+    dmr_block_crypto_load_ctx(&state, slot, 1, 24, &ctx);
+    if (capture_print_info(&ctx, 1, output, sizeof output) != 0) {
+        return 1;
+    }
+    rc |= expect_int("crypto banner breaks the line before PDU ALG", output[0] == '\n', 1);
+    rc |= expect_int("crypto banner emits no literal backslash-n", strstr(output, "\\n") == NULL, 1);
+    return rc;
+}
+
+static int
 test_aes128_zero_mi_uses_reference_ecb_block_count(void) {
     static const uint8_t ciphertext[16] = {0x69, 0xC4, 0xE0, 0xD8, 0x6A, 0x7B, 0x04, 0x30,
                                            0xD8, 0xCD, 0xB7, 0x80, 0x70, 0xB4, 0xC5, 0x5A};
@@ -429,6 +452,7 @@ main(void) {
     rc |= test_aes_nonzero_mi_keeps_ofb_path();
     rc |= test_print_info_reveals_full_aes128_key();
     rc |= test_print_info_reveals_full_aes256_key_when_first_segment_zero();
+    rc |= test_print_info_starts_on_its_own_line();
     rc |= test_rc4_decrypts_window_with_key_id_lookup();
     rc |= test_des_decrypts_window_with_manual_key_fallback();
     rc |= test_basic_privacy_decrypts_window();

--- a/tests/protocol/dmr/test_dmr_dburst_profile.c
+++ b/tests/protocol/dmr/test_dmr_dburst_profile.c
@@ -21,6 +21,7 @@
 #include "dmr_dburst_profile.h"
 #include "dmr_r34_internal.h"
 #include "dsd-neo/core/safe_api.h"
+#include "test_support.h"
 
 static int g_pi_calls;
 static int g_flco_calls;
@@ -81,14 +82,6 @@ reset_handler_counters(void) {
     DSD_MEMSET(g_r34_soft_bytes, 0, sizeof(g_r34_soft_bytes));
     DSD_MEMSET(g_r34_hard_bytes, 0, sizeof(g_r34_hard_bytes));
     DSD_MEMSET(g_r34_candidates, 0, sizeof(g_r34_candidates));
-}
-
-FILE*
-// NOLINTNEXTLINE(misc-use-internal-linkage)
-dsd_fopen_private(const char* path, const char* mode) {
-    (void)path;
-    (void)mode;
-    return NULL;
 }
 
 uint16_t
@@ -309,6 +302,15 @@ static int
 expect_u32(const char* tag, uint32_t got, uint32_t want) {
     if (got != want) {
         DSD_FPRINTF(stderr, "%s: got 0x%08X want 0x%08X\n", tag, got, want);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_true(const char* tag, int got) {
+    if (!got) {
+        DSD_FPRINTF(stderr, "%s: expected true\n", tag);
         return 1;
     }
     return 0;
@@ -666,6 +668,124 @@ test_trellis_candidate_and_fallback_paths(void) {
     return rc;
 }
 
+static int
+slurp_file(const char* path, char* out, size_t out_size) {
+    if (out == NULL || out_size == 0U) {
+        return 1;
+    }
+    out[0] = '\0';
+
+    FILE* fp = fopen(path, "rb");
+    if (fp == NULL) {
+        return 1;
+    }
+    const size_t nread = fread(out, 1U, out_size - 1U, fp);
+    out[nread] = '\0';
+    (void)fclose(fp);
+    return 0;
+}
+
+static int
+capture_handler_stderr(dsd_opts* opts, dsd_state* state, uint8_t info[196], uint8_t databurst, char* out,
+                       size_t out_size) {
+    dsd_test_capture_stderr cap;
+
+    if (out == NULL || out_size == 0U) {
+        return 1;
+    }
+    out[0] = '\0';
+    if (dsd_test_capture_stderr_begin(&cap, "dsdneo_dmr_dburst") != 0) {
+        return 1;
+    }
+
+    dmr_data_burst_handler(opts, state, info, databurst, NULL);
+
+    if (dsd_test_capture_stderr_end(&cap) != 0) {
+        (void)remove(cap.path);
+        return 1;
+    }
+
+    const int rc = slurp_file(cap.path, out, out_size);
+    (void)remove(cap.path);
+    return rc;
+}
+
+/* Regression guard for #343: these format strings once carried an escaped backslash, so the
+   dumps emitted a literal "\n" and were glued onto the tail of the sync banner. */
+static int
+test_console_dumps_use_real_newlines(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t info[196];
+    char out[4096];
+
+    prepare_handler_state(&opts, &state, info, 0x07U, 0U, 1U, 0);
+    opts.payload = 1;
+    if (capture_handler_stderr(&opts, &state, info, 0x07U, out, sizeof(out)) != 0) {
+        DSD_FPRINTF(stderr, "payload dump capture failed\n");
+        return 1;
+    }
+    rc |= expect_true("payload-dump-emits-no-escape", strstr(out, "\\n") == NULL);
+    const char* payload = strstr(out, " DMR PDU Payload ");
+    if (payload == NULL) {
+        DSD_FPRINTF(stderr, "payload dump missing from output: '%s'\n", out);
+        return 1;
+    }
+    rc |= expect_true("payload-dump-starts-on-own-line", memchr(out, '\n', (size_t)(payload - out)) != NULL);
+
+    prepare_handler_state(&opts, &state, info, 0x0BU, 0U, 1U, 0);
+    if (capture_handler_stderr(&opts, &state, info, 0x0BU, out, sizeof(out)) != 0) {
+        DSD_FPRINTF(stderr, "USBD banner capture failed\n");
+        return 1;
+    }
+    rc |= expect_true("usbd-banner-emits-no-escape", strstr(out, "\\n") == NULL);
+    const char* usbd = strstr(out, " USBD - Service: ");
+    if (usbd == NULL) {
+        DSD_FPRINTF(stderr, "USBD banner missing from output: '%s'\n", out);
+        return 1;
+    }
+    rc |= expect_true("usbd-banner-starts-on-own-line", memchr(out, '\n', (size_t)(usbd - out)) != NULL);
+    return rc;
+}
+
+/* Structured DSP output is line oriented; every record must begin its own line so downstream
+   parsers can split it, and so it stays consistent with the voice/SBRC writers. */
+static int
+test_dsp_structured_output_records_are_line_separated(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t info[196];
+    char out[4096];
+    char dsp_path[DSD_TEST_PATH_MAX];
+
+    const int fd = dsd_test_mkstemp(dsp_path, sizeof(dsp_path), "dsdneo_dmr_dsp_out");
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "DSP output temp file creation failed\n");
+        return 1;
+    }
+    (void)dsd_close(fd);
+
+    prepare_handler_state(&opts, &state, info, 0x07U, 0U, 1U, 0);
+    opts.use_dsp_output = 1;
+    DSD_SNPRINTF(opts.dsp_out_file, sizeof(opts.dsp_out_file), "%s", dsp_path);
+
+    dmr_data_burst_handler(&opts, &state, info, 0x07U, NULL);
+
+    const int read_rc = slurp_file(dsp_path, out, sizeof(out));
+    (void)remove(dsp_path);
+    if (read_rc != 0) {
+        DSD_FPRINTF(stderr, "DSP output read back failed\n");
+        return 1;
+    }
+
+    rc |= expect_true("dsp-output-emits-no-escape", strstr(out, "\\n") == NULL);
+    rc |= expect_true("dsp-output-cach-record-on-own-line", strstr(out, "\n2 98 ") != NULL);
+    rc |= expect_true("dsp-output-burst-record-on-own-line", strstr(out, "\n2 07 ") != NULL);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -675,6 +795,8 @@ main(void) {
     rc |= test_bptc_ras_and_usbd_services();
     rc |= test_confirmed_sequence_paths();
     rc |= test_trellis_candidate_and_fallback_paths();
+    rc |= test_console_dumps_use_real_newlines();
+    rc |= test_dsp_structured_output_records_are_line_separated();
     if (rc == 0) {
         printf("DMR_DBURST_PROFILE: OK\n");
     }


### PR DESCRIPTION
Fixes #343

## What was wrong

The reporter is right. The `fprintf` → `DSD_FPRINTF` refactors in #95 and #130 double-escaped the newline in a set of DMR format strings, so they print the two characters `\` and `n` rather than breaking the line. The pre-refactor sources at each site carried a real `"\n"`.

Reproduced under test — the captured stderr contains the reporter's exact symptom:

```
| Color Code=XX | USBD \n USBD - Service: Location Information Protocol (0) ...
```

## Scope: three reported sites, five actual

A sweep of every C/C++ source turned up two more in the same function that the report did not cover:

| file | line | site |
|---|---|---|
| `dmr_dburst.c` | 802 | `-Z` payload dump (reported) |
| `dmr_dburst.c` | 710 | USBD service banner (reported) |
| `dmr_block_crypto.c` | 166 | `PDU ALG` / `Key ID` banner (reported) |
| `dmr_dburst.c` | 219 | structured DSP output, CACH record (**missed**) |
| `dmr_dburst.c` | 225 | structured DSP output, data burst record (**missed**) |

The DSP-output pair is a real corruption rather than a cosmetic one. That file (`-D` / `use_dsp_output`) is line oriented, so DMR data bursts were being appended with no record separator at all. Every sibling writer — `dmr_ms.c`, `dmr_bs.c`, `dmr_le.c` — already emits a real newline there, so this was also an inconsistency inside one output format.

The four remaining `"\\n"` occurrences under `src/` (`iq_capture.c`, `rdio_export.c`) are intentional JSON/CSV escapers and are left alone.

## Fix

One character per site, exactly as proposed in the issue, extended to the two additional sites.

Output after the fix:

```
| Color Code=XX | R12U
 DMR PDU Payload [00][00][00][00][00][00][00][00][00][00][00][00]
```

```
| Color Code=XX | USBD
 USBD - Service: Location Information Protocol (0) - Payload: ...
```

and the DSP file now emits `\n2 98 …` / `\n2 07 …` as separate records.

## Tests

This class already bit once: `test_flco_output_uses_real_newlines` exists in `test_dmr_flco_privacy_modes.c` from an earlier fix to `dmr_flco.c`, but the sweep stopped at that one file. Following that precedent, all five sites are now guarded. The tests were written first and confirmed failing on all seven assertions before the fix.

- `test_dmr_dburst_profile.c`
  - `test_console_dumps_use_real_newlines` — captures handler stderr and asserts the payload dump and USBD banner each start on their own line and contain no literal escape.
  - `test_dsp_structured_output_records_are_line_separated` — round-trips the real DSP output file through `dsd_fopen_private` and asserts records are line separated.
- `test_dmr_block_crypto.c`
  - `test_print_info_starts_on_its_own_line` — asserts the crypto banner breaks the line before `PDU ALG`.

`dsd-neo_test_dmr_dburst_profile` now links `dsd-neo_test_support` for the stderr-capture and temp-file helpers; its local `dsd_fopen_private` stub was dropped in favour of the real platform implementation so the DSP output path is genuinely exercised.

## Guardrail

Per-site tests pin the sites we know about; they cannot catch the sixth. Since this class has now escaped twice, the third commit adds `dsd-neo.no-escaped-control-char-in-format-string` to `semgrep/dsd-neo.yml`. It flags `"\\n"`, `"\\t"`, and `"\\r"` appearing in the **format-string argument** of the printing wrappers — `DSD_FPRINTF`, `DSD_SNPRINTF`, `DSD_VSNPRINTF`, `LOG_*`, `printf`.

Keying on the format-string argument rather than on the literal itself is what keeps the intentional escapers clean: `iq_capture.c` assigns `"\\n"` to a lookup table and `rdio_export.c` passes it to `fputs`, so neither is a format string and neither matches.

Validated by scanning the pre-fix sources of all four files: exactly the five real defects, zero false positives. Scoped to `android/apps/include/src`, since tests legitimately embed doubled escapes in JSON round-trip fixtures.

## Verification

- `ctest --preset dev-debug` — 535/535 pass.
- `tools/semgrep.sh --strict` — 519 rules over 1387 files, 0 findings.
- `tools/preflight_ci.sh` — exit 0: clang-format, clang-tidy, cppcheck `--strict`, IWYU (0 suggested), GCC `-fanalyzer` (0 diagnostics), Semgrep (full-tree pass, since rules changed), gersemi, Lizard, and the install/security guardrails.
- Shipped I/Q fixtures contain no DMR data bursts, so the dumps cannot be reached from `DECODE_IQ_*`; verification is at the unit level against the real captured `stderr` bytes.
