### PR TITLE
dmr: keep OTA PI header ALG/KEY ID when --dmr-force-algid is set

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -497,7 +497,8 @@ those values for the current CLI run only.
 - Import keys CSV (decimal): `-k <file>`
 - Import keys CSV (hex): `-K <file>`
 - Force key over identifiers: `-4` (DMR BP/NXDN scrambler), `-0` (DMR RC4 when PI/LE missing),
-  `--dmr-force-algid <hex>` (DMR ALGID when PI/LE missing; `-M` is reserved for M17 in DSD-neo)
+  `--dmr-force-algid <hex>` (DMR ALGID when PI/LE missing; a fallback only — an ALG ID or KEY ID
+  received over the air via PI header/LE always takes precedence; `-M` is reserved for M17 in DSD-neo)
 - Disable DMR Late Entry IDs: `-3` (avoid false ENC)
 
 ## Tools & Extras

--- a/include/dsd-neo/core/audio.h
+++ b/include/dsd-neo/core/audio.h
@@ -164,7 +164,13 @@ void audio_mix_mono_from_slots_f32(const float* left, const float* right, size_t
 /** @brief Return 1 when P25p2 decode should queue audio for the slot under decrypt and media policy. */
 int dsd_p25p2_decode_audio_allowed(const dsd_opts* opts, const dsd_state* state, int slot, int alg);
 
-/** @brief Apply a forced DMR ALGID to encrypted current-slot metadata. Returns 1 when applied. */
+/**
+ * @brief Apply a forced DMR ALGID to encrypted current-slot metadata when no OTA ALG ID is known.
+ *
+ * Fallback only: a slot whose ALG ID was already learned over the air (PI header, LE single
+ * burst) is left untouched, and a known KEY ID is never replaced by the 0xFF sentinel.
+ * Returns 1 when applied.
+ */
 int dsd_dmr_apply_forced_algid(dsd_state* state);
 
 /** @brief Flush partially buffered P25p2 SS18 audio on call end/release. */

--- a/src/core/audio/dsd_audio_gate.c
+++ b/src/core/audio/dsd_audio_gate.c
@@ -238,14 +238,21 @@ dsd_dmr_apply_forced_algid(dsd_state* state) {
         return 0;
     }
 
-    if (state->currentslot == 0 && (state->dmr_so & 0x40) != 0) {
+    // Fallback only: OTA identifiers from a verified PI header or LE single burst take
+    // precedence, so a slot that already carries an ALG ID is left untouched and a known
+    // KEY ID is never replaced by the 0xFF "no key id" sentinel (issue #351).
+    if (state->currentslot == 0 && (state->dmr_so & 0x40) != 0 && state->payload_algid == 0) {
         state->payload_algid = state->M & 0xFF;
-        state->payload_keyid = 0xFF;
+        if (state->payload_keyid == 0) {
+            state->payload_keyid = 0xFF;
+        }
         return 1;
     }
-    if (state->currentslot == 1 && (state->dmr_soR & 0x40) != 0) {
+    if (state->currentslot == 1 && (state->dmr_soR & 0x40) != 0 && state->payload_algidR == 0) {
         state->payload_algidR = state->M & 0xFF;
-        state->payload_keyidR = 0xFF;
+        if (state->payload_keyidR == 0) {
+            state->payload_keyidR = 0xFF;
+        }
         return 1;
     }
 

--- a/tests/core/test_core_dmr_voice_alg_gate.c
+++ b/tests/core/test_core_dmr_voice_alg_gate.c
@@ -103,6 +103,40 @@ main(void) {
     state.M = 0x16;
     rc |= expect_eq("force-algid-tyt16-mode-ignored", dsd_dmr_apply_forced_algid(&state), 0);
 
+    // Issue #351: the forced ALGID is a fallback for missing PI/LE identifiers. A CRC-verified
+    // PI header's ALG ID and KEY ID must survive the per-voice-frame forced-algid application,
+    // or key lookup selects rkey_array[0xFF] instead of the header's key for the whole call.
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.M = 0x21;
+    state.currentslot = 0;
+    state.dmr_so = 0x40;
+    state.payload_algid = 0x21;
+    state.payload_keyid = 0x03;
+    rc |= expect_eq("force-algid-ota-present-skipped", dsd_dmr_apply_forced_algid(&state), 0);
+    rc |= expect_eq("force-algid-ota-alg-preserved", state.payload_algid, 0x21);
+    rc |= expect_eq("force-algid-ota-key-preserved", state.payload_keyid, 0x03);
+
+    // OTA identifiers win even when they disagree with the forced value.
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.M = 0x21;
+    state.currentslot = 1;
+    state.dmr_soR = 0x40;
+    state.payload_algidR = 0x22;
+    state.payload_keyidR = 0x02;
+    rc |= expect_eq("force-algid-slot1-ota-present-skipped", dsd_dmr_apply_forced_algid(&state), 0);
+    rc |= expect_eq("force-algid-slot1-ota-alg-preserved", state.payload_algidR, 0x22);
+    rc |= expect_eq("force-algid-slot1-ota-key-preserved", state.payload_keyidR, 0x02);
+
+    // A known KEY ID without an ALG ID keeps the key id; only the missing ALG ID is filled.
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.M = 0x21;
+    state.currentslot = 0;
+    state.dmr_so = 0x40;
+    state.payload_keyid = 0x03;
+    rc |= expect_eq("force-algid-fills-missing-alg", dsd_dmr_apply_forced_algid(&state), 1);
+    rc |= expect_eq("force-algid-fill-alg", state.payload_algid, 0x21);
+    rc |= expect_eq("force-algid-known-key-preserved", state.payload_keyid, 0x03);
+
     if (rc == 0) {
         printf("CORE_DMR_VOICE_ALG_GATE: OK\n");
     }

--- a/tests/protocol/dmr/test_dmr_le_infer_algid.c
+++ b/tests/protocol/dmr/test_dmr_le_infer_algid.c
@@ -168,6 +168,42 @@ test_fragment_wrapper_maps_slot2_to_slot1_and_triggers_decode(void) {
 }
 
 static void
+test_forced_algid_preserves_pi_header_keyid(void) {
+    // Issue #351: --dmr-force-algid is applied on every LE fragment. The KEY ID a
+    // CRC-verified DMRA PI header stored for the call must survive that application,
+    // or key lookup selects rkey_array[0xFF] instead of the header's key.
+    static dsd_opts opts;
+    static dsd_state state;
+    static dsd_state encoded;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(&encoded, 0, sizeof(encoded));
+
+    const uint32_t mi = 0xA1B2C3D4U;
+    state.currentslot = 0;
+    state.M = 0x21;             // --dmr-force-algid 21
+    state.dmr_so = 0x40U;       // service options carry the privacy bit
+    state.payload_algid = 0x21; // CRC-verified PI header already decoded for this call
+    state.payload_keyid = 0x03;
+    state.payload_mi = 0x01020304ULL;
+
+    fill_le_fragments_for_mi(&encoded, 0, mi);
+    for (uint8_t vc = 1; vc <= 6; vc++) {
+        uint8_t ambe_fr[4][24];
+        uint8_t ambe_fr2[4][24];
+        uint8_t ambe_fr3[4][24];
+        write_nibble_to_ambe(ambe_fr, (uint8_t)encoded.late_entry_mi_fragment[0][vc][0]);
+        write_nibble_to_ambe(ambe_fr2, (uint8_t)encoded.late_entry_mi_fragment[0][vc][1]);
+        write_nibble_to_ambe(ambe_fr3, (uint8_t)encoded.late_entry_mi_fragment[0][vc][2]);
+        dmr_late_entry_mi_fragment(&opts, &state, vc, ambe_fr, ambe_fr2, ambe_fr3);
+    }
+
+    assert(state.payload_algid == 0x21);
+    assert(state.payload_keyid == 0x03);
+    assert((uint32_t)state.payload_mi == mi);
+}
+
+static void
 test_verified_mi_updates_existing_slot_mi(void) {
     static dsd_opts opts;
     static dsd_state state;
@@ -247,6 +283,7 @@ main(void) {
     run_case(1, 0x0123456789ABCDULL, 0x22334455U, 0x22);
 
     test_fragment_wrapper_maps_slot2_to_slot1_and_triggers_decode();
+    test_forced_algid_preserves_pi_header_keyid();
     test_verified_mi_updates_existing_slot_mi();
     test_alg_refresh_on_error_refreshes_each_encrypted_slot();
     test_alg_refresh_ignores_invalid_current_slot();


### PR DESCRIPTION
Fixes #351

## Summary

- Root cause of #351: `dsd_dmr_apply_forced_algid()` runs on every voice frame and every late-entry fragment, and unconditionally overwrote the slot's ALG ID and KEY ID (KID → 0xFF) whenever `--dmr-force-algid` was active and the SO privacy bit was set. On the reporter's TIII RAS network the CRC-verified DMRA PI header delivers the true KEY ID (e.g. 03), which was stomped immediately, so key selection looked up `rkey_array[0xFF]` instead of `rkey_array[0x03]` — hence the garbled voice, the `DMR PI C- ... KEY ID: FF` logs, the event-history KID 0, and the reporter's "add key ID FF to Keys.csv" workaround half-working.
- Fix: the forced ALGID is now a fallback, matching its documented intent ("over **Missing** PI header/LE Encryption Identifiers"). It applies only when the slot has no OTA ALG ID and never replaces a known KEY ID with the 0xFF sentinel. Behavior on PI-less systems (the flag's original purpose) is unchanged; `docs/cli.md` now states the precedence rule.
- Spec grounding (multi-source, per review requirement): ETSI TS 102 361 parts 1/2/4 deliberately leave the PI header's privacy fields undefined ("not defined in the present document"); the DMRA layout (octet 0 ALGID, octet 1 FID, octet 2 KID, octets 3–6 MI) and per-transmission KID constancy (only the MI evolves, via per-superframe LFSR) are confirmed bit-exactly by SDRTrunk (`EncryptionParameters.java`, `EmbeddedEncryptionParameters.java`), upstream DSD-FME (`dmr_pi.c`, `dmr_le.c`), and Motorola patent US8422679B2. No primary source reserves KID 0x00/0xFF — 0xFF is an internal DSD-FME-lineage sentinel only, so a signaled KID must always survive. (Upstream DSD-FME at current master has the identical override bug while its own banner documents fallback intent; SDRTrunk has no force concept and always trusts OTA.)
- Tests: new unit assertions in `CORE_DMR_VOICE_ALG_GATE` covering the fallback contract (OTA ALG+KID preserved, OTA-wins-on-disagreement, missing-ALG-with-known-KID keeps the KID), plus an LE-path regression in `DMR_LE_INFER_ALGID` driving `dmr_late_entry_mi_fragment` with a PI-header-provided KEY ID under forced ALGID. Both were verified red against the old behavior before the fix (stash-revert), then green with it.

Not addressed here (follow-ups from the issue): the TG-driven key-selection feature request (second half of #351), and the `state->M != 0` gate that still ignores LE single-burst enc identifiers while forcing (those bits are parsed without CRC verification).

## Review

- [ ] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: crypto.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. (None added.)
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (539/539)
- [x] `tools/preflight_ci.sh` (`--base origin/main`, exit 0)
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes (none)
- [ ] `tools/zizmor.sh` for workflow changes (none)
- [ ] `tools/osv_scan.sh` for dependency input changes (none)
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes (none)

## Risk

- Security/dependency impact: none — no new dependencies or APIs; corrects which loaded key is selected for DMR voice decrypt so the signaled KEY ID wins over the internal sentinel.
- CLI/UI behavior impact: `--dmr-force-algid` is now fallback-only. On systems that transmit PI headers, decrypt uses the header's KEY ID and the event history shows it; PI-less systems behave exactly as before.
- Compatibility or packaging impact: none.
