### PR TITLE
dmr: label the compressed-IP IPv4 Identification in the MNIS and SAP 3 paths

### DIFF
--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -1246,7 +1246,7 @@ dmr_block_type1_mnis_event_category(uint8_t mnis_type) {
 
 static void
 dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, uint8_t mnis_type, uint32_t msrc,
-                                    uint32_t mdst) {
+                                    uint32_t mdst, uint16_t mnis_ip_id) {
     if (mnis_type == 0x11) {
         uint8_t pdu_crc_ok = dmr_block_type1_lrrp_crc_ok(ctx->state, ctx->slot);
         dmr_lrrp(ctx->opts, ctx->state, len, msrc, mdst, ctx->state->dmr_pdu_sf[ctx->slot] + 7, pdu_crc_ok);
@@ -1270,28 +1270,32 @@ dmr_block_type1_handle_mnis_payload(dmr_block_assembler_ctx* ctx, uint16_t len, 
         dsd_event_history_transaction_end(&transaction);
     }
 
-    if (mnis_type != 0x11 && mnis_type != 0x01) {
-        char mnis_str[200];
+    // LRRP/LOCN rewrite dmr_lrrp_gps with the decoded position and ARS appends its summary to it,
+    // so emit that slot string and the decoded result reaches the history row, not just the live
+    // slot pane. The remaining MNIS types decode nothing, so emit the bare endpoints instead.
+    char mnis_str[200];
+    const char* base = ctx->state->dmr_lrrp_gps[ctx->slot];
+    if (mnis_type != 0x11 && mnis_type != 0x01 && mnis_type != 0x33) {
         DSD_MEMSET(mnis_str, 0, sizeof(mnis_str));
         DSD_SNPRINTF(mnis_str, sizeof(mnis_str), "MNIS TGT: %lld; SRC: %lld;", ctx->state->dmr_lrrp_target[ctx->slot],
                      ctx->state->dmr_lrrp_source[ctx->slot]);
-        const dsd_call_observation observation = dsd_call_observation_data(
-            ctx->state->lastsynctype, ctx->slot, (uint64_t)ctx->state->dmr_lrrp_source[ctx->slot],
-            (uint64_t)ctx->state->dmr_lrrp_target[ctx->slot]);
-        // ARS decodes append their summary to dmr_lrrp_gps, which already carries the same
-        // endpoints; emit that so the decoded registration reaches the history row and not just
-        // the live slot pane. Other MNIS types have nothing extra to say, so keep mnis_str.
-        const char* notice = (mnis_type == 0x33) ? ctx->state->dmr_lrrp_gps[ctx->slot] : mnis_str;
-        (void)dsd_event_emit_data_notice_classified(ctx->opts, ctx->state, ctx->slot, &observation,
-                                                    dmr_block_type1_mnis_event_category(mnis_type), notice);
-    } else if (mnis_type == 0x11 || mnis_type == 0x01) {
-        const dsd_call_observation observation = dsd_call_observation_data(
-            ctx->state->lastsynctype, ctx->slot, (uint64_t)ctx->state->dmr_lrrp_source[ctx->slot],
-            (uint64_t)ctx->state->dmr_lrrp_target[ctx->slot]);
-        (void)dsd_event_emit_data_notice_classified(ctx->opts, ctx->state, ctx->slot, &observation,
-                                                    dmr_block_type1_mnis_event_category(mnis_type),
-                                                    ctx->state->dmr_lrrp_gps[ctx->slot]);
+        base = mnis_str;
     }
+    // The service handlers overwrite or append to the slot string at will, so the IP ID is
+    // attached here, at emission time, and every MNIS notice carries it: the event log is what
+    // offline per-radio loss analysis reads (issue #342), and stderr was its only home before.
+    char notice[256];
+    DSD_SNPRINTF(notice, sizeof(notice), "%s", base);
+    size_t notice_len = strlen(notice);
+    while (notice_len > 0U && notice[notice_len - 1U] == ' ') {
+        notice[--notice_len] = '\0';
+    }
+    DSD_SNPRINTF(notice + notice_len, sizeof(notice) - notice_len, " IP ID: %04X;", mnis_ip_id);
+    const dsd_call_observation observation =
+        dsd_call_observation_data(ctx->state->lastsynctype, ctx->slot, (uint64_t)ctx->state->dmr_lrrp_source[ctx->slot],
+                                  (uint64_t)ctx->state->dmr_lrrp_target[ctx->slot]);
+    (void)dsd_event_emit_data_notice_classified(ctx->opts, ctx->state, ctx->slot, &observation,
+                                                dmr_block_type1_mnis_event_category(mnis_type), notice);
 }
 
 static void
@@ -1327,7 +1331,7 @@ dmr_block_type1_handle_mnis(dmr_block_assembler_ctx* ctx) {
     DSD_FPRINTF(stderr, " IP ID: %04X", mnis_ip_id);
     DSD_SNPRINTF(ctx->state->dmr_lrrp_gps[ctx->slot], sizeof(ctx->state->dmr_lrrp_gps[ctx->slot]),
                  "MNIS SRC: %d; DST: %d; ", msrc, mdst);
-    dmr_block_type1_handle_mnis_payload(ctx, len, mnis_type, msrc, mdst);
+    dmr_block_type1_handle_mnis_payload(ctx, len, mnis_type, msrc, mdst, mnis_ip_id);
 }
 
 static void

--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -1310,7 +1310,7 @@ dmr_block_type1_handle_mnis(dmr_block_assembler_ctx* ctx) {
     uint32_t msrc = ctx->state->dmr_lrrp_source[ctx->slot];
     uint32_t mdst = ctx->state->dmr_lrrp_target[ctx->slot];
     uint8_t mnis_type = ctx->state->dmr_pdu_sf[ctx->slot][4];
-    uint16_t mnis_unk;
+    uint16_t mnis_ip_id;
 
     if (len > 150) {
         len = 150;
@@ -1318,8 +1318,13 @@ dmr_block_type1_handle_mnis(dmr_block_assembler_ctx* ctx) {
     DSD_FPRINTF(stderr, "\n SRC(MNIS): %08d; ", msrc);
     DSD_FPRINTF(stderr, "\n DST(MNIS): %08d; ", mdst);
     dmr_block_type1_print_mnis_type(mnis_type);
-    mnis_unk = (ctx->state->dmr_pdu_sf[ctx->slot][5] << 8) | ctx->state->dmr_pdu_sf[ctx->slot][6];
-    DSD_FPRINTF(stderr, " ???: %04X", mnis_unk);
+    // Octets 5-6: IPv4 Identification of the tunneled datagram. Motorola does not publish this
+    // header, but the ETSI-standard compressed UDP/IPv4 header sends exactly this field verbatim
+    // because a decompressor cannot regenerate it (TS 102 361-3 5.6/7.2.3), independent MOTOTRBO
+    // decoders rebuild valid datagrams reading these octets as the IP ID, and live captures show
+    // the per-host once-per-datagram counter an IP stack puts there, shared by LRRP and ARS.
+    mnis_ip_id = (ctx->state->dmr_pdu_sf[ctx->slot][5] << 8) | ctx->state->dmr_pdu_sf[ctx->slot][6];
+    DSD_FPRINTF(stderr, " IP ID: %04X", mnis_ip_id);
     DSD_SNPRINTF(ctx->state->dmr_lrrp_gps[ctx->slot], sizeof(ctx->state->dmr_lrrp_gps[ctx->slot]),
                  "MNIS SRC: %d; DST: %d; ", msrc, mdst);
     dmr_block_type1_handle_mnis_payload(ctx, len, mnis_type, msrc, mdst);

--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -419,8 +419,10 @@ dmr_udp_comp_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* 
     const char* src_port_desc = dmr_udp_comp_port_idx_desc(spid);
     const char* dst_port_desc = dmr_udp_comp_port_idx_desc(dpid);
 
-    DSD_FPRINTF(stderr, "\n Compressed IP Idx: %d; Opcode: %d; Src Idx: %d (%s); Dst Idx: %d (%s); ", ipid, opcode,
-                said, src_idx_desc, daid, dst_idx_desc);
+    // ETSI TS 102 361-3 Table 7.14: the leading 16 bits are the IPv4 Identification, carried
+    // verbatim because the decompressor cannot regenerate it - not one of the index fields.
+    DSD_FPRINTF(stderr, "\n IP ID: %04X; Opcode: %d; Src Idx: %d (%s); Dst Idx: %d (%s); ", ipid, opcode, said,
+                src_idx_desc, daid, dst_idx_desc);
     DSD_FPRINTF(stderr, "\n Src Port Idx: %d (%s); Dst Port Idx: %d (%s); ", spid, src_port_desc, dpid, dst_port_desc);
 
     const int has_gps = dmr_udp_comp_decode_payload(opts, state, spid, dpid, len, ptr, DMR_PDU);
@@ -428,7 +430,7 @@ dmr_udp_comp_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, const uint8_t* 
     uint8_t slot = (state->currentslot == 1) ? 1 : 0;
     char comp_string[500];
     DSD_MEMSET(comp_string, 0, sizeof(comp_string));
-    DSD_SNPRINTF(comp_string, sizeof(comp_string), "IPC: %d; OP: %d; SRC: %d:%d (%s):(%s); DST: %d:%d (%s):(%s); ",
+    DSD_SNPRINTF(comp_string, sizeof(comp_string), "IP ID: %04X; OP: %d; SRC: %d:%d (%s):(%s); DST: %d:%d (%s):(%s); ",
                  ipid, opcode, said, spid, src_idx_desc, src_port_desc, daid, dpid, dst_idx_desc, dst_port_desc);
     const dsd_call_observation observation = dsd_call_observation_data(state->lastsynctype, slot, said, daid);
     const dsd_event_category category = dmr_udp_event_category(spid, dpid);

--- a/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
@@ -625,6 +625,9 @@ main(void) {
         }
         rc |= expect_has_substr(g_datacall_text, "SRC: 1:1", "compressed source summary");
         rc |= expect_has_substr(g_datacall_text, "DST: 2:63", "compressed destination summary");
+        // ETSI TS 102 361-3 Table 7.14 names the leading 16 bits "IPv4 Identification"; the
+        // notice used to call them "IPC", which read like one of the compression index fields.
+        rc |= expect_has_substr(g_datacall_text, "IP ID: 1234;", "compressed IPv4 identification label");
         rc |= expect_category(g_datacall_category, DSD_EVENT_CATEGORY_DATA, "compressed text category");
     }
 

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -1180,6 +1180,30 @@ test_type1_mnis_notice_labels_match_observation(void) {
     return rc;
 }
 
+// Octets 5-6 of the MNIS proprietary header used to print as "???:". The field is the IPv4
+// Identification of the compressed UDP/IPv4 datagram (issue #342: a per-host counter shared by
+// LRRP and ARS) - the one IP header field DMR compressed-IP transport carries verbatim - so the
+// header dump has to name it instead of shrugging.
+static int
+test_type1_mnis_header_prints_ip_id(void) {
+    // LRRP-type MNIS PDU with IP ID 0x8526, a value from the issue #342 capture range.
+    static const uint8_t pdu[24] = {0x1F, 0x10, 0x02, 0x01, 0x11, 0x85, 0x26, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5E, 0x6C, 0xA7, 0x5C};
+    char output[2048];
+    int rc = 0;
+
+    if (run_type1_mnis_pdu_captured(pdu, 0U, "dmr_mnis_ip_id", output, sizeof(output)) != 0) {
+        return 1;
+    }
+
+    rc |= expect_contains("mnis-ip-id", output, "IP ID: 8526");
+    if (strstr(output, "???") != NULL) {
+        DSD_FPRINTF(stderr, "mnis-ip-id: header dump still prints the unknown-field placeholder\n");
+        rc = 1;
+    }
+    return rc;
+}
+
 static void
 test_crc_valid_type1_pdu_dispatches_short_data_and_udp_saps(void) {
     uint8_t block[12] = {0x83, 0x10, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0, 0, 0, 0};
@@ -1651,6 +1675,7 @@ main(int argc, char** argv) {
     rc |= test_type1_mnis_short_pdu_length_underflow_guard();
     rc |= test_type1_mnis_locn_length_is_not_offset_adjusted();
     rc |= test_type1_mnis_notice_labels_match_observation();
+    rc |= test_type1_mnis_header_prints_ip_id();
     test_irrecoverable_header_resets_data_state();
     rc |= test_response_headers_emit_control_events();
     test_response_header_event_acceptance_gates();

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -1204,6 +1204,34 @@ test_type1_mnis_header_prints_ip_id(void) {
     return rc;
 }
 
+// The IP ID reaches the stderr header dump but dies there: the emitted notice - what the history
+// rows and the -J event log keep - carried only the service summary, so per-radio loss analysis
+// (issue #342) had to scrape stderr. Every MNIS notice must carry the ID, including LRRP, whose
+// decoder overwrites the slot summary string the other services append to - the ID has to be
+// attached at emission time, not stored in that string.
+static int
+test_type1_mnis_notice_carries_ip_id(void) {
+    // The ARS registration PDU from issue #337 (IP ID octets 5-6 = 0x84D4) and an LRRP-type PDU
+    // with IP ID 0x8526 from the issue #342 capture range.
+    static const uint8_t ars_pdu[24] = {0x1F, 0x10, 0x02, 0x01, 0x33, 0x84, 0xD4, 0x00, 0x09, 0xF0, 0x20, 0x04,
+                                        0x31, 0x32, 0x33, 0x34, 0x00, 0x00, 0x5E, 0x6C, 0xA7, 0x5C, 0x00, 0x00};
+    static const uint8_t lrrp_pdu[24] = {0x1F, 0x10, 0x02, 0x01, 0x11, 0x85, 0x26, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x5E, 0x6C, 0xA7, 0x5C};
+    char output[2048];
+    int rc = 0;
+
+    if (run_type1_mnis_pdu_captured(ars_pdu, 0U, "dmr_mnis_notice_ipid_ars", output, sizeof(output)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("mnis-notice-ip-id-ars", g_datacall_last_text, "IP ID: 84D4;");
+
+    if (run_type1_mnis_pdu_captured(lrrp_pdu, 0U, "dmr_mnis_notice_ipid_lrrp", output, sizeof(output)) != 0) {
+        return 1;
+    }
+    rc |= expect_contains("mnis-notice-ip-id-lrrp", g_datacall_last_text, "IP ID: 8526;");
+    return rc;
+}
+
 static void
 test_crc_valid_type1_pdu_dispatches_short_data_and_udp_saps(void) {
     uint8_t block[12] = {0x83, 0x10, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0, 0, 0, 0};
@@ -1676,6 +1704,7 @@ main(int argc, char** argv) {
     rc |= test_type1_mnis_locn_length_is_not_offset_adjusted();
     rc |= test_type1_mnis_notice_labels_match_observation();
     rc |= test_type1_mnis_header_prints_ip_id();
+    rc |= test_type1_mnis_notice_carries_ip_id();
     test_irrecoverable_header_resets_data_state();
     rc |= test_response_headers_emit_control_events();
     test_response_header_event_acceptance_gates();


### PR DESCRIPTION
Closes #342.

## Problem

Octets 5–6 of the Motorola MNIS proprietary data header printed as a shrug:

```c
mnis_unk = (ctx->state->dmr_pdu_sf[ctx->slot][5] << 8) | ctx->state->dmr_pdu_sf[ctx->slot][6];
DSD_FPRINTF(stderr, " ???: %04X", mnis_unk);
```

Issue #342 establishes from a few-thousand-packet live capture that the field is a per-sender datagram counter — dense, monotonic per radio, shared by LRRP and ARS from the same host, arriving in reassembly order — and hypothesizes it is the IPv4 Identification of the tunneled datagram, carried explicitly because MNIS transports its services over compressed UDP/IPv4 and an IP ID cannot be regenerated by a decompressor.

Validating that hypothesis also turned up a mislabel in the sibling path: the ETSI-standard compressed UDP/IPv4 decode (`dmr_udp_comp_pdu()`, SAP 3) prints its leading 16 bits as `Compressed IP Idx` / `IPC` — attaching the *index* reading to the one field in that header that is not an index (the indexes are SAID/DAID and SPID/DPID).

## Fix

- `dmr_block_type1_handle_mnis()` now prints ` IP ID: %04X` with a comment carrying the evidence basis; `mnis_unk` is renamed `mnis_ip_id`.
- `dmr_udp_comp_pdu()` renders the same field as `IP ID` (hex) on stderr and in the emitted notice, so the one datagram counter reads identically across both compressed-IP decode paths.
- The MNIS event notice now carries the IP ID too (`dmr_block_type1_handle_mnis_payload()`), appended at emission time because the LRRP decoder overwrites the slot summary string a stored prefix would ride in. Before this, the ID reached stderr only, so the offline loss analysis the reporter runs (issue #342 follow-up) had to scrape stderr; the `-J` event log is now self-sufficient for it, matching what the SAP 3 path already emitted.

## Sources

The identification rests on three independent lines that all converge; no source contradicts it:

- **ETSI TS 102 361-3 V1.3.1** (§5.6, §7.2.2.5, §7.2.3/Table 7.14): the standard DMR compressed UDP/IPv4 header opens with the full 16-bit IPv4 Identification — the only IP-header field sent verbatim — "which supports fragmentation … is sent in its entirety", with every other field regenerated from constants, recomputation, or the SAID/DAID/SPID/DPID indexes. MNIS is Motorola's proprietary variant of the same design, riding the reserved inner SAP 1 behind a DPF-15 header (TS 102 361-1 §8.2.1.4 leaves octets 2–9 to the manufacturer, so ETSI text alone cannot name the field — but the mechanism is normative precedent).
- **Independent decoders**: rick51231/node-dmr-lib parses these exact octets as `ipIdent` and functionally uses them as `packet.identification` when rebuilding complete IPv4/UDP datagrams from MOTOTRBO air and wireline traffic (`src/DMR/DataHeader/ProprietaryCompressed.js`, `src/IP/IPUDPPacket.js`), and writes the real IP ID back into them when transmitting. SDRTrunk names the same octets `PACKET_NUMBER` under an explicit "speculative" disclaimer (`MNISProprietaryDataHeader.java`) — behaviorally compatible, never consumed. Upstream DSD-FME still prints `???`.
- **General practice**: RFC 2507 §6–7 requires non-TCP IPv4 Identification be carried "as-is" in compressed headers; RFC 1144 §3.1 describes the per-host once-per-packet ID counter that the issue's captures show.

No public Motorola document describes this header, so a Motorola-level per-host sequence number would be observationally identical; the label follows the mechanism every corroborating source converges on.

## Out of scope

- Reinterpreting octets 2–4 (compression opcode, SAID/DAID, SPID/DPID under the node-dmr-lib model): only one source reads them that way — sdrtrunk reads them differently — so it fails the two-source bar. The existing service labels stay.
- A live in-decoder gap/loss detector from ID jumps (suggested in the issue): researched and declined. The issue's second capture shows the out-of-order arrival is one-directional radio-side queue lag (IDs stamped at datagram creation, LRRP draining through a windowed transmit queue that ARS bypasses), so a detector is now designable — but no comparable tool ships one, RFC 6864 deprecates non-fragmentation IP ID use in general, demand is one user who already computes loss offline, and it would be several hundred lines of stateful protocol code for a retrospective statistic. The notice change above makes the event log sufficient for that offline analysis instead.

## Tests

All written first and watched failing for the stated reason:

- `test_type1_mnis_header_prints_ip_id` (`DMR_RELAXED_HEADER_IP`): drives a captured-shape LRRP-type MNIS PDU with IP ID `0x8526` — a value from the issue's observed range — through the block assembler; asserts ` IP ID: 8526` appears and the `???` placeholder does not.
- `DMR_LRRP_IP_UDP_LENGTHS` case 7 now pins `IP ID: 1234;` in the compressed-UDP notice (fixture octets 0–1 are `0x12 0x34`).
- `test_type1_mnis_notice_carries_ip_id` (`DMR_RELAXED_HEADER_IP`): asserts the emitted notice carries `IP ID:` for both an ARS PDU (summary appended to the slot string) and an LRRP PDU (slot string overwritten by the position decoder — the case a stored prefix would lose).

537/537 tests pass; `tools/preflight_ci.sh` clean.

