### PR TITLE
ci(android): let curl retry the vcpkg bootstrap download on a reset

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -86,6 +86,26 @@ jobs:
           ccache --set-config=max_size=500M
           ccache --set-config=compression=true
 
+      # vcpkg's bootstrap fetches the vcpkg-tool binary with `curl --retry 3`,
+      # but curl only spends that retry budget on timeouts and 5xx/429
+      # responses: a connection-level failure -- curl 35, "Recv failure:
+      # Connection reset by peer" -- aborts on the first attempt and fails the
+      # job before any of our code is built. --retry-all-errors extends the
+      # existing budget to those resets. It goes in a curlrc because run-vcpkg
+      # invokes bootstrap-vcpkg.sh itself, so there is no command line of ours
+      # to add it to, and because it then also covers the curl calls vcpkg
+      # makes for port sources. Linux-only: the Windows bootstrap downloads
+      # through tls12-download.exe, which never reads this file.
+      - name: Make curl retry connection resets
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > "$HOME/.curlrc" << 'EOF'
+          retry = 3
+          retry-all-errors
+          retry-delay = 5
+          EOF
+
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.5
         with:
@@ -477,6 +497,26 @@ jobs:
           ccache --zero-stats
           ccache --set-config=max_size=500M
           ccache --set-config=compression=true
+
+      # vcpkg's bootstrap fetches the vcpkg-tool binary with `curl --retry 3`,
+      # but curl only spends that retry budget on timeouts and 5xx/429
+      # responses: a connection-level failure -- curl 35, "Recv failure:
+      # Connection reset by peer" -- aborts on the first attempt and fails the
+      # job before any of our code is built. --retry-all-errors extends the
+      # existing budget to those resets. It goes in a curlrc because run-vcpkg
+      # invokes bootstrap-vcpkg.sh itself, so there is no command line of ours
+      # to add it to, and because it then also covers the curl calls vcpkg
+      # makes for port sources. Linux-only: the Windows bootstrap downloads
+      # through tls12-download.exe, which never reads this file.
+      - name: Make curl retry connection resets
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > "$HOME/.curlrc" << 'EOF'
+          retry = 3
+          retry-all-errors
+          retry-delay = 5
+          EOF
 
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@b1a0dd252f06b9e25b3c022a9a03bd7a427fb6a2 # v11.5


### PR DESCRIPTION
## Summary

- `android-ci` failed on the latest merge to `main` ([run 32592535075](https://github.com/arancormonk/dsd-neo/actions/runs/32592535075), commit d5bb26d4). The "APK (Qt Quick app)" job died in `Setup vcpkg`:

  ```
  Downloading vcpkg-glibc...
  curl: (35) Recv failure: Connection reset by peer
  ```

- Root cause: vcpkg's `bootstrap-vcpkg.sh` fetches the vcpkg-tool binary with `curl --retry 3`, but curl spends that retry budget only on timeouts and 5xx/429 responses. A connection-level failure (curl 35) is **not** retried unless `--retry-all-errors` is also given, so a single peer reset aborted on the first attempt and failed the job before any of our code was built. Not a regression in d5bb26d4 — `arm64 CLI (NDK cross build)` bootstrapped the same vcpkg commit successfully in the same run, minutes earlier.
- Fix: write a `~/.curlrc` with `retry-all-errors` before `Setup vcpkg` in the two android-ci jobs that use vcpkg. `run-vcpkg` invokes `bootstrap-vcpkg.sh` itself, so there is no command line of ours to extend; a curlrc reaches it, and it also covers the curl calls vcpkg makes when fetching port sources (the longer, flakier phase).
- Scoped to Linux on purpose: the Windows bootstrap downloads via `tls12-download.exe`, which never reads a curlrc, so `windows-ci`'s two vcpkg jobs are left alone rather than given inert config.

### Verification

Reproduced against a local server that accepts the TLS ClientHello and then resets the connection (`SO_LINGER 0`), which yields the exact CI error string. Running the bootstrap's own command line:

| `$HOME/.curlrc` | connection attempts | result |
| --- | --- | --- |
| absent | **1** | `curl: (35) Recv failure: Connection reset by peer` — matches CI |
| this PR's | **4** (1 + 3 retries) | retries as intended |

The step body was extracted from the workflow YAML and run verbatim for that second row, so the heredoc and the file it writes are what CI will use.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: **workflow** (CI only; no shipped code).
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. — n/a, no code change; the behavior change was verified empirically (above), and there is no CTest seam for a workflow step.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. — none added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification. — no new actions, no permission changes, no new pins.

## Tests And Guardrails

- [x] `tools/preflight_ci.sh` — exit 0 (actionlint, zizmor, semgrep, workflow Git/download pin guardrails, vcpkg overlay pins, secret redaction, lizard)
- [x] `tools/zizmor.sh` for workflow changes — no findings
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, `tools/check_vcpkg_overlay_pins.sh` — all clean via preflight
- [ ] `cmake --build --preset dev-debug -j` — not run; the diff is one workflow file and touches no build input.
- [ ] `ctest --preset dev-debug --output-on-failure` — same.
- [ ] `tools/cmake_format_check.sh` — n/a, no CMake changes.
- [ ] `tools/osv_scan.sh` — n/a, no dependency inputs changed.

## Risk

- Security/dependency impact: no new action, dependency, or pin. The curlrc only affects curl invocations inside the two ubuntu runners for the life of the job. It widens curl's retry budget, so a genuinely unreachable host now costs up to ~15s more before the job fails.
- CLI/UI behavior impact: none — no shipped code changes.
- Compatibility or packaging impact: none. This PR's own `android-ci` run exercises both changed jobs end to end.
