### PR TITLE
bump: version metadata to 2.8.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(dsd-neo VERSION 2.8.0 LANGUAGES C CXX)
+project(dsd-neo VERSION 2.8.1 LANGUAGES C CXX)
 if(POLICY CMP0083)
     cmake_policy(SET CMP0083 NEW)
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dsd-neo",
-  "version-string": "2.8.0",
+  "version-string": "2.8.1",
   "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "description": "Digital Speech Decoder: DSD-neo",
   "homepage": "https://github.com/arancormonk/dsd-neo",


### PR DESCRIPTION
Bump project version metadata from 2.8.0 to 2.8.1 in `CMakeLists.txt` (project()) and `vcpkg.json` (version-string).