### PR TITLE
feat: unbounded scan lists for trunk-scan targets and -Y channel maps

### DIFF
--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -119,7 +119,7 @@ Columns:
 
 Validation notes:
 
-- Maximum 32 targets.
+- No target-count limit; bounded only by memory.
 - Duplicate IDs and duplicate `(type, frequency_hz)` rows are rejected.
 - `chan_csv` on `dmr-conventional` rows is rejected.
 - Global `-C`/`[trunking] chan_csv` is rejected in trunk scan mode so channel maps do not leak across systems.

--- a/docs/radioreference-import.md
+++ b/docs/radioreference-import.md
@@ -260,8 +260,6 @@ multi-select list, sorted by name, showing each repeater's frequency and colour 
 - **Exactly one repeater** produces no file at all. The session simply tunes that frequency. This
   is deliberate: a one-entry scan list makes the scanner retune to the frequency it is already on
   at every hangtime expiry.
-- The list is **capped at 26 entries** — the runtime's positional frequency array holds 26 — and the
-  screen shows a running count against that ceiling. Selecting more truncates, with a warning.
 - Duplicate frequencies are dropped, with a warning: two repeaters can share one output.
 - **Scanning needs an RTL-SDR or a rigctl-controlled radio.** On a WAV, UDP or TCP source the
   scanner never steps, so the session looks stuck on one frequency. The preview says so.

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -55,7 +55,7 @@ Column behavior:
 
 Target list limits and validation:
 
-- Maximum 32 targets.
+- No target-count limit; bounded only by memory.
 - Blank rows are skipped.
 - Every data row must contain the seven fields above.
 - The header may have optional columns after `notes`, but the first seven header names must match the required prefix.

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -419,6 +419,12 @@ struct dsd_state {
     uint16_t trunk_chan_map_used[DSD_TRUNK_CHAN_MAP_SIZE];
     uint32_t trunk_chan_map_used_count;
     uint64_t trunk_chan_map_seq;
+    /* Scan-list tail beyond the 26 embedded slots (NULL until a longer list is
+     * imported). dsd_state_trunk_lcn_slot() abstracts both segments. Never inside
+     * a UI_SNAPSHOT_COPY_RANGE: the first range ends at trunk_lcn_freq and members
+     * from trunk_chan_map on are copied explicitly. */
+    long int* trunk_lcn_freq_ext;
+    size_t trunk_lcn_freq_ext_capacity;
     // DMR Tier III: simple provenance/trust for learned LCN->freq mappings
     // 0=unset, 1=learned (unconfirmed), 2=trusted (confirmed on-current-site CC)
     uint8_t dmr_lcn_trust[0x1000];
@@ -1384,6 +1390,38 @@ dsd_state_set_trunk_chan_freq(dsd_state* state, uint32_t channel, long int freq)
     }
     state->trunk_chan_map_seq++;
 }
