### PR TITLE
dmr: let consistent data bursts lock the color-code confidence gate

### DIFF
--- a/src/protocol/dmr/dmr_confidence.c
+++ b/src/protocol/dmr/dmr_confidence.c
@@ -9,9 +9,10 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
-#define DMR_CONFIDENCE_UNKNOWN_CC     16U
-#define DMR_CONFIDENCE_LOCK_OBSERVES  2U
-#define DMR_CONFIDENCE_VOICE_OBSERVES 2U
+#define DMR_CONFIDENCE_UNKNOWN_CC      16U
+#define DMR_CONFIDENCE_LOCK_OBSERVES   2U
+#define DMR_CONFIDENCE_VOICE_OBSERVES  2U
+#define DMR_CONFIDENCE_RELOCK_OBSERVES 4U
 
 static int
 dmr_confidence_valid_cc(unsigned int color_code) {
@@ -56,10 +57,35 @@ dmr_confidence_observe_cc(dsd_state* state, unsigned int color_code, int may_loc
 
     if (state->dmr_confidence_locked) {
         if (state->dmr_confidence_color_code == color_code) {
+            // Matching evidence restarts any pending re-lock streak so sporadic
+            // co-channel interference never accumulates into a re-lock.
+            state->dmr_confidence_candidate_cc = DMR_CONFIDENCE_UNKNOWN_CC;
+            state->dmr_confidence_candidate_count = 0;
             return DMR_CONFIDENCE_LOCKED;
         }
         if (state->dmr_confidence_mismatch_count < 255U) {
             state->dmr_confidence_mismatch_count++;
+        }
+        // Sustained consistent evidence of a different colour code re-locks the
+        // gate (the channel identity changed without a carrier drop) instead of
+        // rejecting every burst until the next no-carrier reset. The candidate
+        // fields are unused while locked, so they carry the mismatch streak.
+        if (state->dmr_confidence_candidate_cc != color_code) {
+            state->dmr_confidence_candidate_cc = (uint8_t)color_code;
+            state->dmr_confidence_candidate_count = 1;
+        } else if (state->dmr_confidence_candidate_count < 255U) {
+            state->dmr_confidence_candidate_count++;
+        }
+        if (state->dmr_confidence_candidate_count >= DMR_CONFIDENCE_RELOCK_OBSERVES) {
+            state->dmr_confidence_color_code = (uint8_t)color_code;
+            state->dmr_color_code = color_code;
+            state->dmr_confidence_candidate_cc = DMR_CONFIDENCE_UNKNOWN_CC;
+            state->dmr_confidence_candidate_count = 0;
+            state->dmr_confidence_mismatch_count = 0;
+            // The previous system identity is gone; voice slots must
+            // re-qualify under the new colour code before audio resumes.
+            dmr_confidence_clear_voice(state);
+            return DMR_CONFIDENCE_LOCKED;
         }
         return DMR_CONFIDENCE_REJECT;
     }
@@ -122,17 +148,17 @@ dmr_confidence_note_voice_burst(dsd_state* state, unsigned int slot, unsigned in
 }
 
 dmr_confidence_result
-dmr_confidence_note_data_burst(dsd_state* state, unsigned int color_code, unsigned int burst) {
+dmr_confidence_note_data_burst(dsd_state* state, unsigned int color_code) {
+    // Any data burst with a valid slot type may contribute to the colour-code
+    // lock, not just IDLE: a dedicated TIII TSCC transmits continuous CSBK
+    // signalling and may never carry IDLE bursts or voice (issue #348).
     if (!state || !dmr_confidence_valid_cc(color_code)) {
         return DMR_CONFIDENCE_REJECT;
     }
     if (state->dmr_confidence_locked) {
         return dmr_confidence_observe_cc(state, color_code, 0);
     }
-    if (burst == 9U) {
-        return dmr_confidence_observe_cc(state, color_code, 1);
-    }
-    return DMR_CONFIDENCE_PENDING;
+    return dmr_confidence_observe_cc(state, color_code, 1);
 }
 
 int

--- a/src/protocol/dmr/dmr_confidence.h
+++ b/src/protocol/dmr/dmr_confidence.h
@@ -22,7 +22,7 @@ void dmr_confidence_reset(dsd_state* state);
 void dmr_confidence_reset_slot(dsd_state* state, unsigned int slot);
 void dmr_confidence_note_voice_sync(dsd_state* state, unsigned int slot);
 dmr_confidence_result dmr_confidence_note_voice_burst(dsd_state* state, unsigned int slot, unsigned int color_code);
-dmr_confidence_result dmr_confidence_note_data_burst(dsd_state* state, unsigned int color_code, unsigned int burst);
+dmr_confidence_result dmr_confidence_note_data_burst(dsd_state* state, unsigned int color_code);
 int dmr_confidence_voice_slot_open(const dsd_state* state, unsigned int slot);
 int dmr_confidence_any_voice_open(const dsd_state* state);
 

--- a/src/protocol/dmr/dmr_data.c
+++ b/src/protocol/dmr/dmr_data.c
@@ -240,8 +240,7 @@ dmr_data_collect_slot_type_suffix(dmr_data_sync_ctx* ctx) {
         (uint8_t)((ctx->SlotType[4] << 3) + (ctx->SlotType[5] << 2) + (ctx->SlotType[6] << 1) + ctx->SlotType[7]);
 
     if (ctx->state->dmr_ms_mode == 0) {
-        dmr_confidence_result confidence =
-            dmr_confidence_note_data_burst(ctx->state, ctx->state->color_code, ctx->burst);
+        dmr_confidence_result confidence = dmr_confidence_note_data_burst(ctx->state, ctx->state->color_code);
         if (confidence == DMR_CONFIDENCE_REJECT) {
             ctx->confidence_reject = 1;
         } else if (confidence != DMR_CONFIDENCE_LOCKED && ctx->burst != 9U) {

--- a/tests/protocol/dmr/test_dmr_confidence_gate.c
+++ b/tests/protocol/dmr/test_dmr_confidence_gate.c
@@ -19,30 +19,44 @@ init_state(dsd_state* state) {
 }
 
 static void
-test_non_idle_data_does_not_lock_from_fresh_start(void) {
+test_single_data_burst_does_not_lock(void) {
     static dsd_state state;
     init_state(&state);
 
-    for (int i = 0; i < 8; i++) {
-        assert(dmr_confidence_note_data_burst(&state, 11, 1) == DMR_CONFIDENCE_PENDING);
-    }
+    assert(dmr_confidence_note_data_burst(&state, 11) == DMR_CONFIDENCE_PENDING);
 
     assert(state.dmr_confidence_locked == 0);
     assert(state.dmr_color_code == 16);
 }
 
 static void
-test_idle_data_can_lock_color_code(void) {
+test_repeated_data_bursts_lock_color_code(void) {
+    // Regression for issue #348: a dedicated TIII TSCC carries continuous CSBK
+    // signalling (C_ALOHA) and may never transmit IDLE bursts or voice, so
+    // consistent data bursts of any type must be able to lock the gate. CC 0
+    // is a valid colour code (and the Tier III default, ETSI TS 102 361-4
+    // clause 6.2.1.3) and must not be confused with the "unknown" sentinel.
     static dsd_state state;
     init_state(&state);
 
-    assert(dmr_confidence_note_data_burst(&state, 3, 9) == DMR_CONFIDENCE_PENDING);
-    assert(dmr_confidence_note_data_burst(&state, 3, 9) == DMR_CONFIDENCE_LOCKED);
-    assert(dmr_confidence_note_data_burst(&state, 3, 1) == DMR_CONFIDENCE_LOCKED);
+    assert(dmr_confidence_note_data_burst(&state, 0) == DMR_CONFIDENCE_PENDING);
+    assert(dmr_confidence_note_data_burst(&state, 0) == DMR_CONFIDENCE_LOCKED);
     assert(state.dmr_confidence_locked == 1);
-    assert(state.dmr_confidence_color_code == 3);
+    assert(state.dmr_confidence_color_code == 0);
     assert(state.dmr_confidence_mismatch_count == 0);
-    assert(state.dmr_color_code == 3);
+    assert(state.dmr_color_code == 0);
+}
+
+static void
+test_inconsistent_cc_restarts_candidate_count(void) {
+    static dsd_state state;
+    init_state(&state);
+
+    assert(dmr_confidence_note_data_burst(&state, 5) == DMR_CONFIDENCE_PENDING);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_PENDING);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_LOCKED);
+    assert(state.dmr_confidence_color_code == 7);
+    assert(state.dmr_color_code == 7);
 }
 
 static void
@@ -50,11 +64,86 @@ test_locked_color_code_rejects_mismatch(void) {
     static dsd_state state;
     init_state(&state);
 
-    assert(dmr_confidence_note_data_burst(&state, 3, 9) == DMR_CONFIDENCE_PENDING);
-    assert(dmr_confidence_note_data_burst(&state, 3, 9) == DMR_CONFIDENCE_LOCKED);
-    assert(dmr_confidence_note_data_burst(&state, 11, 9) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 3) == DMR_CONFIDENCE_PENDING);
+    assert(dmr_confidence_note_data_burst(&state, 3) == DMR_CONFIDENCE_LOCKED);
+    assert(dmr_confidence_note_data_burst(&state, 11) == DMR_CONFIDENCE_REJECT);
     assert(state.dmr_confidence_mismatch_count == 1);
     assert(state.dmr_confidence_color_code == 3);
+}
+
+static void
+test_sustained_mismatch_relocks_to_new_color_code(void) {
+    // A locked gate must not reject forever: if the channel now carries a
+    // consistent different colour code (site change without carrier loss),
+    // sustained evidence re-locks instead of dropping every burst until the
+    // next no-carrier reset.
+    static dsd_state state;
+    init_state(&state);
+
+    assert(dmr_confidence_note_data_burst(&state, 3) == DMR_CONFIDENCE_PENDING);
+    assert(dmr_confidence_note_data_burst(&state, 3) == DMR_CONFIDENCE_LOCKED);
+
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_LOCKED);
+    assert(state.dmr_confidence_locked == 1);
+    assert(state.dmr_confidence_color_code == 7);
+    assert(state.dmr_color_code == 7);
+}
+
+static void
+test_matching_burst_restarts_relock_streak(void) {
+    // Sporadic co-channel interference must not accumulate toward a re-lock:
+    // seeing the locked colour code again restarts the mismatch streak.
+    static dsd_state state;
+    init_state(&state);
+
+    assert(dmr_confidence_note_data_burst(&state, 3) == DMR_CONFIDENCE_PENDING);
+    assert(dmr_confidence_note_data_burst(&state, 3) == DMR_CONFIDENCE_LOCKED);
+
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 3) == DMR_CONFIDENCE_LOCKED);
+
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(state.dmr_confidence_locked == 1);
+    assert(state.dmr_confidence_color_code == 3);
+    assert(state.dmr_color_code == 3);
+}
+
+static void
+test_relock_closes_voice_gates(void) {
+    // Re-locking means the previous system identity is gone; open voice
+    // slots must re-qualify under the new colour code before audio resumes.
+    static dsd_state state;
+    init_state(&state);
+
+    dmr_confidence_note_voice_sync(&state, 0);
+    assert(dmr_confidence_note_voice_burst(&state, 0, 3) == DMR_CONFIDENCE_PENDING);
+    assert(dmr_confidence_note_voice_burst(&state, 0, 3) == DMR_CONFIDENCE_LOCKED);
+    assert(dmr_confidence_voice_slot_open(&state, 0) == 1);
+
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_REJECT);
+    assert(dmr_confidence_note_data_burst(&state, 7) == DMR_CONFIDENCE_LOCKED);
+    assert(state.dmr_confidence_color_code == 7);
+    assert(dmr_confidence_voice_slot_open(&state, 0) == 0);
+    assert(dmr_confidence_any_voice_open(&state) == 0);
+}
+
+static void
+test_invalid_color_code_rejected(void) {
+    static dsd_state state;
+    init_state(&state);
+
+    assert(dmr_confidence_note_data_burst(&state, 16) == DMR_CONFIDENCE_REJECT);
+    assert(state.dmr_confidence_locked == 0);
+    assert(state.dmr_color_code == 16);
 }
 
 static void
@@ -104,9 +193,14 @@ test_reset_clears_gate_state(void) {
 
 int
 main(void) {
-    test_non_idle_data_does_not_lock_from_fresh_start();
-    test_idle_data_can_lock_color_code();
+    test_single_data_burst_does_not_lock();
+    test_repeated_data_bursts_lock_color_code();
+    test_inconsistent_cc_restarts_candidate_count();
     test_locked_color_code_rejects_mismatch();
+    test_sustained_mismatch_relocks_to_new_color_code();
+    test_matching_burst_restarts_relock_streak();
+    test_relock_closes_voice_gates();
+    test_invalid_color_code_rejected();
     test_voice_requires_voice_sync_before_open();
     test_reset_clears_gate_state();
     printf("DMR confidence gate: OK\n");

--- a/tests/protocol/dmr/test_dmr_data_sync.c
+++ b/tests/protocol/dmr/test_dmr_data_sync.c
@@ -176,10 +176,9 @@ dmr_debug_format_burst(char* out, size_t out_size, const dsd_state* state, uint8
 
 dmr_confidence_result
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-dmr_confidence_note_data_burst(dsd_state* state, unsigned int color_code, unsigned int burst) {
+dmr_confidence_note_data_burst(dsd_state* state, unsigned int color_code) {
     (void)state;
     (void)color_code;
-    (void)burst;
     return g_confidence_result;
 }
 


### PR DESCRIPTION
## Summary

Fixes #348 (revisit of #40).

The confidence gate introduced in 77e18d44 (for #86) only allowed the data-path color-code lock from IDLE bursts (type 9) or voice. A dedicated Tier III TSCC transmits continuous CSBK signalling (C_ALOHA/broadcast fill) and may never carry IDLE bursts or voice, so on such systems the gate never locked: every CSBK was dropped before dispatch, `dmr_color_code` stayed at the unknown sentinel 16 (shown as DCC 16), and no TIII site/network identity was ever decoded. The RAS CRC bypass from #40 (363b3a5c) is intact — the CSBKs just never reached it.

## Why this is the right behavior

- **ETSI TS 102 361-4 V1.12.1**: an idle TSCC transmits Aloha/Broadcast CSBKs (cl. 4.8, 4.9.1.1, 6.1.1.2); the other timeslot of the TSCC physical channel may be a TSCCAS, a second TSCC, or a payload channel — nothing guarantees a receiver parked on a TSCC ever sees an IDLE burst. CC 0 is valid and is the Tier III default (cl. 6.2.1.3).
- **SDRTrunk** accepts any burst whose slot-type Golay(20,8) / EMB QR(16,7,6) FEC decodes; color code is never a gate, and Tier III control state is driven purely by CSBK opcodes.
- **DSD-FME** sets the color code from a single successful Golay decode and dispatches every burst immediately.

## Changes

- Any Golay-valid data burst (TACT already validated upstream) now feeds the existing two-observation color-code lock, not just IDLE. The #86 protection is preserved: a single marginal burst still cannot publish, and a locked gate still rejects mismatched color codes.
- Closes the permanent-reject gap: four consecutive consistent observations of a *different* color code re-lock the gate (and close voice gates so audio re-qualifies) instead of rejecting every burst until the next no-carrier reset. A burst matching the locked code restarts the streak, so sporadic co-channel interference cannot accumulate into a re-lock.
- The now-unused `burst` parameter was dropped from `dmr_confidence_note_data_burst()`.

## Tests

- `DMR_CONFIDENCE_GATE`: new cases for CSBK-only lock (including CC 0 vs. the unknown sentinel), single-burst no-lock, inconsistent-CC restart, sustained-mismatch re-lock, matching-burst streak restart, and voice-gate closure on re-lock (all written first and watched fail).
- Full suite: 537/537 passing, including the `iq-decode` replays; `tools/preflight_ci.sh` clean.

A follow-up worth doing: turn the reporter's offered DSDPlus raw recording into a `DECODE_IQ` fixture for a CSBK-only RAS TSCC — the existing `DECODE_IQ_DMR_T3_CC` recording locks via the voice path and cannot catch this class of regression.