### PR TITLE
build: release 2.8.0, and give an empty chooser one exit path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(dsd-neo VERSION 2.7.0 LANGUAGES C CXX)
+project(dsd-neo VERSION 2.8.0 LANGUAGES C CXX)
 if(POLICY CMP0083)
     cmake_policy(SET CMP0083 NEW)
 endif()

--- a/src/ui/terminal/menu_prompts.c
+++ b/src/ui/terminal/menu_prompts.c
@@ -1170,10 +1170,18 @@ void
 ui_chooser_start_at(const char* title, const char* const* items, int count, int initial_sel, ui_chooser_done_fn on_done,
                     void* user_ctx) {
     if (!items || count <= 0) {
+        // An empty list cancels straight away, but it still leaves by the one
+        // door every other chooser result uses: publish the callback into
+        // g_chooser and let ui_chooser_finish() deliver it. That keeps the
+        // reentry guard (on_done cleared before the callback runs) on this path
+        // too, and it keeps the callback's context reachable only through the
+        // chooser state that pairs it with its callback - never handed straight
+        // from one caller's argument list to whatever function pointer the
+        // caller passed in.
         ui_chooser_close();
-        if (on_done) {
-            on_done(user_ctx, -1);
-        }
+        g_chooser.on_done = on_done;
+        g_chooser.user = user_ctx;
+        ui_chooser_finish(-1);
         return;
     }
     g_chooser.active = 1;

--- a/tests/ui/test_ui_prompt_validation.c
+++ b/tests/ui/test_ui_prompt_validation.c
@@ -327,6 +327,22 @@ test_chooser_edge_paths(void) {
     assert(selected == -1);
     assert(ui_chooser_active() == 0);
 
+    /* An empty list cancels through the same path a selection takes, so the
+       chooser state is torn down before the callback runs: a callback that
+       opens its own chooser from the cancel keeps it. */
+    static ChooserCapture empty_reentry;
+    empty_reentry = (ChooserCapture){0, -2, -2};
+    ui_chooser_start("Empty reentry", NULL, 0, capture_chooser_reentry, &empty_reentry);
+    assert(empty_reentry.calls == 1);
+    assert(empty_reentry.first_sel == -1);
+    assert(ui_chooser_active() == 1);
+    UiChooserTestSnapshot reentered = ui_chooser_test_snapshot();
+    assert(reentered.count == 2);
+    assert(ui_chooser_handle_key(27) == 1);
+    assert(empty_reentry.calls == 2);
+    assert(empty_reentry.second_sel == -1);
+    assert(ui_chooser_active() == 0);
+
     selected = -2;
     ui_chooser_start("Single", CHOOSER_ONE, 1, capture_chooser_selected, &selected);
     assert(ui_chooser_handle_key(KEY_RESIZE) == 1);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dsd-neo",
-  "version-string": "2.7.0",
+  "version-string": "2.8.0",
   "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "description": "Digital Speech Decoder: DSD-neo",
   "homepage": "https://github.com/arancormonk/dsd-neo",


### PR DESCRIPTION
Closes the two open `cpp/type-confusion` code-scanning alerts (1803, 1804) and
moves version metadata to 2.8.0.

## The alerts

Both had one root cause, and it was at neither reported location.
`ui_chooser_start_at()` answered an empty item list by handing the caller's
context straight back to the caller's callback:

```c
ui_chooser_close();
if (on_done) {
    on_done(user_ctx, -1);
}
```

Every other chooser result leaves through `ui_chooser_finish()`, which reads the
callback and its context back out of `g_chooser`, so the pair that was stored
together is the pair that runs. The empty-list cancel was the one place a
context travelled from a caller's argument list into an indirect call, and a
whole-program analyzer that resolves that call site to every
`ui_chooser_done_fn` in the build therefore sees each caller's context reach
every other caller's cast. CodeQL reported the two sinks whose own context is
not heap-allocated - the `rr_panel.c` panel singleton and a stack capture in the
chooser tests - as `cpp/type-confusion`; the heap-allocated ones were spared
only because their own allocation reaches the cast as well.

## The fix

Publish `on_done`/`user_ctx` into `g_chooser` and finish through
`ui_chooser_finish()`. Behaviour is unchanged - close, then callback with `-1` -
and the cancel now gets the same single exit the rest of the widget uses,
reentry guard included: `on_done` is cleared before the callback runs. The new
test covers a callback that opens its own chooser from an empty list's cancel,
which is the ordering that guard protects.

## Verification

CodeQL 2.26.3, `cpp-security-and-quality` suite, databases built from the same
`dev-debug` preset CI uses, baseline (`48754f82`) vs this branch:

| | baseline | this branch |
| --- | --- | --- |
| `cpp/type-confusion` | 2 (`rr_panel.c:116`, `test_ui_prompt_validation.c:304`) | 0 |
| whole suite, repo query-filters applied | 18 | 16 - 2 resolved, 0 new |

555/555 ctest pass, and `tools/preflight_ci.sh` is clean (clang-format, gersemi,
clang-tidy, cppcheck, IWYU, GCC `-fanalyzer`, Semgrep, Lizard).

## Version

`CMakeLists.txt` and `vcpkg.json` are the whole bump; the Android
`versionCode`/`versionName` derive from `PROJECT_VERSION`/`GIT_TAG`.