+
+/**
+ * Address the scan-list LCN slot at index i. The first 26 slots live in the
+ * embedded trunk_lcn_freq array (protocol fixed-slot writers keep raw-indexing
+ * those); slots >= 26 live in the heap tail trunk_lcn_freq_ext. Callers must
+ * guarantee 0 <= i < lcn_freq_count for reads, or that the index is addressable
+ * (trunk_lcn_freq_ext_capacity > i - 26) for writes into the tail.
+ */
+static inline long int*
+dsd_state_trunk_lcn_slot(dsd_state* state, int i) {
+    return i < 26 ? &state->trunk_lcn_freq[i] : &state->trunk_lcn_freq_ext[i - 26];
+}
+
+/** Const-qualified dsd_state_trunk_lcn_slot() for read-only contexts. */
+static inline const long int*
+dsd_state_trunk_lcn_slot_const(const dsd_state* state, int i) {
+    return i < 26 ? &state->trunk_lcn_freq[i] : &state->trunk_lcn_freq_ext[i - 26];
+}
+
+/**
+ * Ensure scan-list indices 0..count_needed-1 are addressable via
+ * dsd_state_trunk_lcn_slot(): grows the heap tail by doubling and zero-fills
+ * the new tail; no-op when count_needed <= 26. Returns 0 on success, -1 on
+ * allocation failure (state left valid, contents preserved).
+ */
+int dsd_state_trunk_lcn_reserve(dsd_state* state, size_t count_needed);
+
+/**
+ * Free the scan-list heap tail and zero its pointer/capacity. The embedded
+ * 26 slots are part of dsd_state and need no release.
+ */
+void dsd_state_trunk_lcn_free(dsd_state* state);
 
 static inline int
 dsd_state_minmax_window_size(int requested) {

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -21,7 +21,6 @@ extern "C" {
 #endif
 
 enum {
-    DSD_TRUNK_SCAN_MAX_TARGETS = 32,
     DSD_TRUNK_SCAN_DWELL_MIN_MS = 250,
     DSD_TRUNK_SCAN_DWELL_MAX_MS = 600000,
     DSD_TRUNK_SCAN_IDLE_DWELL_DEFAULT_MS = 3000,
@@ -55,9 +54,21 @@ typedef struct {
 } dsd_trunk_scan_target;
 
 typedef struct {
-    dsd_trunk_scan_target targets[DSD_TRUNK_SCAN_MAX_TARGETS];
+    dsd_trunk_scan_target* targets; /**< Owned heap array; NULL when empty. */
     size_t count;
+    size_t capacity;
 } dsd_trunk_scan_target_list;
+
+/**
+ * @brief Release a target list's owned storage and zero it.
+ *
+ * The list returned by a successful dsd_trunk_scan_load_targets_csv() owns its
+ * `targets` array; callers must reset it once the coordinator has copied the
+ * targets out. A failed load never writes `*out`, so nothing to reset there.
+ *
+ * @param list List to clear; NULL is ignored.
+ */
+void dsd_trunk_scan_target_list_reset(dsd_trunk_scan_target_list* list);
 
 int dsd_trunk_scan_load_targets_csv(const char* path, const dsd_opts* opts, dsd_trunk_scan_target_list* out, char* err,
                                     size_t err_sz);

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -1860,13 +1860,9 @@ try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
 
 static int
 apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
-    const int lcn_capacity = (int)(sizeof(state->trunk_lcn_freq) / sizeof(state->trunk_lcn_freq[0]));
     int count = state->lcn_freq_count;
     if (count <= 0) {
         return UI_CMD_APPLY_COMPLETED;
-    }
-    if (count > lcn_capacity) {
-        count = lcn_capacity;
     }
 
     int next = state->lcn_freq_roll;
@@ -1876,8 +1872,8 @@ apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
     const int start = next;
     long freq = 0;
     for (int examined = 0; examined < count; examined++) {
-        freq = state->trunk_lcn_freq[next];
-        if (freq != 0 && (next == 0 || state->trunk_lcn_freq[next - 1] != freq)) {
+        freq = *dsd_state_trunk_lcn_slot(state, next);
+        if (freq != 0 && (next == 0 || *dsd_state_trunk_lcn_slot(state, next - 1) != freq)) {
             break;
         }
         next++;

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -332,16 +332,25 @@ svc_udp_output_config(dsd_opts* opts, dsd_state* state, const char* host, int po
  * LCN the new map leaves empty. lcn_freq_roll indexes trunk_lcn_freq, so a
  * shorter list has to restart the hunt rather than resume mid-way.
  */
-static void
+static int
 chan_map_adopt(dsd_state* dst, const dsd_state* src) {
+    if (dsd_state_trunk_lcn_reserve(dst, (size_t)src->lcn_freq_count) != 0) {
+        LOG_ERROR("channel map adopt out of memory\n");
+        return -1;
+    }
     DSD_MEMCPY(dst->trunk_chan_map, src->trunk_chan_map, sizeof dst->trunk_chan_map);
     DSD_MEMCPY(dst->trunk_chan_map_used, src->trunk_chan_map_used, sizeof dst->trunk_chan_map_used);
     dst->trunk_chan_map_used_count = src->trunk_chan_map_used_count;
     DSD_MEMCPY(dst->trunk_lcn_freq, src->trunk_lcn_freq, sizeof dst->trunk_lcn_freq);
+    if (src->lcn_freq_count > 26) {
+        DSD_MEMCPY(dst->trunk_lcn_freq_ext, src->trunk_lcn_freq_ext,
+                   (size_t)(src->lcn_freq_count - 26) * sizeof(dst->trunk_lcn_freq_ext[0]));
+    }
     dst->lcn_freq_count = src->lcn_freq_count;
     dst->lcn_freq_roll = 0;
     DSD_MEMSET(dst->dmr_lcn_trust, 0, sizeof dst->dmr_lcn_trust);
     dst->trunk_chan_map_seq++;
+    return 0;
 }
 
 int
@@ -372,12 +381,14 @@ svc_import_channel_map(dsd_opts* opts, dsd_state* state, const char* path) {
     // that would replace the live map with zeros; refuse instead, which is what
     // the additive import used to do by doing nothing.
     const int mapped_any = (imported->trunk_chan_map_used_count > 0);
+    int adopt_rc = -1;
     if (import_rc == 0 && mapped_any) {
-        chan_map_adopt(state, imported);
+        adopt_rc = chan_map_adopt(state, imported);
     }
     dsd_state_ext_free_all(imported);
+    dsd_state_trunk_lcn_free(imported);
     free(imported);
-    return (import_rc == 0 && mapped_any) ? 0 : -1;
+    return (import_rc == 0 && mapped_any && adopt_rc == 0) ? 0 : -1;
 }
 
 int
@@ -395,6 +406,7 @@ svc_clear_channel_map(dsd_opts* opts, dsd_state* state) {
     DSD_MEMSET(state->trunk_chan_map_used, 0, sizeof state->trunk_chan_map_used);
     state->trunk_chan_map_used_count = 0;
     DSD_MEMSET(state->trunk_lcn_freq, 0, sizeof state->trunk_lcn_freq);
+    dsd_state_trunk_lcn_free(state);
     state->lcn_freq_count = 0;
     state->lcn_freq_roll = 0;
     // Provenance goes with the map, exactly as in chan_map_adopt(): a surviving

--- a/src/app_control/ui_snapshot.c
+++ b/src/app_control/ui_snapshot.c
@@ -110,6 +110,26 @@ ui_snapshot_copy_trunk_chan_map(dsd_state* dst, const dsd_state* src) {
     dst->trunk_chan_map_seq = src->trunk_chan_map_seq;
 }
 
+/* The embedded trunk_lcn_freq[26] is a plain array copied by the byte ranges
+ * above; the scan-list heap tail past slot 26 needs an explicit deep copy.
+ * Runs after the range that carries lcn_freq_count/lcn_freq_roll so dst is
+ * never left claiming more entries than its tail holds: on reserve failure the
+ * count is clamped back to the 26 embedded slots and the roll restarted. */
+static void
+ui_snapshot_copy_trunk_lcn_freq_ext(dsd_state* dst, const dsd_state* src) {
+    const int count = src->lcn_freq_count > 0 ? src->lcn_freq_count : 0;
+    if (count <= 26) {
+        return;
+    }
+    const size_t ext_count = (size_t)count - 26;
+    if (dsd_state_trunk_lcn_reserve(dst, (size_t)count) != 0) {
+        dst->lcn_freq_count = 26;
+        dst->lcn_freq_roll = 0;
+        return;
+    }
+    DSD_MEMCPY(dst->trunk_lcn_freq_ext, src->trunk_lcn_freq_ext, ext_count * sizeof(dst->trunk_lcn_freq_ext[0]));
+}
+
 static void
 ui_snapshot_copy_render_state(dsd_state* dst, const dsd_state* src) {
     UI_SNAPSHOT_COPY_RANGE(dst, src, dibit_buf, trunk_lcn_freq);
@@ -124,6 +144,7 @@ ui_snapshot_copy_render_state(dsd_state* dst, const dsd_state* src) {
     UI_SNAPSHOT_COPY_RANGE(dst, src, dmr_alias_format, DMRvcR);
     UI_SNAPSHOT_COPY_RANGE(dst, src, octet_counter, p25_p2_audio_allowed);
     UI_SNAPSHOT_COPY_RANGE(dst, src, p25_p2_audio_ring_count, dstar_gps);
+    ui_snapshot_copy_trunk_lcn_freq_ext(dst, src);
     UI_SNAPSHOT_COPY_RANGE(dst, src, m17_pbc_ct, straight_frame_step);
     UI_SNAPSHOT_COPY_RANGE(dst, src, vertex_ks_count, ui_msg);
 }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(
         util/dsd_misc.c
         util/bit_packing.c
         util/dsd_init.c
+        util/dsd_state_trunk_lcn.c
         util/enc_lockout.c
         util/dsd_events.c
         util/call_state.c

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -719,11 +719,11 @@ csv_chan_freq_plausible(long int freq) {
     return hz >= CSV_CHAN_FREQ_MIN_HZ && hz <= CSV_CHAN_FREQ_MAX_HZ;
 }
 
-static void
+static int
 csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field, long int* chan_number,
                             int* freq_parsed) {
     if (!state || !field || !chan_number) {
-        return;
+        return 0;
     }
     if (field_count == 0) {
         long int parsed_chan = 0;
@@ -732,14 +732,14 @@ csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field
         } else {
             *chan_number = -1;
         }
-        return;
+        return 0;
     }
     if (field_count != 1) {
-        return;
+        return 0;
     }
 
     if (*chan_number < 0 || *chan_number >= 0xFFFF) {
-        return;
+        return 0;
     }
 
     long int freq = 0;
@@ -751,16 +751,21 @@ csv_chan_import_apply_field(dsd_state* state, int field_count, const char* field
         }
     }
 
-    if (state->lcn_freq_count < 0
-        || state->lcn_freq_count >= (int)(sizeof(state->trunk_lcn_freq) / sizeof(state->trunk_lcn_freq[0]))) {
-        return;
+    if (state->lcn_freq_count < 0) {
+        return 0;
+    }
+    if (dsd_state_trunk_lcn_reserve(state, (size_t)state->lcn_freq_count + 1) != 0) {
+        LOG_ERROR("channel map import out of memory\n");
+        return -1;
     }
 
     // The LCN list is positional -- EDACS reads it in row order -- so a row the
     // map refused still has to take its slot, as a 0 every consumer reads as
-    // "unknown". Dropping it would renumber every LCN below it.
-    state->trunk_lcn_freq[state->lcn_freq_count] = usable ? freq : 0L;
+    // "unknown". Dropping it would renumber every LCN below it. Slots past the
+    // 26 embedded entries land in the heap tail via dsd_state_trunk_lcn_slot().
+    *dsd_state_trunk_lcn_slot(state, state->lcn_freq_count) = usable ? freq : 0L;
     state->lcn_freq_count++; // keep tally of number of Frequencies imported
+    return 0;
 }
 
 /* id_ok may be NULL; set when the key-id column actually parsed as decimal. */
@@ -819,7 +824,7 @@ csv_key_import_dec_apply_field(dsd_state* state, int field_count, const char* fi
     }
 }
 
-/** @brief Parse one channel row into @p state. @return 1 when a frequency loaded. */
+/** @brief Parse one channel row into @p state. @return 1 when a frequency loaded, -1 on allocation failure. */
 static int
 chan_import_row(dsd_state* state, char* buffer, int* out_field_count, long int* out_chan_number) {
     int field_count = 0;
@@ -829,7 +834,9 @@ chan_import_row(dsd_state* state, char* buffer, int* out_field_count, long int* 
 
     const char* field = dsd_strtok_r(buffer, ",", &saveptr); //seperate by comma
     while (field) {
-        csv_chan_import_apply_field(state, field_count, field, &chan_number, &freq_parsed);
+        if (csv_chan_import_apply_field(state, field_count, field, &chan_number, &freq_parsed) != 0) {
+            return -1;
+        }
         field = dsd_strtok_r(NULL, ",", &saveptr);
         field_count++;
     }
@@ -865,6 +872,10 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
             continue;
         }
         const int freq_parsed = chan_import_row(state, buffer, &field_count, &chan_number);
+        if (freq_parsed < 0) {
+            fclose(fp);
+            return -1;
+        }
         if (stats) {
             // A dry run exists to produce the three counters; echoing every row
             // through the process-global logger would put thousands of records
@@ -1241,6 +1252,7 @@ csv_validate_into_throwaway(const char* path, dsd_csv_validation* out, csv_valid
         rc = run(path, state, out);
         dsd_state_ext_free_all(state);
     }
+    dsd_state_trunk_lcn_free(state);
     free(state);
 
     if (rc != 0) {

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -1147,6 +1147,7 @@ freeState(dsd_state* state) {
     }
 
     dsd_state_ext_free_all(state);
+    dsd_state_trunk_lcn_free(state);
 
 #ifdef USE_CODEC2
     if (state->codec2_3200) {

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Scan-list heap tail (slots past the 26 embedded trunk_lcn_freq[]).
+ *
+ * Kept out of dsd_init.c so test targets that link individual core sources
+ * (menu services, UI snapshot, trunk scan) can attach the real implementation
+ * without dragging in the full initState/freeState dependency chain.
+ */
+
+#include <dsd-neo/core/state.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+int
+dsd_state_trunk_lcn_reserve(dsd_state* state, size_t count_needed) {
+    if (!state) {
+        return -1;
+    }
+    if (count_needed <= 26) {
+        return 0;
+    }
+    const size_t ext_needed = count_needed - 26;
+    if (ext_needed <= state->trunk_lcn_freq_ext_capacity) {
+        return 0;
+    }
+    size_t capacity = state->trunk_lcn_freq_ext_capacity > 0 ? state->trunk_lcn_freq_ext_capacity : 16;
+    while (capacity < ext_needed) {
+        if (capacity > SIZE_MAX / 2) {
+            capacity = ext_needed;
+            break;
+        }
+        capacity *= 2;
+    }
+    if (capacity > SIZE_MAX / sizeof(long int)) {
+        return -1;
+    }
+    long int* ext = (long int*)realloc(state->trunk_lcn_freq_ext, capacity * sizeof *ext);
+    if (!ext) {
+        return -1;
+    }
+    DSD_MEMSET(ext + state->trunk_lcn_freq_ext_capacity, 0,
+               (capacity - state->trunk_lcn_freq_ext_capacity) * sizeof *ext);
+    state->trunk_lcn_freq_ext = ext;
+    state->trunk_lcn_freq_ext_capacity = capacity;
+    return 0;
+}
+
+void
+dsd_state_trunk_lcn_free(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    free(state->trunk_lcn_freq_ext);
+    state->trunk_lcn_freq_ext = NULL;
+    state->trunk_lcn_freq_ext_capacity = 0;
+}

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1299,7 +1299,7 @@ no_carrier_step_scanner_mode_if_needed(const dsd_opts* opts, dsd_state* state, t
         state->lcn_freq_roll = 0;
     }
 
-    long int freq = state->trunk_lcn_freq[state->lcn_freq_roll];
+    long int freq = *dsd_state_trunk_lcn_slot(state, state->lcn_freq_roll);
     // Tracks whether the receiver has physically moved yet, so a later leg failing cannot retract a
     // move that already happened. With both rigctl and an RTL front end configured the rigctl leg
     // runs first and commits s_last_rigctl_freq; if the RTL tune then fails the scan step is

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -78,6 +78,9 @@ typedef struct {
     long int trunk_vc_freq[2];
     time_t p25_patch_last_update[8];
     long int trunk_lcn_freq[26];
+    long int* trunk_lcn_freq_ext;
+    size_t trunk_lcn_freq_ext_count;
+    size_t trunk_lcn_freq_ext_capacity;
     dsd_trunk_cc_candidates cc_candidates;
     p25_nb_entry_t p25_nb_entries[P25_NB_MAX];
     p25_secondary_cc_entry_t p25_secondary_cc_entries[P25_SECONDARY_CC_MAX];
@@ -181,7 +184,7 @@ typedef struct {
 } dsd_trunk_scan_target_runtime;
 
 typedef struct {
-    dsd_trunk_scan_target_runtime targets[DSD_TRUNK_SCAN_MAX_TARGETS];
+    dsd_trunk_scan_target_runtime* targets;
     dsd_trunk_scan_snapshot scratch_snapshot;
     size_t count;
     size_t active;
@@ -509,6 +512,31 @@ scan_parse_target_overrides(dsd_trunk_scan_target* target, const dsd_trunk_scan_
 }
 
 static int
+scan_target_list_reserve(dsd_trunk_scan_target_list* list, size_t needed) {
+    if (needed <= list->capacity) {
+        return 0;
+    }
+    size_t capacity = list->capacity > 0 ? list->capacity : 32;
+    while (capacity < needed) {
+        if (capacity > SIZE_MAX / 2) {
+            capacity = needed;
+            break;
+        }
+        capacity *= 2;
+    }
+    if (capacity > SIZE_MAX / sizeof(dsd_trunk_scan_target)) {
+        return -1;
+    }
+    dsd_trunk_scan_target* targets = (dsd_trunk_scan_target*)realloc(list->targets, capacity * sizeof *targets);
+    if (!targets) {
+        return -1;
+    }
+    list->targets = targets;
+    list->capacity = capacity;
+    return 0;
+}
+
+static int
 scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_trunk_scan_row_parse* parse) {
     char* fields[DSD_TRUNK_SCAN_MAX_CSV_FIELDS] = {0};
     size_t field_count = 0;
@@ -558,6 +586,10 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
         return -1;
     }
 
+    if (scan_target_list_reserve(parsed, parsed->count + 1) != 0) {
+        scan_set_error(parse->err, parse->err_sz, "out of memory loading trunk scan targets");
+        return -1;
+    }
     parsed->targets[parsed->count++] = target;
     return 0;
 }
@@ -640,11 +672,6 @@ scan_load_target_csv_rows(FILE* fp, char* line, size_t line_sz, dsd_trunk_scan_t
         if (trimmed_line[0] == '\0') {
             continue;
         }
-        if (parsed->count >= DSD_TRUNK_SCAN_MAX_TARGETS) {
-            scan_set_error(parse->err, parse->err_sz, "too many trunk scan targets (max %d)",
-                           DSD_TRUNK_SCAN_MAX_TARGETS);
-            return -1;
-        }
 
         parse->row = row;
         if (scan_parse_target_row(trimmed_line, parsed, parse) != 0) {
@@ -691,18 +718,57 @@ dsd_trunk_scan_load_targets_csv(const char* path, const dsd_opts* opts, dsd_trun
     int rows_rc = scan_load_target_csv_rows(fp, line, sizeof line, &parsed, &parse);
     fclose(fp);
     if (rows_rc != 0) {
+        dsd_trunk_scan_target_list_reset(&parsed);
         return -1;
     }
     if (parsed.count == 0) {
         scan_set_error(err, err_sz, "trunk scan target CSV has no targets");
+        dsd_trunk_scan_target_list_reset(&parsed);
         return -1;
     }
     *out = parsed;
     return 0;
 }
 
+void
+dsd_trunk_scan_target_list_reset(dsd_trunk_scan_target_list* list) {
+    if (!list) {
+        return;
+    }
+    free(list->targets);
+    list->targets = NULL;
+    list->count = 0;
+    list->capacity = 0;
+}
+
+static int
+trunk_scan_snapshot_lcn_ext_reserve(dsd_trunk_scan_snapshot* snapshot, size_t ext_needed) {
+    if (ext_needed <= snapshot->trunk_lcn_freq_ext_capacity) {
+        return 0;
+    }
+    size_t capacity = snapshot->trunk_lcn_freq_ext_capacity > 0 ? snapshot->trunk_lcn_freq_ext_capacity : 8;
+    while (capacity < ext_needed) {
+        if (capacity > SIZE_MAX / 2) {
+            capacity = ext_needed;
+            break;
+        }
+        capacity *= 2;
+    }
+    if (capacity > SIZE_MAX / sizeof(long int)) {
+        return -1;
+    }
+    long int* ext = (long int*)realloc(snapshot->trunk_lcn_freq_ext, capacity * sizeof *ext);
+    if (!ext) {
+        return -1;
+    }
+    snapshot->trunk_lcn_freq_ext = ext;
+    snapshot->trunk_lcn_freq_ext_capacity = capacity;
+    return 0;
+}
+
 static void
 trunk_scan_snapshot_clear(dsd_trunk_scan_snapshot* snapshot) {
+    free(snapshot->trunk_lcn_freq_ext);
     DSD_MEMSET(snapshot, 0, sizeof(*snapshot));
     snapshot->dmr_mfid = -1;
     snapshot->dmr_color_code = 16;
@@ -814,6 +880,20 @@ trunk_scan_save_p25_identity_snapshot(const dsd_state* state, dsd_trunk_scan_sna
     DSD_MEMCPY(snapshot->trunk_vc_freq, state->trunk_vc_freq, sizeof(snapshot->trunk_vc_freq));
     trunk_scan_save_enc_lockout_snapshot(state, snapshot);
     DSD_MEMCPY(snapshot->trunk_lcn_freq, state->trunk_lcn_freq, sizeof(snapshot->trunk_lcn_freq));
+    if (state->lcn_freq_count > 26) {
+        const size_t ext_count = (size_t)state->lcn_freq_count - 26;
+        if (trunk_scan_snapshot_lcn_ext_reserve(snapshot, ext_count) == 0) {
+            DSD_MEMCPY(snapshot->trunk_lcn_freq_ext, state->trunk_lcn_freq_ext,
+                       ext_count * sizeof(snapshot->trunk_lcn_freq_ext[0]));
+            snapshot->trunk_lcn_freq_ext_count = ext_count;
+        } else {
+            /* Tail capture failed; the dmr save clamps the snapshot count to
+             * the 26 embedded slots so the snapshot stays self-consistent. */
+            snapshot->trunk_lcn_freq_ext_count = 0;
+        }
+    } else {
+        snapshot->trunk_lcn_freq_ext_count = 0;
+    }
     DSD_MEMCPY(snapshot->trunk_chan_map, state->trunk_chan_map, sizeof(snapshot->trunk_chan_map));
     DSD_MEMCPY(snapshot->trunk_chan_map_used, state->trunk_chan_map_used, sizeof(snapshot->trunk_chan_map_used));
     snapshot->trunk_chan_map_used_count = state->trunk_chan_map_used_count;
@@ -1015,6 +1095,10 @@ trunk_scan_save_dmr_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* sn
     snapshot->dmr_rest_channel = state->dmr_rest_channel;
     snapshot->lcn_freq_count = state->lcn_freq_count;
     snapshot->lcn_freq_roll = state->lcn_freq_roll;
+    if (snapshot->lcn_freq_count > 26 && snapshot->trunk_lcn_freq_ext_count == 0) {
+        snapshot->lcn_freq_count = 26;
+        snapshot->lcn_freq_roll = 0;
+    }
     snapshot->is_con_plus = state->is_con_plus;
 }
 
@@ -1031,8 +1115,17 @@ trunk_scan_restore_dmr_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot*
     DSD_MEMCPY(state->dmr_branding_sub, snapshot->dmr_branding_sub, sizeof(state->dmr_branding_sub));
     DSD_MEMCPY(state->dmr_site_parms, snapshot->dmr_site_parms, sizeof(state->dmr_site_parms));
     state->dmr_rest_channel = snapshot->dmr_rest_channel;
-    state->lcn_freq_count = snapshot->lcn_freq_count;
     state->lcn_freq_roll = snapshot->lcn_freq_roll;
+    state->lcn_freq_count = snapshot->lcn_freq_count;
+    if (state->lcn_freq_count > 26) {
+        if (dsd_state_trunk_lcn_reserve(state, (size_t)state->lcn_freq_count) == 0) {
+            DSD_MEMCPY(state->trunk_lcn_freq_ext, snapshot->trunk_lcn_freq_ext,
+                       (size_t)(state->lcn_freq_count - 26) * sizeof(state->trunk_lcn_freq_ext[0]));
+        } else {
+            state->lcn_freq_count = 26;
+            state->lcn_freq_roll = 0;
+        }
+    }
     state->is_con_plus = snapshot->is_con_plus;
 }
 
@@ -1864,9 +1957,22 @@ trunk_scan_uninstall_runtime_hooks(const dsd_trunk_scan_coord* coord) {
 }
 
 static void
+trunk_scan_coord_free(dsd_trunk_scan_coord* coord) {
+    if (!coord) {
+        return;
+    }
+    for (size_t i = 0; i < coord->count; i++) {
+        free(coord->targets[i].snapshot.trunk_lcn_freq_ext);
+    }
+    free(coord->scratch_snapshot.trunk_lcn_freq_ext);
+    free(coord->targets);
+    free(coord);
+}
+
+static void
 trunk_scan_free(void* ptr) {
     trunk_scan_uninstall_runtime_hooks((const dsd_trunk_scan_coord*)ptr);
-    free(ptr);
+    trunk_scan_coord_free((dsd_trunk_scan_coord*)ptr);
 }
 
 static void
@@ -1881,11 +1987,8 @@ trunk_scan_install_runtime_hooks(dsd_trunk_scan_coord* coord) {
     dsd_trunk_scan_hooks_set(hooks);
 }
 
-int
-dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t err_sz) {
-    if (!opts || !state || !opts->trunk_scan_enabled) {
-        return 0;
-    }
+static int
+trunk_scan_init_validate(const dsd_opts* opts, const dsd_state* state, char* err, size_t err_sz) {
     if (opts->scanner_mode == 1) {
         scan_set_error(err, err_sz, "--trunk-scan cannot be combined with -Y scanner mode");
         return -1;
@@ -1906,6 +2009,45 @@ dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t e
         scan_set_error(err, err_sz, "--trunk-scan requires an open RTL input or rigctl tuning");
         return -1;
     }
+    return 0;
+}
+
+static dsd_trunk_scan_coord*
+trunk_scan_coord_create(const dsd_trunk_scan_target_list* list, const dsd_opts* opts, char* err, size_t err_sz) {
+    dsd_trunk_scan_coord* coord = (dsd_trunk_scan_coord*)calloc(1, sizeof(*coord));
+    if (!coord) {
+        scan_set_error(err, err_sz, "failed to allocate trunk scan coordinator");
+        return NULL;
+    }
+    coord->count = list->count;
+    coord->targets = (dsd_trunk_scan_target_runtime*)calloc(list->count, sizeof *coord->targets);
+    if (!coord->targets) {
+        scan_set_error(err, err_sz, "failed to allocate trunk scan targets");
+        free(coord);
+        return NULL;
+    }
+    trunk_scan_capture_saved_opts(coord, opts);
+    return coord;
+}
+
+/* Undo a partially-attached init: restore the global opts the coordinator
+ * captured, release the coordinator and its snapshots, and drop the target
+ * list's owned storage. */
+static void
+trunk_scan_init_release(dsd_opts* opts, dsd_trunk_scan_coord* coord, dsd_trunk_scan_target_list* list) {
+    trunk_scan_restore_saved_opts(opts, coord);
+    trunk_scan_coord_free(coord);
+    dsd_trunk_scan_target_list_reset(list);
+}
+
+int
+dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t err_sz) {
+    if (!opts || !state || !opts->trunk_scan_enabled) {
+        return 0;
+    }
+    if (trunk_scan_init_validate(opts, state, err, err_sz) != 0) {
+        return -1;
+    }
 
     dsd_trunk_scan_target_list list;
     if (dsd_trunk_scan_load_targets_csv(opts->trunk_scan_targets_csv, opts, &list, err, err_sz) != 0) {
@@ -1913,26 +2055,23 @@ dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t e
     }
     trunk_scan_warn_ignored_target_gain(opts, state, &list);
 
-    dsd_trunk_scan_coord* coord = (dsd_trunk_scan_coord*)calloc(1, sizeof(*coord));
+    dsd_trunk_scan_coord* coord = trunk_scan_coord_create(&list, opts, err, err_sz);
     if (!coord) {
-        scan_set_error(err, err_sz, "failed to allocate trunk scan coordinator");
+        dsd_trunk_scan_target_list_reset(&list);
         return -1;
     }
-    coord->count = list.count;
-    trunk_scan_capture_saved_opts(coord, opts);
 
     if (trunk_scan_build_target_runtime(coord, opts, state, &list, err, err_sz) != 0) {
-        trunk_scan_restore_saved_opts(opts, coord);
-        free(coord);
+        trunk_scan_init_release(opts, coord, &list);
         return -1;
     }
 
     if (dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_TRUNK_SCAN, coord, trunk_scan_free) != 0) {
-        trunk_scan_restore_saved_opts(opts, coord);
-        free(coord);
+        trunk_scan_init_release(opts, coord, &list);
         scan_set_error(err, err_sz, "failed to attach trunk scan coordinator");
         return -1;
     }
+    dsd_trunk_scan_target_list_reset(&list);
     trunk_scan_install_runtime_hooks(coord);
     if (trunk_scan_switch_to(opts, state, coord, 0, 0) != 0 && coord->count > 1) {
         trunk_scan_advance(opts, state, coord);

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -214,11 +214,8 @@ p25_diag_freq_in_lcn_list(const dsd_state* state, long freq) {
     if (count < 0) {
         count = 0;
     }
-    if (count > 26) {
-        count = 26;
-    }
     for (int i = 0; i < count; i++) {
-        if (state->trunk_lcn_freq[i] == freq) {
+        if (*dsd_state_trunk_lcn_slot_const(state, i) == freq) {
             return 1;
         }
     }
@@ -4875,8 +4872,8 @@ next_lcn_freq(dsd_state* state, long* out_freq) {
     }
     // Skip duplicates
     if (state->lcn_freq_roll > 0) {
-        long prev = state->trunk_lcn_freq[state->lcn_freq_roll - 1];
-        long cur = state->trunk_lcn_freq[state->lcn_freq_roll];
+        long prev = *dsd_state_trunk_lcn_slot(state, state->lcn_freq_roll - 1);
+        long cur = *dsd_state_trunk_lcn_slot(state, state->lcn_freq_roll);
         if (prev == cur) {
             state->lcn_freq_roll++;
             if (state->lcn_freq_roll >= state->lcn_freq_count) {
@@ -4884,7 +4881,8 @@ next_lcn_freq(dsd_state* state, long* out_freq) {
             }
         }
     }
-    long f = (state->lcn_freq_roll < state->lcn_freq_count) ? state->trunk_lcn_freq[state->lcn_freq_roll] : 0;
+    long f =
+        (state->lcn_freq_roll < state->lcn_freq_count) ? *dsd_state_trunk_lcn_slot(state, state->lcn_freq_roll) : 0;
     state->lcn_freq_roll++;
     if (f != 0) {
         *out_freq = f;

--- a/src/runtime/radioreference/rr_generate.c
+++ b/src/runtime/radioreference/rr_generate.c
@@ -46,10 +46,9 @@
 #define RR_FREQ_MIN_HZ     100000LL
 #define RR_FREQ_MAX_HZ     6000000000LL
 
-/* state->trunk_lcn_freq[] holds 26 entries. EDACS indexes it as lcn - 1 with
- * lcn < 26, so a 26th EDACS row is stored but unreachable; scanner mode rolls
- * over 0..lcn_freq_count-1 and can reach all 26. */
-#define RR_LCN_LIST_MAX    26U
+/* EDACS indexes the runtime's scan list as lcn - 1 with lcn < 26, so only the
+ * first 25 slots are reachable for EDACS. The list itself is heap-backed and
+ * unbounded; scanner mode rolls over 0..lcn_freq_count-1. */
 #define RR_EDACS_LCN_MAX   25U
 
 /* Connect Plus LCNs are 4 bits (dmr_csbk.c); Tier III channel numbers are 12
@@ -694,8 +693,8 @@ typedef struct {
  * Column 2 in row order IS the hunt rotation try_next_cc() walks, so the primary
  * control channel goes first, then the alternates, then every remaining site
  * frequency - on a Phase 2 system any site channel can carry the CC after a
- * rotation or failover. Duplicates are dropped and the list is capped at the 26
- * slots trunk_lcn_freq[] holds. Nothing is ever padded: a 0 slot does not skip
+ * rotation or failover. Duplicates are dropped; the ranked list is bounded by
+ * the site's own frequency count. Nothing is ever padded: a 0 slot does not skip
  * to the next row, it burns a hunt cycle on the known primary, and LCN-sourced
  * probes never get the cooldown a failed candidate-array entry gets.
  *
@@ -707,40 +706,44 @@ typedef struct {
  */
 static size_t
 rr_p25_rank_freqs(const dsd_rr_site* site, size_t* order, size_t max, rr_p25_skips* skips) {
-    long long chosen[RR_LCN_LIST_MAX] = {0};
+    long long* chosen = (long long*)calloc(site->freq_count > 0U ? site->freq_count : 1U, sizeof *chosen);
     size_t count = 0;
 
-    for (int pass = 0; pass < 3; pass++) {
-        for (size_t i = 0; i < site->freq_count; i++) {
-            const dsd_rr_site_freq* freq = &site->freqs[i];
-            const int rank = freq->is_control ? 0 : (freq->is_alt_control ? 1 : 2);
-            if (rank != pass) {
-                continue;
-            }
-            if (!rr_freq_usable(freq->freq_hz)) {
-                skips->unusable++;
-                continue;
-            }
-            int duplicate = 0;
-            for (size_t k = 0; k < count; k++) {
-                if (chosen[k] == freq->freq_hz) {
-                    duplicate = 1;
-                    break;
+    if (chosen) {
+
+        for (int pass = 0; pass < 3; pass++) {
+            for (size_t i = 0; i < site->freq_count; i++) {
+                const dsd_rr_site_freq* freq = &site->freqs[i];
+                const int rank = freq->is_control ? 0 : (freq->is_alt_control ? 1 : 2);
+                if (rank != pass) {
+                    continue;
                 }
+                if (!rr_freq_usable(freq->freq_hz)) {
+                    skips->unusable++;
+                    continue;
+                }
+                int duplicate = 0;
+                for (size_t k = 0; k < count; k++) {
+                    if (chosen[k] == freq->freq_hz) {
+                        duplicate = 1;
+                        break;
+                    }
+                }
+                if (duplicate) {
+                    skips->duplicate++;
+                    continue;
+                }
+                if (count >= max) {
+                    skips->truncated++;
+                    continue;
+                }
+                chosen[count] = freq->freq_hz;
+                order[count] = i;
+                count++;
             }
-            if (duplicate) {
-                skips->duplicate++;
-                continue;
-            }
-            if (count >= max) {
-                skips->truncated++;
-                continue;
-            }
-            chosen[count] = freq->freq_hz;
-            order[count] = i;
-            count++;
         }
     }
+    free(chosen);
     return count;
 }
 
@@ -761,20 +764,28 @@ rr_p25_rank_freqs(const dsd_rr_site* site, size_t* order, size_t max, rr_p25_ski
  */
 static int
 rr_p25_identifiers_usable(const dsd_rr_site* site, const size_t* order, size_t count) {
-    long seen[RR_LCN_LIST_MAX] = {0};
-    for (size_t i = 0; i < count; i++) {
+    long* seen = (long*)calloc(count > 0U ? count : 1U, sizeof *seen);
+    if (!seen) {
+        return 0;
+    }
+    int usable = (count > 0U) ? 1 : 0;
+    for (size_t i = 0; i < count && usable; i++) {
         const long chan = rr_freq_channel(&site->freqs[order[i]], 1);
         if (chan < RR_P25_IDENTIFIER_MIN || chan > RR_CHAN_NUMBER_MAX) {
-            return 0;
+            usable = 0;
         }
         for (size_t k = 0; k < i; k++) {
             if (seen[k] == chan) {
-                return 0;
+                usable = 0;
+                break;
             }
         }
-        seen[i] = chan;
+        if (usable) {
+            seen[i] = chan;
+        }
     }
-    return (count > 0U) ? 1 : 0;
+    free(seen);
+    return usable;
 }
 
 /**
@@ -786,10 +797,21 @@ rr_p25_identifiers_usable(const dsd_rr_site* site, const size_t* order, size_t c
  */
 static void
 rr_chan_p25(const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warnings) {
-    size_t order[RR_LCN_LIST_MAX] = {0};
+    size_t* order = (size_t*)calloc(site->freq_count > 0U ? site->freq_count : 1U, sizeof *order);
+    if (!order) {
+        rr_warn(warnings, "could not allocate the scan list");
+        return;
+    }
     rr_p25_skips skips = {0U, 0U, 0U};
-    const size_t count = rr_p25_rank_freqs(site, order, RR_LCN_LIST_MAX, &skips);
+    size_t count = rr_p25_rank_freqs(site, order, site->freq_count, &skips);
+    /* The ranked indexes reference site->freqs, so the count never exceeds the
+     * site's frequency list by construction; clamping keeps that invariant
+     * visible where the heap allocation is sized. */
+    if (count > site->freq_count) {
+        count = site->freq_count;
+    }
     if (count == 0U) {
+        free(order);
         rr_warn(warnings, "This P25 site lists no usable frequencies, so no channel map was generated.");
         return;
     }
@@ -823,6 +845,7 @@ rr_chan_p25(const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warning
         const long chan = verbatim ? rr_freq_channel(freq, 1) : (long)(i + 1U);
         rr_text_chan_row(text, chan, freq->freq_hz, NULL);
     }
+    free(order);
 }
 
 /**
@@ -1023,11 +1046,14 @@ rr_chan_edacs(const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warni
  */
 static void
 rr_chan_conventional(const dsd_rr_site* sites, size_t site_count, rr_text* text, dsd_rr_warning_list* warnings) {
-    long long chosen[RR_LCN_LIST_MAX] = {0};
+    long long* chosen = (long long*)calloc(site_count > 0U ? site_count : 1U, sizeof *chosen);
+    if (!chosen) {
+        rr_warn(warnings, "could not allocate the scan list");
+        return;
+    }
     size_t count = 0;
     size_t duplicates = 0;
     size_t empty = 0;
-    size_t truncated = 0;
 
     for (size_t i = 0; i < site_count; i++) {
         const long long freq_hz = dsd_rr_site_first_freq_hz(&sites[i]);
@@ -1044,10 +1070,6 @@ rr_chan_conventional(const dsd_rr_site* sites, size_t site_count, rr_text* text,
         }
         if (duplicate) {
             duplicates++;
-            continue;
-        }
-        if (count >= RR_LCN_LIST_MAX) {
-            truncated++;
             continue;
         }
         chosen[count] = freq_hz;
@@ -1067,16 +1089,12 @@ rr_chan_conventional(const dsd_rr_site* sites, size_t site_count, rr_text* text,
                            duplicates);
         rr_warn(warnings, msg);
     }
-    if (truncated > 0U) {
-        (void)DSD_SNPRINTF(msg, sizeof(msg), "%zu selected repeater(s) past the 26-frequency scan limit were dropped.",
-                           truncated);
-        rr_warn(warnings, msg);
-    }
 
     /* One repeater means "tune it and decode": a one-entry scan list makes
      * no_carrier_step_scanner_mode_if_needed() retune to the frequency it is
      * already on at every hangtime expiry, which is pure churn. */
     if (count < 2U) {
+        free(chosen);
         return;
     }
 
@@ -1085,6 +1103,7 @@ rr_chan_conventional(const dsd_rr_site* sites, size_t site_count, rr_text* text,
     }
     rr_warn(warnings, "Scanning across repeaters needs an RTL-SDR or a rigctl-controlled radio; on any other input the "
                       "session stays on the first frequency.");
+    free(chosen);
 }
 
 /**

--- a/src/ui/qt/qml/RadioReferenceScreen.qml
+++ b/src/ui/qt/qml/RadioReferenceScreen.qml
@@ -61,11 +61,6 @@ Item {
     property string notice: ""
     property bool noticeIsProblem: false
 
-    // A scan list holds 26 entries (trunk_lcn_freq[]) and the generator
-    // truncates past that with a warning. Conventional systems can have far more
-    // repeaters than this, so the count is always shown against the ceiling.
-    readonly property int scanListMax: 26
-
     readonly property bool systemLoaded: radioReference.systemDetails.sid !== undefined
                                          && radioReference.systemDetails.sid > 0
 
@@ -1159,11 +1154,10 @@ Item {
                         rightPadding: Theme.cardPadding
                         bottomPadding: 6
                         visible: radioReference.conventional
-                        text: qsTr("%1 of %2 repeaters selected").arg(screen.selectedSites.length)
-                                                                 .arg(screen.scanListMax)
+                        text: qsTr("%1 repeater(s) selected").arg(screen.selectedSites.length)
                         font.family: Theme.sans
                         font.pixelSize: 12
-                        color: screen.selectedSites.length > screen.scanListMax ? Theme.magenta : Theme.textSubdued
+                        color: Theme.textSubdued
                         wrapMode: Text.Wrap
                     }
 

--- a/src/ui/qt/radio_reference_model.h
+++ b/src/ui/qt/radio_reference_model.h
@@ -26,6 +26,7 @@
 #ifndef DSD_NEO_SRC_UI_QT_RADIO_REFERENCE_MODEL_H_
 #define DSD_NEO_SRC_UI_QT_RADIO_REFERENCE_MODEL_H_
 
+#include <QByteArray>
 #include <QList>
 #include <QMap>
 #include <QObject>

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -849,7 +849,8 @@ ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* stat
     if (opts->scanner_mode == 1) {
         printw("| Scan Mode: ");
         if (state->lcn_freq_roll != 0) {
-            printw(" Frequency: %.06lf MHz", (double)state->trunk_lcn_freq[state->lcn_freq_roll - 1] / 1000000);
+            printw(" Frequency: %.06lf MHz",
+                   (double)*dsd_state_trunk_lcn_slot_const(state, state->lcn_freq_roll - 1) / 1000000);
         }
         printw(" Speed: %.02lf sec \n",
                opts->trunk_hangtime); // default aligned to OP25 (2.0s) unless overridden

--- a/src/ui/terminal/rr_panel.c
+++ b/src/ui/terminal/rr_panel.c
@@ -803,13 +803,7 @@ rr_panel_draw_heading(WINDOW* win, int body_w, const dsd_rr_system_info* info, c
     if (cx <= (int)strlen(line) + 2) {
         return;
     }
-    if (counter.over_cap) {
-        wattron(win, COLOR_PAIR(RR_PANEL_CP_WARN) | A_BOLD);
-    }
     mvwaddnstr(win, 2, cx, counter.text, (int)strlen(counter.text));
-    if (counter.over_cap) {
-        wattroff(win, COLOR_PAIR(RR_PANEL_CP_WARN) | A_BOLD);
-    }
 }
 
 static void

--- a/src/ui/terminal/rr_panel_format.c
+++ b/src/ui/terminal/rr_panel_format.c
@@ -18,6 +18,7 @@
 #include <dsd-neo/runtime/radioreference.h>
 #include <dsd-neo/runtime/radioreference_generate.h>
 #include <dsd-neo/runtime/radioreference_import.h>
+#include <stdlib.h>
 
 /**
  * @brief Resolve the row's trailing tag and the frequency it advertises.
@@ -80,23 +81,26 @@ rr_panel_counter_state(const dsd_rr_site* sites, size_t site_count, rr_panel_sit
         return;
     }
     DSD_MEMSET(out, 0, sizeof *out);
-    out->cap = RR_PANEL_LCN_CAP;
-    long long chosen[RR_PANEL_LCN_CAP];
-    DSD_MEMSET(chosen, 0, sizeof chosen);
+    long long* chosen = (long long*)calloc(site_count > 0U ? site_count : 1U, sizeof *chosen);
+    if (chosen == NULL) {
+        (void)DSD_SNPRINTF(out->text, sizeof out->text, "[ selection unavailable ]");
+        return;
+    }
+    size_t count = 0;
     if (sites != NULL && is_selected != NULL) {
         for (size_t i = 0; i < site_count; i++) {
             if (!is_selected(user, i)) {
                 continue;
             }
             /* Mirrors rr_chan_conventional (src/runtime/radioreference/rr_generate.c): empty
-             * first, then duplicate, then the cap - so the cap counts DISTINCT frequencies. */
+             * first, then duplicates - the kept count is DISTINCT frequencies, with no cap. */
             const long long hz = dsd_rr_site_first_freq_hz(&sites[i]);
             if (hz == 0) {
                 out->empty++;
                 continue;
             }
             int duplicate = 0;
-            for (int k = 0; k < out->kept; k++) {
+            for (size_t k = 0; k < count; k++) {
                 if (chosen[k] == hz) {
                     duplicate = 1;
                     break;
@@ -106,20 +110,13 @@ rr_panel_counter_state(const dsd_rr_site* sites, size_t site_count, rr_panel_sit
                 out->duplicates++;
                 continue;
             }
-            if (out->kept >= out->cap) {
-                out->dropped++;
-                continue;
-            }
-            chosen[out->kept] = hz;
-            out->kept++;
+            chosen[count] = hz;
+            count++;
         }
     }
-    out->over_cap = (out->dropped > 0) ? 1 : 0;
-    if (out->over_cap) {
-        (void)DSD_SNPRINTF(out->text, sizeof out->text, "[ %d of %d - %d dropped ]", out->kept, out->cap, out->dropped);
-        return;
-    }
-    (void)DSD_SNPRINTF(out->text, sizeof out->text, "[ %d of %d ]", out->kept, out->cap);
+    out->kept = (int)count;
+    free(chosen);
+    (void)DSD_SNPRINTF(out->text, sizeof out->text, "[ %d distinct frequencies ]", out->kept);
 }
 
 // cppcheck-suppress-end funcArgNamesDifferentUnnamed

--- a/src/ui/terminal/rr_panel_format.h
+++ b/src/ui/terminal/rr_panel_format.h
@@ -19,18 +19,11 @@
 #include <dsd-neo/runtime/radioreference.h>
 #include <dsd-neo/runtime/radioreference_import.h>
 
-/* Mirrors RR_LCN_LIST_MAX (`#define RR_LCN_LIST_MAX    26U` in
- * src/runtime/radioreference/rr_generate.c), which is file-static there. */
-#define RR_PANEL_LCN_CAP 26
-
 typedef struct {
-    int kept;       /* distinct usable frequencies kept, 0..RR_PANEL_LCN_CAP */
+    int kept;       /* distinct usable frequencies kept, no cap */
     int empty;      /* selected sites whose first usable frequency is 0 */
     int duplicates; /* selected sites repeating an already-kept frequency */
-    int dropped;    /* selected sites past the cap */
-    int cap;        /* always RR_PANEL_LCN_CAP */
-    int over_cap;   /* dropped > 0 */
-    char text[40];  /* "[ 3 of 26 ]" or "[ 26 of 26 - 1 dropped ]" */
+    char text[40];  /* "[ 3 distinct frequencies ]" */
 } RrPanelCounter;
 
 typedef int (*rr_panel_site_selected_fn)(const void* user, size_t index);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1526,6 +1526,8 @@ add_executable(
     # svc_clear_keys() drops the DMR TG->key ID map through keyring_dmr_tg_map_reset().
     ${PROJECT_SOURCE_DIR}/src/core/vocoder/keyring.c
     ${PROJECT_SOURCE_DIR}/src/core/vocoder/keyring_dmr_tg_map.c
+    # chan_map_adopt()/svc_clear_channel_map() own the scan-list heap tail.
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
 )
 target_include_directories(
     dsd-neo_test_ui_menu_services
@@ -2782,6 +2784,7 @@ add_executable(
     ui/test_ui_snapshot_event_history.c
     ${PROJECT_SOURCE_DIR}/src/core/util/talkgroup_policy.c
     ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
     ${PROJECT_SOURCE_DIR}/src/core/util/synctype.c
     ${PROJECT_SOURCE_DIR}/src/app_control/call_view.c
     ${PROJECT_SOURCE_DIR}/src/app_control/notification_status.c
@@ -4194,6 +4197,7 @@ add_executable(
     engine/test_engine_trunk_scan.c
     ${PROJECT_SOURCE_DIR}/src/engine/trunk_scan.c
     ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
 )
 target_include_directories(
     dsd-neo_test_engine_trunk_scan

--- a/tests/core/test_core_csv_import.c
+++ b/tests/core/test_core_csv_import.c
@@ -52,6 +52,7 @@ static void
 free_test_state(dsd_state* state) {
     if (state) {
         dsd_state_ext_free_all(state);
+        dsd_state_trunk_lcn_free(state);
     }
     free(state);
 }
@@ -547,6 +548,75 @@ test_channel_import_rejects_malformed_rows_without_reusing_previous_channel(void
     }
     if (state->lcn_freq_count != 3 || state->trunk_lcn_freq[0] != 851000000L || state->trunk_lcn_freq[1] != 0L
         || state->trunk_lcn_freq[2] != 853000000L) {
+        failed = 1;
+    }
+
+    (void)remove(tmpl);
+    free(opts);
+    free_test_state(state);
+    return failed;
+}
+
+static int
+test_channel_import_extends_past_26_entries(void) {
+    int failed = 0;
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    char tmpl[] = "dsd-neo-test-channel-large-XXXXXX";
+    int fd = -1;
+
+    if (!opts || !state) {
+        free(opts);
+        free_test_state(state);
+        return 1;
+    }
+    fd = dsd_mkstemp(tmpl);
+    if (fd < 0) {
+        free(opts);
+        free_test_state(state);
+        return 1;
+    }
+    (void)dsd_close(fd);
+
+    // 40 data rows: every row takes its positional LCN slot, so slots run
+    // past the 26 embedded trunk_lcn_freq entries into the heap tail. Channel
+    // 2 carries a garbage frequency to prove the 0-placeholder pattern
+    // (existing test) survives on both sides of the 26-entry boundary.
+    char body[2048];
+    body[0] = '\0';
+    (void)DSD_SNPRINTF(body + strlen(body), sizeof(body) - strlen(body), "channel,frequency\n");
+    for (int i = 1; i <= 40; i++) {
+        if (i == 2) {
+            (void)DSD_SNPRINTF(body + strlen(body), sizeof(body) - strlen(body), "%d,notafrequency\n", i);
+        } else {
+            (void)DSD_SNPRINTF(body + strlen(body), sizeof(body) - strlen(body), "%d,%ld\n", i,
+                               851000000L + (long)(i - 1) * 12500L);
+        }
+    }
+    if (write_text_file(tmpl, body) != 0) {
+        (void)remove(tmpl);
+        free(opts);
+        free_test_state(state);
+        return 1;
+    }
+
+    DSD_SNPRINTF(opts->chan_in_file, sizeof(opts->chan_in_file), "%s", tmpl);
+    if (csvChanImport(opts, state) != 0) {
+        DSD_FPRINTF(stderr, "40-row channel import returned error\n");
+        failed = 1;
+    }
+    if (state->lcn_freq_count != 40 || state->trunk_lcn_freq_ext == NULL || state->trunk_lcn_freq_ext_capacity < 14U) {
+        DSD_FPRINTF(stderr, "channel import tail state wrong count=%d ext=%p cap=%zu\n", state->lcn_freq_count,
+                    (void*)state->trunk_lcn_freq_ext, state->trunk_lcn_freq_ext_capacity);
+        failed = 1;
+    }
+    if (state->trunk_lcn_freq[0] != 851000000L || state->trunk_lcn_freq[1] != 0L
+        || state->trunk_lcn_freq[2] != 851025000L) {
+        DSD_FPRINTF(stderr, "embedded LCN slot pattern broken\n");
+        failed = 1;
+    }
+    if (*dsd_state_trunk_lcn_slot(state, 26) != 851325000L || *dsd_state_trunk_lcn_slot(state, 39) != 851487500L) {
+        DSD_FPRINTF(stderr, "ext LCN tail rows 27/40 mismatch\n");
         failed = 1;
     }
 
@@ -1092,6 +1162,9 @@ main(void) {
         return 1;
     }
     if (test_channel_import_rejects_malformed_rows_without_reusing_previous_channel() != 0) {
+        return 1;
+    }
+    if (test_channel_import_extends_past_26_entries() != 0) {
         return 1;
     }
     if (test_group_import_range_after_many_exact_rows() != 0) {

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -649,6 +649,47 @@ main(void) {
         return 1;
     }
 
+    // Scan lists past 26 entries spill into a heap tail; the scanner step has to
+    // hop through those via dsd_state_trunk_lcn_slot() exactly like the embedded
+    // slots, and wrap from the tail back to the head of the list.
+    opts->scanner_mode = 1;
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_hangtime = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    rc |= expect_true("scanner-ext-tail-reserve", dsd_state_trunk_lcn_reserve(state, 30) == 0);
+    for (int i = 0; i < 30; i++) {
+        *dsd_state_trunk_lcn_slot(state, i) = 944012500 + 12500 * (long)i;
+    }
+    state->lcn_freq_count = 30;
+    state->lcn_freq_roll = 26;
+    state->last_cc_sync_time = time(NULL) - 11;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_tune_calls = 0;
+
+    noCarrier(opts, state);
+
+    rc |= expect_true("scanner-ext-tail-hop-retuned", g_rtl_tune_calls > 0 && g_rtl_tune_freq == 944337500U);
+    rc |= expect_true("scanner-ext-tail-hop-advanced", state->lcn_freq_roll == 27);
+
+    state->lcn_freq_roll = 29;
+    state->last_cc_sync_time = time(NULL) - 11;
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("scanner-ext-tail-last-retuned", g_rtl_tune_calls > 0 && g_rtl_tune_freq == 944375000U);
+    rc |= expect_true("scanner-ext-tail-last-advanced", state->lcn_freq_roll == 30);
+
+    // roll == count wraps to the head on the next pass (engine.c clamps before reading).
+    state->last_cc_sync_time = time(NULL) - 11;
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("scanner-ext-tail-wraps-to-head", g_rtl_tune_calls > 0 && g_rtl_tune_freq == 944012500U);
+    rc |= expect_true("scanner-ext-tail-wrap-advanced", state->lcn_freq_roll == 1);
+
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
     // With both backends configured the rigctl leg runs first. If it lands and the RTL leg then
     // fails, the scan step is abandoned -- but the radio has already moved off the frequency the
     // open call was decoded from. The end must still be EXPLICIT: reporting sync loss would leave

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -384,6 +384,7 @@ test_parser_valid_mixed_targets_and_relative_chan_csv(void) {
         }
     }
 
+    dsd_trunk_scan_target_list_reset(&list);
     cleanup_paths(dir, target_path, chan_path);
     return test_rc;
 }
@@ -423,6 +424,7 @@ test_parser_accepts_quoted_chan_csv_with_comma(void) {
         test_rc = 1;
     }
 
+    dsd_trunk_scan_target_list_reset(&list);
     cleanup_paths(dir, target_path, chan_path);
     return test_rc;
 }
@@ -477,6 +479,7 @@ test_parser_accepts_optional_modulation_and_gain_columns(void) {
         }
     }
 
+    dsd_trunk_scan_target_list_reset(&list);
     cleanup_paths(dir, target_path, NULL);
     return test_rc;
 }
@@ -498,9 +501,12 @@ expect_parser_rejects(const char* name, const char* body) {
     opts.trunk_scan_idle_dwell_ms = 3000;
     opts.trunk_scan_activity_hold_ms = 1200;
     dsd_trunk_scan_target_list list;
-    DSD_MEMSET(&list, 0xA5, sizeof list);
+    static dsd_trunk_scan_target sentinel[7];
+    DSD_MEMSET(sentinel, 0, sizeof sentinel);
+    DSD_SNPRINTF(sentinel[0].id, sizeof sentinel[0].id, "%s", "sentinel");
+    list.targets = sentinel;
     list.count = 7;
-    DSD_SNPRINTF(list.targets[0].id, sizeof list.targets[0].id, "%s", "sentinel");
+    list.capacity = 7;
     char err[256] = {0};
     int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
     int test_rc = 0;
@@ -508,7 +514,8 @@ expect_parser_rejects(const char* name, const char* body) {
         DSD_FPRINTF(stderr, "%s should have been rejected\n", name);
         test_rc = 1;
     }
-    if (list.count != 7 || strcmp(list.targets[0].id, "sentinel") != 0) {
+    if (list.count != 7 || list.targets != sentinel || list.capacity != 7
+        || strcmp(list.targets[0].id, "sentinel") != 0) {
         DSD_FPRINTF(stderr, "%s mutated output on failure\n", name);
         test_rc = 1;
     }
@@ -578,17 +585,45 @@ test_parser_rejects_invalid_inputs(void) {
 }
 
 static int
-test_parser_rejects_too_many_targets(void) {
+test_parser_accepts_100_targets(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
     char body[8192];
     body[0] = '\0';
-    for (int i = 0; i < DSD_TRUNK_SCAN_MAX_TARGETS + 1; i++) {
+    for (int i = 0; i < 100; i++) {
         char row[128];
         DSD_SNPRINTF(row, sizeof row, "id%d,dmr-conventional,%u,,,,\n", i, 461000000U + (unsigned)i);
         if (append_text(body, sizeof body, row) != 0) {
+            cleanup_paths(dir, NULL, NULL);
             return 1;
         }
     }
-    return expect_parser_rejects("too-many-targets", body);
+    char target_path[DSD_TEST_PATH_MAX];
+    if (write_targets_file(dir, body, target_path, sizeof target_path) != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.trunk_scan_idle_dwell_ms = 3000;
+    opts.trunk_scan_activity_hold_ms = 1200;
+    dsd_trunk_scan_target_list list;
+    DSD_MEMSET(&list, 0, sizeof list);
+    char err[256] = {0};
+    int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || list.count != 100 || list.targets == NULL || strcmp(list.targets[99].id, "id99") != 0
+        || list.targets[99].frequency_hz != 461000099U || list.targets[99].dwell_ms != 3000
+        || list.targets[99].activity_hold_ms != 1200) {
+        DSD_FPRINTF(stderr, "parser 100 targets rc=%d count=%zu err=%s\n", rc, list.count, err);
+        test_rc = 1;
+    }
+    dsd_trunk_scan_target_list_reset(&list);
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
 }
 
 static int
@@ -904,6 +939,60 @@ test_coordinator_idle_rotation_and_state_restore(void) {
         test_rc = 1;
     }
     test_rc |= expect_target0_p25_state(&state);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_coordinator_rotation_past_32_targets(void) {
+    char body[8192];
+    body[0] = '\0';
+    for (int i = 0; i < 40; i++) {
+        char row[128];
+        DSD_SNPRINTF(row, sizeof row, "id%d,dmr-conventional,%u,,,,\n", i, 461000000U + (unsigned)i);
+        if (append_text(body, sizeof body, row) != 0) {
+            return 1;
+        }
+    }
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets(body, target_path, sizeof target_path, dir, sizeof dir) != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "scan init 40 targets failed rc=%d err=%s\n", rc, err);
+        test_rc = 1;
+    }
+    for (size_t i = 1; i < 40 && test_rc == 0; i++) {
+        trunk_scan_test_set_now(0.25 * (double)i);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        if (dsd_engine_trunk_scan_active_index(&state) != i) {
+            DSD_FPRINTF(stderr, "scan rotation stalled at index %zu (expected %zu)\n",
+                        dsd_engine_trunk_scan_active_index(&state), i);
+            test_rc = 1;
+        }
+    }
+    if (test_rc == 0) {
+        trunk_scan_test_set_now(0.25 * 40.0);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+            DSD_FPRINTF(stderr, "scan did not wrap from index 39 to 0\n");
+            test_rc = 1;
+        }
+    }
 
     dsd_engine_trunk_scan_shutdown(&opts, &state);
     trunk_scan_test_clear_now();
@@ -3543,8 +3632,9 @@ main(void) {
     rc |= run_with_default_tune_hook(test_parser_accepts_quoted_chan_csv_with_comma);
     rc |= run_with_default_tune_hook(test_parser_accepts_optional_modulation_and_gain_columns);
     rc |= run_with_default_tune_hook(test_parser_rejects_invalid_inputs);
-    rc |= run_with_default_tune_hook(test_parser_rejects_too_many_targets);
+    rc |= run_with_default_tune_hook(test_parser_accepts_100_targets);
     rc |= run_with_default_tune_hook(test_coordinator_idle_rotation_and_state_restore);
+    rc |= run_with_default_tune_hook(test_coordinator_rotation_past_32_targets);
     rc |= run_with_default_tune_hook(test_call_identity_state_isolated_per_target);
     rc |= run_with_default_tune_hook(test_call_event_lifecycle_isolated_per_target);
     rc |= run_with_default_tune_hook(test_call_event_current_rows_isolated_per_target);

--- a/tests/fixtures/radioreference/NOTES.md
+++ b/tests/fixtures/radioreference/NOTES.md
@@ -199,8 +199,9 @@ What the wire actually shows, across sid 9340 (36 sites) and sid 12244 (2 sites)
 - Site descriptions are plain place names (`Waukee`, `Ames`, `Marion`, `North Liberty`), which is
   what makes a multi-site picker usable.
 
-**Why 36 sites matters:** `state->trunk_lcn_freq[]` holds 26 entries, so a scan list built from
-this system must truncate and warn. That is the golden the fixture exists for.
+**Why 36 sites matters:** the runtime scan list is heap-backed and unbounded, so a scan list built
+from this system now carries every distinct repeater (33) without truncating. The fixture exercises
+a large list end to end — dedup, row count, and round-trip — at a size old 26-slot builds cut off.
 
 **No NXDN Conventional Networked system was findable** in any of the 33 counties probed across
 Iowa and Florida, though flavor 45 is in the live flavor table. The classifier branch is therefore

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -69,6 +69,8 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/src/core/file/dsd_import.c
         ${PROJECT_SOURCE_DIR}/src/core/util/bit_packing.c
         ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
+        # dsd_import.c owns the scan-list heap tail through these.
+        ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
         ${PROJECT_SOURCE_DIR}/src/core/util/talkgroup_policy.c
         # csvDmrTgKeyImport() clears the live map through keyring_dmr_tg_map_reset().
         ${PROJECT_SOURCE_DIR}/src/core/vocoder/keyring.c

--- a/tests/runtime/test_runtime_rr_generate.c
+++ b/tests/runtime/test_runtime_rr_generate.c
@@ -737,9 +737,10 @@ test_chan_p25_identifiers(void) {
 }
 
 static void
-test_chan_p25_cap(void) {
-    /* trunk_lcn_freq[] holds 26 entries and nothing is ever padded: a 0 slot
-     * does not skip to the next row, it burns a hunt cycle. */
+test_chan_p25_full_list(void) {
+    /* The ranked hunt list is heap-backed and bounded only by the site's own
+     * frequency count, and nothing is ever padded: a 0 slot does not skip to
+     * the next row, it burns a hunt cycle. */
     dsd_rr_site_freq freqs[30];
     for (int i = 0; i < 30; i++) {
         freq_set(&freqs[i], i + 1, 851000000LL + ((long long)i * 12500LL), (i == 0) ? "d" : "", NULL);
@@ -751,8 +752,9 @@ test_chan_p25_cap(void) {
     size_t len = 0;
     dsd_rr_warning_list warnings;
     DSD_MEMSET(&warnings, 0, sizeof(warnings));
-    expect("p25 capped generated", dsd_rr_generate_chan_csv(DSD_RR_PROTO_P25, &site, 1U, &text, &len, &warnings) == 0);
-    expect("p25 truncation warned", warned(&warnings, "26-slot"));
+    expect("p25 full list generated",
+           dsd_rr_generate_chan_csv(DSD_RR_PROTO_P25, &site, 1U, &text, &len, &warnings) == 0);
+    expect("p25 no truncation warning", !warned(&warnings, "26-slot"));
 
     size_t rows = 0;
     for (const char* p = text; p != NULL && *p != '\0'; p++) {
@@ -760,13 +762,13 @@ test_chan_p25_cap(void) {
             rows++;
         }
     }
-    expect_size("p25 capped at 26 rows plus header", rows, 27U);
+    expect_size("p25 emits 30 rows plus header", rows, 31U);
     expect("p25 emits no zero placeholder", strstr(text, ",0\n") == NULL);
 
     dsd_csv_validation counts;
     DSD_MEMSET(&counts, 0, sizeof(counts));
     if (validate_generated(text, 0, &counts) == 0) {
-        expect_counts("p25 round-trip", &counts, 26U, 0U);
+        expect_counts("p25 round-trip", &counts, 30U, 0U);
     }
     free(text);
     dsd_rr_warning_list_free(&warnings);
@@ -911,8 +913,8 @@ test_chan_tier3_fixture(void) {
 
 static void
 test_chan_tier3_no_false_cap(void) {
-    /* The 26-entry limit applies only to the positional LCN list. Rows past it
-     * still land in trunk_chan_map[], which is 0xFFFF wide, so DMR and NXDN maps
+    /* The positional LCN list is heap-backed and unbounded, and DMR/NXDN rows
+     * land in trunk_chan_map[], which is 0xFFFF wide, so DMR and NXDN maps
      * must not be capped or warned about. */
     dsd_rr_site_freq freqs[30];
     char ch_id[8];
@@ -1217,19 +1219,19 @@ test_chan_conventional_truncation(void) {
         dsd_rr_site_list_free(&sites);
         return;
     }
-    /* 36 single-frequency repeaters, 33 of them distinct: this is the fixture
-     * that forces the 26-slot truncation. */
+    /* 36 single-frequency repeaters, 33 of them distinct: this fixture
+     * exercises a large scan list that pre-2026 builds truncated at 26 rows;
+     * every distinct repeater now lands in the map. */
     expect_size("36 conventional repeaters", sites.count, 36U);
 
     char* text = NULL;
     size_t len = 0;
     dsd_rr_warning_list warnings;
     DSD_MEMSET(&warnings, 0, sizeof(warnings));
-    expect("conventional truncated generated",
+    expect("conventional full list generated",
            dsd_rr_generate_chan_csv(DSD_RR_PROTO_DMR_CONV, sites.items, sites.count, &text, &len, &warnings) == 0);
     expect("conventional duplicates warned", warned(&warnings, "3 selected repeater(s) share a frequency"));
-    expect("conventional truncation warned",
-           warned(&warnings, "7 selected repeater(s) past the 26-frequency scan limit"));
+    expect("conventional no truncation warning", !warned(&warnings, "past the 26-frequency scan limit"));
 
     size_t rows = 0;
     for (const char* p = text; p != NULL && *p != '\0'; p++) {
@@ -1237,16 +1239,16 @@ test_chan_conventional_truncation(void) {
             rows++;
         }
     }
-    expect_size("conventional capped at 26 rows plus header", rows, 27U);
+    expect_size("conventional emits 33 rows plus header", rows, 34U);
     expect("conventional first row", text != NULL && strstr(text, "\n1,146755000\n") != NULL);
-    expect("conventional last row", text != NULL && strstr(text, "\n26,443200000\n") != NULL);
+    expect("conventional has a 33rd row", text != NULL && strstr(text, "\n33,") != NULL);
 
     dsd_csv_validation counts;
     DSD_MEMSET(&counts, 0, sizeof(counts));
     if (text != NULL && validate_generated(text, 0, &counts) == 0) {
-        /* All 26 are reachable here: scanner mode rolls over 0..count-1 rather
+        /* All 33 are reachable here: scanner mode rolls over 0..count-1 rather
          * than indexing lcn - 1, unlike EDACS. */
-        expect_counts("conventional round-trip", &counts, 26U, 0U);
+        expect_counts("conventional round-trip", &counts, 33U, 0U);
     }
     free(text);
     dsd_rr_warning_list_free(&warnings);
@@ -1333,7 +1335,7 @@ main(void) {
     test_group_csv_fixture();
     test_chan_p25_ranking();
     test_chan_p25_identifiers();
-    test_chan_p25_cap();
+    test_chan_p25_full_list();
     test_chan_p25_fixture();
     test_chan_conplus();
     test_chan_tier3_fixture();

--- a/tests/runtime/test_runtime_rr_import.c
+++ b/tests/runtime/test_runtime_rr_import.c
@@ -744,12 +744,12 @@ test_plan_blocked(void) {
 
 static void
 test_plan_site_ids_large_selection(void) {
-    /* The scan list caps at 26 frequencies (RR_LCN_LIST_MAX) and says so in a
-     * warning, so a big conventional selection has always produced a usable
-     * 26-row map plus the full talkgroup list. site_ids only records the
-     * selection for a later refresh, and refusing the whole import - talkgroups
-     * included - over that bookkeeping field was disproportionate. A selection
-     * this size must build. */
+    /* The scan list is heap-backed and unbounded, so a big conventional
+     * selection produces a full map plus the full talkgroup list, with no
+     * truncation warning. site_ids only records the selection for a later
+     * refresh, and refusing the whole import - talkgroups included - over
+     * that bookkeeping field was disproportionate. A selection this size
+     * must build. */
     enum { RR_TEST_LARGE = 200 };
 
     dsd_rr_site_freq freqs[RR_TEST_LARGE];
@@ -777,8 +777,15 @@ test_plan_site_ids_large_selection(void) {
     /* First and last id both survive: a silent truncation would drop the tail. */
     expect("id list starts at the first selection", strncmp(plan.site_ids, "10000,", 6) == 0);
     expect("id list ends at the last selection", strstr(plan.site_ids, ",10199") != NULL);
-    expect("the scan-list cap is reported rather than the import refused",
-           warned(&plan.warnings, "174 selected repeater(s) past the 26-frequency scan limit were dropped."));
+    expect("the scan list is not truncated", !warned(&plan.warnings, "past the 26-frequency scan limit"));
+    /* The plan carries the full deduped list: 200 data rows plus header. */
+    size_t rows = 0;
+    for (const char* p = plan.chan_csv_text; p != NULL && *p != '\0'; p++) {
+        if (*p == '\n') {
+            rows++;
+        }
+    }
+    expect("plan chan map carries all 200 rows", rows == (size_t)RR_TEST_LARGE + 1U);
     dsd_rr_import_plan_free(&plan);
 }
 

--- a/tests/ui/qml/tst_radioreference_screen.qml
+++ b/tests/ui/qml/tst_radioreference_screen.qml
@@ -211,12 +211,15 @@ Item {
             var count = findChild(tc.screen, "radioReferenceRepeaterCount")
             tryVerify(function () { return count.visible },
                       2000, "a conventional system did not show the repeater count")
-            verify(count.text.indexOf("26") >= 0,
-                   "the repeater count does not name the 26-entry ceiling: " + count.text)
+            // The count line reports the selection itself; the scan list grows
+            // with every distinct repeater, so no ceiling is promised here.
+            compare(count.text, "0 repeater(s) selected",
+                    "the repeater count does not read the empty selection")
 
             tc.screen.toggleSite(0)
             tc.screen.toggleSite(1)
             compare(tc.screen.selectedSites.length, 2, "a conventional system refused a second repeater")
+            compare(count.text, "2 repeater(s) selected", "the repeater count did not follow the selection")
             tc.screen.toggleSite(0)
             compare(tc.screen.selectedSites.length, 1, "tapping a chosen repeater did not deselect it")
 

--- a/tests/ui/test_ui_qt_radio_reference_model.cpp
+++ b/tests/ui/test_ui_qt_radio_reference_model.cpp
@@ -557,15 +557,18 @@ test_conventional_system(void) {
     expect_str("one repeater takes plain -fs", single.value(QStringLiteral("decodeFlag")).toString(),
                QStringLiteral("-fs"));
 
-    /* Past 26 the generator truncates, and the user has to be told. */
+    /* No ceiling: every distinct repeater frequency lands in the map however
+     * long the list grows — pre-2026 builds truncated at 26 rows. These 30
+     * repeaters carry 27 distinct frequencies. */
     QVariantList many;
     for (int i = 0; i < 30; i++) {
         many.append(i);
     }
-    const QVariantMap capped = h.model.buildImportPlan(many, QVariantMap());
-    expect_int("the scan list caps at 26 rows", row_count(capped.value(QStringLiteral("chanCsvText")).toString()), 27);
-    expect("truncation is reported", warned(capped, QStringLiteral("scan limit")));
-    expect("shared repeater frequencies are reported", warned(capped, QStringLiteral("share a frequency")));
+    const QVariantMap uncapped = h.model.buildImportPlan(many, QVariantMap());
+    expect_int("all 27 distinct frequencies are emitted",
+               row_count(uncapped.value(QStringLiteral("chanCsvText")).toString()), 28);
+    expect("no truncation warning", !warned(uncapped, QStringLiteral("scan limit")));
+    expect("shared repeater frequencies are reported", warned(uncapped, QStringLiteral("share a frequency")));
 }
 
 void

--- a/tests/ui/test_ui_rr_panel.c
+++ b/tests/ui/test_ui_rr_panel.c
@@ -83,7 +83,7 @@ test_site_row_conventional_with_color_code(void) {
 }
 
 static void
-test_counter_under_cap(void) {
+test_counter_counts_distinct_frequencies(void) {
     dsd_rr_site_freq freqs[3];
     dsd_rr_site sites[3];
     const long long hz[3] = {146755000LL, 444525000LL, 443125000LL};
@@ -97,16 +97,13 @@ test_counter_under_cap(void) {
     assert(counter.kept == 3);
     assert(counter.empty == 0);
     assert(counter.duplicates == 0);
-    assert(counter.dropped == 0);
-    assert(counter.cap == 26);
-    assert(counter.over_cap == 0);
-    assert(strcmp(counter.text, "[ 3 of 26 ]") == 0);
+    assert(strcmp(counter.text, "[ 3 distinct frequencies ]") == 0);
 }
 
 static void
-test_counter_over_cap_needs_distinct_frequencies(void) {
-    /* 27 selected repeaters with 27 DISTINCT frequencies: the generator caps on distinct
-     * frequencies, so 26 are kept and exactly one is dropped. */
+test_counter_keeps_every_distinct_frequency(void) {
+    /* 27 selected repeaters with 27 DISTINCT frequencies: the scan list is
+     * unbounded, so all 27 are kept. */
     dsd_rr_site_freq freqs[27];
     dsd_rr_site sites[27];
     for (size_t i = 0; i < 27; i++) {
@@ -116,14 +113,12 @@ test_counter_over_cap_needs_distinct_frequencies(void) {
     }
     RrPanelCounter counter;
     rr_panel_counter_state(sites, 27, select_all, NULL, &counter);
-    assert(counter.kept == 26);
-    assert(counter.dropped == 1);
-    assert(counter.over_cap == 1);
-    assert(strcmp(counter.text, "[ 26 of 26 - 1 dropped ]") == 0);
+    assert(counter.kept == 27);
+    assert(strcmp(counter.text, "[ 27 distinct frequencies ]") == 0);
 }
 
 static void
-test_counter_drops_empty_and_duplicates_before_the_cap(void) {
+test_counter_skips_empty_and_duplicates(void) {
     dsd_rr_site_freq freqs[3];
     dsd_rr_site sites[4];
     const long long hz[3] = {146755000LL, 146755000LL, 443125000LL};
@@ -139,9 +134,7 @@ test_counter_drops_empty_and_duplicates_before_the_cap(void) {
     assert(counter.kept == 2);
     assert(counter.duplicates == 1);
     assert(counter.empty == 1);
-    assert(counter.dropped == 0);
-    assert(counter.over_cap == 0);
-    assert(strcmp(counter.text, "[ 2 of 26 ]") == 0);
+    assert(strcmp(counter.text, "[ 2 distinct frequencies ]") == 0);
 }
 
 static void
@@ -206,9 +199,9 @@ main(void) {
     test_site_row_trunked_with_control();
     test_site_row_trunked_without_control();
     test_site_row_conventional_with_color_code();
-    test_counter_under_cap();
-    test_counter_over_cap_needs_distinct_frequencies();
-    test_counter_drops_empty_and_duplicates_before_the_cap();
+    test_counter_counts_distinct_frequencies();
+    test_counter_keeps_every_distinct_frequency();
+    test_counter_skips_empty_and_duplicates();
     test_plan_line_normal();
     test_plan_line_blocked();
     test_plan_line_awaiting_a_selection();


### PR DESCRIPTION
Closes #369.

## Summary

- **Trunk scan (`--trunk-scan`)**: target list grows on demand — `dsd_trunk_scan_target_list` is now `{targets*, count, capacity}` with an owned-buffer `reset()`; the 32-target cap and its error are gone. The coordinator heap-allocates per-target runtime state and frees it on every teardown/failure path.
- **`-Y` conventional scanner**: hybrid storage — the embedded `trunk_lcn_freq[26]` stays (EDACS/DMR/P25 fixed-slot writers keep raw-indexing it, so every protocol write is valid by construction), entries past 26 live in a heap tail behind `dsd_state_trunk_lcn_slot()`/`_reserve()`/`_free()` (`src/core/util/dsd_state_trunk_lcn.c`). The `-C` importer appends unbounded (positional-0 placeholder semantics preserved) and fails the run cleanly on OOM. Count-bounded consumers (engine scanner step, P25 SM dedup + `next_lcn_freq`, ncurses scan display, manual LCN cycle) moved to the accessor; all copiers (menu adopt/clear, UI snapshot, trunk-scan snapshot save/restore) deep-copy the tail with OOM-consistent count clamping.
- **RadioReference**: `RR_LCN_LIST_MAX` lifted (EDACS `lcn <= 25` protocol semantics kept — that test passes unmodified); conventional/P25 writers heap-allocate and never truncate; the Qt `scanListMax` ceiling and the ncurses panel's mirrored cap are gone (panel now tallies distinct frequencies, no ceiling).

Deliberately unchanged: EDACS LCN reachability, `dmr_csbk.c`'s rest-channel collapse to ≤ 25 learned entries, and the ncurses trunk display showing the first 26 LCN rows of a longer list (layout cap).

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes are reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. (Solo maintainer; full guardrail set run — see below. Human review pending.)
- [x] High-risk areas touched are marked: **parser** (CSV importer paths) / allocator (new heap tail) / none-of-the-others.
- [x] Outside review was requested when available, or unavailability is documented. (None available; solo maintainer.)
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
  - `test_parser_accepts_100_targets` (loader growth + failure never mutates `*out`, sentinel-checked), `test_coordinator_rotation_past_32_targets` (rotation through index 39 and wrap), 40-row channel-map import (embedded pattern + ext slots 26/39), scanner-hop through ext entries with wrap at 30, RR cap tests flipped to unbounded expectations. Unmodified fixed-slot siblings (P25 SM, EDACS, VPDU, UI, DMR grant policy) all pass unchanged.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. (asan-ubsan full suite proves ownership: loader partial-failure frees, coordinator teardown, importer growth, snapshot ext save/restore, `g_pub` growth — no leaks.)
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. (No new suppressions; the one clang-analyzer `ArrayBound` finding was fixed with an explicit invariant clamp in `rr_chan_p25`, not suppressed.)
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification. (New TU uses plain `realloc`/`free` matching `dsd_init.c`'s direct allocation style; safe wrappers elsewhere.)

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — 563/563
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh` for broad or high-risk changes — clean (clang-tidy, IWYU, Lizard, gitleaks, osv, zizmor, fuzz build + smoke)
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes — N/A (no workflow changes; run anyway inside quality_preflight)
- [ ] `tools/osv_scan.sh` for dependency input changes — N/A (no dependency changes; run anyway inside quality_preflight)
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes — N/A (run inside preflight)

CLI behavior verified on the real binary: a 33-target CSV + an invalid row 34 now reports `row 35 has invalid target type 'nxdn'` (previously row 33 died with "too many trunk scan targets"); a 40-row `-Y -C` map logs all 40 `Channel [` rows (previously 26 + silent drop).

## Risk

- Security/dependency impact: none — no new dependencies. New heap allocations carry `SIZE_MAX` overflow guards and are freed in `freeState()`, the dry-run/menu throwaway states, and every failure path; asan-ubsan full suite is green.
- CLI/UI behavior impact: both scan lists accept any length (allocation failure is the only bound and exits cleanly). RadioReference sessions no longer truncate large conventional selections and the Qt/ncurses counters no longer show a 26 ceiling. The ncurses trunk display still shows the first 26 LCN rows of a longer list (layout cap, intentional).
- Compatibility or packaging impact: `dsd_trunk_scan_target_list` is a public struct layout change (embedded array → pointer + count + capacity) — breaking for out-of-tree consumers of that header; every in-tree caller is migrated and the new `dsd_trunk_scan_target_list_reset()` documents the ownership transfer. `dsd_state` grows a pointer + capacity pair (placed outside every `UI_SNAPSHOT_COPY_RANGE`; verified by offset). One new TU in `dsd-neo_core` and four test/fuzz targets link it.
