### PR TITLE
feat: add NXDN trunk and NXDN96/NXDN48 conventional trunk-scan target types

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -376,6 +376,12 @@ run_check() {
 
 run_check "CMake install(TARGETS) runtime destinations" tools/check_install_runtime_destinations.sh
 
+if command -v cmake > /dev/null 2>&1; then
+  run_check "architecture rules guardrail" tools/check_arch_rules.sh
+else
+  mark_missing_tool "cmake" "architecture rules guardrail"
+fi
+
 if command -v rg > /dev/null 2>&1; then
   run_check "secret redaction guardrail" tools/check_secret_redaction.sh
   run_check "workflow Git pin guardrail" tools/check_workflow_git_pins.sh

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -34,6 +34,9 @@ jobs:
           tools/check_workflow_download_pins.sh
           tools/check_vcpkg_overlay_pins.sh
 
+      - name: Check architecture rules
+        run: tools/check_arch_rules.sh
+
   script-lint:
     name: shell/workflow lint
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,7 @@ tools/quality_preflight.sh
 
 Additional focused checks:
 
+- Cross-module includes or new headers: `tools/check_arch_rules.sh`
 - CMake changes: `tools/cmake_format_check.sh`
 - Workflow changes: `tools/workflow_lint.sh` and `tools/zizmor.sh`
 - Dependency input changes: `tools/osv_scan.sh`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ This project is an active work in progress as we decouple from the upstream fork
 - Built‑in trunking workflow
 
   - Follow P25 and DMR trunked voice automatically using channel maps and group lists (`-C ...csv`, `-G group.csv`, `-T`, `--frontend terminal`; `-N` is the short alias).
-  - Rotate one tuner across CSV-defined P25 trunk, DMR trunk, and one-frequency DMR targets with `--trunk-scan targets.csv`.
+  - Rotate one tuner across CSV-defined P25 trunk, DMR trunk, NXDN trunk, and one-frequency DMR, NXDN96 and NXDN48
+    targets with `--trunk-scan targets.csv`.
   - On‑the‑fly retune control via rigctl (`-U`) for external SDR front-ends (e.g., SDR++). For RTL/RTL‑TCP input, DSD-neo retunes directly (optional external UDP retune control can be enabled on loopback with `--rtl-udp-control <port>`; remote exposure requires `--rtl-udp-control-bind <ipv4>`; see `docs/udp-control.md`).
 
 - RTL‑SDR quality‑of‑life features

--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ Quick examples
   - `tools/cmake_format_check.sh` (CMake formatting with gersemi; use `--fix` to rewrite).
   - `tools/gitleaks.sh` (secret scanning with SARIF output for GitHub code scanning).
 - Security guardrails:
+  - `tools/check_arch_rules.sh` (module include boundaries and forbidden constructs from `cmake/arch_rules.cmake`; see `docs/code_map.md`).
   - `tools/check_secret_redaction.sh` (blocks formatted key/keystream output outside the redaction formatter helpers).
   - `tools/check_workflow_git_pins.sh` (blocks floating public GitHub source checkouts in workflows and CI helper scripts).
   - `tools/check_workflow_download_pins.sh` (blocks mutable release helper downloads and digestless AppImage container refs).
@@ -478,7 +479,7 @@ Quick examples
   - `tools/check_release_hardening.ps1` (verifies Windows PE ASLR, NX, and high-entropy VA hardening).
 - Fuzzing: `tools/fuzz_smoke.sh` configures/builds the `fuzz-asan-debug` preset and runs bounded libFuzzer smoke passes.
 - Git hooks: `tools/install-git-hooks.sh` enables auto‑format on commit and a CI-aligned pre-push analysis pass
-  (security guardrails including workflow source/download pins, install-destination checks, clang-format, CMake format,
+  (architecture rules, security guardrails including workflow source/download pins, install-destination checks, clang-format, CMake format,
   clang-tidy, cppcheck, IWYU, GCC fanalyzer, Lizard, Semgrep, zizmor, OSV scan, and shell/workflow lint) on changed
   paths.
 - Optional full scan-build pre-push/preflight pass: set `DSD_HOOK_RUN_SCAN_BUILD=1`.

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Quick examples
 
 - UDP in → Pulse out with UI: `dsd-neo -i udp -o pulse --frontend terminal`
 - DMR trunking from TCP PCM input (with rigctl): `dsd-neo -fs -i tcp -U 4532 -T -C dmr_t3_chan.csv -G group.csv --frontend terminal`
-- Single-tuner P25/DMR trunk scan from RTL-SDR: `dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal`
+- Single-tuner P25/DMR/NXDN trunk scan from RTL-SDR: `dsd-neo -fa -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal`
 - IQ capture + inspect + replay: `dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq --frontend terminal` then `dsd-neo --iq-info p25-control.iq.json` then `dsd-neo --iq-replay p25-control.iq.json -f1 --frontend terminal`
 
 ## Configuration

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Levels/Audio: `-g 0|1..50`, `-n 0..100`, `-nm`, `-8`, `-V 0|1|2|3`, `-z 0|1|2`, `-y`, `-v 0xF`
 - Modes: `-fa | -fs | -fr | -f1 | -f2 | -fd | -fx | -fy | -fz | -fU | -fi | -fn | -fp | -fh | -fH | -fe | -fE | -fm`
 - Inversions/filtering: `-xx`, `-xr`, `-xd`, `-xz`, `-l`, `-q`
-- Trunking/scan: `-T`, `-Y`, `--trunk-scan targets.csv`, `-C chan.csv`, `-G group.csv`, `-W`, `-E`, `-p`, `-e`, `-I 1234`, `-U 4532`, `-B 12000`, `-t 1`, `--enc-lockout|--enc-follow`
+- Trunking/scan: `-T`, `-Y`, `--trunk-scan targets.csv` (P25/DMR/NXDN targets; use `-fa` for mixed lists with NXDN), `-C chan.csv`, `-G group.csv`, `-W`, `-E`, `-p`, `-e`, `-I 1234`, `-U 4532`, `-B 12000`, `-t 1`, `--enc-lockout|--enc-follow`
 - RTL‑SDR strings: `-i rtl:dev:freq:gain:ppm:bw:sql:vol[:bias=on|off]` or `-i rtltcp:host:port:freq:gain:ppm:bw:sql:vol[:bias=on|off]`
 - Soapy selection: `-i soapy`, `-i soapy:driver=airspy[,serial=...]`, or `-i soapy[:args]:freq[:gain[:ppm[:bw[:sql[:vol]]]]]` (discover args with `SoapySDRUtil --find`)
 - RTL retune control: `--rtl-udp-control <port>` binds to loopback by default; use
@@ -29,7 +29,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Follow DMR trunking (TCP PCM input + rigctl): `dsd-neo -fs -i tcp -U 4532 -T -C dmr_t3_chan.csv -G group.csv --frontend terminal`
 - Follow DMR trunking (RTL‑SDR): `dsd-neo -fs -i rtl:0:450M:26:-2:48:0:2 -T -C connect_plus_chan.csv -G group.csv --frontend terminal`
 - Follow DMR trunking (SoapySDR): `dsd-neo -fs -i soapy:driver=airspy -T -C connect_plus_chan.csv -G group.csv --frontend terminal`
-- Scan several P25/DMR targets with one tuner: `dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal`
+- Scan several P25/DMR targets with one tuner: `dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal` (use `-fa` instead of `-ft` when the list contains NXDN targets; `-fn` for NXDN-only lists)
 - Capture RTL I/Q + metadata: `dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq --frontend terminal`
 - Inspect a capture: `dsd-neo --iq-info p25-control.iq.json`
 - Replay a capture through demod: `dsd-neo --iq-replay p25-control.iq.json -f1 --frontend terminal`
@@ -319,15 +319,15 @@ Notes
 - Enable trunking (NXDN/P25/EDACS/DMR): `-T`
 - Conventional scan mode: `-Y` (not trunking; scans for sync on enabled decoders)
 - Single-tuner trunk scan mode: `--trunk-scan <targets.csv>`
-  - Rotates one tuner across CSV-defined P25 trunk, DMR trunk, and one-frequency DMR targets. Full guide:
-    `docs/trunk-scan.md`.
+  - Rotates one tuner across CSV-defined P25 trunk, DMR trunk, DMR conventional, and NXDN trunk/conventional targets.
+    Full guide: `docs/trunk-scan.md`.
   - Requires a live retuning path: RTL-family input opened by DSD-neo, or rigctl control such as `-U 4532`.
   - Use per-target `chan_csv` entries in the target CSV; global `-C` is rejected in this mode.
   - Optional per-target `modulation` and `rtl_gain` columns can override demod hints and RTL-family tuner gain for the
     active target.
   - Cannot be combined with conventional `-Y` scan mode or IQ replay.
   - Idle dwell: `--trunk-scan-dwell-ms <250..600000>` (default `3000`).
-  - Conventional DMR activity hold: `--trunk-scan-activity-hold-ms <250..600000>` (default `1200`).
+  - Conventional DMR/NXDN activity hold: `--trunk-scan-activity-hold-ms <250..600000>` (default `1200`).
   - Single-tuner limitation: systems not currently parked can be missed while another target is being monitored.
 - Channel map CSV: `-C <file>` (e.g., `connect_plus_chan.csv`)
 - Group list CSV (allow/block + labels, optional `priority/preempt/audio/record/stream` policy columns): `-G <file>`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -290,10 +290,10 @@ Notes
 
   A detected sync locks the active rate, level count, timing, and RTL-family channel profile. Passive analog monitoring
   (`-fA`) and already-framed M17 UDP input (`-fU`) are not frame-sync hunt candidates.
-- The three Auto entry points intentionally differ: CLI `-fa` installs the complete matrix above; config
-  `decode = "auto"` preserves the protocol flags established during initialization or by the current overlay; and the
-  interactive Auto choice preserves the current candidate set. This lets configs and interactive setup retain a
-  deliberately narrowed scanner while `-fa` remains the explicit full-search preset.
+- All three Auto entry points install the complete matrix above: CLI `-fa`, config `decode = "auto"`, and the
+  interactive Auto choice select the same decoder set. Only `-fa` also resets the demodulator to C4FM and the audio
+  layout to stereo; the config path leaves those to its `demod` and `dmr_mono` keys, and the interactive path to the
+  wizard's own answers. To scan a deliberately narrowed set, name the narrower preset rather than Auto.
 - In TCP PCM mode, SPS hunting still runs when no signal is present, but repeated idle `Sync: no sync` and `SPS hunt`
   console diagnostics are suppressed.
 - P25p2 on a single frequency may require `-X` (below) if MAC_SIGNAL is missing.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Levels/Audio: `-g 0|1..50`, `-n 0..100`, `-nm`, `-8`, `-V 0|1|2|3`, `-z 0|1|2`, `-y`, `-v 0xF`
 - Modes: `-fa | -fs | -fr | -f1 | -f2 | -fd | -fx | -fy | -fz | -fU | -fi | -fn | -fp | -fh | -fH | -fe | -fE | -fm`
 - Inversions/filtering: `-xx`, `-xr`, `-xd`, `-xz`, `-l`, `-q`
-- Trunking/scan: `-T`, `-Y`, `--trunk-scan targets.csv` (P25/DMR/NXDN targets; use `-fa` for mixed lists with NXDN), `-C chan.csv`, `-G group.csv`, `-W`, `-E`, `-p`, `-e`, `-I 1234`, `-U 4532`, `-B 12000`, `-t 1`, `--enc-lockout|--enc-follow`
+- Trunking/scan: `-T`, `-Y`, `--trunk-scan targets.csv` (P25/DMR/NXDN96/NXDN48 targets; use `-fa` for mixed lists with NXDN), `-C chan.csv`, `-G group.csv`, `-W`, `-E`, `-p`, `-e`, `-I 1234`, `-U 4532`, `-B 12000`, `-t 1`, `--enc-lockout|--enc-follow`
 - RTL‑SDR strings: `-i rtl:dev:freq:gain:ppm:bw:sql:vol[:bias=on|off]` or `-i rtltcp:host:port:freq:gain:ppm:bw:sql:vol[:bias=on|off]`
 - Soapy selection: `-i soapy`, `-i soapy:driver=airspy[,serial=...]`, or `-i soapy[:args]:freq[:gain[:ppm[:bw[:sql[:vol]]]]]` (discover args with `SoapySDRUtil --find`)
 - RTL retune control: `--rtl-udp-control <port>` binds to loopback by default; use
@@ -29,7 +29,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Follow DMR trunking (TCP PCM input + rigctl): `dsd-neo -fs -i tcp -U 4532 -T -C dmr_t3_chan.csv -G group.csv --frontend terminal`
 - Follow DMR trunking (RTL‑SDR): `dsd-neo -fs -i rtl:0:450M:26:-2:48:0:2 -T -C connect_plus_chan.csv -G group.csv --frontend terminal`
 - Follow DMR trunking (SoapySDR): `dsd-neo -fs -i soapy:driver=airspy -T -C connect_plus_chan.csv -G group.csv --frontend terminal`
-- Scan several P25/DMR/NXDN targets with one tuner: `dsd-neo -fa -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal` (`-ft` is enough when the list has no NXDN targets; `-fn` for NXDN-only lists)
+- Scan several P25/DMR/NXDN targets with one tuner: `dsd-neo -fa -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal` (`-ft` is enough when the list has no NXDN targets; `-fn` for NXDN96-only lists, `-fi` for NXDN48-only lists, `-fa` whenever both NXDN rates appear)
 - Capture RTL I/Q + metadata: `dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq --frontend terminal`
 - Inspect a capture: `dsd-neo --iq-info p25-control.iq.json`
 - Replay a capture through demod: `dsd-neo --iq-replay p25-control.iq.json -f1 --frontend terminal`
@@ -319,15 +319,16 @@ Notes
 - Enable trunking (NXDN/P25/EDACS/DMR): `-T`
 - Conventional scan mode: `-Y` (not trunking; scans for sync on enabled decoders)
 - Single-tuner trunk scan mode: `--trunk-scan <targets.csv>`
-  - Rotates one tuner across CSV-defined P25 trunk, DMR trunk, DMR conventional, and NXDN trunk/conventional targets.
-    Full guide: `docs/trunk-scan.md`.
+  - Rotates one tuner across CSV-defined P25 trunk, DMR trunk, DMR conventional, NXDN trunk, NXDN96 conventional
+    (`nxdn-conventional`) and NXDN48 conventional (`nxdn48-conventional`) targets. Full guide: `docs/trunk-scan.md`.
   - Requires a live retuning path: RTL-family input opened by DSD-neo, or rigctl control such as `-U 4532`.
   - Use per-target `chan_csv` entries in the target CSV; global `-C` is rejected in this mode.
   - Optional per-target `modulation` and `rtl_gain` columns can override demod hints and RTL-family tuner gain for the
     active target.
   - Cannot be combined with conventional `-Y` scan mode or IQ replay.
   - Idle dwell: `--trunk-scan-dwell-ms <250..600000>` (default `3000`).
-  - Conventional DMR/NXDN activity hold: `--trunk-scan-activity-hold-ms <250..600000>` (default `1200`).
+  - Conventional DMR/NXDN activity hold (both NXDN rates): `--trunk-scan-activity-hold-ms <250..600000>`
+    (default `1200`).
   - Single-tuner limitation: systems not currently parked can be missed while another target is being monitored.
 - Channel map CSV: `-C <file>` (e.g., `connect_plus_chan.csv`)
 - Group list CSV (allow/block + labels, optional `priority/preempt/audio/record/stream` policy columns): `-G <file>`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,7 +29,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Follow DMR trunking (TCP PCM input + rigctl): `dsd-neo -fs -i tcp -U 4532 -T -C dmr_t3_chan.csv -G group.csv --frontend terminal`
 - Follow DMR trunking (RTL‑SDR): `dsd-neo -fs -i rtl:0:450M:26:-2:48:0:2 -T -C connect_plus_chan.csv -G group.csv --frontend terminal`
 - Follow DMR trunking (SoapySDR): `dsd-neo -fs -i soapy:driver=airspy -T -C connect_plus_chan.csv -G group.csv --frontend terminal`
-- Scan several P25/DMR targets with one tuner: `dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal` (use `-fa` instead of `-ft` when the list contains NXDN targets; `-fn` for NXDN-only lists)
+- Scan several P25/DMR/NXDN targets with one tuner: `dsd-neo -fa -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal` (`-ft` is enough when the list has no NXDN targets; `-fn` for NXDN-only lists)
 - Capture RTL I/Q + metadata: `dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq --frontend terminal`
 - Inspect a capture: `dsd-neo --iq-info p25-control.iq.json`
 - Replay a capture through demod: `dsd-neo --iq-replay p25-control.iq.json -f1 --frontend terminal`

--- a/docs/code-quality-guardrails.md
+++ b/docs/code-quality-guardrails.md
@@ -34,6 +34,7 @@ Run the smallest useful set before opening a PR, then broaden it when the change
 - Sanitizer-sensitive code: `ctest --preset asan-ubsan-debug --output-on-failure` after configuring/building the matching preset.
 - Threading changes: `ctest --preset tsan-debug --output-on-failure` where the affected tests are supported by TSan.
 - Fuzz-facing changes: `tools/fuzz_smoke.sh`.
+- Cross-module includes or new headers: `tools/check_arch_rules.sh` (also run by pre-push and CI).
 - CMake changes: `tools/cmake_format_check.sh`.
 - Workflow changes: `tools/workflow_lint.sh` and `tools/zizmor.sh`.
 - Dependency input changes: `tools/osv_scan.sh`.

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -286,7 +286,8 @@ Qt Quick frontend (`src/ui/qt`):
 - Platform-free by rule: it may include Qt and `include/dsd-neo/app_control/` headers, never engine/io/protocol
   internals, and never platform APIs (`QJniObject`, `<android/*.h>`). Platform specifics live behind the `DecoderHost`
   interface, implemented per host (`android/decoder_host_android.cpp` today).
-- Backend code must never include Qt headers; `cmake/arch_rules.cmake` enforces both directions.
+- Backend code must never include Qt headers; `cmake/arch_rules.cmake` enforces both directions
+  (`tools/check_arch_rules.sh`, run by the pre-push hook and the CI guardrails job).
 
 Build files: `src/ui/CMakeLists.txt`, `src/ui/terminal/CMakeLists.txt`, `src/ui/qt/CMakeLists.txt`
 

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -538,11 +538,12 @@ changing the selected frame mask. This allows shared presets such as `auto` and
 `tdma` to use the single-slot DMR decoder while retaining their non-DMR
 candidates.
 
-`decode = "auto"` preserves the protocol candidates already established by
-initialization and any active configuration/profile overlay; it does not replace
-them with the CLI full-search preset. Interactive Auto has the same preservation
-semantics. In contrast, CLI `-fa` explicitly enables every digital candidate in
-the five-profile hunt matrix:
+`decode = "auto"` enables every digital candidate in the five-profile hunt
+matrix below, exactly as CLI `-fa` and the interactive Auto choice do. All three
+entry points select the same decoder set; only `-fa` additionally resets the
+demodulator to C4FM and the audio layout to stereo, because on the config path
+those belong to the `demod` and `dmr_mono` keys, which are applied after the
+preset and therefore win. The hunt matrix:
 
 | Hunt profile | Symbol rate | Levels | Candidates |
 | --- | ---: | ---: | --- |
@@ -554,6 +555,12 @@ the five-profile hunt matrix:
 
 Profiles without an enabled candidate are skipped. A successful sync retains
 the active rate, level count, symbol timing, and RTL-family channel profile.
+
+Autosave records the decoder set only when a preset reproduces it exactly: an
+`-fa` session saves `decode = "auto"` and reloads with every decoder enabled,
+while a session whose decoder set matches no preset saves no `decode` key at
+all and reloads with the initialization defaults left alone. Independent keys
+such as `dmr_mono` are still saved either way.
 Passive analog monitoring and already-framed M17 UDP input are outside this
 frame-sync hunt.
 

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -344,7 +344,7 @@ small subset is exposed as config keys for convenience (for example
 | `enabled` | BOOL | Enable single-tuner trunk scan | `false` |
 | `targets_csv` | PATH | Scan target list CSV | (empty) |
 | `idle_dwell_ms` | INT (250-600000) | Default idle dwell per target | `3000` |
-| `activity_hold_ms` | INT (250-600000) | Conventional DMR activity hold | `1200` |
+| `activity_hold_ms` | INT (250-600000) | Conventional DMR/NXDN activity hold | `1200` |
 
 **[radioreference] section:**
 | Key | Type | Description | Default |

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -108,20 +108,20 @@ Columns:
 | Column | Required | Behavior |
 |--------|----------|----------|
 | `id` | Yes | Unique short target name used in log messages. Empty or too-long IDs are rejected. |
-| `type` | Yes | One of `p25-trunk`, `dmr-trunk`, or `dmr-conventional`. |
+| `type` | Yes | One of `p25-trunk`, `dmr-trunk`, `dmr-conventional`, `nxdn-trunk`, or `nxdn-conventional`. |
 | `frequency_hz` | Yes | Decimal Hz only. Normal 64-bit builds accept `1..4294967295`; 32-bit builds may reject values above `LONG_MAX`. Do not use `K`/`M`/`G` suffixes in CSV. |
-| `chan_csv` | No | Optional channel-map path for trunk targets. Paths are resolved relative to this CSV. Leave empty for conventional DMR. |
+| `chan_csv` | No | Optional channel-map path for trunk targets. Paths are resolved relative to this CSV. Leave empty for conventional DMR and conventional NXDN. |
 | `dwell_ms` | No | Per-target idle dwell (`250..600000`). Empty uses `--trunk-scan-dwell-ms` or `[trunk_scan] idle_dwell_ms`. |
-| `activity_hold_ms` | No | Per-target conventional DMR activity hold (`250..600000`). Empty uses `--trunk-scan-activity-hold-ms` or `[trunk_scan] activity_hold_ms`. |
+| `activity_hold_ms` | No | Per-target conventional DMR/NXDN activity hold (`250..600000`). Empty uses `--trunk-scan-activity-hold-ms` or `[trunk_scan] activity_hold_ms`. |
 | `notes` | No | Ignored. Use for local notes. |
-| `modulation` | No | Per-target demod hint. Empty preserves global/default handling. `auto` uses target defaults and overrides global `-m` locks for that target. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR accepts `auto`, `gfsk`. |
+| `modulation` | No | Per-target demod hint. Empty preserves global/default handling. `auto` uses target defaults and overrides global `-m` locks for that target. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR and NXDN accept `auto`, `gfsk`. |
 | `rtl_gain` | No | Per-target RTL-family tuner gain. Empty uses the global/default gain. `0` or `auto` requests device automatic gain. `1..49` requests manual dB gain. Ignored for non-RTL retuning paths. |
 
 Validation notes:
 
 - No target-count limit; bounded only by memory.
 - Duplicate IDs and duplicate `(type, frequency_hz)` rows are rejected.
-- `chan_csv` on `dmr-conventional` rows is rejected.
+- `chan_csv` on conventional (`dmr-conventional`/`nxdn-conventional`) rows is rejected.
 - Global `-C`/`[trunking] chan_csv` is rejected in trunk scan mode so channel maps do not leak across systems.
 - One tuner can only monitor the active target; traffic on other targets can be missed.
 - This parser can handle a quoted `chan_csv` field containing a comma, but it is not a full RFC 4180 parser and does not
@@ -134,6 +134,8 @@ id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gai
 county-p25,p25-trunk,851012500,,3000,,primary P25 control channel,cqpsk,18
 city-dmr,dmr-trunk,452012500,dmr_channels.csv,3000,,DMR Tier III control channel,auto,
 plant,dmr-conventional,461112500,,1500,1200,one-frequency DMR,gfsk,auto
+site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel,auto,
+field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,
 ```
 
 ## Group List CSV (`-G <file>` / `[trunking] group_csv`)

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -89,7 +89,8 @@ ChannelNumber(dec),frequency(Hz),note
 
 ## Trunk Scan Target CSV (`--trunk-scan <file>` / `[trunk_scan] targets_csv`)
 
-Purpose: Rotate one tuner across explicit P25 trunk, DMR trunk, and one-frequency DMR targets. See
+Purpose: Rotate one tuner across explicit P25 trunk, DMR trunk, NXDN trunk, and one-frequency DMR, NXDN96 and
+NXDN48 targets. See
 `docs/trunk-scan.md` for the full setup workflow and troubleshooting guide.
 
 The header must start with this exact prefix:
@@ -108,20 +109,21 @@ Columns:
 | Column | Required | Behavior |
 |--------|----------|----------|
 | `id` | Yes | Unique short target name used in log messages. Empty or too-long IDs are rejected. |
-| `type` | Yes | One of `p25-trunk`, `dmr-trunk`, `dmr-conventional`, `nxdn-trunk`, or `nxdn-conventional`. |
+| `type` | Yes | One of `p25-trunk`, `dmr-trunk`, `dmr-conventional`, `nxdn-trunk`, `nxdn-conventional` (NXDN96, 12.5 kHz), or `nxdn48-conventional` (NXDN48, 6.25 kHz). |
 | `frequency_hz` | Yes | Decimal Hz only. Normal 64-bit builds accept `1..4294967295`; 32-bit builds may reject values above `LONG_MAX`. Do not use `K`/`M`/`G` suffixes in CSV. |
-| `chan_csv` | No | Optional channel-map path for trunk targets. Paths are resolved relative to this CSV. Leave empty for conventional DMR and conventional NXDN. |
+| `chan_csv` | No | Optional channel-map path for trunk targets. Paths are resolved relative to this CSV. Leave empty for conventional DMR and both conventional NXDN types. |
 | `dwell_ms` | No | Per-target idle dwell (`250..600000`). Empty uses `--trunk-scan-dwell-ms` or `[trunk_scan] idle_dwell_ms`. |
-| `activity_hold_ms` | No | Per-target conventional DMR/NXDN activity hold (`250..600000`). Empty uses `--trunk-scan-activity-hold-ms` or `[trunk_scan] activity_hold_ms`. |
+| `activity_hold_ms` | No | Per-target conventional DMR/NXDN (NXDN96 and NXDN48) activity hold (`250..600000`). Empty uses `--trunk-scan-activity-hold-ms` or `[trunk_scan] activity_hold_ms`. |
 | `notes` | No | Ignored. Use for local notes. |
-| `modulation` | No | Per-target demod hint. Empty preserves global/default handling. `auto` uses target defaults and overrides global `-m` locks for that target. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR and NXDN accept `auto`, `gfsk`. |
+| `modulation` | No | Per-target demod hint. Empty preserves global/default handling. `auto` uses target defaults and overrides global `-m` locks for that target. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR and both NXDN rates accept `auto`, `gfsk`. |
 | `rtl_gain` | No | Per-target RTL-family tuner gain. Empty uses the global/default gain. `0` or `auto` requests device automatic gain. `1..49` requests manual dB gain. Ignored for non-RTL retuning paths. |
 
 Validation notes:
 
 - No target-count limit; bounded only by memory.
-- Duplicate IDs and duplicate `(type, frequency_hz)` rows are rejected.
-- `chan_csv` on conventional (`dmr-conventional`/`nxdn-conventional`) rows is rejected.
+- Duplicate IDs and duplicate `(type, frequency_hz)` rows are rejected. `nxdn-conventional` and
+  `nxdn48-conventional` are distinct types, so one frequency may appear once as each.
+- `chan_csv` on conventional (`dmr-conventional`/`nxdn-conventional`/`nxdn48-conventional`) rows is rejected.
 - Global `-C`/`[trunking] chan_csv` is rejected in trunk scan mode so channel maps do not leak across systems.
 - One tuner can only monitor the active target; traffic on other targets can be missed.
 - This parser can handle a quoted `chan_csv` field containing a comma, but it is not a full RFC 4180 parser and does not
@@ -136,6 +138,7 @@ city-dmr,dmr-trunk,452012500,dmr_channels.csv,3000,,DMR Tier III control channel
 plant,dmr-conventional,461112500,,1500,1200,one-frequency DMR,gfsk,auto
 site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel,auto,
 field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,
+field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz) channel,gfsk,
 ```
 
 ## Group List CSV (`-G <file>` / `[trunking] group_csv`)

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -35,6 +35,8 @@ id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gai
 county-p25,p25-trunk,851012500,,3000,,P25 control channel,cqpsk,18
 city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel,auto,
 plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR,gfsk,auto
+site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel,auto,
+field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96,gfsk,
 ```
 
 The repository includes a starter file at `examples/trunk_scan_targets.csv`.
@@ -74,10 +76,11 @@ Target list limits and validation:
 
 ## CLI Usage
 
-For a mixed P25/DMR scan with an RTL-SDR:
+For a mixed scan with an RTL-SDR (the shipped starter file contains P25, DMR and NXDN rows, so use `-fa`; `-ft` is
+enough for a list with no NXDN targets):
 
 ```sh
-dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal
+dsd-neo -fa -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal
 ```
 
 For an external receiver that sends PCM audio over TCP and is tuned through rigctl:
@@ -98,14 +101,18 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
 
 - `--trunk-scan-dwell-ms <ms>` sets the default idle dwell for targets whose `dwell_ms` column is empty. Default:
   `3000`.
-- `--trunk-scan-activity-hold-ms <ms>` sets the default hold time after allowed conventional DMR activity. Default:
-  `1200`.
+- `--trunk-scan-activity-hold-ms <ms>` sets the default hold time after allowed conventional DMR/NXDN activity.
+  Default: `1200`.
 - Per-target CSV values override these defaults.
 
-Use `-fa` (AUTO) or an equivalent config mode (`mode.decode = "auto"`) for mixed scan lists that contain NXDN targets:
-`-ft` enables the P25/DMR decoders but not NXDN96, so NXDN rows would sit idle with a startup warning. Use `-fn` for
-NXDN-only lists. DSD-neo logs a warning at scan start for any target whose decoder is not enabled by the selected
-mode; it does not silently flip mode-preset frame flags.
+Use the `-fa` (AUTO) command-line mode for mixed scan lists that contain NXDN targets: `-ft` enables the P25/DMR
+decoders but not NXDN96, so NXDN rows would sit idle with a startup warning. Use `-fn` for NXDN-only lists. DSD-neo
+logs a warning at scan start for any target whose decoder is not enabled by the selected mode; it does not silently
+flip mode-preset frame flags.
+
+`mode.decode = "auto"` in a config file is not equivalent: the config profile of the AUTO preset deliberately leaves
+the frame flags at their defaults, which do not include NXDN96. Set `mode.decode = "nxdn96"` for NXDN-only lists, or
+pass `-fa` on the command line for mixed lists.
 
 ## Config Usage
 
@@ -188,7 +195,8 @@ Expected log messages include:
 
 ```text
 Trunk scan target 'county-p25' at 851012500 Hz
-Trunk scan enabled with 3 targets
+Trunk scan enabled with 5 targets
+2 trunk scan target(s) have no enabled NXDN96 decoder (first: 'site-nxdn'); use -fn or -fa to decode them
 Trunk scan target 'city-dmr' retune failed; cooling down briefly
 ```
 
@@ -217,6 +225,14 @@ to keep global/default modulation handling.
 
 Leave the field empty to inherit the global/default gain. Use `0` or `auto` for device automatic gain, or an integer
 from `1` to `49` for manual RTL-family gain in dB.
+
+`N trunk scan target(s) have no enabled <NAME> decoder (first: '<id>'); use <flags> to decode them`
+
+The selected decode mode does not enable the decoder those targets need, so they park and dwell without ever
+decoding. One line is logged per decoder class, not per target. Use `-fa` for a mixed list, `-fn` for an NXDN-only
+list, `-ft`/`-f1`/`-f2` for P25, or `-fs`/`-ft` for DMR. DSD-neo does not flip mode-preset frame flags for you.
+Note that `mode.decode = "auto"` in a config file does not enable NXDN96 -- pass `-fa` on the command line, or set
+`mode.decode = "nxdn96"`.
 
 `--trunk-scan cannot be combined with global -C/channel-map config`
 

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -115,9 +115,8 @@ decoders with separate mode presets -- `-fn` enables NXDN96 only and `-fi` enabl
 DSD-neo logs a warning at scan start for any target whose decoder is not enabled by the selected mode; it does not
 silently flip mode-preset frame flags.
 
-`mode.decode = "auto"` in a config file is not equivalent: the config profile of the AUTO preset deliberately leaves
-the frame flags at their defaults, which include neither NXDN rate. Set `mode.decode = "nxdn96"` or
-`mode.decode = "nxdn48"` for a single-rate list, or pass `-fa` on the command line for mixed lists.
+`mode.decode = "auto"` in a config file is equivalent to `-fa` for decoder selection, so it serves mixed lists too.
+Use `mode.decode = "nxdn96"` or `mode.decode = "nxdn48"` when a single-rate list is all you want enabled.
 
 ## Config Usage
 
@@ -250,9 +249,8 @@ from `1` to `49` for manual RTL-family gain in dB.
 The selected decode mode does not enable the decoder those targets need, so they park and dwell without ever
 decoding. One line is logged per decoder class, not per target, and NXDN96 and NXDN48 are separate classes. Use
 `-fa` for a mixed list, `-fn` for an NXDN96-only list, `-fi` for an NXDN48-only list, `-ft`/`-f1`/`-f2` for P25, or
-`-fs`/`-ft` for DMR. A list holding both NXDN rates needs `-fa`. DSD-neo does not flip mode-preset frame flags for
-you. Note that `mode.decode = "auto"` in a config file enables neither NXDN rate -- pass `-fa` on the command line,
-or set `mode.decode = "nxdn96"`/`"nxdn48"`.
+`-fs`/`-ft` for DMR. A list holding both NXDN rates needs `-fa`, or `mode.decode = "auto"` in a config file, which
+selects the same decoders. DSD-neo does not flip mode-preset frame flags for you.
 
 `--trunk-scan cannot be combined with global -C/channel-map config`
 

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -2,7 +2,8 @@
 
 Single-tuner trunk scan lets one retunable receiver rotate across several explicit targets instead of staying on one
 system. Use it when you want one DSD-neo instance to check a small set of P25 trunk, DMR trunk, DMR conventional,
-and NXDN (trunk and conventional) targets, but you do not have a separate receiver for each system.
+and NXDN (trunk, NXDN96 conventional, and NXDN48 conventional) targets, but you do not have a separate receiver for
+each system.
 
 The scan coordinator parks on one target, watches for activity, and moves to the next idle target after the configured
 dwell time. Trunking state and per-target channel maps are kept separate, so a channel number or learned control-channel
@@ -37,6 +38,7 @@ city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel,
 plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR,gfsk,auto
 site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel,auto,
 field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96,gfsk,
+field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz),gfsk,
 ```
 
 The repository includes a starter file at `examples/trunk_scan_targets.csv`.
@@ -46,13 +48,13 @@ Column behavior:
 | Column | Required | Meaning |
 |--------|----------|---------|
 | `id` | Yes | Unique short name used in log messages. Keep it under 64 bytes. |
-| `type` | Yes | `p25-trunk`, `dmr-trunk`, `dmr-conventional`, `nxdn-trunk`, or `nxdn-conventional`. |
+| `type` | Yes | `p25-trunk`, `dmr-trunk`, `dmr-conventional`, `nxdn-trunk`, `nxdn-conventional` (NXDN96, 12.5 kHz), or `nxdn48-conventional` (NXDN48, 6.25 kHz). |
 | `frequency_hz` | Yes | Initial park/control frequency in decimal Hz. Suffixes such as `M` are not accepted in CSV. |
-| `chan_csv` | No | Channel map for a trunk target. Paths are resolved relative to the target CSV file. Leave empty for conventional DMR and conventional NXDN. |
+| `chan_csv` | No | Channel map for a trunk target. Paths are resolved relative to the target CSV file. Leave empty for conventional DMR and both conventional NXDN types. |
 | `dwell_ms` | No | Idle dwell for this target. Empty uses the CLI/config default. Valid range: `250..600000`. |
-| `activity_hold_ms` | No | Conventional DMR/NXDN activity hold for this target. Empty uses the CLI/config default. Valid range: `250..600000`. |
+| `activity_hold_ms` | No | Conventional DMR/NXDN (NXDN96 and NXDN48) activity hold for this target. Empty uses the CLI/config default. Valid range: `250..600000`. |
 | `notes` | No | Ignored by DSD-neo. Use it for local notes. |
-| `modulation` | No | Demod hint for this target. Empty preserves global/default handling. `auto` uses target defaults even when a global `-m` lock is set. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR and NXDN accept `auto`, `gfsk`. |
+| `modulation` | No | Demod hint for this target. Empty preserves global/default handling. `auto` uses target defaults even when a global `-m` lock is set. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR and both NXDN rates accept `auto`, `gfsk`. |
 | `rtl_gain` | No | RTL-family tuner gain for this target. Empty uses the global/default gain. `0` or `auto` requests device automatic gain. `1..49` requests manual dB gain. |
 
 Target list limits and validation:
@@ -67,8 +69,9 @@ Target list limits and validation:
 - Duplicate `id` values are rejected.
 - Duplicate `(type, frequency_hz)` pairs are rejected.
 - `chan_csv` is only valid for `p25-trunk`, `dmr-trunk`, and `nxdn-trunk` targets.
-- `modulation` values are target-type specific: `cqpsk`/`c4fm` are P25-only, and `gfsk` is valid for DMR and NXDN
-  targets.
+- `modulation` values are target-type specific: `cqpsk`/`c4fm` are P25-only, and `gfsk` is valid for DMR and both NXDN
+  target rates.
+- `nxdn-conventional` and `nxdn48-conventional` are distinct types, so the same frequency may appear once as each.
 - `rtl_gain` only affects RTL-family inputs opened by DSD-neo. It is ignored when scan retuning is done through rigctl
   against a non-RTL audio input.
 - The parser is intentionally small. It can handle a quoted `chan_csv` that contains a comma, but it is not a full CSV
@@ -76,8 +79,8 @@ Target list limits and validation:
 
 ## CLI Usage
 
-For a mixed scan with an RTL-SDR (the shipped starter file contains P25, DMR and NXDN rows, so use `-fa`; `-ft` is
-enough for a list with no NXDN targets):
+For a mixed scan with an RTL-SDR (the shipped starter file contains P25, DMR, NXDN96 and NXDN48 rows, so use `-fa`;
+`-ft` is enough for a list with no NXDN targets):
 
 ```sh
 dsd-neo -fa -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal
@@ -101,18 +104,20 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
 
 - `--trunk-scan-dwell-ms <ms>` sets the default idle dwell for targets whose `dwell_ms` column is empty. Default:
   `3000`.
-- `--trunk-scan-activity-hold-ms <ms>` sets the default hold time after allowed conventional DMR/NXDN activity.
-  Default: `1200`.
+- `--trunk-scan-activity-hold-ms <ms>` sets the default hold time after allowed conventional DMR/NXDN activity
+  (NXDN96 and NXDN48 alike). Default: `1200`.
 - Per-target CSV values override these defaults.
 
 Use the `-fa` (AUTO) command-line mode for mixed scan lists that contain NXDN targets: `-ft` enables the P25/DMR
-decoders but not NXDN96, so NXDN rows would sit idle with a startup warning. Use `-fn` for NXDN-only lists. DSD-neo
-logs a warning at scan start for any target whose decoder is not enabled by the selected mode; it does not silently
-flip mode-preset frame flags.
+decoders but neither NXDN rate, so NXDN rows would sit idle with a startup warning. The two NXDN rates are separate
+decoders with separate mode presets -- `-fn` enables NXDN96 only and `-fi` enables NXDN48 only -- so **a list mixing
+`nxdn-conventional` and `nxdn48-conventional` rows requires `-fa`**. Single-rate lists can use the narrower preset.
+DSD-neo logs a warning at scan start for any target whose decoder is not enabled by the selected mode; it does not
+silently flip mode-preset frame flags.
 
 `mode.decode = "auto"` in a config file is not equivalent: the config profile of the AUTO preset deliberately leaves
-the frame flags at their defaults, which do not include NXDN96. Set `mode.decode = "nxdn96"` for NXDN-only lists, or
-pass `-fa` on the command line for mixed lists.
+the frame flags at their defaults, which include neither NXDN rate. Set `mode.decode = "nxdn96"` or
+`mode.decode = "nxdn48"` for a single-rate list, or pass `-fa` on the command line for mixed lists.
 
 ## Config Usage
 
@@ -190,21 +195,27 @@ During scanning:
   channel that differs from the target's `frequency_hz`, DSD-neo adopts it (logging
   `NOTICE: NXDN trunking: site control channel is X MHz; following it`) and re-parks that target there from then on.
   A per-target `chan_csv` containing LCN rows pins the control channel instead, so an operator list always wins.
-- Conventional DMR and conventional NXDN targets stay parked only after allowed activity is decoded: a DMR voice
-  header or data header, or an NXDN VCALL, DCALL or SDCALL header. The allow/block list, private-call tuning,
+- Conventional DMR and conventional NXDN targets (both `nxdn-conventional` and `nxdn48-conventional`) stay parked
+  only after allowed activity is decoded: a DMR voice header or data header, or an NXDN VCALL, DCALL or SDCALL header.
+  NXDN48 and NXDN96 share a sync word and every decoded element, so one NXDN reporting path serves both. The allow/block list, private-call tuning,
   data-call tuning, and encrypted-call tuning controls all apply to that decision, so data headers refresh the hold
   only when data-call tuning is enabled (`-e`, or `tune_data_calls` in a config file); it is off by default.
 - An `nxdn-trunk` target with a `chan_csv` reports channels it was granted but could not map, once per channel while
   it is parked (`NOTICE: NXDN trunking: grant: CH 12 has no frequency mapping in chan_csv (site.csv)`), and a summary
   for each such target at exit. Every target keeps its own list, so one target's gaps are never attributed to another.
+- `nxdn48-conventional` targets park at 2400 sym/s with the 6.25 kHz channel filter; every other GFSK-family target
+  parks at 4800 sym/s with the 12.5 kHz filter. Set `modulation = gfsk` on NXDN48 rows: that pins the symbol-rate
+  hunt to the 2400 profile for the whole dwell, whereas an empty or `auto` column lets the hunt rotate through the
+  other enabled rates during dead air, which also swings the channel filter.
 - When a retune fails, DSD-neo logs a warning, briefly cools that target down, and tries another eligible target.
 
 Expected log messages include:
 
 ```text
 Trunk scan target 'county-p25' at 851012500 Hz
-Trunk scan enabled with 5 targets
+Trunk scan enabled with 6 targets
 2 trunk scan target(s) have no enabled NXDN96 decoder (first: 'site-nxdn'); use -fn or -fa to decode them
+1 trunk scan target(s) have no enabled NXDN48 decoder (first: 'field-nxdn48'); use -fi or -fa to decode them
 Trunk scan target 'city-dmr' retune failed; cooling down briefly
 ```
 
@@ -226,7 +237,7 @@ fields, but not in the target CSV.
 
 `row N has invalid modulation`
 
-Use `auto`, `c4fm`, or `cqpsk` for P25 targets. Use `auto` or `gfsk` for DMR and NXDN targets. Leave the field empty
+Use `auto`, `c4fm`, or `cqpsk` for P25 targets. Use `auto` or `gfsk` for DMR and both NXDN rates. Leave the field empty
 to keep global/default modulation handling.
 
 `row N has invalid rtl_gain`
@@ -237,15 +248,16 @@ from `1` to `49` for manual RTL-family gain in dB.
 `N trunk scan target(s) have no enabled <NAME> decoder (first: '<id>'); use <flags> to decode them`
 
 The selected decode mode does not enable the decoder those targets need, so they park and dwell without ever
-decoding. One line is logged per decoder class, not per target. Use `-fa` for a mixed list, `-fn` for an NXDN-only
-list, `-ft`/`-f1`/`-f2` for P25, or `-fs`/`-ft` for DMR. DSD-neo does not flip mode-preset frame flags for you.
-Note that `mode.decode = "auto"` in a config file does not enable NXDN96 -- pass `-fa` on the command line, or set
-`mode.decode = "nxdn96"`.
+decoding. One line is logged per decoder class, not per target, and NXDN96 and NXDN48 are separate classes. Use
+`-fa` for a mixed list, `-fn` for an NXDN96-only list, `-fi` for an NXDN48-only list, `-ft`/`-f1`/`-f2` for P25, or
+`-fs`/`-ft` for DMR. A list holding both NXDN rates needs `-fa`. DSD-neo does not flip mode-preset frame flags for
+you. Note that `mode.decode = "auto"` in a config file enables neither NXDN rate -- pass `-fa` on the command line,
+or set `mode.decode = "nxdn96"`/`"nxdn48"`.
 
 `--trunk-scan cannot be combined with global -C/channel-map config`
 
-Move channel maps into the target CSV `chan_csv` column. Conventional DMR and conventional NXDN rows must leave
-`chan_csv` empty.
+Move channel maps into the target CSV `chan_csv` column. Conventional DMR and conventional NXDN rows (both NXDN
+rates) must leave `chan_csv` empty.
 
 `--trunk-scan requires an open RTL input or rigctl tuning`
 
@@ -259,9 +271,10 @@ rotating across unrelated scan targets.
 
 ## Limitations
 
-- P25 trunk, DMR trunk, DMR conventional, NXDN trunk, and NXDN conventional targets are supported. NXDN targets are
-  12.5 kHz NXDN96; 6.25 kHz NXDN48 conventional channels are not a trunk-scan target type (use `-Y` with `-fi` for
-  those).
+- P25 trunk, DMR trunk, DMR conventional, NXDN trunk, NXDN96 conventional, and NXDN48 conventional targets are
+  supported. Trunked NXDN targets are 12.5 kHz NXDN96 only: 6.25 kHz NXDN48 Type-D control channels are not a
+  trunk-scan target type, so an NXDN48 site's control channel cannot be followed. `-Y` with `-fi` remains available
+  for scanning NXDN48 channels outside trunk scan.
 - There is one active receiver. Traffic on targets that are not currently parked can be missed.
 - Group policy is global across all scan targets.
 - Target CSV files are simple comma-delimited files, not full RFC 4180 CSV.

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -194,6 +194,9 @@ During scanning:
   header or data header, or an NXDN VCALL, DCALL or SDCALL header. The allow/block list, private-call tuning,
   data-call tuning, and encrypted-call tuning controls all apply to that decision, so data headers refresh the hold
   only when data-call tuning is enabled (`-e`, or `tune_data_calls` in a config file); it is off by default.
+- An `nxdn-trunk` target with a `chan_csv` reports channels it was granted but could not map, once per channel while
+  it is parked (`NOTICE: NXDN trunking: grant: CH 12 has no frequency mapping in chan_csv (site.csv)`), and a summary
+  for each such target at exit. Every target keeps its own list, so one target's gaps are never attributed to another.
 - When a retune fails, DSD-neo logs a warning, briefly cools that target down, and tries another eligible target.
 
 Expected log messages include:

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -1,8 +1,8 @@
 # Single-Tuner Trunk Scan
 
 Single-tuner trunk scan lets one retunable receiver rotate across several explicit targets instead of staying on one
-system. Use it when you want one DSD-neo instance to check a small set of P25 trunk, DMR trunk, and one-frequency DMR
-channels, but you do not have a separate receiver for each system.
+system. Use it when you want one DSD-neo instance to check a small set of P25 trunk, DMR trunk, DMR conventional,
+and NXDN (trunk and conventional) targets, but you do not have a separate receiver for each system.
 
 The scan coordinator parks on one target, watches for activity, and moves to the next idle target after the configured
 dwell time. Trunking state and per-target channel maps are kept separate, so a channel number or learned control-channel
@@ -44,13 +44,13 @@ Column behavior:
 | Column | Required | Meaning |
 |--------|----------|---------|
 | `id` | Yes | Unique short name used in log messages. Keep it under 64 bytes. |
-| `type` | Yes | `p25-trunk`, `dmr-trunk`, or `dmr-conventional`. |
+| `type` | Yes | `p25-trunk`, `dmr-trunk`, `dmr-conventional`, `nxdn-trunk`, or `nxdn-conventional`. |
 | `frequency_hz` | Yes | Initial park/control frequency in decimal Hz. Suffixes such as `M` are not accepted in CSV. |
-| `chan_csv` | No | Channel map for a trunk target. Paths are resolved relative to the target CSV file. Leave empty for conventional DMR. |
+| `chan_csv` | No | Channel map for a trunk target. Paths are resolved relative to the target CSV file. Leave empty for conventional DMR and conventional NXDN. |
 | `dwell_ms` | No | Idle dwell for this target. Empty uses the CLI/config default. Valid range: `250..600000`. |
-| `activity_hold_ms` | No | Conventional DMR activity hold for this target. Empty uses the CLI/config default. Valid range: `250..600000`. |
+| `activity_hold_ms` | No | Conventional DMR/NXDN activity hold for this target. Empty uses the CLI/config default. Valid range: `250..600000`. |
 | `notes` | No | Ignored by DSD-neo. Use it for local notes. |
-| `modulation` | No | Demod hint for this target. Empty preserves global/default handling. `auto` uses target defaults even when a global `-m` lock is set. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR accepts `auto`, `gfsk`. |
+| `modulation` | No | Demod hint for this target. Empty preserves global/default handling. `auto` uses target defaults even when a global `-m` lock is set. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR and NXDN accept `auto`, `gfsk`. |
 | `rtl_gain` | No | RTL-family tuner gain for this target. Empty uses the global/default gain. `0` or `auto` requests device automatic gain. `1..49` requests manual dB gain. |
 
 Target list limits and validation:
@@ -64,8 +64,9 @@ Target list limits and validation:
   values above `LONG_MAX`.
 - Duplicate `id` values are rejected.
 - Duplicate `(type, frequency_hz)` pairs are rejected.
-- `chan_csv` is only valid for `p25-trunk` and `dmr-trunk` targets.
-- `modulation` values are target-type specific: `cqpsk`/`c4fm` are P25-only, and `gfsk` is DMR-only.
+- `chan_csv` is only valid for `p25-trunk`, `dmr-trunk`, and `nxdn-trunk` targets.
+- `modulation` values are target-type specific: `cqpsk`/`c4fm` are P25-only, and `gfsk` is valid for DMR and NXDN
+  targets.
 - `rtl_gain` only affects RTL-family inputs opened by DSD-neo. It is ignored when scan retuning is done through rigctl
   against a non-RTL audio input.
 - The parser is intentionally small. It can handle a quoted `chan_csv` that contains a comma, but it is not a full CSV
@@ -101,8 +102,10 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
   `1200`.
 - Per-target CSV values override these defaults.
 
-Use `-ft` or an equivalent config mode (`mode.decode = "tdma"`) for mixed P25 and DMR scan lists. Narrower modes can be
-used when every target is the same protocol.
+Use `-fa` (AUTO) or an equivalent config mode (`mode.decode = "auto"`) for mixed scan lists that contain NXDN targets:
+`-ft` enables the P25/DMR decoders but not NXDN96, so NXDN rows would sit idle with a startup warning. Use `-fn` for
+NXDN-only lists. DSD-neo logs a warning at scan start for any target whose decoder is not enabled by the selected
+mode; it does not silently flip mode-preset frame flags.
 
 ## Config Usage
 
@@ -174,9 +177,11 @@ During scanning:
 - A non-empty target `modulation` value overrides global CLI/config modulation locks for that target only.
 - A target `rtl_gain` value is applied at the retune boundary. Manual per-target gain temporarily suspends supervisory
   tuner autogain; `auto` and global-auto targets restore the saved autogain setting.
-- P25 and DMR trunk targets stay parked while their trunking state machine is following an active call.
-- Conventional DMR targets stay parked only after allowed activity is decoded. The allow/block list, private-call
-  tuning, data-call tuning, and encrypted-call tuning controls all apply to that decision.
+- P25, DMR, and NXDN trunk targets stay parked while their trunking state machine is following an active call
+  (NXDN stays parked while following an active grant and returns to its control channel at hangtime/release).
+- Conventional DMR and conventional NXDN targets stay parked only after allowed activity is decoded (a DMR voice
+  header or an NXDN VCALL header). The allow/block list, private-call tuning, data-call tuning, and encrypted-call
+  tuning controls all apply to that decision.
 - When a retune fails, DSD-neo logs a warning, briefly cools that target down, and tries another eligible target.
 
 Expected log messages include:
@@ -205,8 +210,8 @@ fields, but not in the target CSV.
 
 `row N has invalid modulation`
 
-Use `auto`, `c4fm`, or `cqpsk` for P25 targets. Use `auto` or `gfsk` for DMR targets. Leave the field empty to keep
-global/default modulation handling.
+Use `auto`, `c4fm`, or `cqpsk` for P25 targets. Use `auto` or `gfsk` for DMR and NXDN targets. Leave the field empty
+to keep global/default modulation handling.
 
 `row N has invalid rtl_gain`
 
@@ -215,7 +220,8 @@ from `1` to `49` for manual RTL-family gain in dB.
 
 `--trunk-scan cannot be combined with global -C/channel-map config`
 
-Move channel maps into the target CSV `chan_csv` column. Conventional DMR rows must leave `chan_csv` empty.
+Move channel maps into the target CSV `chan_csv` column. Conventional DMR and conventional NXDN rows must leave
+`chan_csv` empty.
 
 `--trunk-scan requires an open RTL input or rigctl tuning`
 
@@ -229,7 +235,9 @@ rotating across unrelated scan targets.
 
 ## Limitations
 
-- Only P25 trunk, DMR trunk, and one-frequency DMR conventional targets are supported.
+- P25 trunk, DMR trunk, DMR conventional, NXDN trunk, and NXDN conventional targets are supported. NXDN targets are
+  12.5 kHz NXDN96; 6.25 kHz NXDN48 conventional channels are not a trunk-scan target type (use `-Y` with `-fi` for
+  those).
 - There is one active receiver. Traffic on targets that are not currently parked can be missed.
 - Group policy is global across all scan targets.
 - Target CSV files are simple comma-delimited files, not full RFC 4180 CSV.

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -186,6 +186,10 @@ During scanning:
   tuner autogain; `auto` and global-auto targets restore the saved autogain setting.
 - P25, DMR, and NXDN trunk targets stay parked while their trunking state machine is following an active call
   (NXDN stays parked while following an active grant and returns to its control channel at hangtime/release).
+- `nxdn-trunk` targets follow the site-broadcast outbound control channel: when a DFA site announces a control
+  channel that differs from the target's `frequency_hz`, DSD-neo adopts it (logging
+  `NOTICE: NXDN trunking: site control channel is X MHz; following it`) and re-parks that target there from then on.
+  A per-target `chan_csv` containing LCN rows pins the control channel instead, so an operator list always wins.
 - Conventional DMR and conventional NXDN targets stay parked only after allowed activity is decoded (a DMR voice
   header or an NXDN VCALL header). The allow/block list, private-call tuning, data-call tuning, and encrypted-call
   tuning controls all apply to that decision.

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -190,9 +190,10 @@ During scanning:
   channel that differs from the target's `frequency_hz`, DSD-neo adopts it (logging
   `NOTICE: NXDN trunking: site control channel is X MHz; following it`) and re-parks that target there from then on.
   A per-target `chan_csv` containing LCN rows pins the control channel instead, so an operator list always wins.
-- Conventional DMR and conventional NXDN targets stay parked only after allowed activity is decoded (a DMR voice
-  header or an NXDN VCALL header). The allow/block list, private-call tuning, data-call tuning, and encrypted-call
-  tuning controls all apply to that decision.
+- Conventional DMR and conventional NXDN targets stay parked only after allowed activity is decoded: a DMR voice
+  header or data header, or an NXDN VCALL, DCALL or SDCALL header. The allow/block list, private-call tuning,
+  data-call tuning, and encrypted-call tuning controls all apply to that decision, so data headers refresh the hold
+  only when data-call tuning is enabled (`-e`, or `tune_data_calls` in a config file); it is off by default.
 - When a retune fails, DSD-neo logs a warning, briefly cools that target down, and tries another eligible target.
 
 Expected log messages include:

--- a/examples/trunk_scan_targets.csv
+++ b/examples/trunk_scan_targets.csv
@@ -2,3 +2,5 @@ id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gai
 county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learned from control-channel data,auto,
 city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel using examples/dmr_t3_chan.csv,auto,
 plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,
+site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel; channel map optional when the site broadcasts DFA,auto,
+field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,

--- a/examples/trunk_scan_targets.csv
+++ b/examples/trunk_scan_targets.csv
@@ -4,3 +4,4 @@ city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel 
 plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,
 site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel; channel map optional when the site broadcasts DFA,auto,
 field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,
+field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz) conventional channel,gfsk,

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -81,6 +81,13 @@ void dsd_engine_trunk_scan_tick(dsd_opts* opts, dsd_state* state);
 void* dsd_engine_trunk_scan_active_p25_ctx(void);
 void* dsd_engine_trunk_scan_active_dmr_ctx(void);
 /**
+ * @brief Channel-map path of the currently parked scan target, or NULL when it has none.
+ *
+ * Backs the `active_chan_csv` runtime hook: per-target `chan_csv` files are imported through
+ * throwaway options, so this is the only place the path survives for protocol code to name.
+ */
+const char* dsd_engine_trunk_scan_active_chan_csv(const dsd_state* state);
+/**
  * @brief Report decoded conventional activity so the active target keeps its park.
  *
  * Each entry point only acts when the target currently parked is of its own

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -31,6 +31,8 @@ typedef enum {
     DSD_TRUNK_SCAN_TARGET_P25_TRUNK = 0,
     DSD_TRUNK_SCAN_TARGET_DMR_TRUNK = 1,
     DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL = 2,
+    DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK = 3,
+    DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL = 4,
 } dsd_trunk_scan_target_type;
 
 typedef enum {
@@ -80,6 +82,8 @@ void* dsd_engine_trunk_scan_active_p25_ctx(void);
 void* dsd_engine_trunk_scan_active_dmr_ctx(void);
 void dsd_engine_trunk_scan_dmr_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
                                                      uint32_t source, int is_private, int encrypted, int data_call);
+void dsd_engine_trunk_scan_nxdn_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
+                                                      uint32_t source, int is_private, int encrypted, int data_call);
 size_t dsd_engine_trunk_scan_target_count(const dsd_state* state);
 int dsd_engine_trunk_scan_saved_tuner_autogain(const dsd_state* state, int* out_on);
 int dsd_engine_trunk_scan_active_p25_cqpsk_request(const dsd_state* state, int* out_enable);

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -80,8 +80,31 @@ void dsd_engine_trunk_scan_shutdown(dsd_opts* opts, dsd_state* state);
 void dsd_engine_trunk_scan_tick(dsd_opts* opts, dsd_state* state);
 void* dsd_engine_trunk_scan_active_p25_ctx(void);
 void* dsd_engine_trunk_scan_active_dmr_ctx(void);
+/**
+ * @brief Report decoded conventional activity so the active target keeps its park.
+ *
+ * Each entry point only acts when the target currently parked is of its own
+ * conventional type; anything else (including trunk targets, or trunk scan not
+ * being installed) is ignored. The call identity is run through the global
+ * talkgroup policy, and only an allowed call refreshes the target's
+ * activity hold, so allow/block lists, private-call, data-call and
+ * encrypted-call tuning controls all apply to the park decision.
+ *
+ * Callers must pass identity that has already cleared the protocol's own
+ * FEC/CRC gate: an unverified header would park the coordinator on noise.
+ *
+ * @param opts       Decoder options (policy and hold controls).
+ * @param state      Decoder state owning the scan coordinator.
+ * @param target     Destination talkgroup (group call) or destination unit (private call).
+ * @param source     Source unit id, or 0 when unknown.
+ * @param is_private Non-zero for a private/individual call, zero for a group call.
+ * @param encrypted  Non-zero when the call is encrypted; pass the protocol's corroborated
+ *                   classification, not a single frame's raw cipher field.
+ * @param data_call  Non-zero for data traffic rather than voice.
+ */
 void dsd_engine_trunk_scan_dmr_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
                                                      uint32_t source, int is_private, int encrypted, int data_call);
+/** @copydoc dsd_engine_trunk_scan_dmr_conventional_activity */
 void dsd_engine_trunk_scan_nxdn_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
                                                       uint32_t source, int is_private, int encrypted, int data_call);
 size_t dsd_engine_trunk_scan_target_count(const dsd_state* state);

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -33,6 +33,7 @@ typedef enum {
     DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL = 2,
     DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK = 3,
     DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL = 4,
+    DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL = 5,
 } dsd_trunk_scan_target_type;
 
 typedef enum {
@@ -90,9 +91,11 @@ const char* dsd_engine_trunk_scan_active_chan_csv(const dsd_state* state);
 /**
  * @brief Report decoded conventional activity so the active target keeps its park.
  *
- * Each entry point only acts when the target currently parked is of its own
- * conventional type; anything else (including trunk targets, or trunk scan not
- * being installed) is ignored. The call identity is run through the global
+ * Each entry point only acts when the target currently parked belongs to its own
+ * conventional family; anything else (including trunk targets, or trunk scan not
+ * being installed) is ignored. The NXDN entry point serves both NXDN conventional
+ * types: NXDN48 and NXDN96 share a sync word and every decoded element, so the
+ * protocol layer cannot tell them apart and must not have to. The call identity is run through the global
  * talkgroup policy, and only an allowed call refreshes the target's
  * activity hold, so allow/block lists, private-call, data-call and
  * encrypted-call tuning controls all apply to the park decision.
@@ -117,6 +120,19 @@ void dsd_engine_trunk_scan_nxdn_conventional_activity(const dsd_opts* opts, cons
 size_t dsd_engine_trunk_scan_target_count(const dsd_state* state);
 int dsd_engine_trunk_scan_saved_tuner_autogain(const dsd_state* state, int* out_on);
 int dsd_engine_trunk_scan_active_p25_cqpsk_request(const dsd_state* state, int* out_enable);
+/**
+ * @brief Symbol rate of the parked four-level GFSK scan target, or 0 when there is none.
+ *
+ * The tuning layer cannot derive this on its own. `state->rf_mod == 2` is true for both the
+ * 4800 sym/s targets (DMR, NXDN96) and the 2400 sym/s ones (NXDN48), and `state->sps_hunt_idx`
+ * is rotated by the no-sync SPS hunt, so a plain `-T` session can be sitting on the 2400 profile
+ * during dead air. The coordinator's own target type is the only stable answer.
+ *
+ * @param state Decoder state owning the scan coordinator.
+ * @return 2400 or 4800 for a parked GFSK-family target; 0 when trunk scan is not installed or the
+ *         parked target is P25.
+ */
+int dsd_engine_trunk_scan_active_gfsk_symbol_rate(const dsd_state* state);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/protocol/nxdn/nxdn_trunk_diag.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn_trunk_diag.h
@@ -17,6 +17,48 @@ extern "C" {
 #endif
 
 /**
+ * @brief Channels observed without a frequency mapping, as a movable value.
+ *
+ * The live ledger hangs off `dsd_state`, but single-tuner trunk scan rotates several NXDN
+ * targets through one decoder state, so the coordinator parks each target's ledger alongside the
+ * rest of that target's snapshot.
+ */
+typedef struct {
+    uint8_t missing_seen[(0xFFFFu + 7u) / 8u];
+    uint32_t missing_unique;
+} nxdn_trunk_diag_ledger;
+
+/**
+ * @brief Copy the ledger held in @p state, or zero @p out when there is none.
+ */
+void nxdn_trunk_diag_ledger_save(const dsd_state* state, nxdn_trunk_diag_ledger* out);
+
+/**
+ * @brief Install @p ledger as the ledger held in @p state, replacing any current one.
+ *
+ * An empty ledger against a state that has none is a no-op, so rotating past targets that never
+ * decoded a grant costs no allocation.
+ */
+void nxdn_trunk_diag_ledger_restore(dsd_state* state, const nxdn_trunk_diag_ledger* ledger);
+
+/**
+ * @brief Path of the channel map the diagnostics should report against, or NULL when there is none.
+ *
+ * A global `-C` map wins wherever it is set; under trunk scan the parked target's `chan_csv`
+ * answers instead, since the global option is rejected there.
+ */
+const char* nxdn_trunk_diag_chan_map_path(const dsd_opts* opts, const dsd_state* state);
+
+/**
+ * @brief Log an exit summary for one ledger/channel-map pair.
+ *
+ * Lets the scan coordinator report each parked target's own missing channels from its snapshot.
+ * No-op without a channel map path or when nothing is missing.
+ */
+void nxdn_trunk_diag_log_summary_for(const char* chan_csv, const nxdn_trunk_diag_ledger* ledger,
+                                     const long int* chan_map);
+
+/**
  * @brief Record that a trunked NXDN channel had no known frequency mapping.
  *
  * This is deduplicated per-channel for the lifetime of @p state.

--- a/include/dsd-neo/runtime/decode_mode.h
+++ b/include/dsd-neo/runtime/decode_mode.h
@@ -25,8 +25,12 @@ extern "C" {
 /**
  * @brief Caller profile for decode preset application.
  *
- * Some presets intentionally differ between config and CLI paths to preserve
- * existing behavior.
+ * Every profile selects the same decoders for a given mode. The profiles differ only in the
+ * surrounding audio-layout bookkeeping that another layer already owns: the config path keeps
+ * its own `dmr_mono`/output keys and applies `[mode] demod` after the preset, and the
+ * interactive path carries the wizard's answers. See decode_mode_apply_auto(),
+ * decode_mode_apply_nxdn48()/_nxdn96(), decode_mode_apply_x2tdma() and decode_mode_apply_ysf(),
+ * the only presets that read the profile at all.
  */
 typedef enum DSD_ATTR_PACKED {
     DSD_DECODE_PRESET_PROFILE_CONFIG = 0,
@@ -126,6 +130,20 @@ int dsd_rtl_channel_profile_for(const dsd_opts* opts, int symbol_rate_hz, int le
  * @return Inferred decode mode; `DSDCFG_MODE_AUTO` when no exact preset match.
  */
 dsdneoUserDecodeMode dsd_infer_decode_mode_preset(const dsd_opts* opts);
+
+/**
+ * @brief Decode-mode preset that exactly reproduces @p opts' decoder set, if one does.
+ *
+ * Same answer as dsd_infer_decode_mode_preset() whenever a preset matches, but reports
+ * DSDCFG_MODE_UNSET instead of falling back to AUTO for a decoder set no preset produces.
+ * Persistence needs that distinction: writing `decode = "auto"` for an arbitrary set would
+ * reload as *every* decoder. Callers that only label the current mode for a user should keep
+ * using the AUTO-falling-back spelling.
+ *
+ * @param opts Options to inspect; NULL yields DSDCFG_MODE_UNSET.
+ * @return The matching preset, or DSDCFG_MODE_UNSET when none reproduces the set.
+ */
+dsdneoUserDecodeMode dsd_infer_decode_mode_preset_exact(const dsd_opts* opts);
 
 /**
  * @brief Human-readable name of a decode preset, for anything the operator reads.

--- a/include/dsd-neo/runtime/trunk_scan_hooks.h
+++ b/include/dsd-neo/runtime/trunk_scan_hooks.h
@@ -8,7 +8,7 @@
  * @brief Runtime hook table for single-tuner trunk scan coordination.
  *
  * Protocol code can report periodic scan ticks and decoded conventional DMR
- * activity without depending on engine-owned scan coordinator headers.
+ * and NXDN activity without depending on engine-owned scan coordinator headers.
  */
 
 #ifndef DSD_NEO_INCLUDE_DSD_NEO_RUNTIME_TRUNK_SCAN_HOOKS_H_
@@ -28,6 +28,8 @@ typedef struct {
     void (*tick)(dsd_opts* opts, dsd_state* state);
     void (*dmr_conventional_activity)(const dsd_opts* opts, const dsd_state* state, uint32_t target, uint32_t source,
                                       int is_private, int encrypted, int data_call);
+    void (*nxdn_conventional_activity)(const dsd_opts* opts, const dsd_state* state, uint32_t target, uint32_t source,
+                                       int is_private, int encrypted, int data_call);
     void (*enc_lockout_clear_snapshots)(const dsd_state* state);
 } dsd_trunk_scan_hooks;
 
@@ -38,6 +40,8 @@ void* dsd_trunk_scan_hook_dmr_ctx(void);
 void dsd_trunk_scan_hook_tick(dsd_opts* opts, dsd_state* state);
 void dsd_trunk_scan_hook_dmr_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
                                                    uint32_t source, int is_private, int encrypted, int data_call);
+void dsd_trunk_scan_hook_nxdn_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
+                                                    uint32_t source, int is_private, int encrypted, int data_call);
 
 /**
  * @brief Drop the encrypted-target lockout ledger held in every scan-target snapshot.

--- a/include/dsd-neo/runtime/trunk_scan_hooks.h
+++ b/include/dsd-neo/runtime/trunk_scan_hooks.h
@@ -30,6 +30,7 @@ typedef struct {
                                       int is_private, int encrypted, int data_call);
     void (*nxdn_conventional_activity)(const dsd_opts* opts, const dsd_state* state, uint32_t target, uint32_t source,
                                        int is_private, int encrypted, int data_call);
+    const char* (*active_chan_csv)(const dsd_state* state);
     void (*enc_lockout_clear_snapshots)(const dsd_state* state);
 } dsd_trunk_scan_hooks;
 
@@ -53,6 +54,16 @@ void dsd_trunk_scan_hook_dmr_conventional_activity(const dsd_opts* opts, const d
 /** @copydoc dsd_trunk_scan_hook_dmr_conventional_activity */
 void dsd_trunk_scan_hook_nxdn_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
                                                     uint32_t source, int is_private, int encrypted, int data_call);
+
+/**
+ * @brief Path of the channel map belonging to the currently parked scan target.
+ *
+ * Trunk scan rejects a global `-C` channel map and loads each target's `chan_csv` through
+ * throwaway options, so `opts->chan_in_file` is empty while scanning and protocol code cannot
+ * name the map it is missing entries from. Returns NULL when trunk scan is not installed or the
+ * parked target has no channel map.
+ */
+const char* dsd_trunk_scan_hook_active_chan_csv(const dsd_state* state);
 
 /**
  * @brief Drop the encrypted-target lockout ledger held in every scan-target snapshot.

--- a/include/dsd-neo/runtime/trunk_scan_hooks.h
+++ b/include/dsd-neo/runtime/trunk_scan_hooks.h
@@ -38,8 +38,19 @@ void dsd_trunk_scan_hooks_set(dsd_trunk_scan_hooks hooks);
 void* dsd_trunk_scan_hook_p25_ctx(void);
 void* dsd_trunk_scan_hook_dmr_ctx(void);
 void dsd_trunk_scan_hook_tick(dsd_opts* opts, dsd_state* state);
+/**
+ * @brief Report decoded conventional DMR/NXDN activity to the scan coordinator.
+ *
+ * Lets protocol code refresh the parked target's activity hold without
+ * depending on engine-owned scan headers. No-op when trunk scan is not
+ * installed, and ignored by the coordinator unless the parked target is of the
+ * matching conventional type. Only call these with identity that has already
+ * cleared the protocol's FEC/CRC gate, and pass the corroborated encryption
+ * classification rather than a single frame's raw cipher field.
+ */
 void dsd_trunk_scan_hook_dmr_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
                                                    uint32_t source, int is_private, int encrypted, int data_call);
+/** @copydoc dsd_trunk_scan_hook_dmr_conventional_activity */
 void dsd_trunk_scan_hook_nxdn_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
                                                     uint32_t source, int is_private, int encrypted, int data_call);
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2581,7 +2581,11 @@ dsd_engine_cleanup(dsd_opts* opts, dsd_state* state) {
 
     dsd_exitflag_store(1);
 
-    nxdn_trunk_diag_log_summary(opts, state);
+    // Under trunk scan each target owns a channel map and a ledger, so the coordinator logs one
+    // summary per target from its snapshots as it shuts down.
+    if (opts->trunk_scan_enabled != 1) {
+        nxdn_trunk_diag_log_summary(opts, state);
+    }
     dsd_engine_cleanup_codec2(state);
     dsd_engine_cleanup_watchdog_snapshots(opts, state);
     noCarrier(opts, state);

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -330,6 +330,20 @@ scan_parse_ms_field(const char* s, int default_ms, int* out) {
     return 0;
 }
 
+/* Single home for the two type axes the coordinator dispatches on, so a new target type is
+ * classified in one place instead of in every `type == A || type == B` chain. */
+static int
+trunk_scan_type_is_conventional(dsd_trunk_scan_target_type type) {
+    return type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL || type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL;
+}
+
+/* DMR and NXDN96 share the 4800 sym/s four-level GFSK demod profile. */
+static int
+trunk_scan_type_is_gfsk_family(dsd_trunk_scan_target_type type) {
+    return type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK || type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL
+           || type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK || type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL;
+}
+
 static int
 scan_parse_type(const char* s, dsd_trunk_scan_target_type* out) {
     if (!s || !out) {
@@ -451,9 +465,7 @@ scan_parse_modulation(const char* s, dsd_trunk_scan_target_type type, dsd_trunk_
         *out = DSD_TRUNK_SCAN_MODULATION_CQPSK;
         return 0;
     }
-    if (strcmp(s, "gfsk") == 0
-        && (type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK || type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL
-            || type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK || type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL)) {
+    if (strcmp(s, "gfsk") == 0 && trunk_scan_type_is_gfsk_family(type)) {
         *out = DSD_TRUNK_SCAN_MODULATION_GFSK;
         return 0;
     }
@@ -586,8 +598,7 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
     }
 
     if (chan_csv[0] != '\0') {
-        if (target.type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL
-            || target.type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL) {
+        if (trunk_scan_type_is_conventional(target.type)) {
             scan_set_error(parse->err, parse->err_sz, "row %u sets chan_csv for a conventional target", parse->row);
             return -1;
         }
@@ -798,6 +809,11 @@ trunk_scan_snapshot_clear(dsd_trunk_scan_snapshot* snapshot) {
     snapshot->p25_cc_is_tdma = 2;
     snapshot->p25_vc_cqpsk_pref = -1;
     snapshot->p25_vc_cqpsk_override = -1;
+    /* NXDN "not decoded yet" sentinels, matching initState() (src/core/util/dsd_init.c) and
+     * noCarrier(): RAN 0 is a legal value, so a zeroed snapshot would publish a fabricated
+     * RAN 0 for a target that has never decoded one. */
+    snapshot->nxdn_last_ran = (unsigned int)-1;
+    snapshot->nxdn_location_category[0] = ' ';
 }
 
 static void
@@ -1327,22 +1343,8 @@ trunk_scan_get_const(const dsd_state* state) {
 }
 
 static int
-trunk_scan_target_is_dmr(const dsd_trunk_scan_target* target) {
-    return target
-           && (target->type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK
-               || target->type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL);
-}
-
-static int
 trunk_scan_target_is_p25(const dsd_trunk_scan_target* target) {
     return target && target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK;
-}
-
-static int
-trunk_scan_target_is_nxdn(const dsd_trunk_scan_target* target) {
-    return target
-           && (target->type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK
-               || target->type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL);
 }
 
 static int
@@ -1449,10 +1451,9 @@ trunk_scan_apply_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_
         trunk_scan_apply_p25_target_demod(opts, state, target);
         return;
     }
-    if (!trunk_scan_target_is_dmr(target) && !trunk_scan_target_is_nxdn(target)) {
-        return;
+    if (trunk_scan_type_is_gfsk_family(target->type)) {
+        trunk_scan_apply_dmr_class_target_demod(opts, state, target);
     }
-    trunk_scan_apply_dmr_class_target_demod(opts, state, target);
 }
 
 static void
@@ -1853,35 +1854,68 @@ trunk_scan_warn_ignored_target_gain(const dsd_opts* opts, const dsd_state* state
     LOG_WARN("WARNING: Trunk scan rtl_gain target overrides require RTL-family input; ignoring target gain settings\n");
 }
 
+typedef enum {
+    TRUNK_SCAN_DECODER_P25 = 0,
+    TRUNK_SCAN_DECODER_DMR = 1,
+    TRUNK_SCAN_DECODER_NXDN = 2,
+    TRUNK_SCAN_DECODER_COUNT = 3,
+} trunk_scan_decoder_class;
+
+/* Exhaustive switch with no default: adding a target type must fail the build here rather than
+ * silently classing the new type as "always decodable". */
+static trunk_scan_decoder_class
+trunk_scan_target_decoder_class(dsd_trunk_scan_target_type type) {
+    switch (type) {
+        case DSD_TRUNK_SCAN_TARGET_P25_TRUNK: return TRUNK_SCAN_DECODER_P25;
+        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL: return TRUNK_SCAN_DECODER_DMR;
+        case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL: return TRUNK_SCAN_DECODER_NXDN;
+    }
+    return TRUNK_SCAN_DECODER_P25;
+}
+
 static void
 trunk_scan_warn_disabled_target_decoders(const dsd_opts* opts, const dsd_trunk_scan_target_list* list) {
     if (!opts || !list) {
         return;
     }
+
+    static const struct {
+        const char* name;
+        const char* hint;
+    } k_decoders[TRUNK_SCAN_DECODER_COUNT] = {
+        {"P25", "-ft, -f1, -f2, or -fa"},
+        {"DMR", "-fs, -ft, or -fa"},
+        {"NXDN96", "-fn or -fa"},
+    };
+
+    /* P25 mirrors the engine's own no_carrier_p25_frames_enabled(): a TDMA control channel is
+     * followed with -f2 alone, which leaves frame_p25p1 clear. */
+    const int enabled[TRUNK_SCAN_DECODER_COUNT] = {
+        (opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1),
+        (opts->frame_dmr == 1),
+        (opts->frame_nxdn96 == 1),
+    };
+
+    /* One line per decoder class, not per target: scan lists are unbounded. */
+    size_t missing[TRUNK_SCAN_DECODER_COUNT] = {0};
+    const char* first_id[TRUNK_SCAN_DECODER_COUNT] = {NULL, NULL, NULL};
     for (size_t i = 0; i < list->count; i++) {
-        const dsd_trunk_scan_target* target = &list->targets[i];
-        int enabled = 1;
-        const char* name = "";
-        const char* hint = "";
-        if (target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
-            enabled = opts->frame_p25p1;
-            name = "P25";
-            hint = "-ft, -f1, or -fa";
-        } else if (target->type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK
-                   || target->type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL) {
-            enabled = opts->frame_dmr;
-            name = "DMR";
-            hint = "-fs, -ft, or -fa";
-        } else if (target->type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK
-                   || target->type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL) {
-            enabled = opts->frame_nxdn96;
-            name = "NXDN96";
-            hint = "-fn or -fa";
+        const trunk_scan_decoder_class cls = trunk_scan_target_decoder_class(list->targets[i].type);
+        if (enabled[cls]) {
+            continue;
         }
-        if (!enabled) {
-            LOG_WARN("WARNING: Trunk scan target '%s' has no enabled %s decoder; use %s to decode it\n", target->id,
-                     name, hint);
+        if (missing[cls]++ == 0) {
+            first_id[cls] = list->targets[i].id;
         }
+    }
+    for (int cls = 0; cls < (int)TRUNK_SCAN_DECODER_COUNT; cls++) {
+        if (missing[cls] == 0) {
+            continue;
+        }
+        LOG_WARN("WARNING: %zu trunk scan target(s) have no enabled %s decoder (first: '%s'); use %s to decode them\n",
+                 missing[cls], k_decoders[cls].name, first_id[cls], k_decoders[cls].hint);
     }
 }
 
@@ -2031,15 +2065,17 @@ dsd_engine_trunk_scan_active_dmr_ctx(void) {
     return &rt->dmr_ctx;
 }
 
-void
-dsd_engine_trunk_scan_dmr_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
-                                                uint32_t source, int is_private, int encrypted, int data_call) {
+/* Shared body for every conventional target type: the hold decision is protocol-independent,
+ * so the per-protocol entry points below differ only in which target type may claim the hold. */
+static void
+trunk_scan_conventional_activity(dsd_trunk_scan_target_type expect, const dsd_opts* opts, const dsd_state* state,
+                                 uint32_t target, uint32_t source, int is_private, int encrypted, int data_call) {
     dsd_trunk_scan_coord* coord = trunk_scan_get(state);
     if (!opts || !state || !coord || coord->count == 0) {
         return;
     }
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
-    if (rt->target.type != DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL) {
+    if (rt->target.type != expect) {
         return;
     }
 
@@ -2057,28 +2093,17 @@ dsd_engine_trunk_scan_dmr_conventional_activity(const dsd_opts* opts, const dsd_
 }
 
 void
+dsd_engine_trunk_scan_dmr_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
+                                                uint32_t source, int is_private, int encrypted, int data_call) {
+    trunk_scan_conventional_activity(DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL, opts, state, target, source, is_private,
+                                     encrypted, data_call);
+}
+
+void
 dsd_engine_trunk_scan_nxdn_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
                                                  uint32_t source, int is_private, int encrypted, int data_call) {
-    dsd_trunk_scan_coord* coord = trunk_scan_get(state);
-    if (!opts || !state || !coord || coord->count == 0) {
-        return;
-    }
-    dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
-    if (rt->target.type != DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL) {
-        return;
-    }
-
-    dsd_tg_policy_decision decision;
-    int rc = 0;
-    if (is_private) {
-        rc = dsd_tg_policy_evaluate_private_call(opts, state, source, target, encrypted, data_call, &decision);
-    } else {
-        rc = dsd_tg_policy_evaluate_group_call(opts, state, target, source, encrypted, data_call, &decision);
-    }
-    if (rc == 0 && decision.tune_allowed) {
-        rt->last_allowed_activity_m = trunk_scan_now_m();
-        rt->idle_since_m = -1.0;
-    }
+    trunk_scan_conventional_activity(DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL, opts, state, target, source, is_private,
+                                     encrypted, data_call);
 }
 
 static void

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -333,10 +333,20 @@ scan_parse_ms_field(const char* s, int default_ms, int* out) {
 }
 
 /* Single home for the type axes the coordinator dispatches on, so a new target type is
- * classified in one place instead of in every `type == A || type == B` chain. */
+ * classified in one place instead of in every `type == A || type == B` chain. Each axis is an
+ * exhaustive switch with no default: adding a target type must fail the build here rather than
+ * silently inherit whichever answer the chain happened to fall through to. */
 static int
 trunk_scan_type_is_conventional(dsd_trunk_scan_target_type type) {
-    return type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL || type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL;
+    switch (type) {
+        case DSD_TRUNK_SCAN_TARGET_P25_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK: return 0;
+        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return 1;
+    }
+    return 0;
 }
 
 /* Target types whose control channel is anchored in state->p25_cc_freq. NXDN trunking reads and
@@ -344,14 +354,36 @@ trunk_scan_type_is_conventional(dsd_trunk_scan_target_type type) {
  * alone, which is what stops a stray NXDN element from moving a DMR target's control channel. */
 static int
 trunk_scan_type_anchors_p25_cc_freq(dsd_trunk_scan_target_type type) {
-    return type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK || type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK;
+    switch (type) {
+        case DSD_TRUNK_SCAN_TARGET_P25_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK: return 1;
+        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return 0;
+    }
+    return 0;
 }
 
-/* DMR and NXDN96 share the 4800 sym/s four-level GFSK demod profile. */
+/* Symbol rate of a target's four-level GFSK demod profile, or 0 for the P25 class. DMR and NXDN96
+ * share 4800 sym/s; NXDN48 runs the same four-level GFSK demodulator at 2400 sym/s, which is the
+ * only axis that separates it from an nxdn-conventional target. */
+static int
+trunk_scan_type_gfsk_symbol_rate(dsd_trunk_scan_target_type type) {
+    switch (type) {
+        case DSD_TRUNK_SCAN_TARGET_P25_TRUNK: return 0;
+        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL: return 4800;
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return 2400;
+    }
+    return 0;
+}
+
 static int
 trunk_scan_type_is_gfsk_family(dsd_trunk_scan_target_type type) {
-    return type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK || type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL
-           || type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK || type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL;
+    return trunk_scan_type_gfsk_symbol_rate(type) > 0;
 }
 
 static int
@@ -377,6 +409,10 @@ scan_parse_type(const char* s, dsd_trunk_scan_target_type* out) {
     }
     if (strcmp(s, "nxdn-conventional") == 0) {
         *out = DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL;
+        return 0;
+    }
+    if (strcmp(s, "nxdn48-conventional") == 0) {
+        *out = DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL;
         return 0;
     }
     return -1;
@@ -1420,10 +1456,18 @@ trunk_scan_p25_cc_sps(const dsd_opts* opts, const dsd_state* state) {
 }
 
 static int
-trunk_scan_dmr_sps(const dsd_opts* opts, const dsd_state* state) {
+trunk_scan_gfsk_sps(const dsd_opts* opts, const dsd_state* state, dsd_trunk_scan_target_type type) {
     (void)state;
     int demod_rate = trunk_scan_demod_rate(opts);
-    return dsd_opts_compute_sps_rate(opts, 4800, demod_rate);
+    return dsd_opts_compute_sps_rate(opts, trunk_scan_type_gfsk_symbol_rate(type), demod_rate);
+}
+
+/* The four-level GFSK family spans two symbol rates, and the SPS hunt profile is the only thing
+ * that tells the NXDN sync search which one to look for (dsd_frame_sync_active_nxdn_variant()
+ * reads it back to label the variant when -fa enables both). */
+static int
+trunk_scan_gfsk_sps_hunt_profile(int symbol_rate_hz) {
+    return symbol_rate_hz == 2400 ? DSD_FRAME_SYNC_SPS_PROFILE_2400_4 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
 }
 
 static void
@@ -1444,12 +1488,12 @@ trunk_scan_apply_p25_target_demod(const dsd_opts* opts, dsd_state* state, const 
 }
 
 static void
-trunk_scan_apply_dmr_class_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_trunk_scan_target* target) {
-    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+trunk_scan_apply_gfsk_class_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_trunk_scan_target* target) {
+    state->sps_hunt_idx = trunk_scan_gfsk_sps_hunt_profile(trunk_scan_type_gfsk_symbol_rate(target->type));
     state->sps_hunt_counter = 0;
-    int dmr_sps = trunk_scan_dmr_sps(opts, state);
-    state->samplesPerSymbol = dmr_sps;
-    state->symbolCenter = dsd_opts_symbol_center(dmr_sps);
+    int gfsk_sps = trunk_scan_gfsk_sps(opts, state, target->type);
+    state->samplesPerSymbol = gfsk_sps;
+    state->symbolCenter = dsd_opts_symbol_center(gfsk_sps);
     if (target->modulation == DSD_TRUNK_SCAN_MODULATION_GFSK || target->modulation == DSD_TRUNK_SCAN_MODULATION_AUTO
         || !opts->mod_cli_lock) {
         state->rf_mod = 2;
@@ -1466,7 +1510,7 @@ trunk_scan_apply_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_
         return;
     }
     if (trunk_scan_type_is_gfsk_family(target->type)) {
-        trunk_scan_apply_dmr_class_target_demod(opts, state, target);
+        trunk_scan_apply_gfsk_class_target_demod(opts, state, target);
     }
 }
 
@@ -1548,7 +1592,8 @@ trunk_scan_apply_target_opts(dsd_opts* opts, const dsd_trunk_scan_coord* coord, 
         case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK: opts->trunk_enable = 1; break;
         case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
-        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL: opts->trunk_enable = 0; break;
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: opts->trunk_enable = 0; break;
     }
 }
 
@@ -1686,13 +1731,14 @@ trunk_scan_retune_active(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_target
     }
     const long int freq = trunk_scan_retune_freq(state, &rt->target);
     if (trunk_scan_type_is_conventional(rt->target.type)) {
-        return dsd_engine_scan_tune_to_freq(opts, state, freq, trunk_scan_dmr_sps(opts, state), out_request_id);
+        return dsd_engine_scan_tune_to_freq(opts, state, freq, trunk_scan_gfsk_sps(opts, state, rt->target.type),
+                                            out_request_id);
     }
     /* Trunk targets re-park on their control channel; only the two axes differ per type. */
     state->p25_cc_freq = trunk_scan_type_anchors_p25_cc_freq(rt->target.type) ? freq : 0;
     state->trunk_cc_freq = freq;
-    const int cc_sps =
-        trunk_scan_target_is_p25(&rt->target) ? trunk_scan_p25_cc_sps(opts, state) : trunk_scan_dmr_sps(opts, state);
+    const int cc_sps = trunk_scan_target_is_p25(&rt->target) ? trunk_scan_p25_cc_sps(opts, state)
+                                                             : trunk_scan_gfsk_sps(opts, state, rt->target.type);
     return dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, cc_sps, out_request_id);
 }
 
@@ -1864,8 +1910,9 @@ trunk_scan_warn_ignored_target_gain(const dsd_opts* opts, const dsd_state* state
 typedef enum {
     TRUNK_SCAN_DECODER_P25 = 0,
     TRUNK_SCAN_DECODER_DMR = 1,
-    TRUNK_SCAN_DECODER_NXDN = 2,
-    TRUNK_SCAN_DECODER_COUNT = 3,
+    TRUNK_SCAN_DECODER_NXDN96 = 2,
+    TRUNK_SCAN_DECODER_NXDN48 = 3,
+    TRUNK_SCAN_DECODER_COUNT = 4,
 } trunk_scan_decoder_class;
 
 /* Exhaustive switch with no default: adding a target type must fail the build here rather than
@@ -1877,7 +1924,8 @@ trunk_scan_target_decoder_class(dsd_trunk_scan_target_type type) {
         case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL: return TRUNK_SCAN_DECODER_DMR;
         case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK:
-        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL: return TRUNK_SCAN_DECODER_NXDN;
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL: return TRUNK_SCAN_DECODER_NXDN96;
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return TRUNK_SCAN_DECODER_NXDN48;
     }
     return TRUNK_SCAN_DECODER_P25;
 }
@@ -1895,19 +1943,22 @@ trunk_scan_warn_disabled_target_decoders(const dsd_opts* opts, const dsd_trunk_s
         {"P25", "-ft, -f1, -f2, or -fa"},
         {"DMR", "-fs, -ft, or -fa"},
         {"NXDN96", "-fn or -fa"},
+        {"NXDN48", "-fi or -fa"},
     };
 
     /* P25 mirrors the engine's own no_carrier_p25_frames_enabled(): a TDMA control channel is
-     * followed with -f2 alone, which leaves frame_p25p1 clear. */
+     * followed with -f2 alone, which leaves frame_p25p1 clear. The two NXDN variants are separate
+     * gates because -fn and -fi each enable only one of them; -fa enables both. */
     const int enabled[TRUNK_SCAN_DECODER_COUNT] = {
         (opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1),
         (opts->frame_dmr == 1),
         (opts->frame_nxdn96 == 1),
+        (opts->frame_nxdn48 == 1),
     };
 
     /* One line per decoder class, not per target: scan lists are unbounded. */
     size_t missing[TRUNK_SCAN_DECODER_COUNT] = {0};
-    const char* first_id[TRUNK_SCAN_DECODER_COUNT] = {NULL, NULL, NULL};
+    const char* first_id[TRUNK_SCAN_DECODER_COUNT] = {0};
     for (size_t i = 0; i < list->count; i++) {
         const trunk_scan_decoder_class cls = trunk_scan_target_decoder_class(list->targets[i].type);
         if (enabled[cls]) {
@@ -2082,17 +2133,40 @@ dsd_engine_trunk_scan_active_dmr_ctx(void) {
     return &rt->dmr_ctx;
 }
 
+typedef enum {
+    TRUNK_SCAN_CONVENTIONAL_FAMILY_DMR = 0,
+    TRUNK_SCAN_CONVENTIONAL_FAMILY_NXDN = 1,
+} trunk_scan_conventional_family;
+
+/* Which conventional family a target belongs to, i.e. which protocol's activity reports may claim
+ * its park. Exhaustive switch with no default: the NXDN protocol hooks cannot tell NXDN48 from
+ * NXDN96 -- the sync word and every element are identical, only the symbol rate differs -- so both
+ * NXDN conventional types answer to the same entry point, and a new type must be classified here
+ * rather than silently belonging to no family. */
+static int
+trunk_scan_type_in_conventional_family(dsd_trunk_scan_target_type type, trunk_scan_conventional_family family) {
+    switch (type) {
+        case DSD_TRUNK_SCAN_TARGET_P25_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK: return 0;
+        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL: return family == TRUNK_SCAN_CONVENTIONAL_FAMILY_DMR;
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return family == TRUNK_SCAN_CONVENTIONAL_FAMILY_NXDN;
+    }
+    return 0;
+}
+
 /* Shared body for every conventional target type: the hold decision is protocol-independent,
- * so the per-protocol entry points below differ only in which target type may claim the hold. */
+ * so the per-protocol entry points below differ only in which family may claim the hold. */
 static void
-trunk_scan_conventional_activity(dsd_trunk_scan_target_type expect, const dsd_opts* opts, const dsd_state* state,
+trunk_scan_conventional_activity(trunk_scan_conventional_family family, const dsd_opts* opts, const dsd_state* state,
                                  uint32_t target, uint32_t source, int is_private, int encrypted, int data_call) {
     dsd_trunk_scan_coord* coord = trunk_scan_get(state);
     if (!opts || !state || !coord || coord->count == 0) {
         return;
     }
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
-    if (rt->target.type != expect) {
+    if (!trunk_scan_type_in_conventional_family(rt->target.type, family)) {
         return;
     }
 
@@ -2112,14 +2186,14 @@ trunk_scan_conventional_activity(dsd_trunk_scan_target_type expect, const dsd_op
 void
 dsd_engine_trunk_scan_dmr_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
                                                 uint32_t source, int is_private, int encrypted, int data_call) {
-    trunk_scan_conventional_activity(DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL, opts, state, target, source, is_private,
+    trunk_scan_conventional_activity(TRUNK_SCAN_CONVENTIONAL_FAMILY_DMR, opts, state, target, source, is_private,
                                      encrypted, data_call);
 }
 
 void
 dsd_engine_trunk_scan_nxdn_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
                                                  uint32_t source, int is_private, int encrypted, int data_call) {
-    trunk_scan_conventional_activity(DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL, opts, state, target, source, is_private,
+    trunk_scan_conventional_activity(TRUNK_SCAN_CONVENTIONAL_FAMILY_NXDN, opts, state, target, source, is_private,
                                      encrypted, data_call);
 }
 
@@ -2303,6 +2377,18 @@ size_t
 dsd_engine_trunk_scan_target_count(const dsd_state* state) {
     const dsd_trunk_scan_coord* coord = trunk_scan_get_const(state);
     return coord ? coord->count : 0;
+}
+
+int
+dsd_engine_trunk_scan_active_gfsk_symbol_rate(const dsd_state* state) {
+    if (!state) {
+        return 0;
+    }
+    const dsd_trunk_scan_coord* coord = trunk_scan_get_const(state);
+    if (!coord || coord->active >= coord->count) {
+        return 0;
+    }
+    return trunk_scan_type_gfsk_symbol_rate(coord->targets[coord->active].target.type);
 }
 
 int

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -19,6 +19,7 @@
 #endif
 #include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/protocol/nxdn/nxdn_trunk_diag.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/log.h>
@@ -178,6 +179,7 @@ typedef struct {
     uint8_t nxdn_base_freq;
     uint8_t nxdn_step;
     uint8_t nxdn_bw;
+    nxdn_trunk_diag_ledger nxdn_diag;
 } dsd_trunk_scan_snapshot;
 
 typedef struct {
@@ -1178,6 +1180,9 @@ trunk_scan_save_nxdn_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* s
     snapshot->nxdn_base_freq = state->nxdn_base_freq;
     snapshot->nxdn_step = state->nxdn_step;
     snapshot->nxdn_bw = state->nxdn_bw;
+    // Channels seen without a mapping are a property of the site, not of the decoder, so each
+    // target keeps its own ledger rather than accumulating every target's misses in one.
+    nxdn_trunk_diag_ledger_save(state, &snapshot->nxdn_diag);
 }
 
 static void
@@ -1192,6 +1197,7 @@ trunk_scan_restore_nxdn_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot
     state->nxdn_base_freq = snapshot->nxdn_base_freq;
     state->nxdn_step = snapshot->nxdn_step;
     state->nxdn_bw = snapshot->nxdn_bw;
+    nxdn_trunk_diag_ledger_restore(state, &snapshot->nxdn_diag);
 }
 
 static void
@@ -2053,6 +2059,16 @@ dsd_engine_trunk_scan_active_p25_ctx(void) {
     return &rt->p25_ctx;
 }
 
+const char*
+dsd_engine_trunk_scan_active_chan_csv(const dsd_state* state) {
+    const dsd_trunk_scan_coord* coord = trunk_scan_get_const(state);
+    if (!coord || coord->active >= coord->count) {
+        return NULL;
+    }
+    const char* chan_csv = coord->targets[coord->active].target.chan_csv;
+    return (chan_csv[0] != '\0') ? chan_csv : NULL;
+}
+
 void*
 dsd_engine_trunk_scan_active_dmr_ctx(void) {
     if (!g_trunk_scan_coord || g_trunk_scan_coord->count == 0) {
@@ -2144,6 +2160,7 @@ trunk_scan_install_runtime_hooks(dsd_trunk_scan_coord* coord) {
     hooks.tick = dsd_engine_trunk_scan_tick;
     hooks.dmr_conventional_activity = dsd_engine_trunk_scan_dmr_conventional_activity;
     hooks.nxdn_conventional_activity = dsd_engine_trunk_scan_nxdn_conventional_activity;
+    hooks.active_chan_csv = dsd_engine_trunk_scan_active_chan_csv;
     hooks.enc_lockout_clear_snapshots = trunk_scan_clear_enc_lockout_snapshots;
     dsd_trunk_scan_hooks_set(hooks);
 }
@@ -2242,12 +2259,32 @@ dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t e
     return 0;
 }
 
+// Each target carries its own missing-channel ledger and channel map, so the exit summary the
+// engine logs once for a single system becomes one line per target with a channel map here.
+static void
+trunk_scan_log_nxdn_diag_summaries(dsd_trunk_scan_coord* coord, const dsd_state* state) {
+    if (!coord || coord->count == 0) {
+        return;
+    }
+    if (coord->active < coord->count) {
+        trunk_scan_save_target_snapshot(coord, state, &coord->targets[coord->active]);
+    }
+    for (size_t i = 0; i < coord->count; i++) {
+        const dsd_trunk_scan_target_runtime* rt = &coord->targets[i];
+        if (rt->target.type != DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
+            continue;
+        }
+        nxdn_trunk_diag_log_summary_for(rt->target.chan_csv, &rt->snapshot.nxdn_diag, rt->snapshot.trunk_chan_map);
+    }
+}
+
 void
 dsd_engine_trunk_scan_shutdown(dsd_opts* opts, dsd_state* state) {
-    const dsd_trunk_scan_coord* coord = trunk_scan_get(state);
+    dsd_trunk_scan_coord* coord = trunk_scan_get(state);
     if (!coord) {
         return;
     }
+    trunk_scan_log_nxdn_diag_summaries(coord, state);
     trunk_scan_restore_saved_opts(opts, coord);
     trunk_scan_uninstall_runtime_hooks(coord);
     (void)dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_TRUNK_SCAN, NULL, NULL);

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -168,6 +168,16 @@ typedef struct {
     uint8_t dmr_confidence_mismatch_count;
     uint8_t p25_chan_tdma_explicit[16];
     uint8_t dmr_lcn_trust[0x1000];
+    uint16_t nxdn_grant_chan;
+    long int nxdn_grant_freq;
+    unsigned int nxdn_last_ran;
+    uint32_t nxdn_location_sys_code;
+    uint16_t nxdn_location_site_code;
+    char nxdn_location_category[14];
+    uint8_t nxdn_rcn;
+    uint8_t nxdn_base_freq;
+    uint8_t nxdn_step;
+    uint8_t nxdn_bw;
 } dsd_trunk_scan_snapshot;
 
 typedef struct {
@@ -337,6 +347,14 @@ scan_parse_type(const char* s, dsd_trunk_scan_target_type* out) {
         *out = DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL;
         return 0;
     }
+    if (strcmp(s, "nxdn-trunk") == 0) {
+        *out = DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK;
+        return 0;
+    }
+    if (strcmp(s, "nxdn-conventional") == 0) {
+        *out = DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL;
+        return 0;
+    }
     return -1;
 }
 
@@ -434,7 +452,8 @@ scan_parse_modulation(const char* s, dsd_trunk_scan_target_type type, dsd_trunk_
         return 0;
     }
     if (strcmp(s, "gfsk") == 0
-        && (type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK || type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL)) {
+        && (type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK || type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL
+            || type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK || type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL)) {
         *out = DSD_TRUNK_SCAN_MODULATION_GFSK;
         return 0;
     }
@@ -567,8 +586,9 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
     }
 
     if (chan_csv[0] != '\0') {
-        if (target.type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL) {
-            scan_set_error(parse->err, parse->err_sz, "row %u sets chan_csv for conventional DMR target", parse->row);
+        if (target.type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL
+            || target.type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL) {
+            scan_set_error(parse->err, parse->err_sz, "row %u sets chan_csv for a conventional target", parse->row);
             return -1;
         }
         if (dsd_path_resolve_relative_to_file(parse->resolved_path, chan_csv, target.chan_csv, sizeof target.chan_csv)
@@ -1130,6 +1150,35 @@ trunk_scan_restore_dmr_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot*
 }
 
 static void
+trunk_scan_save_nxdn_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* snapshot) {
+    snapshot->nxdn_grant_chan = state->nxdn_grant_chan;
+    snapshot->nxdn_grant_freq = state->nxdn_grant_freq;
+    snapshot->nxdn_last_ran = state->nxdn_last_ran;
+    snapshot->nxdn_location_sys_code = state->nxdn_location_sys_code;
+    snapshot->nxdn_location_site_code = state->nxdn_location_site_code;
+    DSD_MEMCPY(snapshot->nxdn_location_category, state->nxdn_location_category,
+               sizeof(snapshot->nxdn_location_category));
+    snapshot->nxdn_rcn = state->nxdn_rcn;
+    snapshot->nxdn_base_freq = state->nxdn_base_freq;
+    snapshot->nxdn_step = state->nxdn_step;
+    snapshot->nxdn_bw = state->nxdn_bw;
+}
+
+static void
+trunk_scan_restore_nxdn_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot* snapshot) {
+    state->nxdn_grant_chan = snapshot->nxdn_grant_chan;
+    state->nxdn_grant_freq = snapshot->nxdn_grant_freq;
+    state->nxdn_last_ran = snapshot->nxdn_last_ran;
+    state->nxdn_location_sys_code = snapshot->nxdn_location_sys_code;
+    state->nxdn_location_site_code = snapshot->nxdn_location_site_code;
+    DSD_MEMCPY(state->nxdn_location_category, snapshot->nxdn_location_category, sizeof(state->nxdn_location_category));
+    state->nxdn_rcn = snapshot->nxdn_rcn;
+    state->nxdn_base_freq = snapshot->nxdn_base_freq;
+    state->nxdn_step = snapshot->nxdn_step;
+    state->nxdn_bw = snapshot->nxdn_bw;
+}
+
+static void
 trunk_scan_save_timing_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* snapshot) {
     snapshot->last_cc_sync_time = state->last_cc_sync_time;
     snapshot->p25_last_cc_msg_time = state->p25_last_cc_msg_time;
@@ -1191,6 +1240,7 @@ trunk_scan_save_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* snapsh
     trunk_scan_save_p25_catalog_snapshot(state, snapshot);
     trunk_scan_save_p25_eval_snapshot(state, snapshot);
     trunk_scan_save_dmr_snapshot(state, snapshot);
+    trunk_scan_save_nxdn_snapshot(state, snapshot);
     trunk_scan_save_timing_snapshot(state, snapshot);
     trunk_scan_save_cc_candidate_snapshot(state, snapshot);
 }
@@ -1206,6 +1256,7 @@ trunk_scan_restore_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot* sna
     trunk_scan_restore_p25_catalog_snapshot(state, snapshot);
     trunk_scan_restore_p25_eval_snapshot(state, snapshot);
     trunk_scan_restore_dmr_snapshot(state, snapshot);
+    trunk_scan_restore_nxdn_snapshot(state, snapshot);
     trunk_scan_restore_timing_snapshot(state, snapshot);
     trunk_scan_restore_cc_candidate_snapshot(state, snapshot);
 }
@@ -1288,6 +1339,13 @@ trunk_scan_target_is_p25(const dsd_trunk_scan_target* target) {
 }
 
 static int
+trunk_scan_target_is_nxdn(const dsd_trunk_scan_target* target) {
+    return target
+           && (target->type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK
+               || target->type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL);
+}
+
+static int
 trunk_scan_p25_sm_mode_from_ctx(const p25_sm_ctx_t* ctx) {
     switch (p25_sm_get_state(ctx)) {
         case P25_SM_ON_CC: return DSD_P25_SM_MODE_ON_CC;
@@ -1353,29 +1411,24 @@ trunk_scan_dmr_sps(const dsd_opts* opts, const dsd_state* state) {
 }
 
 static void
-trunk_scan_apply_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_trunk_scan_target* target) {
-    if (!opts || !state || !target) {
-        return;
+trunk_scan_apply_p25_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_trunk_scan_target* target) {
+    state->sps_hunt_idx =
+        state->p25_cc_is_tdma == 1 ? DSD_FRAME_SYNC_SPS_PROFILE_6000_4 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state->sps_hunt_counter = 0;
+    int p25_sps = trunk_scan_p25_cc_sps(opts, state);
+    state->samplesPerSymbol = p25_sps;
+    state->symbolCenter = dsd_opts_symbol_center(p25_sps);
+    if (target->modulation == DSD_TRUNK_SCAN_MODULATION_CQPSK) {
+        state->rf_mod = 1;
+    } else if (target->modulation == DSD_TRUNK_SCAN_MODULATION_C4FM) {
+        state->rf_mod = 0;
+    } else if (target->modulation == DSD_TRUNK_SCAN_MODULATION_AUTO || !opts->mod_cli_lock) {
+        state->rf_mod = (state->p25_cc_is_tdma == 1) ? 1 : 0;
     }
-    if (trunk_scan_target_is_p25(target)) {
-        state->sps_hunt_idx =
-            state->p25_cc_is_tdma == 1 ? DSD_FRAME_SYNC_SPS_PROFILE_6000_4 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
-        state->sps_hunt_counter = 0;
-        int p25_sps = trunk_scan_p25_cc_sps(opts, state);
-        state->samplesPerSymbol = p25_sps;
-        state->symbolCenter = dsd_opts_symbol_center(p25_sps);
-        if (target->modulation == DSD_TRUNK_SCAN_MODULATION_CQPSK) {
-            state->rf_mod = 1;
-        } else if (target->modulation == DSD_TRUNK_SCAN_MODULATION_C4FM) {
-            state->rf_mod = 0;
-        } else if (target->modulation == DSD_TRUNK_SCAN_MODULATION_AUTO || !opts->mod_cli_lock) {
-            state->rf_mod = (state->p25_cc_is_tdma == 1) ? 1 : 0;
-        }
-        return;
-    }
-    if (!trunk_scan_target_is_dmr(target)) {
-        return;
-    }
+}
+
+static void
+trunk_scan_apply_dmr_class_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_trunk_scan_target* target) {
     state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
     state->sps_hunt_counter = 0;
     int dmr_sps = trunk_scan_dmr_sps(opts, state);
@@ -1385,6 +1438,21 @@ trunk_scan_apply_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_
         || !opts->mod_cli_lock) {
         state->rf_mod = 2;
     }
+}
+
+static void
+trunk_scan_apply_target_demod(const dsd_opts* opts, dsd_state* state, const dsd_trunk_scan_target* target) {
+    if (!opts || !state || !target) {
+        return;
+    }
+    if (trunk_scan_target_is_p25(target)) {
+        trunk_scan_apply_p25_target_demod(opts, state, target);
+        return;
+    }
+    if (!trunk_scan_target_is_dmr(target) && !trunk_scan_target_is_nxdn(target)) {
+        return;
+    }
+    trunk_scan_apply_dmr_class_target_demod(opts, state, target);
 }
 
 static void
@@ -1462,8 +1530,10 @@ trunk_scan_apply_target_opts(dsd_opts* opts, const dsd_trunk_scan_coord* coord, 
     opts->trunk_is_tuned = 0;
     switch (target->type) {
         case DSD_TRUNK_SCAN_TARGET_P25_TRUNK:
-        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK: opts->trunk_enable = 1; break;
-        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL: opts->trunk_enable = 0; break;
+        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK: opts->trunk_enable = 1; break;
+        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL: opts->trunk_enable = 0; break;
     }
 }
 
@@ -1477,7 +1547,7 @@ trunk_scan_seed_target_state(dsd_state* state, const dsd_trunk_scan_target* targ
     state->p25_last_vc_tune_time_m = 0.0;
     state->dmr_rest_channel = -1;
 
-    if (target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
+    if (target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK || target->type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
         state->p25_cc_freq = (long int)target->frequency_hz;
         state->trunk_cc_freq = (long int)target->frequency_hz;
         state->trunk_lcn_freq[0] = (long int)target->frequency_hz;
@@ -1587,7 +1657,7 @@ trunk_scan_retune_freq(const dsd_state* state, const dsd_trunk_scan_target* targ
     if (target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
         return trunk_scan_p25_retune_freq(state, target);
     }
-    if (target->type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
+    if (target->type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK || target->type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
         return trunk_scan_dmr_retune_freq(state, target);
     }
     return (long int)target->frequency_hz;
@@ -1607,6 +1677,11 @@ trunk_scan_retune_active(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_target
     }
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
         state->p25_cc_freq = 0;
+        state->trunk_cc_freq = freq;
+        return dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, trunk_scan_dmr_sps(opts, state), out_request_id);
+    }
+    if (rt->target.type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
+        state->p25_cc_freq = freq;
         state->trunk_cc_freq = freq;
         return dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, trunk_scan_dmr_sps(opts, state), out_request_id);
     }
@@ -1730,6 +1805,9 @@ trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coor
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
         return (opts->trunk_is_tuned == 1 || dmr_sm_get_state(&rt->dmr_ctx) == DMR_SM_TUNED);
     }
+    if (rt->target.type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
+        return opts->trunk_is_tuned == 1;
+    }
     double now_m = trunk_scan_now_m();
     double hold_s = (double)rt->target.activity_hold_ms / 1000.0;
     return rt->last_allowed_activity_m > 0.0 && (now_m - rt->last_allowed_activity_m) < hold_s;
@@ -1773,6 +1851,38 @@ trunk_scan_warn_ignored_target_gain(const dsd_opts* opts, const dsd_state* state
         return;
     }
     LOG_WARN("WARNING: Trunk scan rtl_gain target overrides require RTL-family input; ignoring target gain settings\n");
+}
+
+static void
+trunk_scan_warn_disabled_target_decoders(const dsd_opts* opts, const dsd_trunk_scan_target_list* list) {
+    if (!opts || !list) {
+        return;
+    }
+    for (size_t i = 0; i < list->count; i++) {
+        const dsd_trunk_scan_target* target = &list->targets[i];
+        int enabled = 1;
+        const char* name = "";
+        const char* hint = "";
+        if (target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
+            enabled = opts->frame_p25p1;
+            name = "P25";
+            hint = "-ft, -f1, or -fa";
+        } else if (target->type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK
+                   || target->type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL) {
+            enabled = opts->frame_dmr;
+            name = "DMR";
+            hint = "-fs, -ft, or -fa";
+        } else if (target->type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK
+                   || target->type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL) {
+            enabled = opts->frame_nxdn96;
+            name = "NXDN96";
+            hint = "-fn or -fa";
+        }
+        if (!enabled) {
+            LOG_WARN("WARNING: Trunk scan target '%s' has no enabled %s decoder; use %s to decode it\n", target->id,
+                     name, hint);
+        }
+    }
 }
 
 static void
@@ -1946,6 +2056,31 @@ dsd_engine_trunk_scan_dmr_conventional_activity(const dsd_opts* opts, const dsd_
     }
 }
 
+void
+dsd_engine_trunk_scan_nxdn_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
+                                                 uint32_t source, int is_private, int encrypted, int data_call) {
+    dsd_trunk_scan_coord* coord = trunk_scan_get(state);
+    if (!opts || !state || !coord || coord->count == 0) {
+        return;
+    }
+    dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    if (rt->target.type != DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL) {
+        return;
+    }
+
+    dsd_tg_policy_decision decision;
+    int rc = 0;
+    if (is_private) {
+        rc = dsd_tg_policy_evaluate_private_call(opts, state, source, target, encrypted, data_call, &decision);
+    } else {
+        rc = dsd_tg_policy_evaluate_group_call(opts, state, target, source, encrypted, data_call, &decision);
+    }
+    if (rc == 0 && decision.tune_allowed) {
+        rt->last_allowed_activity_m = trunk_scan_now_m();
+        rt->idle_since_m = -1.0;
+    }
+}
+
 static void
 trunk_scan_uninstall_runtime_hooks(const dsd_trunk_scan_coord* coord) {
     if (g_trunk_scan_coord != coord) {
@@ -1983,6 +2118,7 @@ trunk_scan_install_runtime_hooks(dsd_trunk_scan_coord* coord) {
     hooks.dmr_ctx = dsd_engine_trunk_scan_active_dmr_ctx;
     hooks.tick = dsd_engine_trunk_scan_tick;
     hooks.dmr_conventional_activity = dsd_engine_trunk_scan_dmr_conventional_activity;
+    hooks.nxdn_conventional_activity = dsd_engine_trunk_scan_nxdn_conventional_activity;
     hooks.enc_lockout_clear_snapshots = trunk_scan_clear_enc_lockout_snapshots;
     dsd_trunk_scan_hooks_set(hooks);
 }
@@ -2054,6 +2190,7 @@ dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t e
         return -1;
     }
     trunk_scan_warn_ignored_target_gain(opts, state, &list);
+    trunk_scan_warn_disabled_target_decoders(opts, &list);
 
     dsd_trunk_scan_coord* coord = trunk_scan_coord_create(&list, opts, err, err_sz);
     if (!coord) {

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -332,11 +332,19 @@ scan_parse_ms_field(const char* s, int default_ms, int* out) {
     return 0;
 }
 
-/* Single home for the two type axes the coordinator dispatches on, so a new target type is
+/* Single home for the type axes the coordinator dispatches on, so a new target type is
  * classified in one place instead of in every `type == A || type == B` chain. */
 static int
 trunk_scan_type_is_conventional(dsd_trunk_scan_target_type type) {
     return type == DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL || type == DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL;
+}
+
+/* Target types whose control channel is anchored in state->p25_cc_freq. NXDN trunking reads and
+ * writes that field the same way P25 does; DMR trunking keeps it at 0 and uses trunk_cc_freq
+ * alone, which is what stops a stray NXDN element from moving a DMR target's control channel. */
+static int
+trunk_scan_type_anchors_p25_cc_freq(dsd_trunk_scan_target_type type) {
+    return type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK || type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK;
 }
 
 /* DMR and NXDN96 share the 4800 sym/s four-level GFSK demod profile. */
@@ -1554,7 +1562,7 @@ trunk_scan_seed_target_state(dsd_state* state, const dsd_trunk_scan_target* targ
     state->p25_last_vc_tune_time_m = 0.0;
     state->dmr_rest_channel = -1;
 
-    if (target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK || target->type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
+    if (trunk_scan_type_anchors_p25_cc_freq(target->type)) {
         state->p25_cc_freq = (long int)target->frequency_hz;
         state->trunk_cc_freq = (long int)target->frequency_hz;
         state->trunk_lcn_freq[0] = (long int)target->frequency_hz;
@@ -1664,7 +1672,7 @@ trunk_scan_retune_freq(const dsd_state* state, const dsd_trunk_scan_target* targ
     if (target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
         return trunk_scan_p25_retune_freq(state, target);
     }
-    if (target->type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK || target->type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
+    if (!trunk_scan_type_is_conventional(target->type)) {
         return trunk_scan_dmr_retune_freq(state, target);
     }
     return (long int)target->frequency_hz;
@@ -1677,22 +1685,15 @@ trunk_scan_retune_active(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_target
         *out_request_id = 0U;
     }
     const long int freq = trunk_scan_retune_freq(state, &rt->target);
-    if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
-        state->p25_cc_freq = freq;
-        state->trunk_cc_freq = freq;
-        return dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, trunk_scan_p25_cc_sps(opts, state), out_request_id);
+    if (trunk_scan_type_is_conventional(rt->target.type)) {
+        return dsd_engine_scan_tune_to_freq(opts, state, freq, trunk_scan_dmr_sps(opts, state), out_request_id);
     }
-    if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
-        state->p25_cc_freq = 0;
-        state->trunk_cc_freq = freq;
-        return dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, trunk_scan_dmr_sps(opts, state), out_request_id);
-    }
-    if (rt->target.type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
-        state->p25_cc_freq = freq;
-        state->trunk_cc_freq = freq;
-        return dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, trunk_scan_dmr_sps(opts, state), out_request_id);
-    }
-    return dsd_engine_scan_tune_to_freq(opts, state, freq, trunk_scan_dmr_sps(opts, state), out_request_id);
+    /* Trunk targets re-park on their control channel; only the two axes differ per type. */
+    state->p25_cc_freq = trunk_scan_type_anchors_p25_cc_freq(rt->target.type) ? freq : 0;
+    state->trunk_cc_freq = freq;
+    const int cc_sps =
+        trunk_scan_target_is_p25(&rt->target) ? trunk_scan_p25_cc_sps(opts, state) : trunk_scan_dmr_sps(opts, state);
+    return dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, cc_sps, out_request_id);
 }
 
 static int

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -21,6 +21,7 @@
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25p2_frame.h>
 #include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <time.h>
@@ -113,7 +114,9 @@ static void DSD_ATTR_USED
 dsd_engine_apply_cc_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     // Skipping is safe for the other protocols rather than merely harmless: DMR and NXDN96 are
     // already parked at 4800 sym/s with the four-level profile, and NXDN48/EDACS carry rates
-    // this function cannot express at all.
+    // this function cannot express at all. An nxdn48-conventional scan target relies on that
+    // skip: the coordinator seeds its 2400 sym/s timing, and the front end gets the matching
+    // 6.25 kHz chain from dsd_engine_gfsk_cc_symbol_rate().
     if (!opts || !state || state->p25_cc_freq == 0 || !dsd_engine_cc_is_p25(state)) {
         return;
     }
@@ -297,15 +300,37 @@ dsd_engine_prepare_p25_cc_rtl_chain(const dsd_opts* opts, dsd_state* state, long
                                                  profile, ted_sps, 0);
 }
 
+/*
+ * Four-level GFSK control/park channel. The symbol rate is a parameter because the family spans
+ * two of them: DMR and NXDN96 at 4800 sym/s in a 12.5 kHz channel, NXDN48 at 2400 sym/s in a
+ * 6.25 kHz one. dsd_rtl_channel_profile_for() owns the rate-to-filter mapping, so the front end
+ * and the SPS hunt cannot drift apart on which filter a rate wants.
+ */
 static void
-dsd_engine_prepare_dmr_cc_rtl_chain(const dsd_opts* opts, const dsd_state* state, long int target_freq_hz,
-                                    int ted_sps) {
+dsd_engine_prepare_gfsk_cc_rtl_chain(const dsd_opts* opts, const dsd_state* state, long int target_freq_hz, int ted_sps,
+                                     int symbol_rate_hz) {
     int retune_ted_sps = ted_sps;
     if (state->rtl_ctx) {
-        retune_ted_sps = dsd_opts_compute_sps_rate(opts, 4800, (int)rtl_stream_output_rate(state->rtl_ctx));
+        retune_ted_sps = dsd_opts_compute_sps_rate(opts, symbol_rate_hz, (int)rtl_stream_output_rate(state->rtl_ctx));
     }
-    dsd_engine_prepare_retune_profile_for_target(opts, state, (uint32_t)target_freq_hz, 0, 4800, 4,
-                                                 RTL_STREAM_CHANNEL_PROFILE_12K5, retune_ted_sps, 0);
+    dsd_engine_prepare_retune_profile_for_target(opts, state, (uint32_t)target_freq_hz, 0, symbol_rate_hz, 4,
+                                                 dsd_rtl_channel_profile_for(opts, symbol_rate_hz, 4, 2),
+                                                 retune_ted_sps, 0);
+}
+
+/*
+ * Symbol rate for a four-level GFSK retune, or 0 when this is not one.
+ *
+ * Only NXDN48 needs the coordinator's answer: every other GFSK-family target runs 4800 sym/s,
+ * which state->rf_mod == 2 already selects. Keeping the rf_mod gate for those leaves plain -T
+ * DMR/NXDN96 retune behavior byte-for-byte unchanged, including under a modulation lock.
+ */
+static int
+dsd_engine_gfsk_cc_symbol_rate(const dsd_state* state) {
+    if (dsd_engine_trunk_scan_active_gfsk_symbol_rate(state) == 2400) {
+        return 2400;
+    }
+    return (state && state->rf_mod == 2) ? 4800 : 0;
 }
 
 static void
@@ -332,9 +357,12 @@ dsd_engine_prepare_cc_rtl_chain(const dsd_opts* opts, dsd_state* state, long int
         dsd_engine_prepare_p25_cc_rtl_chain(opts, state, target_freq_hz, ted_sps);
         return;
     }
-    if (state->rf_mod == 2 && ted_sps > 0) {
-        dsd_engine_prepare_dmr_cc_rtl_chain(opts, state, target_freq_hz, ted_sps);
-        return;
+    if (ted_sps > 0) {
+        const int gfsk_rate = dsd_engine_gfsk_cc_symbol_rate(state);
+        if (gfsk_rate > 0) {
+            dsd_engine_prepare_gfsk_cc_rtl_chain(opts, state, target_freq_hz, ted_sps, gfsk_rate);
+            return;
+        }
     }
     dsd_engine_prepare_current_cc_rtl_chain(opts, state, target_freq_hz, ted_sps);
 }

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -71,13 +71,24 @@ dsd_engine_select_p25_sps_profile(dsd_state* state, int is_tdma) {
     state->sps_hunt_counter = 0;
 }
 
+/*
+ * Whether the control channel currently being followed is a P25 one.
+ *
+ * p25_cc_freq is not the answer: NXDN and EDACS trunking anchor that same field, so the
+ * frequency being set proves only that some protocol has a control channel. Everything derived
+ * from a P25 control channel -- the 4800/6000 symbol rate, the C4FM/QPSK choice, the P25 SPS
+ * hunt profile -- is wrong for those protocols, which run GFSK at their own rates.
+ */
 static int
-dsd_engine_is_p25_profile_retune(const dsd_opts* opts, const dsd_state* state, int ted_sps) {
-    if (!opts || !state || opts->trunk_enable != 1 || ted_sps <= 0) {
-        return 0;
-    }
+dsd_engine_cc_is_p25(const dsd_state* state) {
     if (dsd_engine_trunk_scan_active_p25_ctx() != NULL) {
         return 1;
+    }
+    // Under trunk scan the coordinator knows the parked target's protocol, and that beats sync
+    // history: a target that has not synced yet reads as P25 by synctype alone, because
+    // DSD_SYNC_P25P1_POS is 0.
+    if (dsd_engine_trunk_scan_target_count(state) > 0) {
+        return 0;
     }
     if (state->rf_mod == 2) {
         return 0;
@@ -90,9 +101,20 @@ dsd_engine_is_p25_profile_retune(const dsd_opts* opts, const dsd_state* state, i
     return 1;
 }
 
+static int
+dsd_engine_is_p25_profile_retune(const dsd_opts* opts, const dsd_state* state, int ted_sps) {
+    if (!opts || !state || opts->trunk_enable != 1 || ted_sps <= 0) {
+        return 0;
+    }
+    return dsd_engine_cc_is_p25(state);
+}
+
 static void DSD_ATTR_USED
 dsd_engine_apply_cc_symbol_timing(const dsd_opts* opts, dsd_state* state) {
-    if (!opts || !state || state->p25_cc_freq == 0) {
+    // Skipping is safe for the other protocols rather than merely harmless: DMR and NXDN96 are
+    // already parked at 4800 sym/s with the four-level profile, and NXDN48/EDACS carry rates
+    // this function cannot express at all.
+    if (!opts || !state || state->p25_cc_freq == 0 || !dsd_engine_cc_is_p25(state)) {
         return;
     }
     const int sym_rate = (state->p25_cc_is_tdma == 1) ? 6000 : 4800;

--- a/src/protocol/dmr/dmr_block.c
+++ b/src/protocol/dmr/dmr_block.c
@@ -25,6 +25,7 @@
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <dsd-neo/protocol/pdu.h>
 #include <dsd-neo/runtime/colors.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/unicode.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -611,6 +612,16 @@ dmr_dheader(dsd_opts* opts, dsd_state* state, uint8_t dheader[], uint8_t dheader
                      f.sap_string, f.target, f.source);
         if (f.a == 1) {
             dsd_append(state->dmr_lrrp_gps[slot], sizeof state->dmr_lrrp_gps[slot], "- RSP REQ ");
+        }
+        // Data traffic keeps a parked conventional DMR scan target, the same way dmr_flco()
+        // reports voice. Only these formats carry a fresh identity: a response header (dpf 1) is
+        // an ACK for an earlier PDU, and a proprietary header (dpf 15) deliberately inherits the
+        // previous transmission's addresses. The explicit CRC test matters because the gate above
+        // also admits headers under the relaxed-CRC options, and an unverified identity would
+        // park the coordinator on noise; the standard header carries no encryption field, so the
+        // encrypted flag is 0 (the MFID-specific ENC bit lives in the dpf 15 header excluded here).
+        if (CRCCorrect == 1) {
+            dsd_trunk_scan_hook_dmr_conventional_activity(opts, state, f.target, f.source, (f.gi == 0) ? 1 : 0, 0, 1);
         }
     }
     state->data_header_sap[slot] = f.sap;

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -1707,16 +1707,26 @@ nxdn_cch_info_channel_version(dsd_state* state, uint32_t location_id, uint8_t ch
  */
 static int
 nxdn_cc_is_operator_pinned(const dsd_opts* opts, const dsd_state* state) {
+    if (opts->trunk_scan_enabled != 1) {
+        return state->trunk_lcn_freq[0] != 0;
+    }
+
+    // Only the parked target's own control channel may move, and only an nxdn-trunk target has one
+    // this broadcast can describe. Checked before the "nothing learned yet" case below: under -fa
+    // an NXDN element decoded while parked on another target type is stray traffic (or a false
+    // sync), and adopting from it would plant a control channel on a target that has none, or move
+    // one that belongs to another protocol.
+    //   - conventional targets run with trunk_enable == 0 and have no control channel at all;
+    //   - a p25-trunk target owns the coordinator's P25 SM context and carries its control channel
+    //     in the same p25_cc_freq field this adoption would overwrite;
+    //   - a dmr-trunk target owns the DMR SM context (and keeps p25_cc_freq at 0).
+    if (opts->trunk_enable != 1 || dsd_trunk_scan_hook_p25_ctx() != NULL || dsd_trunk_scan_hook_dmr_ctx() != NULL) {
+        return 1;
+    }
     if (state->trunk_lcn_freq[0] == 0) {
         return 0;
     }
-    if (opts->trunk_scan_enabled != 1) {
-        return 1;
-    }
-    // Coordinator contract: p25-trunk and nxdn-trunk targets carry p25_cc_freq while dmr-trunk
-    // targets keep it at 0, so a stray NXDN broadcast decoded under -fa while parked on a DMR
-    // target cannot retune it. More entries than the single seeded slot mean a per-target
-    // chan_csv supplied real LCNs.
+    // More entries than the single seeded slot mean a per-target chan_csv supplied real LCNs.
     return (state->lcn_freq_count > 1 || state->p25_cc_freq == 0) ? 1 : 0;
 }
 

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -36,6 +36,7 @@
 #include <dsd-neo/protocol/nxdn/nxdn_trunk_diag.h>
 #include <dsd-neo/protocol/p25/p25_frequency.h>
 #include <dsd-neo/runtime/colors.h>
+#include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/rigctl_query_hooks.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
@@ -1672,6 +1673,28 @@ nxdn_cch_info_channel_version(dsd_state* state, uint32_t location_id, uint8_t ch
     UNUSED(state);
 }
 
+/*
+ * Whether the operator has pinned the control channel, in which case a site broadcast must not
+ * move it. A learned or imported LCN list is operator intent; the trunk-scan coordinator's
+ * slot-0 seed is only the target CSV's park frequency, which may be a few kHz off the real
+ * outbound CC, so the broadcast is allowed to correct it. p25_has_user_lcn_list()
+ * (src/protocol/p25/p25_trunk_sm.c) draws the same line for P25.
+ */
+static int
+nxdn_cc_is_operator_pinned(const dsd_opts* opts, const dsd_state* state) {
+    if (state->trunk_lcn_freq[0] == 0) {
+        return 0;
+    }
+    if (opts->trunk_scan_enabled != 1) {
+        return 1;
+    }
+    // Coordinator contract: p25-trunk and nxdn-trunk targets carry p25_cc_freq while dmr-trunk
+    // targets keep it at 0, so a stray NXDN broadcast decoded under -fa while parked on a DMR
+    // target cannot retune it. More entries than the single seeded slot mean a per-target
+    // chan_csv supplied real LCNs.
+    return (state->lcn_freq_count > 1 || state->p25_cc_freq == 0) ? 1 : 0;
+}
+
 static int
 nxdn_cch_info_dfa_version(dsd_opts* opts, dsd_state* state, const uint8_t* Message, size_t message_bits,
                           uint32_t location_id, uint8_t channel1sts) {
@@ -1719,11 +1742,18 @@ nxdn_cch_info_dfa_version(dsd_opts* opts, dsd_state* state, const uint8_t* Messa
 
     const long int freq1 = nxdn_channel_to_frequency(opts, state, OFN1);
     nxdn_channel_to_frequency(opts, state, IFN1);
-    if (state->trunk_lcn_freq[0] == 0 && freq1 != 0) {
+    if (freq1 != 0 && !nxdn_cc_is_operator_pinned(opts, state)) {
+        const long int previous_cc = state->trunk_cc_freq;
         state->trunk_lcn_freq[0] = freq1;
         state->p25_cc_freq = freq1;
         state->trunk_cc_freq = freq1;
         state->lcn_freq_count = 1;
+        // Announce only a real move: under trunk scan this runs on every CCH_INFO, and once the
+        // park frequency has been corrected the adoption is idempotent.
+        if (previous_cc != 0 && previous_cc != freq1) {
+            LOG_INFO("NOTICE: NXDN trunking: site control channel is %.6lf MHz; following it\n",
+                     (double)freq1 / 1000000.0);
+        }
     }
 
     return 1;

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -37,6 +37,7 @@
 #include <dsd-neo/protocol/p25/p25_frequency.h>
 #include <dsd-neo/runtime/colors.h>
 #include <dsd-neo/runtime/rigctl_query_hooks.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -2327,6 +2328,10 @@ nxdn_vcall_process(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_inf
     nxdn_vcall_load_key(opts, state, info);
     nxdn_vcall_print_cipher(opts, state, info);
     nxdn_vcall_apply_state(state, info);
+    if (info->message_type == 0x01U) {
+        dsd_trunk_scan_hook_nxdn_conventional_activity(opts, state, info->destination_id, info->source_unit_id,
+                                                       info->call_type == 4U ? 1 : 0, info->cipher_type != 0U, 0);
+    }
     if (info->message_type == 0x01U && state->NxdnElementsContent.VCallCrcIsGood != 0U) {
         nxdn_vcall_publish(opts, state, info);
     }

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -2328,11 +2328,16 @@ nxdn_vcall_process(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_inf
     nxdn_vcall_load_key(opts, state, info);
     nxdn_vcall_print_cipher(opts, state, info);
     nxdn_vcall_apply_state(state, info);
-    if (info->message_type == 0x01U) {
-        dsd_trunk_scan_hook_nxdn_conventional_activity(opts, state, info->destination_id, info->source_unit_id,
-                                                       info->call_type == 4U ? 1 : 0, info->cipher_type != 0U, 0);
-    }
     if (info->message_type == 0x01U && state->NxdnElementsContent.VCallCrcIsGood != 0U) {
+        // Held behind the same CRC gate as the publish below: a miscorrected VCALL carries a
+        // garbage destination_id, and letting it refresh the conventional scan hold would park
+        // the coordinator on noise for a full activity_hold_ms per corrupt burst. The encryption
+        // flag is the corroborated classification nxdn_vcall_apply_state() just applied, not the
+        // raw element field -- a lone flipped cipher_type would otherwise drop the hold mid-call
+        // under --enc-lockout, the exact defect nxdn_enc_class.c exists to prevent.
+        dsd_trunk_scan_hook_nxdn_conventional_activity(
+            opts, state, info->destination_id, info->source_unit_id,
+            nxdn_vcall_kind(info->call_type) == DSD_CALL_KIND_PRIVATE_VOICE ? 1 : 0, state->nxdn_cipher_type != 0U, 0);
         nxdn_vcall_publish(opts, state, info);
     }
     nxdn_vcall_run_enc_lockout(opts, state, info);

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -99,8 +99,8 @@ static void nxdn_element_handle_vcall_iv(dsd_opts* opts, dsd_state* state, const
 static void nxdn_pdu_scrambler_keystream_creation(uint8_t* ks, int lfsr, int len_bits);
 static void nxdn_lfsr128_expand_iv_from_mi64(uint64_t mi, uint8_t out[16]);
 static int nxdn_load_data_aes_key(const dsd_state* state, uint8_t key_id, uint8_t out_key[32]);
-static void nxdn_sdcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* Message);
-static void nxdn_dcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* Message, size_t message_bits);
+static void nxdn_sdcall_header(const dsd_opts* opts, dsd_state* state, const uint8_t* Message);
+static void nxdn_dcall_header(const dsd_opts* opts, dsd_state* state, const uint8_t* Message, size_t message_bits);
 static void nxdn_sdcall_iv(dsd_opts* opts, dsd_state* state, const uint8_t* Message);
 static int nxdn_dcall_data(dsd_opts* opts, dsd_state* state, int type, const uint8_t* Message, size_t message_bits);
 static void NXDN_decode_VCALL(dsd_opts* opts, dsd_state* state, const uint8_t* Message);
@@ -207,6 +207,7 @@ nxdn_element_handle_idle(dsd_opts* opts, dsd_state* state, const uint8_t* elemen
 }
 
 static void
+// cppcheck-suppress constParameterCallback -- signature is fixed by the message-type dispatch table.
 nxdn_element_handle_sdcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* elements, size_t elements_bits) {
     if (elements_bits < 79U) {
         DSD_FPRINTF(stderr, " SDCALL Header Too Short (%zu bits); ", elements_bits);
@@ -234,6 +235,7 @@ nxdn_element_handle_sdcall_iv(dsd_opts* opts, dsd_state* state, const uint8_t* e
 }
 
 static void
+// cppcheck-suppress constParameterCallback -- signature is fixed by the message-type dispatch table.
 nxdn_element_handle_dcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* elements, size_t elements_bits) {
     nxdn_dcall_header(opts, state, elements, elements_bits);
 }
@@ -678,7 +680,7 @@ nxdn_data_header_report_scan_activity(const dsd_opts* opts, const dsd_state* sta
 }
 
 static void
-nxdn_sdcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* Message) {
+nxdn_sdcall_header(const dsd_opts* opts, dsd_state* state, const uint8_t* Message) {
     if (state == NULL || Message == NULL) {
         return;
     }
@@ -908,7 +910,7 @@ nxdn_dcall_header_apply(dsd_state* state, const struct nxdn_dcall_header_info* i
 }
 
 static void
-nxdn_dcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* Message, size_t message_bits) {
+nxdn_dcall_header(const dsd_opts* opts, dsd_state* state, const uint8_t* Message, size_t message_bits) {
     if (state == NULL || Message == NULL) {
         return;
     }

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -653,10 +653,32 @@ nxdn_sdcall_iv(dsd_opts* opts, dsd_state* state, const uint8_t* Message) {
     DSD_FPRINTF(stderr, "%s", KNRM);
 }
 
+/*
+ * Report a decoded data-call header to the trunk-scan coordinator, so a parked conventional NXDN
+ * target keeps its activity hold for data traffic and not only for voice. A header is the only
+ * data element carrying a call identity; the blocks that follow it carry none.
+ *
+ * Held behind the link layer's CRC gate for the same reason the VCALL site is: an unverified
+ * header carries a garbage identity, and acting on one parks the coordinator on noise for a full
+ * activity_hold_ms. The header's own two-bit cipher field is the encryption classification --
+ * data calls have no equivalent of the voice hysteresis in nxdn_enc_class.c -- and a misread
+ * costs at most one hold refresh, because talkgroup policy exempts data calls from the
+ * encrypted-target lockout ledger.
+ */
+static void
+nxdn_data_header_report_scan_activity(const dsd_opts* opts, const dsd_state* state, uint8_t call_type, uint16_t source,
+                                      uint16_t target, uint8_t cipher) {
+    if (state->NxdnElementsContent.VCallCrcIsGood == 0U) {
+        return;
+    }
+    // call_type 4 is the individual/private call, spelled the same way as the trunked data-grant
+    // path in NXDN_decode_VCALL_ASSGN().
+    dsd_trunk_scan_hook_nxdn_conventional_activity(opts, state, target, source, (call_type == 4U) ? 1 : 0,
+                                                   (cipher != 0U) ? 1 : 0, 1);
+}
+
 static void
 nxdn_sdcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* Message) {
-    UNUSED(opts);
-
     if (state == NULL || Message == NULL) {
         return;
     }
@@ -743,6 +765,8 @@ nxdn_sdcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* Message) {
     // Not a DMR talkgroup: clear the qualifier so a stale DMR group flag cannot make the
     // --dmr-tg-key-csv lookup treat this address as one.
     state->dmr_data_target_is_group[0] = 0;
+
+    nxdn_data_header_report_scan_activity(opts, state, call_type, source, target, cipher);
 }
 
 struct nxdn_dcall_header_info {
@@ -885,8 +909,6 @@ nxdn_dcall_header_apply(dsd_state* state, const struct nxdn_dcall_header_info* i
 
 static void
 nxdn_dcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* Message, size_t message_bits) {
-    UNUSED(opts);
-
     if (state == NULL || Message == NULL) {
         return;
     }
@@ -902,6 +924,7 @@ nxdn_dcall_header(dsd_opts* opts, dsd_state* state, const uint8_t* Message, size
     nxdn_dcall_header_parse(&info, state, Message, message_bits);
     nxdn_dcall_header_print(&info, state);
     nxdn_dcall_header_apply(state, &info);
+    nxdn_data_header_report_scan_activity(opts, state, info.call_type, info.source, info.target, info.cipher);
 }
 
 enum { NXDN_DCALL_MAX_BITS = 24 * 128, NXDN_DCALL_MAX_BYTES = NXDN_DCALL_MAX_BITS / 8 };

--- a/src/protocol/nxdn/nxdn_trunk_diag.c
+++ b/src/protocol/nxdn/nxdn_trunk_diag.c
@@ -8,16 +8,22 @@
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/protocol/nxdn/nxdn_trunk_diag.h>
 #include <dsd-neo/runtime/log.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
-typedef struct {
-    uint8_t missing_seen[(0xFFFFu + 7u) / 8u];
-    uint32_t missing_unique;
-} nxdn_trunk_diag_t;
+typedef nxdn_trunk_diag_ledger nxdn_trunk_diag_t;
+
+static nxdn_trunk_diag_t*
+nxdn_trunk_diag_get(const dsd_state* state) {
+    if (!state) {
+        return NULL;
+    }
+    return DSD_STATE_EXT_GET_AS(nxdn_trunk_diag_t, (dsd_state*)state, DSD_STATE_EXT_PROTO_NXDN_TRUNK_DIAG);
+}
 
 static nxdn_trunk_diag_t*
 nxdn_trunk_diag_get_or_create(dsd_state* state) {
@@ -25,7 +31,7 @@ nxdn_trunk_diag_get_or_create(dsd_state* state) {
         return NULL;
     }
 
-    nxdn_trunk_diag_t* diag = DSD_STATE_EXT_GET_AS(nxdn_trunk_diag_t, state, DSD_STATE_EXT_PROTO_NXDN_TRUNK_DIAG);
+    nxdn_trunk_diag_t* diag = nxdn_trunk_diag_get(state);
     if (diag) {
         return diag;
     }
@@ -66,15 +72,10 @@ nxdn_trunk_diag_note_missing_channel(dsd_state* state, uint16_t channel) {
     return 1;
 }
 
-size_t
-nxdn_trunk_diag_collect_unmapped_channels(const dsd_state* state, uint16_t* out, size_t out_cap) {
-    if (!state) {
-        return 0;
-    }
-
-    const nxdn_trunk_diag_t* diag =
-        DSD_STATE_EXT_GET_AS(const nxdn_trunk_diag_t, (dsd_state*)state, DSD_STATE_EXT_PROTO_NXDN_TRUNK_DIAG);
-    if (!diag || diag->missing_unique == 0) {
+static size_t
+nxdn_trunk_diag_collect_from(const nxdn_trunk_diag_ledger* ledger, const long int* chan_map, uint16_t* out,
+                             size_t out_cap) {
+    if (!ledger || !chan_map || ledger->missing_unique == 0) {
         return 0;
     }
 
@@ -84,10 +85,10 @@ nxdn_trunk_diag_collect_unmapped_channels(const dsd_state* state, uint16_t* out,
     for (unsigned int ch = 1; ch < 0xFFFFu; ch++) {
         const size_t byte_idx = (size_t)ch / 8u;
         const uint8_t bit_mask = (uint8_t)(1u << (ch % 8u));
-        if ((diag->missing_seen[byte_idx] & bit_mask) == 0) {
+        if ((ledger->missing_seen[byte_idx] & bit_mask) == 0) {
             continue;
         }
-        if (state->trunk_chan_map[ch] != 0) {
+        if (chan_map[ch] != 0) {
             continue;
         }
 
@@ -100,13 +101,75 @@ nxdn_trunk_diag_collect_unmapped_channels(const dsd_state* state, uint16_t* out,
     return total;
 }
 
+size_t
+nxdn_trunk_diag_collect_unmapped_channels(const dsd_state* state, uint16_t* out, size_t out_cap) {
+    if (!state) {
+        return 0;
+    }
+    return nxdn_trunk_diag_collect_from(nxdn_trunk_diag_get(state), state->trunk_chan_map, out, out_cap);
+}
+
+void
+nxdn_trunk_diag_ledger_save(const dsd_state* state, nxdn_trunk_diag_ledger* out) {
+    if (!out) {
+        return;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+
+    const nxdn_trunk_diag_t* diag = nxdn_trunk_diag_get(state);
+    if (!diag) {
+        return;
+    }
+    DSD_MEMCPY(out, diag, sizeof(*out));
+}
+
+void
+nxdn_trunk_diag_ledger_restore(dsd_state* state, const nxdn_trunk_diag_ledger* ledger) {
+    if (!state || !ledger) {
+        return;
+    }
+
+    nxdn_trunk_diag_t* diag = nxdn_trunk_diag_get(state);
+    if (!diag) {
+        // Nothing recorded on either side: rotating past targets that never decoded a grant must
+        // not allocate a ledger for each of them.
+        if (ledger->missing_unique == 0) {
+            return;
+        }
+        diag = nxdn_trunk_diag_get_or_create(state);
+        if (!diag) {
+            return;
+        }
+    }
+    DSD_MEMCPY(diag, ledger, sizeof(*diag));
+}
+
+const char*
+nxdn_trunk_diag_chan_map_path(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts) {
+        return NULL;
+    }
+    if (opts->chan_in_file[0] != '\0') {
+        return opts->chan_in_file;
+    }
+    if (opts->trunk_scan_enabled != 1) {
+        return NULL;
+    }
+
+    // Trunk scan rejects a global -C map and imports each target's chan_csv through throwaway
+    // options, so the coordinator is the only holder of the path.
+    const char* path = dsd_trunk_scan_hook_active_chan_csv(state);
+    return (path && path[0] != '\0') ? path : NULL;
+}
+
 void
 nxdn_trunk_diag_log_missing_channel_once(const dsd_opts* opts, dsd_state* state, uint16_t channel,
                                          const char* context) {
     if (!opts || !state) {
         return;
     }
-    if (opts->chan_in_file[0] == '\0') {
+    const char* chan_csv = nxdn_trunk_diag_chan_map_path(opts, state);
+    if (!chan_csv) {
         return;
     }
     if (channel == 0 || channel >= 0xFFFFu) {
@@ -121,10 +184,9 @@ nxdn_trunk_diag_log_missing_channel_once(const dsd_opts* opts, dsd_state* state,
 
     if (context && context[0] != '\0') {
         LOG_INFO("NOTICE: NXDN trunking: %s: CH %u has no frequency mapping in chan_csv (%s)\n", context, channel,
-                 opts->chan_in_file);
+                 chan_csv);
     } else {
-        LOG_INFO("NOTICE: NXDN trunking: CH %u has no frequency mapping in chan_csv (%s)\n", channel,
-                 opts->chan_in_file);
+        LOG_INFO("NOTICE: NXDN trunking: CH %u has no frequency mapping in chan_csv (%s)\n", channel, chan_csv);
     }
 }
 
@@ -171,17 +233,14 @@ nxdn_trunk_diag_summary_finalize(char* msg, size_t msg_cap, size_t used) {
 }
 
 void
-nxdn_trunk_diag_log_summary(const dsd_opts* opts, const dsd_state* state) {
-    if (!opts || !state) {
-        return;
-    }
-    if (opts->chan_in_file[0] == '\0') {
+nxdn_trunk_diag_log_summary_for(const char* chan_csv, const nxdn_trunk_diag_ledger* ledger, const long int* chan_map) {
+    if (!chan_csv || chan_csv[0] == '\0') {
         return;
     }
 
     uint16_t missing[16];
     const size_t cap = sizeof(missing) / sizeof(missing[0]);
-    const size_t total = nxdn_trunk_diag_collect_unmapped_channels(state, missing, cap);
+    const size_t total = nxdn_trunk_diag_collect_from(ledger, chan_map, missing, cap);
     if (total == 0) {
         return;
     }
@@ -189,7 +248,7 @@ nxdn_trunk_diag_log_summary(const dsd_opts* opts, const dsd_state* state) {
     char msg[512];
     int n =
         DSD_SNPRINTF(msg, sizeof msg, "NXDN trunking: %zu channel%s missing frequency mapping in chan_csv (%s):", total,
-                     (total == 1) ? " is" : "s are", opts->chan_in_file);
+                     (total == 1) ? " is" : "s are", chan_csv);
     if (n < 0) {
         return;
     }
@@ -201,4 +260,13 @@ nxdn_trunk_diag_log_summary(const dsd_opts* opts, const dsd_state* state) {
     nxdn_trunk_diag_summary_finalize(msg, sizeof msg, used);
 
     LOG_INFO("NOTICE: %s", msg);
+}
+
+void
+nxdn_trunk_diag_log_summary(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return;
+    }
+    nxdn_trunk_diag_log_summary_for(nxdn_trunk_diag_chan_map_path(opts, state), nxdn_trunk_diag_get(state),
+                                    state->trunk_chan_map);
 }

--- a/src/protocol/p25/p25_frequency.c
+++ b/src/protocol/p25/p25_frequency.c
@@ -533,8 +533,12 @@ nxdn_channel_to_frequency(dsd_opts* opts, dsd_state* state, uint16_t channel) {
 
     //first, check channel map for imported value, DFA systems most likely won't need an import,
     //unless it has 'system definable' attributes
-    if (state->trunk_chan_map[channel] != 0) {
-        freq = state->trunk_chan_map[channel];
+    // trunk_chan_map holds DSD_TRUNK_CHAN_MAP_SIZE entries, so the largest uint16_t channel is one
+    // past the end; a miscorrected 16-bit outbound number reaches here unfiltered. Only the map
+    // lookup is bounded -- DFA below is arithmetic and stays valid for every channel number.
+    const long int mapped = dsd_state_trunk_chan_valid(channel) ? state->trunk_chan_map[channel] : 0;
+    if (mapped != 0) {
+        freq = mapped;
         DSD_FPRINTF(stderr, "\n  Frequency [%.6lf] MHz", (double)freq / 1000000);
         return (freq);
     }
@@ -594,8 +598,9 @@ nxdn_channel_to_frequency_quiet(dsd_state* state, uint16_t channel) {
         return 0;
     }
 
-    // First: imported/learned mapping.
-    long int freq = state->trunk_chan_map[channel];
+    // First: imported/learned mapping. Bounded because the largest uint16_t channel is one past
+    // the end of trunk_chan_map; the DFA fallback below is arithmetic and needs no bound.
+    long int freq = dsd_state_trunk_chan_valid(channel) ? state->trunk_chan_map[channel] : 0;
     if (freq != 0) {
         return freq;
     }

--- a/src/runtime/bootstrap/interactive.c
+++ b/src/runtime/bootstrap/interactive.c
@@ -226,7 +226,7 @@ interactive_configure_input_source(dsd_opts* opts, dsd_state* state, int* src) {
 static int
 interactive_choose_decode_mode(void) {
     DSD_FPRINTF(stderr, "\nWhat do you want to decode?\n");
-    DSD_FPRINTF(stderr, "  1) Auto (P25, YSF, D-STAR, X2-TDMA, DMR) [default]\n");
+    DSD_FPRINTF(stderr, "  1) Auto (all digital modes) [default]\n");
     DSD_FPRINTF(stderr, "  2) P25 Phase 1 only\n");
     DSD_FPRINTF(stderr, "  3) P25 Phase 2 only\n");
     DSD_FPRINTF(stderr, "  4) DMR\n");

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -392,8 +392,8 @@ dsd_cli_usage_section_trunking_and_tools(void) {
     printf("      --trunk-scan <targets.csv>  Enable single-tuner trunk scan target rotation.\n");
     printf("                 Uses per-target chan_csv values; cannot be combined with global -C or IQ replay.\n");
     printf("      --trunk-scan-dwell-ms <ms>  Set default idle dwell per target (250..600000, default 3000).\n");
-    printf(
-        "      --trunk-scan-activity-hold-ms <ms>  Set conventional DMR activity hold (250..600000, default 1200).\n");
+    printf("      --trunk-scan-activity-hold-ms <ms>  Set conventional DMR/NXDN activity hold (250..600000, default "
+           "1200).\n");
     printf("  -W            Use Imported Group List as a Trunking Allow/White List -- Only Tune with Mode A\n");
     printf("  -p            Disable Tune to Private Calls (DMR TIII, P25, NXDN Type-C and Type-D)\n");
     printf("  -E            Disable Tune to Group Calls (DMR TIII, Con+, Cap+, P25, NXDN Type-C, and Type-D)\n");

--- a/src/runtime/config_schema.c
+++ b/src/runtime/config_schema.c
@@ -93,8 +93,8 @@ static const dsdcfg_schema_entry_t s_schema[] = {
     {"trunk_scan", "enabled", "Enable single-tuner trunk scan mode", "false", NULL, DSDCFG_TYPE_BOOL, 0, 0},
     {"trunk_scan", "targets_csv", "Trunk scan target list CSV file path", "", NULL, DSDCFG_TYPE_PATH, 0, 0},
     {"trunk_scan", "idle_dwell_ms", "Default idle dwell per scan target", "3000", NULL, DSDCFG_TYPE_INT, 250, 600000},
-    {"trunk_scan", "activity_hold_ms", "Default conventional DMR activity hold", "1200", NULL, DSDCFG_TYPE_INT, 250,
-     600000},
+    {"trunk_scan", "activity_hold_ms", "Default conventional DMR/NXDN activity hold", "1200", NULL, DSDCFG_TYPE_INT,
+     250, 600000},
 
     /* [logging] section */
     {"logging", "event_log", "Event history log file path", "", NULL, DSDCFG_TYPE_PATH, 0, 0},

--- a/src/runtime/config_user.cpp
+++ b/src/runtime/config_user.cpp
@@ -1702,7 +1702,10 @@ snapshot_output_config(const dsd_opts* opts, dsdneoUserConfig* cfg) {
 static void
 snapshot_mode_config(const dsd_opts* opts, const dsd_state* state, dsdneoUserConfig* cfg) {
     cfg->has_mode = 1;
-    cfg->decode_mode = dsd_infer_decode_mode_preset(opts);
+    /* Exact, not the AUTO-falling-back spelling: a decoder set no preset reproduces must render
+       no `decode` key at all. Saving it as "auto" would reload as every decoder enabled, so a
+       session that never chose a mode would come back wider than it was saved. */
+    cfg->decode_mode = dsd_infer_decode_mode_preset_exact(opts);
     cfg->has_dmr_mono = 1;
     cfg->dmr_mono = opts->dmr_mono ? 1 : 0;
     /* The only snapshotter that reads dsd_state. NOT unconditional, unlike

--- a/src/runtime/decode_mode.c
+++ b/src/runtime/decode_mode.c
@@ -148,19 +148,27 @@ dsd_apply_decode_mode_symbol_timing(dsdneoUserDecodeMode mode, int effective_inp
 
 static void
 decode_mode_apply_auto(dsdDecodePresetProfile p, dsd_opts* o, dsd_state* s) {
+    /* AUTO means "hunt every digital protocol", and it means that from all three entry points.
+       The config and interactive paths used to skip this block entirely -- a behavior-preserving
+       carve-out from when their preset code was separate -- which left `decode = "auto"` and the
+       wizard's Auto decoding only the dsd_init defaults, no NXDN, dPMR, ProVoice or M17. It also
+       broke the autosave round trip: a -fa session saves as `auto` and came back narrower than it
+       went out. The audio layout and modulation below stay CLI-only, because the config path owns
+       those through [mode] demod and its output keys, and the interactive path through the wizard's
+       own answers. */
+    o->frame_dstar = 1;
+    o->frame_x2tdma = 1;
+    o->frame_p25p1 = 1;
+    o->frame_p25p2 = 1;
+    o->inverted_p2 = 0;
+    o->frame_nxdn48 = 1;
+    o->frame_nxdn96 = 1;
+    o->frame_dmr = 1;
+    o->frame_dpmr = 1;
+    o->frame_provoice = 1;
+    o->frame_ysf = 1;
+    o->frame_m17 = 1;
     if (p == DSD_DECODE_PRESET_PROFILE_CLI) {
-        o->frame_dstar = 1;
-        o->frame_x2tdma = 1;
-        o->frame_p25p1 = 1;
-        o->frame_p25p2 = 1;
-        o->inverted_p2 = 0;
-        o->frame_nxdn48 = 1;
-        o->frame_nxdn96 = 1;
-        o->frame_dmr = 1;
-        o->frame_dpmr = 1;
-        o->frame_provoice = 1;
-        o->frame_ysf = 1;
-        o->frame_m17 = 1;
         /* Cleared together, like every sibling preset does. Applied mid-session
          * (the Qt radio panel's decode chips), a preset that leaves the previous
          * one's GFSK flag set publishes mod_c4fm=1 && mod_gfsk=1 -- an opts pair
@@ -171,7 +179,9 @@ decode_mode_apply_auto(dsdDecodePresetProfile p, dsd_opts* o, dsd_state* s) {
          * frame_sync_apply_cli_mod_lock() re-derives rf_mod from these flags on
          * every pass -- so clearing mod_gfsk here would turn `-mg -fa` into a
          * permanent C4FM lock the SPS hunt is then forbidden to correct. The
-         * mid-session path clears the lock before it applies a preset. */
+         * mid-session path clears the lock before it applies a preset. On the config
+         * path the lock is set by [mode] demod, which apply_demod_config() applies
+         * after this preset, so that key wins there regardless. */
         if (!o->mod_cli_lock) {
             o->mod_c4fm = 1;
             o->mod_qpsk = 0;
@@ -638,7 +648,7 @@ dsd_apply_decode_mode_preset(dsdneoUserDecodeMode mode, dsdDecodePresetProfile p
 }
 
 dsdneoUserDecodeMode
-dsd_infer_decode_mode_preset(const dsd_opts* opts) {
+dsd_infer_decode_mode_preset_exact(const dsd_opts* opts) {
     enum {
         DSD_MODE_BIT_DSTAR = 1u << 0,
         DSD_MODE_BIT_X2TDMA = 1u << 1,
@@ -654,7 +664,7 @@ dsd_infer_decode_mode_preset(const dsd_opts* opts) {
     };
 
     if (!opts) {
-        return DSDCFG_MODE_AUTO;
+        return DSDCFG_MODE_UNSET;
     }
 
     if (opts->analog_only && opts->monitor_input_audio) {
@@ -682,6 +692,10 @@ dsd_infer_decode_mode_preset(const dsd_opts* opts) {
         unsigned mask;
         dsdneoUserDecodeMode mode;
     } map[] = {
+        {DSD_MODE_BIT_DSTAR | DSD_MODE_BIT_X2TDMA | DSD_MODE_BIT_P25P1 | DSD_MODE_BIT_P25P2 | DSD_MODE_BIT_NXDN48
+             | DSD_MODE_BIT_NXDN96 | DSD_MODE_BIT_DMR | DSD_MODE_BIT_DPMR | DSD_MODE_BIT_PROVOICE | DSD_MODE_BIT_YSF
+             | DSD_MODE_BIT_M17,
+         DSDCFG_MODE_AUTO},
         {DSD_MODE_BIT_P25P1 | DSD_MODE_BIT_P25P2 | DSD_MODE_BIT_DMR, DSDCFG_MODE_TDMA},
         {DSD_MODE_BIT_DMR, DSDCFG_MODE_DMR},
         {DSD_MODE_BIT_P25P1, DSDCFG_MODE_P25P1},
@@ -702,7 +716,13 @@ dsd_infer_decode_mode_preset(const dsd_opts* opts) {
         }
     }
 
-    return DSDCFG_MODE_AUTO;
+    return DSDCFG_MODE_UNSET;
+}
+
+dsdneoUserDecodeMode
+dsd_infer_decode_mode_preset(const dsd_opts* opts) {
+    const dsdneoUserDecodeMode mode = dsd_infer_decode_mode_preset_exact(opts);
+    return mode == DSDCFG_MODE_UNSET ? DSDCFG_MODE_AUTO : mode;
 }
 
 const char*

--- a/src/runtime/trunk_scan_hooks.c
+++ b/src/runtime/trunk_scan_hooks.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
+#include <stddef.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 

--- a/src/runtime/trunk_scan_hooks.c
+++ b/src/runtime/trunk_scan_hooks.c
@@ -47,6 +47,11 @@ dsd_trunk_scan_hook_nxdn_conventional_activity(const dsd_opts* opts, const dsd_s
     }
 }
 
+const char*
+dsd_trunk_scan_hook_active_chan_csv(const dsd_state* state) {
+    return g_trunk_scan_hooks.active_chan_csv ? g_trunk_scan_hooks.active_chan_csv(state) : NULL;
+}
+
 void
 dsd_trunk_scan_hook_enc_lockout_clear_snapshots(const dsd_state* state) {
     if (g_trunk_scan_hooks.enc_lockout_clear_snapshots) {

--- a/src/runtime/trunk_scan_hooks.c
+++ b/src/runtime/trunk_scan_hooks.c
@@ -40,6 +40,14 @@ dsd_trunk_scan_hook_dmr_conventional_activity(const dsd_opts* opts, const dsd_st
 }
 
 void
+dsd_trunk_scan_hook_nxdn_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
+                                               uint32_t source, int is_private, int encrypted, int data_call) {
+    if (g_trunk_scan_hooks.nxdn_conventional_activity) {
+        g_trunk_scan_hooks.nxdn_conventional_activity(opts, state, target, source, is_private, encrypted, data_call);
+    }
+}
+
+void
 dsd_trunk_scan_hook_enc_lockout_clear_snapshots(const dsd_state* state) {
     if (g_trunk_scan_hooks.enc_lockout_clear_snapshots) {
         g_trunk_scan_hooks.enc_lockout_clear_snapshots(state);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -277,6 +277,18 @@ dsd_neo_add_public_header_smoke_test(
   C
 )
 dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_runtime_trunk_scan_hooks
+  HEADERS_PUBLIC_RUNTIME_TRUNK_SCAN_HOOKS
+  dsd-neo/runtime/trunk_scan_hooks.h
+  C
+)
+dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_protocol_nxdn_trunk_diag
+  HEADERS_PUBLIC_PROTOCOL_NXDN_TRUNK_DIAG
+  dsd-neo/protocol/nxdn/nxdn_trunk_diag.h
+  C
+)
+dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_runtime_cli
   HEADERS_PUBLIC_RUNTIME_CLI
   dsd-neo/runtime/cli.h
@@ -4198,6 +4210,7 @@ add_executable(
     ${PROJECT_SOURCE_DIR}/src/engine/trunk_scan.c
     ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
     ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/nxdn/nxdn_trunk_diag.c
 )
 target_include_directories(
     dsd-neo_test_engine_trunk_scan

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4190,6 +4190,7 @@ add_executable(
     dsd-neo_test_engine_trunk_retune_regression
     engine/test_engine_trunk_retune_regression.c
     ${PROJECT_SOURCE_DIR}/src/engine/trunk_tuning.c
+    ${PROJECT_SOURCE_DIR}/src/runtime/decode_mode.c
 )
 target_include_directories(
     dsd-neo_test_engine_trunk_retune_regression

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -1155,6 +1155,17 @@ test_decode_mode_profiles_agree_with_the_sps_hunt_table(void) {
      * they share a preset symbol timing but not a symbol rate. */
     assert(dsd_decode_mode_profile_for(DSDCFG_MODE_NXDN48).symbol_rate_hz == 2400);
     assert(dsd_decode_mode_profile_for(DSDCFG_MODE_NXDN96).symbol_rate_hz == 4800);
+
+    /* AUTO's whole promise is that the hunt may visit every profile, and a config file selects
+     * the same AUTO the command line does. The profile argument decides audio layout, never the
+     * decoder set, so every candidate must be reachable from the config path too. */
+    for (int profile_index = 0; profile_index < dsd_frame_sync_test_sps_hunt_profile_count(); profile_index++) {
+        static dsd_opts opts;
+        static dsd_state state;
+        reset(&opts, &state);
+        assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_AUTO, DSD_DECODE_PRESET_PROFILE_CONFIG, &opts, &state) == 0);
+        assert(dsd_frame_sync_test_sps_hunt_profile_has_candidate(&opts, profile_index) == 1);
+    }
 }
 
 static void

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -507,6 +507,91 @@ main(void) {
     assert(state->symbolCenter == 8);
     assert(state->rf_mod == 2);
 
+    /* NXDN trunking populates p25_cc_freq the same way P25 does, so a return to an NXDN control
+     * channel must not be mistaken for a P25 one: rewriting rf_mod to C4FM/QPSK drops the GFSK
+     * slicing an NXDN96 (or DMR-class) control channel needs. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    opts->use_rigctl = 1;
+    opts->rigctl_sockfd = 1;
+
+    state->p25_cc_freq = 461000000;
+    state->trunk_cc_freq = 461000000;
+    state->p25_cc_is_tdma = 2; /* initState() sentinel: no P25 control channel seen */
+    state->synctype = DSD_SYNC_NXDN_POS;
+    state->lastsynctype = DSD_SYNC_NXDN_POS;
+    state->samplesPerSymbol = 10;
+    state->symbolCenter = 4;
+    state->rf_mod = 2;
+    state->sps_hunt_counter = 5;
+
+    g_setfreq_calls = 0;
+    g_last_setfreq_hz = 0;
+
+    assert(dsd_engine_return_to_cc_request(opts, state, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+
+    assert(g_setfreq_calls == 1);
+    assert(g_last_setfreq_hz == 461000000);
+    assert(state->rf_mod == 2);
+    assert(state->samplesPerSymbol == 10);
+    assert(state->symbolCenter == 4);
+    assert(state->sps_hunt_counter == 5);
+
+    /* EDACS also anchors p25_cc_freq and runs GFSK; same rule applies. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    opts->use_rigctl = 1;
+    opts->rigctl_sockfd = 1;
+
+    state->p25_cc_freq = 856000000;
+    state->trunk_cc_freq = 856000000;
+    state->p25_cc_is_tdma = 2;
+    state->synctype = DSD_SYNC_EDACS_POS;
+    state->lastsynctype = DSD_SYNC_EDACS_POS;
+    state->samplesPerSymbol = 5;
+    state->symbolCenter = 2;
+    state->rf_mod = 2;
+
+    g_setfreq_calls = 0;
+    assert(dsd_engine_return_to_cc_request(opts, state, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_setfreq_calls == 1);
+    assert(state->rf_mod == 2);
+    assert(state->samplesPerSymbol == 5);
+    assert(state->symbolCenter == 2);
+
+    /* A parked non-P25 trunk-scan target that has not synced yet reads as P25 by synctype alone
+     * (DSD_SYNC_P25P1_POS is 0), so the coordinator's own target type is the authority. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->trunk_scan_enabled = 1;
+    opts->audio_in_type = AUDIO_IN_PULSE;
+    opts->use_rigctl = 1;
+    opts->rigctl_sockfd = 1;
+
+    state->p25_cc_freq = 462000000;
+    state->trunk_cc_freq = 462000000;
+    state->p25_cc_is_tdma = 2;
+    state->samplesPerSymbol = 10;
+    state->symbolCenter = 4;
+    state->rf_mod = 0; /* global -mc lock with an empty target modulation column */
+    state->sps_hunt_counter = 5;
+    g_trunk_scan_target_count = 2;
+    g_trunk_scan_active_p25_target = 0;
+
+    g_setfreq_calls = 0;
+    assert(dsd_engine_return_to_cc_request(opts, state, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_setfreq_calls == 1);
+    assert(state->sps_hunt_counter == 5);
+    g_trunk_scan_target_count = 0;
+
     /* A fixed input without rigctl has no tuner backend and must not fabricate
      * successful voice, control-channel, or scan retunes. */
     DSD_MEMSET(opts, 0, sizeof(*opts));

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -72,6 +72,7 @@ static int g_rtl_pending_tuner_autogain_is_set = 0;
 static int g_rtl_pending_tuner_autogain_on = 0;
 static uint32_t g_rtl_pending_target_freq_hz = 0;
 static size_t g_trunk_scan_target_count = 0;
+static int g_trunk_scan_active_gfsk_symbol_rate = 0;
 static int g_trunk_scan_saved_autogain_is_set = 0;
 static int g_trunk_scan_saved_autogain_on = 0;
 static int g_trunk_scan_active_p25_cqpsk_is_set = 0;
@@ -216,6 +217,13 @@ dsd_engine_trunk_scan_saved_tuner_autogain(const dsd_state* state, int* out_on) 
         *out_on = g_trunk_scan_saved_autogain_on;
     }
     return g_trunk_scan_saved_autogain_is_set;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_engine_trunk_scan_active_gfsk_symbol_rate(const dsd_state* state) {
+    (void)state;
+    return g_trunk_scan_active_gfsk_symbol_rate;
 }
 
 int
@@ -832,6 +840,59 @@ main(void) {
     assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_12K5);
     assert(g_rtl_ted_sps == 10);
     assert(g_rtl_ted_sps_override == 0);
+
+    /* A parked nxdn48-conventional scan target runs 2400 sym/s in a 6.25 kHz channel. rf_mod == 2
+     * is true for every GFSK-family target, so only the coordinator's own answer separates it from
+     * the 4800 sym/s DMR/NXDN96 case above -- and a wrong filter here never self-corrects, because
+     * a pinned SPS hunt stops re-applying the demod profile. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_scan_enabled = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 2;
+    g_trunk_scan_target_count = 2;
+    g_trunk_scan_active_gfsk_symbol_rate = 2400;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 1;
+    g_rtl_symbol_rate_hz = 4800;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_12K5;
+    g_rtl_ted_sps = 10;
+    g_rtl_ted_sps_override = 10;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_scan_tune_to_freq(opts, state, 461556250, 20, NULL) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_pending_active == 0);
+    assert(g_rtl_cqpsk_enable == 0);
+    assert(g_rtl_symbol_rate_hz == 2400);
+    assert(g_rtl_symbol_levels == 4);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_6K25);
+    assert(g_rtl_ted_sps == 20); /* 48000 / 2400 from the stubbed RTL output rate */
+    assert(g_rtl_ted_sps_override == 0);
+
+    /* A parked 4800-class scan target keeps the 12.5 kHz chain. */
+    g_trunk_scan_active_gfsk_symbol_rate = 4800;
+    g_rtl_symbol_rate_hz = 2400;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_6K25;
+    g_rtl_ted_sps = 20;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_scan_tune_to_freq(opts, state, 461112500, 10, NULL) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_12K5);
+    assert(g_rtl_ted_sps == 10);
+
+    /* Outside trunk scan the coordinator answers 0 and the rf_mod == 2 gate still picks 4800. */
+    g_trunk_scan_target_count = 0;
+    g_trunk_scan_active_gfsk_symbol_rate = 0;
+    g_rtl_symbol_rate_hz = 2400;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_6K25;
+    g_rtl_ted_sps = 20;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_scan_tune_to_freq(opts, state, 461112500, 10, NULL) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_12K5);
+    assert(g_rtl_ted_sps == 10);
+    rtl_stream_clear_pending_retune_profile();
 
     /* Trunk-scan RTL retunes queue the active target/global gain with the
      * demod profile so gain changes happen at the retune boundary. */

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -363,6 +363,7 @@ test_parser_valid_mixed_targets_and_relative_chan_csv(void) {
     opts.trunk_scan_idle_dwell_ms = 3000;
     opts.trunk_scan_activity_hold_ms = 1200;
     dsd_trunk_scan_target_list list;
+    DSD_MEMSET(&list, 0, sizeof list);
     char err[256] = {0};
     int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
 
@@ -417,6 +418,7 @@ test_parser_accepts_nxdn_targets(void) {
     opts.trunk_scan_idle_dwell_ms = 3000;
     opts.trunk_scan_activity_hold_ms = 1200;
     dsd_trunk_scan_target_list list;
+    DSD_MEMSET(&list, 0, sizeof list);
     char err[256] = {0};
     int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
 
@@ -472,6 +474,7 @@ test_parser_accepts_quoted_chan_csv_with_comma(void) {
     opts.trunk_scan_idle_dwell_ms = 3000;
     opts.trunk_scan_activity_hold_ms = 1200;
     dsd_trunk_scan_target_list list;
+    DSD_MEMSET(&list, 0, sizeof list);
     char err[256] = {0};
     int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
 
@@ -510,6 +513,7 @@ test_parser_accepts_optional_modulation_and_gain_columns(void) {
     opts.trunk_scan_idle_dwell_ms = 3000;
     opts.trunk_scan_activity_hold_ms = 1200;
     dsd_trunk_scan_target_list list;
+    DSD_MEMSET(&list, 0, sizeof list);
     char err[256] = {0};
     int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
 
@@ -2294,7 +2298,9 @@ test_nxdn_state_isolated_per_target(void) {
         DSD_FPRINTF(stderr, "nxdn identity scan did not rotate to second target\n");
         test_rc = 1;
     }
-    test_rc |= expect_nxdn_identity("fresh target", &state, 0, 0, 0U, 0U, 0, "", 0, 0, 0, 0);
+    /* A never-visited target must come back with the "no RAN decoded" sentinel, not a
+     * fabricated RAN 0. */
+    test_rc |= expect_nxdn_identity("fresh target", &state, 0, 0, (unsigned int)-1, 0U, 0, " ", 0, 0, 0, 0);
 
     seed_nxdn_identity(&state, 34, 462037500, 9U, 0x44U, 5, "Type-C", 2, 110, 25, 6);
     trunk_scan_test_set_now(0.52);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -407,7 +407,8 @@ test_parser_accepts_nxdn_targets(void) {
     static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n";
     if (write_targets_file_with_header(dir, header,
                                        "nxdn,nxdn-trunk,461000000,chan.csv,,,site,gfsk\n"
-                                       "conv,nxdn-conventional,462000000,,250,500,,auto\n",
+                                       "conv,nxdn-conventional,462000000,,250,500,,auto\n"
+                                       "conv48,nxdn48-conventional,462000000,,250,500,,gfsk\n",
                                        target_path, sizeof target_path)
         != 0) {
         cleanup_paths(dir, NULL, chan_path);
@@ -424,7 +425,7 @@ test_parser_accepts_nxdn_targets(void) {
     int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
 
     int test_rc = 0;
-    if (rc != 0 || list.count != 2) {
+    if (rc != 0 || list.count != 3) {
         DSD_FPRINTF(stderr, "parser nxdn rc=%d count=%zu err=%s\n", rc, list.count, err);
         test_rc = 1;
     }
@@ -441,6 +442,15 @@ test_parser_accepts_nxdn_targets(void) {
             || list.targets[1].activity_hold_ms != 500
             || list.targets[1].modulation != DSD_TRUNK_SCAN_MODULATION_AUTO) {
             DSD_FPRINTF(stderr, "parser nxdn conventional target 1 mismatch\n");
+            test_rc = 1;
+        }
+        /* Same frequency as target 1 on purpose: the two NXDN conventional variants are distinct
+           target types, so the (type, frequency) duplicate check must not collapse them. */
+        if (list.targets[2].type != DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL
+            || list.targets[2].frequency_hz != 462000000U || list.targets[2].dwell_ms != 250
+            || list.targets[2].activity_hold_ms != 500 || list.targets[2].modulation != DSD_TRUNK_SCAN_MODULATION_GFSK
+            || list.targets[2].chan_csv[0] != '\0') {
+            DSD_FPRINTF(stderr, "parser nxdn48 conventional target 2 mismatch\n");
             test_rc = 1;
         }
     }
@@ -645,6 +655,10 @@ test_parser_rejects_invalid_inputs(void) {
     rc |= expect_parser_rejects_with_header(
         "nxdn-unsupported-modulation", "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n",
         "a,nxdn-trunk,461000000,,,,,cqpsk\n");
+    rc |= expect_parser_rejects("nxdn48-conventional-chan-csv", "a,nxdn48-conventional,461556250,chan.csv,,,\n");
+    rc |= expect_parser_rejects_with_header(
+        "nxdn48-unsupported-modulation", "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n",
+        "a,nxdn48-conventional,461556250,,,,,c4fm\n");
     rc |= expect_parser_rejects_with_header("invalid-rtl-gain",
                                             "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,rtl_gain\n",
                                             "a,p25-trunk,851000000,,,,,50\n");
@@ -2120,6 +2134,197 @@ test_mixed_target_switch_resets_nxdn_demod_profile(void) {
 }
 
 static int
+test_nxdn48_target_selects_2400_demod_profile(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("n96,nxdn-conventional,461000000,,250,,\n"
+                             "n48,nxdn48-conventional,461556250,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    g_scan_tune_to_freq_ted_sps = 0;
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "nxdn48 demod scan init failed rc=%d err=%s\n", rc, err);
+        test_rc = 1;
+    }
+    if (test_rc == 0
+        && (state.sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4 || state.samplesPerSymbol != 10
+            || state.symbolCenter != 4 || state.rf_mod != 2 || g_scan_tune_to_freq_ted_sps != 10)) {
+        DSD_FPRINTF(stderr, "nxdn96 target profile wrong idx=%d sps=%d center=%d rf_mod=%d ted=%d\n",
+                    state.sps_hunt_idx, state.samplesPerSymbol, state.symbolCenter, state.rf_mod,
+                    g_scan_tune_to_freq_ted_sps);
+        test_rc = 1;
+    }
+
+    /* Poison every axis the coordinator owns: parking an NXDN48 target must re-seed all of them. */
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.sps_hunt_counter = 17;
+    state.samplesPerSymbol = 8;
+    state.symbolCenter = 3;
+    state.rf_mod = 0;
+    g_scan_tune_to_freq_ted_sps = 0;
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || state.sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_2400_4
+        || state.sps_hunt_counter != 0 || state.samplesPerSymbol != 20 || state.symbolCenter != 9 || state.rf_mod != 2
+        || g_scan_tune_to_freq_ted_sps != 20) {
+        DSD_FPRINTF(stderr,
+                    "nxdn48 target profile wrong active=%zu idx=%d counter=%d sps=%d center=%d rf_mod=%d ted=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), state.sps_hunt_idx, state.sps_hunt_counter,
+                    state.samplesPerSymbol, state.symbolCenter, state.rf_mod, g_scan_tune_to_freq_ted_sps);
+        test_rc = 1;
+    }
+
+    /* Rotating back must not leak the 2400 timing into the NXDN96 target. */
+    g_scan_tune_to_freq_ted_sps = 0;
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || state.sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4
+        || state.samplesPerSymbol != 10 || state.symbolCenter != 4 || state.rf_mod != 2
+        || g_scan_tune_to_freq_ted_sps != 10) {
+        DSD_FPRINTF(stderr, "nxdn96 target inherited 2400 timing active=%zu idx=%d sps=%d center=%d ted=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), state.sps_hunt_idx, state.samplesPerSymbol,
+                    state.symbolCenter, g_scan_tune_to_freq_ted_sps);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_nxdn48_target_uses_rtl_output_rate_for_sps(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("n48,nxdn48-conventional,461556250,,250,,\n"
+                             "n96,nxdn-conventional,461000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    dsd_rtl_stream_metrics_hooks metrics_hooks = {0};
+    metrics_hooks.output_rate_hz = fake_rtl_output_rate_hz;
+    g_fake_rtl_output_rate_hz = 24000U;
+    dsd_rtl_stream_metrics_hooks_set(&metrics_hooks);
+
+    g_scan_tune_to_freq_ted_sps = 0;
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    /* 24000 / 2400 = 10, the same sps NXDN96 gets at 48 kHz -- so only the hunt profile separates them. */
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0
+        || state.sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_2400_4 || state.samplesPerSymbol != 10
+        || state.symbolCenter != 4 || g_scan_tune_to_freq_ted_sps != 10) {
+        DSD_FPRINTF(stderr, "nxdn48 target ignored RTL output rate rc=%d idx=%d sps=%d center=%d ted=%d err=%s\n", rc,
+                    state.sps_hunt_idx, state.samplesPerSymbol, state.symbolCenter, g_scan_tune_to_freq_ted_sps, err);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* One init cycle with the given NXDN frame flags; returns the captured stderr in `buf`. */
+static int
+run_nxdn_decoder_warning_case(const char* label, const char* target_path, int frame_nxdn48, int frame_nxdn96, char* buf,
+                              size_t buf_sz) {
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    opts.frame_nxdn48 = frame_nxdn48;
+    opts.frame_nxdn96 = frame_nxdn96;
+
+    dsd_test_capture_stderr cap;
+    if (dsd_test_capture_stderr_begin(&cap, "trunkscan48warn") != 0) {
+        DSD_FPRINTF(stderr, "%s: stderr capture failed\n", label);
+        return 1;
+    }
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    (void)dsd_test_capture_stderr_end(&cap);
+    if (dsd_test_capture_stderr_read(&cap, buf, buf_sz) != 0) {
+        DSD_FPRINTF(stderr, "%s: stderr read failed\n", label);
+        return 1;
+    }
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "%s: scan init failed rc=%d err=%s\n", label, rc, err);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_warns_when_nxdn48_decoder_disabled(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("n48,nxdn48-conventional,461556250,,250,,\n"
+                             "n96,nxdn-conventional,461000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    int test_rc = 0;
+    char buf[4096];
+
+    /* NXDN96 enabled only: the NXDN48 row is the one that cannot decode. */
+    if (run_nxdn_decoder_warning_case("nxdn48-disabled", target_path, 0, 1, buf, sizeof buf) != 0) {
+        test_rc = 1;
+    } else if (!strstr(buf, "1 trunk scan target(s) have no enabled NXDN48 decoder (first: 'n48')")
+               || !strstr(buf, "use -fi or -fa to decode them") || strstr(buf, "NXDN96 decoder") != NULL) {
+        DSD_FPRINTF(stderr, "nxdn48 disabled warning wrong:\n%s\n", buf);
+        test_rc = 1;
+    }
+
+    /* NXDN48 enabled only: the NXDN96 row is the one that cannot decode. */
+    if (run_nxdn_decoder_warning_case("nxdn96-disabled", target_path, 1, 0, buf, sizeof buf) != 0) {
+        test_rc = 1;
+    } else if (!strstr(buf, "1 trunk scan target(s) have no enabled NXDN96 decoder (first: 'n96')")
+               || !strstr(buf, "use -fn or -fa to decode them") || strstr(buf, "NXDN48 decoder") != NULL) {
+        DSD_FPRINTF(stderr, "nxdn96 disabled warning wrong:\n%s\n", buf);
+        test_rc = 1;
+    }
+
+    /* Both enabled (-fa): neither variant warns. */
+    if (run_nxdn_decoder_warning_case("both-enabled", target_path, 1, 1, buf, sizeof buf) != 0) {
+        test_rc = 1;
+    } else if (strstr(buf, "NXDN48 decoder") != NULL || strstr(buf, "NXDN96 decoder") != NULL) {
+        DSD_FPRINTF(stderr, "both-enabled warned anyway:\n%s\n", buf);
+        test_rc = 1;
+    }
+
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
 test_nxdn_conventional_activity_hold(void) {
     char dir[DSD_TEST_PATH_MAX];
     char target_path[DSD_TEST_PATH_MAX];
@@ -2268,7 +2473,130 @@ test_conventional_activity_data_call_respects_tune_data_calls(void) {
                                                dsd_engine_trunk_scan_dmr_conventional_activity);
     rc |= run_conventional_data_call_hold_case("dmr-data-not-followed", dmr_body, 0, 1,
                                                dsd_engine_trunk_scan_dmr_conventional_activity);
+
+    /* The NXDN entry point serves both conventional variants: nxdn_element.c reports VCALL/DCALL
+       identity without knowing whether the site is 6.25 or 12.5 kHz. */
+    static const char nxdn48_body[] = "a,nxdn48-conventional,461556250,,250,250,\n"
+                                      "b,nxdn48-conventional,462556250,,250,250,\n";
+    rc |= run_conventional_data_call_hold_case("nxdn48-data-followed", nxdn48_body, 1, 0,
+                                               dsd_engine_trunk_scan_nxdn_conventional_activity);
+    rc |= run_conventional_data_call_hold_case("nxdn48-data-not-followed", nxdn48_body, 0, 1,
+                                               dsd_engine_trunk_scan_nxdn_conventional_activity);
     return rc;
+}
+
+/*
+ * The NXDN entry point holds either NXDN conventional variant, and neither conventional family
+ * may claim the other's park: a DMR voice header decoded while an NXDN48 target is parked says
+ * nothing about that target's channel.
+ */
+static int
+test_conventional_activity_families_do_not_cross(void) {
+    static const char nxdn48_first[] = "n48,nxdn48-conventional,461556250,,250,250,\n"
+                                       "dmrc,dmr-conventional,461112500,,250,250,\n";
+    static const char dmr_first[] = "dmrc,dmr-conventional,461112500,,250,250,\n"
+                                    "n48,nxdn48-conventional,461556250,,250,250,\n";
+    int rc = 0;
+
+    /* NXDN hook holds a parked nxdn48-conventional target (data-call tuning on to reuse the helper). */
+    rc |= run_conventional_data_call_hold_case("nxdn-hook-holds-nxdn48", nxdn48_first, 1, 0,
+                                               dsd_engine_trunk_scan_nxdn_conventional_activity);
+    /* DMR hook must not: the target rotates away despite the reported activity. */
+    rc |= run_conventional_data_call_hold_case("dmr-hook-skips-nxdn48", nxdn48_first, 1, 1,
+                                               dsd_engine_trunk_scan_dmr_conventional_activity);
+    /* And the NXDN hook must not claim a parked dmr-conventional target. */
+    rc |= run_conventional_data_call_hold_case("nxdn-hook-skips-dmr", dmr_first, 1, 1,
+                                               dsd_engine_trunk_scan_nxdn_conventional_activity);
+    return rc;
+}
+
+static int
+test_nxdn48_conventional_activity_hold(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,nxdn48-conventional,461556250,,250,250,\n"
+                             "b,nxdn48-conventional,462556250,,250,250,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "nxdn48 conventional scan init failed rc=%d err=%s\n", rc, err);
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_nxdn_conventional_activity(&opts, &state, 1001, 2002, 0, 0, 0);
+    trunk_scan_test_set_now(0.30);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "NXDN48 conventional activity did not hold the target\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.61);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    trunk_scan_test_set_now(0.87);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "NXDN48 target did not rotate after conventional hold and dwell\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+
+    reset_scan_opts_state(&opts, &state);
+    opts.trunk_use_allow_list = 1;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    trunk_scan_test_set_now(0.0);
+    rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "nxdn48 allowlist scan init failed: %s\n", err);
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_nxdn_conventional_activity(&opts, &state, 1001, 2002, 0, 0, 0);
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "blocked allow-list traffic held NXDN48 conventional target\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+
+    reset_scan_opts_state(&opts, &state);
+    opts.trunk_tune_enc_calls = 0;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    trunk_scan_test_set_now(0.0);
+    rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "nxdn48 encrypted lockout scan init failed: %s\n", err);
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_nxdn_conventional_activity(&opts, &state, 1001, 2002, 1, 1, 0);
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "encrypted NXDN48 conventional traffic held target despite lockout\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
 }
 
 static int
@@ -4296,8 +4624,13 @@ main(void) {
     rc |= run_with_default_tune_hook(test_conventional_activity_encrypted_lockout_does_not_hold);
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_seeds_control_channel);
     rc |= run_with_default_tune_hook(test_mixed_target_switch_resets_nxdn_demod_profile);
+    rc |= run_with_default_tune_hook(test_nxdn48_target_selects_2400_demod_profile);
+    rc |= run_with_default_tune_hook(test_nxdn48_target_uses_rtl_output_rate_for_sps);
+    rc |= run_with_default_tune_hook(test_warns_when_nxdn48_decoder_disabled);
     rc |= run_with_default_tune_hook(test_nxdn_conventional_activity_hold);
     rc |= run_with_default_tune_hook(test_conventional_activity_data_call_respects_tune_data_calls);
+    rc |= run_with_default_tune_hook(test_conventional_activity_families_do_not_cross);
+    rc |= run_with_default_tune_hook(test_nxdn48_conventional_activity_hold);
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_holds_while_tuned);
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_follows_corrected_cc);
     rc |= run_with_default_tune_hook(test_nxdn_state_isolated_per_target);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -2206,6 +2206,70 @@ test_nxdn_conventional_activity_hold(void) {
     return test_rc;
 }
 
+/*
+ * Data traffic holds a conventional target exactly as far as data-call tuning allows: reported
+ * activity is run through the same talkgroup policy as voice, and --trunk-tune-data-calls is off
+ * by default, so a data header holds the park only when the operator asked to follow data.
+ */
+static int
+run_conventional_data_call_hold_case(const char* tag, const char* body, int tune_data_calls, size_t expect_active,
+                                     void (*report)(const dsd_opts*, const dsd_state*, uint32_t, uint32_t, int, int,
+                                                    int)) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets(body, target_path, sizeof target_path, dir, sizeof dir) != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.trunk_tune_data_calls = tune_data_calls;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "%s: data-call scan init failed: %s\n", tag, err);
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.10);
+    report(&opts, &state, 1001, 2002, 0, 0, 1);
+    trunk_scan_test_set_now(0.30);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != expect_active) {
+        DSD_FPRINTF(stderr, "%s: data-call activity left active=%zu want %zu\n", tag,
+                    dsd_engine_trunk_scan_active_index(&state), expect_active);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_conventional_activity_data_call_respects_tune_data_calls(void) {
+    static const char nxdn_body[] = "a,nxdn-conventional,461000000,,250,250,\n"
+                                    "b,nxdn-conventional,462000000,,250,250,\n";
+    static const char dmr_body[] = "a,dmr-conventional,461000000,,250,250,\n"
+                                   "b,dmr-conventional,462000000,,250,250,\n";
+    int rc = 0;
+
+    rc |= run_conventional_data_call_hold_case("nxdn-data-followed", nxdn_body, 1, 0,
+                                               dsd_engine_trunk_scan_nxdn_conventional_activity);
+    rc |= run_conventional_data_call_hold_case("nxdn-data-not-followed", nxdn_body, 0, 1,
+                                               dsd_engine_trunk_scan_nxdn_conventional_activity);
+    rc |= run_conventional_data_call_hold_case("dmr-data-followed", dmr_body, 1, 0,
+                                               dsd_engine_trunk_scan_dmr_conventional_activity);
+    rc |= run_conventional_data_call_hold_case("dmr-data-not-followed", dmr_body, 0, 1,
+                                               dsd_engine_trunk_scan_dmr_conventional_activity);
+    return rc;
+}
+
 static int
 test_nxdn_trunk_target_holds_while_tuned(void) {
     char dir[DSD_TEST_PATH_MAX];
@@ -4129,6 +4193,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_seeds_control_channel);
     rc |= run_with_default_tune_hook(test_mixed_target_switch_resets_nxdn_demod_profile);
     rc |= run_with_default_tune_hook(test_nxdn_conventional_activity_hold);
+    rc |= run_with_default_tune_hook(test_conventional_activity_data_call_respects_tune_data_calls);
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_holds_while_tuned);
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_follows_corrected_cc);
     rc |= run_with_default_tune_hook(test_nxdn_state_isolated_per_target);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -2606,6 +2606,77 @@ test_p25_pending_retune_holds_scan_dwell(void) {
     return test_rc;
 }
 
+/*
+ * Once the NXDN decoder corrects an nxdn-trunk target's control channel from the site broadcast
+ * (nxdn_cch_info_dfa_version), the coordinator must carry that correction across rotations and
+ * re-park on it rather than on the stale CSV frequency. Pins the snapshot + retune contract the
+ * decoder-side adoption depends on.
+ */
+static int
+test_nxdn_trunk_target_follows_corrected_cc(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,nxdn-trunk,461000000,,250,,\n"
+                             "b,nxdn-trunk,462000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_freq = 0;
+
+    const long int corrected_cc = 461012500L;
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0 || g_counting_tune_to_cc_freq != 461000000L) {
+        DSD_FPRINTF(stderr, "corrected-cc scan init failed rc=%d active=%zu freq=%ld err=%s\n", rc,
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_freq, err);
+        test_rc = 1;
+    }
+
+    /* The decoder adopts the site-broadcast outbound control channel while parked on target A. */
+    state.trunk_lcn_freq[0] = corrected_cc;
+    state.p25_cc_freq = corrected_cc;
+    state.trunk_cc_freq = corrected_cc;
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || g_counting_tune_to_cc_freq != 462000000L) {
+        DSD_FPRINTF(stderr, "corrected-cc scan did not rotate to second target active=%zu freq=%ld\n",
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_freq);
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "corrected-cc scan did not rotate back to first target\n");
+        test_rc = 1;
+    }
+    if (g_counting_tune_to_cc_freq != corrected_cc) {
+        DSD_FPRINTF(stderr, "re-park used stale CSV frequency %ld instead of corrected %ld\n",
+                    g_counting_tune_to_cc_freq, corrected_cc);
+        test_rc = 1;
+    }
+    if (state.p25_cc_freq != corrected_cc || state.trunk_cc_freq != corrected_cc) {
+        DSD_FPRINTF(stderr, "re-park did not restore corrected CC p25=%ld trunk=%ld\n", state.p25_cc_freq,
+                    state.trunk_cc_freq);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
 static int
 test_p25_pending_retune_adopts_sm_retry(void) {
     char dir[DSD_TEST_PATH_MAX];
@@ -4059,6 +4130,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_mixed_target_switch_resets_nxdn_demod_profile);
     rc |= run_with_default_tune_hook(test_nxdn_conventional_activity_hold);
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_holds_while_tuned);
+    rc |= run_with_default_tune_hook(test_nxdn_trunk_target_follows_corrected_cc);
     rc |= run_with_default_tune_hook(test_nxdn_state_isolated_per_target);
     rc |= run_with_default_tune_hook(test_state_ext_cleanup_clears_scan_hooks);
     rc |= run_with_default_tune_hook(test_protocol_hooks_only_expose_matching_target_contexts);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -390,6 +390,64 @@ test_parser_valid_mixed_targets_and_relative_chan_csv(void) {
 }
 
 static int
+test_parser_accepts_nxdn_targets(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char chan_path[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(chan_path, sizeof chan_path, dir, "chan.csv") != 0
+        || write_text_file(chan_path, "channel,frequency\n1,461037500\n") != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n";
+    if (write_targets_file_with_header(dir, header,
+                                       "nxdn,nxdn-trunk,461000000,chan.csv,,,site,gfsk\n"
+                                       "conv,nxdn-conventional,462000000,,250,500,,auto\n",
+                                       target_path, sizeof target_path)
+        != 0) {
+        cleanup_paths(dir, NULL, chan_path);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.trunk_scan_idle_dwell_ms = 3000;
+    opts.trunk_scan_activity_hold_ms = 1200;
+    dsd_trunk_scan_target_list list;
+    char err[256] = {0};
+    int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
+
+    int test_rc = 0;
+    if (rc != 0 || list.count != 2) {
+        DSD_FPRINTF(stderr, "parser nxdn rc=%d count=%zu err=%s\n", rc, list.count, err);
+        test_rc = 1;
+    }
+    if (test_rc == 0) {
+        if (list.targets[0].type != DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK || list.targets[0].frequency_hz != 461000000U
+            || list.targets[0].dwell_ms != 3000 || list.targets[0].activity_hold_ms != 1200
+            || list.targets[0].modulation != DSD_TRUNK_SCAN_MODULATION_GFSK
+            || !strstr(list.targets[0].chan_csv, "chan.csv")) {
+            DSD_FPRINTF(stderr, "parser nxdn trunk target 0 mismatch\n");
+            test_rc = 1;
+        }
+        if (list.targets[1].type != DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL
+            || list.targets[1].frequency_hz != 462000000U || list.targets[1].dwell_ms != 250
+            || list.targets[1].activity_hold_ms != 500
+            || list.targets[1].modulation != DSD_TRUNK_SCAN_MODULATION_AUTO) {
+            DSD_FPRINTF(stderr, "parser nxdn conventional target 1 mismatch\n");
+            test_rc = 1;
+        }
+    }
+
+    dsd_trunk_scan_target_list_reset(&list);
+    cleanup_paths(dir, target_path, chan_path);
+    return test_rc;
+}
+
+static int
 test_parser_accepts_quoted_chan_csv_with_comma(void) {
     char dir[DSD_TEST_PATH_MAX];
     if (make_temp_dir(dir, sizeof dir) != 0) {
@@ -578,6 +636,10 @@ test_parser_rejects_invalid_inputs(void) {
     rc |= expect_parser_rejects_with_header(
         "unsupported-modulation", "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n",
         "a,dmr-trunk,452000000,,,,,cqpsk\n");
+    rc |= expect_parser_rejects("nxdn-conventional-chan-csv", "a,nxdn-conventional,461000000,chan.csv,,,\n");
+    rc |= expect_parser_rejects_with_header(
+        "nxdn-unsupported-modulation", "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n",
+        "a,nxdn-trunk,461000000,,,,,cqpsk\n");
     rc |= expect_parser_rejects_with_header("invalid-rtl-gain",
                                             "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,rtl_gain\n",
                                             "a,p25-trunk,851000000,,,,,50\n");
@@ -1904,6 +1966,344 @@ test_conventional_activity_encrypted_lockout_does_not_hold(void) {
         DSD_FPRINTF(stderr, "encrypted conventional traffic held target despite lockout\n");
         test_rc = 1;
     }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static void
+seed_nxdn_identity(dsd_state* state, uint16_t grant_chan, long int grant_freq, unsigned int ran, uint32_t sys_code,
+                   uint16_t site_code, const char* category, uint8_t rcn, uint8_t base_freq, uint8_t step, uint8_t bw) {
+    state->nxdn_grant_chan = grant_chan;
+    state->nxdn_grant_freq = grant_freq;
+    state->nxdn_last_ran = ran;
+    state->nxdn_location_sys_code = sys_code;
+    state->nxdn_location_site_code = site_code;
+    DSD_SNPRINTF(state->nxdn_location_category, sizeof state->nxdn_location_category, "%s", category);
+    state->nxdn_rcn = rcn;
+    state->nxdn_base_freq = base_freq;
+    state->nxdn_step = step;
+    state->nxdn_bw = bw;
+}
+
+static int
+expect_nxdn_identity(const char* label, const dsd_state* state, uint16_t grant_chan, long int grant_freq,
+                     unsigned int ran, uint32_t sys_code, uint16_t site_code, const char* category, uint8_t rcn,
+                     uint8_t base_freq, uint8_t step, uint8_t bw) {
+    if (state->nxdn_grant_chan != grant_chan || state->nxdn_grant_freq != grant_freq || state->nxdn_last_ran != ran
+        || state->nxdn_location_sys_code != sys_code || state->nxdn_location_site_code != site_code
+        || strcmp(state->nxdn_location_category, category) != 0 || state->nxdn_rcn != rcn
+        || state->nxdn_base_freq != base_freq || state->nxdn_step != step || state->nxdn_bw != bw) {
+        DSD_FPRINTF(stderr,
+                    "%s NXDN identity mismatch chan=%u freq=%ld ran=%u sys=%u site=%u cat='%s' rcn=%u "
+                    "base=%u step=%u bw=%u\n",
+                    label, state->nxdn_grant_chan, state->nxdn_grant_freq, state->nxdn_last_ran,
+                    state->nxdn_location_sys_code, state->nxdn_location_site_code, state->nxdn_location_category,
+                    state->nxdn_rcn, state->nxdn_base_freq, state->nxdn_step, state->nxdn_bw);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+test_nxdn_trunk_target_seeds_control_channel(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("n,nxdn-trunk,461000000,,250,,\n", target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "nxdn seed scan init failed rc=%d err=%s\n", rc, err);
+        test_rc = 1;
+    }
+    if (test_rc == 0
+        && (state.p25_cc_freq != 461000000 || state.trunk_cc_freq != 461000000 || state.lcn_freq_count < 1
+            || state.trunk_lcn_freq[0] != 461000000)) {
+        DSD_FPRINTF(stderr, "nxdn trunk seed invalid cc=%ld trunk_cc=%ld lcn_count=%d lcn0=%ld\n", state.p25_cc_freq,
+                    state.trunk_cc_freq, state.lcn_freq_count, state.trunk_lcn_freq[0]);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_mixed_target_switch_resets_nxdn_demod_profile(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("p25,p25-trunk,851000000,,250,,\n"
+                             "nxdn,nxdn-trunk,461000000,,250,,\n"
+                             "conv,nxdn-conventional,462000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "nxdn demod scan init failed rc=%d err=%s\n", rc, err);
+        test_rc = 1;
+    }
+
+    state.rf_mod = 1;
+    state.samplesPerSymbol = 8;
+    state.symbolCenter = 3;
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || state.rf_mod != 2 || state.samplesPerSymbol != 10
+        || state.symbolCenter != 4) {
+        DSD_FPRINTF(stderr, "NXDN trunk target inherited P25 demod state active=%zu rf_mod=%d sps=%d center=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), state.rf_mod, state.samplesPerSymbol,
+                    state.symbolCenter);
+        test_rc = 1;
+    }
+
+    state.rf_mod = 1;
+    state.samplesPerSymbol = 8;
+    state.symbolCenter = 3;
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 2 || state.rf_mod != 2 || state.samplesPerSymbol != 10
+        || state.symbolCenter != 4) {
+        DSD_FPRINTF(
+            stderr, "NXDN conventional target inherited P25 demod state active=%zu rf_mod=%d sps=%d center=%d\n",
+            dsd_engine_trunk_scan_active_index(&state), state.rf_mod, state.samplesPerSymbol, state.symbolCenter);
+        test_rc = 1;
+    }
+
+    state.rf_mod = 2;
+    state.samplesPerSymbol = 10;
+    state.symbolCenter = 4;
+    trunk_scan_test_set_now(0.78);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || state.rf_mod != 0 || state.samplesPerSymbol != 10
+        || state.symbolCenter != 4) {
+        DSD_FPRINTF(stderr, "P25 target inherited NXDN demod state active=%zu rf_mod=%d sps=%d center=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), state.rf_mod, state.samplesPerSymbol,
+                    state.symbolCenter);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_nxdn_conventional_activity_hold(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,nxdn-conventional,461000000,,250,250,\n"
+                             "b,nxdn-conventional,462000000,,250,250,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "nxdn conventional scan init failed: %s\n", err);
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_nxdn_conventional_activity(&opts, &state, 1001, 2002, 0, 0, 0);
+    trunk_scan_test_set_now(0.30);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "allowed NXDN conventional activity did not hold target\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.61);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    trunk_scan_test_set_now(0.87);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "NXDN target did not rotate after conventional hold and dwell\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+
+    reset_scan_opts_state(&opts, &state);
+    opts.trunk_use_allow_list = 1;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    trunk_scan_test_set_now(0.0);
+    rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "nxdn allowlist scan init failed: %s\n", err);
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_nxdn_conventional_activity(&opts, &state, 1001, 2002, 0, 0, 0);
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "blocked allow-list traffic held NXDN conventional target\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+
+    reset_scan_opts_state(&opts, &state);
+    opts.trunk_tune_enc_calls = 0;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    trunk_scan_test_set_now(0.0);
+    rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "nxdn encrypted lockout scan init failed: %s\n", err);
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_nxdn_conventional_activity(&opts, &state, 1001, 2002, 1, 1, 0);
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "encrypted NXDN conventional traffic held target despite lockout\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_nxdn_trunk_target_holds_while_tuned(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("n,nxdn-trunk,461000000,,250,,\n"
+                             "c,dmr-conventional,462000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "nxdn hold scan init failed rc=%d err=%s\n", rc, err);
+        test_rc = 1;
+    }
+
+    opts.trunk_is_tuned = 1;
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "tuned NXDN trunk target rotated away while tuned\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "tuned NXDN trunk target rotated away on second tick\n");
+        test_rc = 1;
+    }
+
+    opts.trunk_is_tuned = 0;
+    trunk_scan_test_set_now(0.78);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "NXDN trunk target rotated on idle clock restart tick\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(1.04);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "NXDN trunk target did not rotate after release and dwell\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_nxdn_state_isolated_per_target(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,nxdn-trunk,461000000,,250,,\n"
+                             "b,nxdn-trunk,462000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "nxdn identity scan init failed rc=%d active=%zu err=%s\n", rc,
+                    dsd_engine_trunk_scan_active_index(&state), err);
+        test_rc = 1;
+    }
+
+    seed_nxdn_identity(&state, 12, 461012500, 7U, 0x25U, 3, "Type-C", 1, 96, 12, 4);
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "nxdn identity scan did not rotate to second target\n");
+        test_rc = 1;
+    }
+    test_rc |= expect_nxdn_identity("fresh target", &state, 0, 0, 0U, 0U, 0, "", 0, 0, 0, 0);
+
+    seed_nxdn_identity(&state, 34, 462037500, 9U, 0x44U, 5, "Type-C", 2, 110, 25, 6);
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "nxdn identity scan did not rotate back to first target\n");
+        test_rc = 1;
+    }
+    test_rc |= expect_nxdn_identity("restored target", &state, 12, 461012500, 7U, 0x25U, 3, "Type-C", 1, 96, 12, 4);
 
     dsd_engine_trunk_scan_shutdown(&opts, &state);
     trunk_scan_test_clear_now();
@@ -3631,6 +4031,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_parser_valid_mixed_targets_and_relative_chan_csv);
     rc |= run_with_default_tune_hook(test_parser_accepts_quoted_chan_csv_with_comma);
     rc |= run_with_default_tune_hook(test_parser_accepts_optional_modulation_and_gain_columns);
+    rc |= run_with_default_tune_hook(test_parser_accepts_nxdn_targets);
     rc |= run_with_default_tune_hook(test_parser_rejects_invalid_inputs);
     rc |= run_with_default_tune_hook(test_parser_accepts_100_targets);
     rc |= run_with_default_tune_hook(test_coordinator_idle_rotation_and_state_restore);
@@ -3648,6 +4049,11 @@ main(void) {
     rc |= run_with_default_tune_hook(test_mixed_target_switch_resets_dmr_demod_profile);
     rc |= run_with_default_tune_hook(test_conventional_activity_hold_and_allowlist_block);
     rc |= run_with_default_tune_hook(test_conventional_activity_encrypted_lockout_does_not_hold);
+    rc |= run_with_default_tune_hook(test_nxdn_trunk_target_seeds_control_channel);
+    rc |= run_with_default_tune_hook(test_mixed_target_switch_resets_nxdn_demod_profile);
+    rc |= run_with_default_tune_hook(test_nxdn_conventional_activity_hold);
+    rc |= run_with_default_tune_hook(test_nxdn_trunk_target_holds_while_tuned);
+    rc |= run_with_default_tune_hook(test_nxdn_state_isolated_per_target);
     rc |= run_with_default_tune_hook(test_state_ext_cleanup_clears_scan_hooks);
     rc |= run_with_default_tune_hook(test_protocol_hooks_only_expose_matching_target_contexts);
     rc |= run_with_default_tune_hook(test_dmr_trunk_sm_timeout_releases_scan_hold);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -18,6 +18,7 @@
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/protocol/nxdn/nxdn_trunk_diag.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
@@ -2381,6 +2382,109 @@ test_nxdn_state_isolated_per_target(void) {
     return test_rc;
 }
 
+/*
+ * The NXDN missing-channel diagnostics have to work per target under trunk scan: the coordinator
+ * is the only holder of the parked target's chan_csv path, and one decoder state is shared by
+ * every target, so the ledger of channels seen without a mapping has to travel with the snapshot.
+ */
+static int
+test_nxdn_trunk_diag_isolated_per_target(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char chan_path[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(chan_path, sizeof chan_path, dir, "chan.csv") != 0
+        || write_text_file(chan_path, "channel,frequency\n1,461012500\n") != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    if (write_targets_file(dir,
+                           "a,nxdn-trunk,461000000,chan.csv,250,,\n"
+                           "b,nxdn-trunk,462000000,,250,,\n",
+                           target_path, sizeof target_path)
+        != 0) {
+        cleanup_paths(dir, NULL, chan_path);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "nxdn diag scan init failed rc=%d err=%s\n", rc, err);
+        test_rc = 1;
+    }
+
+    const char* active_csv = dsd_trunk_scan_hook_active_chan_csv(&state);
+    if (!active_csv || !strstr(active_csv, "chan.csv")) {
+        DSD_FPRINTF(stderr, "parked target chan_csv not visible to protocol code: %s\n",
+                    active_csv ? active_csv : "(null)");
+        test_rc = 1;
+    }
+    if (nxdn_trunk_diag_chan_map_path(&opts, &state) == NULL) {
+        DSD_FPRINTF(stderr, "diag path unresolved for a target with a chan_csv\n");
+        test_rc = 1;
+    }
+
+    /* Target A decodes a grant for a channel its map does not cover. */
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &state, 5, "grant");
+    if (nxdn_trunk_diag_collect_unmapped_channels(&state, NULL, 0) != 1) {
+        DSD_FPRINTF(stderr, "missing channel not recorded for parked scan target\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "nxdn diag scan did not rotate to second target\n");
+        test_rc = 1;
+    }
+    if (nxdn_trunk_diag_collect_unmapped_channels(&state, NULL, 0) != 0) {
+        DSD_FPRINTF(stderr, "second target inherited the first target's missing-channel ledger\n");
+        test_rc = 1;
+    }
+    if (dsd_trunk_scan_hook_active_chan_csv(&state) != NULL) {
+        DSD_FPRINTF(stderr, "target without a chan_csv reported one\n");
+        test_rc = 1;
+    }
+    /* Without a channel map there is nothing to report a missing mapping against. */
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &state, 7, "grant");
+    if (nxdn_trunk_diag_collect_unmapped_channels(&state, NULL, 0) != 0) {
+        DSD_FPRINTF(stderr, "target without a chan_csv recorded a missing channel\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "nxdn diag scan did not rotate back to first target\n");
+        test_rc = 1;
+    }
+    uint16_t missing[4];
+    DSD_MEMSET(missing, 0, sizeof missing);
+    if (nxdn_trunk_diag_collect_unmapped_channels(&state, missing, 4) != 1 || missing[0] != 5) {
+        DSD_FPRINTF(stderr, "first target did not get its missing-channel ledger back\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    if (dsd_trunk_scan_hook_active_chan_csv(&state) != NULL) {
+        DSD_FPRINTF(stderr, "scan chan_csv hook still installed after shutdown\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, chan_path);
+    return test_rc;
+}
+
 static int
 test_state_ext_cleanup_clears_scan_hooks(void) {
     char dir[DSD_TEST_PATH_MAX];
@@ -4197,6 +4301,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_holds_while_tuned);
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_follows_corrected_cc);
     rc |= run_with_default_tune_hook(test_nxdn_state_isolated_per_target);
+    rc |= run_with_default_tune_hook(test_nxdn_trunk_diag_isolated_per_target);
     rc |= run_with_default_tune_hook(test_state_ext_cleanup_clears_scan_hooks);
     rc |= run_with_default_tune_hook(test_protocol_hooks_only_expose_matching_target_contexts);
     rc |= run_with_default_tune_hook(test_dmr_trunk_sm_timeout_releases_scan_hold);

--- a/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
+++ b/tests/protocol/dmr/test_dmr_relaxed_header_ip.c
@@ -16,6 +16,7 @@
 #include <dsd-neo/crypto/des.h>
 #include <dsd-neo/fec/rs_12_9.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/unicode.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -1366,6 +1367,113 @@ test_data_header_prints_fsn_and_final_flag(void) {
     return rc;
 }
 
+static int g_scan_activity_calls;
+static uint32_t g_scan_activity_target;
+static uint32_t g_scan_activity_source;
+static int g_scan_activity_is_private;
+static int g_scan_activity_encrypted;
+static int g_scan_activity_data_call;
+
+static void
+capture_scan_dmr_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target, uint32_t source,
+                                       int is_private, int encrypted, int data_call) {
+    (void)opts;
+    (void)state;
+    g_scan_activity_calls++;
+    g_scan_activity_target = target;
+    g_scan_activity_source = source;
+    g_scan_activity_is_private = is_private;
+    g_scan_activity_encrypted = encrypted;
+    g_scan_activity_data_call = data_call;
+}
+
+static void
+reset_scan_activity_capture(void) {
+    g_scan_activity_calls = 0;
+    g_scan_activity_target = 0;
+    g_scan_activity_source = 0;
+    g_scan_activity_is_private = 0;
+    g_scan_activity_encrypted = 0;
+    g_scan_activity_data_call = 0;
+
+    dsd_trunk_scan_hooks hooks = {0};
+    hooks.dmr_conventional_activity = capture_scan_dmr_conventional_activity;
+    dsd_trunk_scan_hooks_set(hooks);
+}
+
+/*
+ * A conventional DMR scan target holds its park on decoded activity. Data traffic counts: the
+ * data header is the DMR counterpart of the voice LC that dmr_flco() already reports, and it is
+ * the only part of a data burst carrying a call identity.
+ */
+static int
+run_dmr_data_header_scan_activity_case(const char* tag, uint8_t dpf, uint8_t gi, uint32_t source, uint32_t target,
+                                       uint32_t crc_correct, int relaxed, int expect_calls, int expect_private) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t dheader[12];
+    uint8_t bits[196];
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(dheader, 0, sizeof(dheader));
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    opts.aggressive_framesync = relaxed ? 0 : 1;
+    reset_scan_activity_capture();
+
+    set_bits(bits, 0, gi, 1);
+    set_bits(bits, 4, dpf, 4);
+    set_bits(bits, 8, 4U, 4); // SAP=4, IP based
+    set_bits(bits, 16, target, 24);
+    set_bits(bits, 40, source, 24);
+    set_bits(bits, 65, 2U, 7); // blocks to follow
+
+    dmr_dheader(&opts, &state, dheader, bits, crc_correct, /*IrrecoverableErrors=*/0);
+
+    int rc = 0;
+    if (g_scan_activity_calls != expect_calls) {
+        DSD_FPRINTF(stderr, "%s: scan activity calls got %d want %d\n", tag, g_scan_activity_calls, expect_calls);
+        rc = 1;
+    }
+    if (expect_calls > 0) {
+        if (g_scan_activity_target != target || g_scan_activity_source != source) {
+            DSD_FPRINTF(stderr, "%s: identity got tgt=%u src=%u want tgt=%u src=%u\n", tag, g_scan_activity_target,
+                        g_scan_activity_source, target, source);
+            rc = 1;
+        }
+        if (g_scan_activity_is_private != expect_private || g_scan_activity_encrypted != 0
+            || g_scan_activity_data_call != 1) {
+            DSD_FPRINTF(stderr, "%s: flags got private=%d enc=%d data=%d want private=%d enc=0 data=1\n", tag,
+                        g_scan_activity_is_private, g_scan_activity_encrypted, g_scan_activity_data_call,
+                        expect_private);
+            rc = 1;
+        }
+    }
+
+    dsd_trunk_scan_hooks_set((dsd_trunk_scan_hooks){0});
+    return rc;
+}
+
+static int
+test_data_header_reports_conventional_scan_activity(void) {
+    int rc = 0;
+
+    /* Unconfirmed group data call. */
+    rc |= run_dmr_data_header_scan_activity_case("dmr-dheader-group", 2U, 1U, 0x000456U, 0x000123U, 1U, 0, 1, 0);
+    /* Confirmed individual data call. */
+    rc |= run_dmr_data_header_scan_activity_case("dmr-dheader-private", 3U, 0U, 0x000456U, 0x000123U, 1U, 0, 1, 1);
+    /* Unified Data Transport carries identity too. */
+    rc |= run_dmr_data_header_scan_activity_case("dmr-dheader-udt", 0U, 1U, 0x000456U, 0x000123U, 1U, 0, 1, 0);
+    /* A response header is an ACK for an earlier PDU, not fresh activity. */
+    rc |= run_dmr_data_header_scan_activity_case("dmr-dheader-response", 1U, 1U, 0x000456U, 0x000123U, 1U, 0, 0, 0);
+    /* A proprietary header deliberately keeps the previous transmission's identity. */
+    rc |= run_dmr_data_header_scan_activity_case("dmr-dheader-proprietary", 15U, 1U, 0x000456U, 0x000123U, 1U, 0, 0, 0);
+    /* Relaxed CRC still prints the header, but an unverified identity must not park the scan. */
+    rc |= run_dmr_data_header_scan_activity_case("dmr-dheader-relaxed-crc", 2U, 1U, 0x000456U, 0x000123U, 0U, 1, 0, 0);
+
+    return rc;
+}
+
 static void
 test_irrecoverable_header_resets_data_state(void) {
     static dsd_opts opts;
@@ -1697,6 +1805,7 @@ main(int argc, char** argv) {
     test_type1_encrypted_notice_reports_missing_key();
     test_type2_rejects_out_of_bounds_aggregate_length();
     int rc = test_data_header_prints_fsn_and_final_flag();
+    rc |= test_data_header_reports_conventional_scan_activity();
     rc |= test_type1_mnis_ars_registration_prints_device_id();
     rc |= test_type1_mnis_ars_fallback_dump_is_bounded();
     rc |= test_ars_message_type_labels();

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -1060,14 +1060,38 @@ test_cch_dfa_maps_secondary_channels_and_seeds_control_frequency(void) {
     return rc;
 }
 
+static int g_parked_scan_ctx_marker;
+
+static void*
+parked_scan_ctx_marker(void) {
+    return &g_parked_scan_ctx_marker;
+}
+
+/*
+ * Model which scan-target context the coordinator would expose while parked: 1 = p25-trunk,
+ * 2 = dmr-trunk, 0 = anything else (nxdn-trunk or a conventional target).
+ */
+static void
+set_parked_scan_target_ctx(int parked_ctx) {
+    dsd_trunk_scan_hooks hooks = {0};
+    if (parked_ctx == 1) {
+        hooks.p25_ctx = parked_scan_ctx_marker;
+    } else if (parked_ctx == 2) {
+        hooks.dmr_ctx = parked_scan_ctx_marker;
+    }
+    dsd_trunk_scan_hooks_set(hooks);
+}
+
 /*
  * CCH_INFO DFA control-channel adoption. The site broadcast is the authority on the outbound
  * control channel: it must override a trunk-scan target's CSV park frequency (which is a guess),
- * but never an operator-supplied LCN list, and never a target the coordinator shaped for DMR.
+ * but never an operator-supplied LCN list, and never a target the coordinator shaped for another
+ * protocol.
  */
 static int
-run_cch_dfa_adoption_case(const char* tag, int trunk_scan_enabled, long int seeded_lcn0, long int seeded_p25_cc,
-                          long int seeded_trunk_cc, int seeded_lcn_count, int expect_adopt) {
+run_cch_dfa_adoption_case(const char* tag, int trunk_scan_enabled, int trunk_enable, int parked_ctx,
+                          long int seeded_lcn0, long int seeded_p25_cc, long int seeded_trunk_cc, int seeded_lcn_count,
+                          int expect_adopt) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
     uint8_t bits[128];
@@ -1089,6 +1113,8 @@ run_cch_dfa_adoption_case(const char* tag, int trunk_scan_enabled, long int seed
     g_mapped_channel_freq = cc_freq;
 
     opts->trunk_scan_enabled = trunk_scan_enabled;
+    opts->trunk_enable = trunk_enable;
+    set_parked_scan_target_ctx(parked_ctx);
     state->trunk_lcn_freq[0] = seeded_lcn0;
     state->p25_cc_freq = seeded_p25_cc;
     state->trunk_cc_freq = seeded_trunk_cc;
@@ -1112,6 +1138,7 @@ run_cch_dfa_adoption_case(const char* tag, int trunk_scan_enabled, long int seed
     DSD_SNPRINTF(label, sizeof label, "%s-trunk-cc", tag);
     rc |= expect_int(label, (int)state->trunk_cc_freq, (int)(expect_adopt ? cc_freq : seeded_trunk_cc));
 
+    set_parked_scan_target_ctx(0);
     free(state);
     free(opts);
     return rc;
@@ -1123,15 +1150,20 @@ test_cch_dfa_control_channel_adoption_pinning(void) {
     int rc = 0;
 
     /* Plain -T with nothing learned yet: first broadcast seeds the control channel. */
-    rc |= run_cch_dfa_adoption_case("cch-adopt-plain-unseeded", 0, 0, 0, 0, 0, 1);
+    rc |= run_cch_dfa_adoption_case("cch-adopt-plain-unseeded", 0, 1, 0, 0, 0, 0, 0, 1);
     /* Plain -T after adoption (or with an imported LCN list): the existing value is pinned. */
-    rc |= run_cch_dfa_adoption_case("cch-adopt-plain-pinned", 0, park, park, park, 1, 0);
+    rc |= run_cch_dfa_adoption_case("cch-adopt-plain-pinned", 0, 1, 0, park, park, park, 1, 0);
     /* Trunk scan parks an nxdn-trunk target on its CSV frequency: the site broadcast wins. */
-    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-park", 1, park, park, park, 1, 1);
+    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-park", 1, 1, 0, park, park, park, 1, 1);
     /* A per-target chan_csv with LCN rows is operator intent: pinned even under scan. */
-    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-lcn-list", 1, park, park, park, 2, 0);
+    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-lcn-list", 1, 1, 0, park, park, park, 2, 0);
     /* A dmr-trunk target keeps p25_cc_freq at 0: a stray NXDN broadcast must not retune it. */
-    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-dmr-target", 1, park, 0, park, 1, 0);
+    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-dmr-target", 1, 1, 2, park, 0, park, 1, 0);
+    /* A p25-trunk target carries its own control channel in p25_cc_freq: a stray NXDN element
+     * decoded under -fa must not move it to an NXDN frequency. */
+    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-p25-target", 1, 1, 1, park, park, park, 1, 0);
+    /* Conventional targets run with trunk_enable == 0 and have no control channel to adopt. */
+    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-conventional-target", 1, 0, 0, 0, 0, 0, 0, 0);
 
     return rc;
 }

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -16,6 +16,7 @@
 #include <dsd-neo/crypto/aes.h>
 #include <dsd-neo/crypto/des.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -1135,6 +1136,114 @@ test_cch_dfa_control_channel_adoption_pinning(void) {
     return rc;
 }
 
+static int g_scan_activity_calls;
+static uint32_t g_scan_activity_target;
+static uint32_t g_scan_activity_source;
+static int g_scan_activity_is_private;
+static int g_scan_activity_encrypted;
+static int g_scan_activity_data_call;
+
+static void
+capture_scan_nxdn_conventional_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target, uint32_t source,
+                                        int is_private, int encrypted, int data_call) {
+    (void)opts;
+    (void)state;
+    g_scan_activity_calls++;
+    g_scan_activity_target = target;
+    g_scan_activity_source = source;
+    g_scan_activity_is_private = is_private;
+    g_scan_activity_encrypted = encrypted;
+    g_scan_activity_data_call = data_call;
+}
+
+static void
+reset_scan_activity_capture(void) {
+    g_scan_activity_calls = 0;
+    g_scan_activity_target = 0;
+    g_scan_activity_source = 0;
+    g_scan_activity_is_private = 0;
+    g_scan_activity_encrypted = 0;
+    g_scan_activity_data_call = 0;
+
+    dsd_trunk_scan_hooks hooks = {0};
+    hooks.nxdn_conventional_activity = capture_scan_nxdn_conventional_activity;
+    dsd_trunk_scan_hooks_set(hooks);
+}
+
+/*
+ * A conventional NXDN scan target holds its park on decoded activity. Data traffic counts:
+ * SDCALL and DCALL headers are the only data elements carrying a call identity, so they are
+ * what the coordinator can run through talkgroup policy.
+ */
+static int
+run_data_header_scan_activity_case(const char* tag, uint8_t message_type, uint8_t crc_ok, uint8_t call_type,
+                                   uint8_t cipher, uint16_t source, uint16_t target, int expect_calls,
+                                   int expect_private, int expect_encrypted) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[128];
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    reset_assignment_capture();
+    reset_scan_activity_capture();
+
+    set_message_type(bits, message_type);
+    write_bits_u64(bits, 16U, call_type, 3U);
+    write_bits_u64(bits, 24U, source, 16U);
+    write_bits_u64(bits, 40U, target, 16U);
+    write_bits_u64(bits, 56U, cipher, 2U);
+    write_bits_u64(bits, 68U, 2U, 4U); /* block count */
+
+    NXDN_Elements_Content_decode(opts, state, crc_ok, bits, sizeof(bits));
+
+    char label[96];
+    int rc = 0;
+    DSD_SNPRINTF(label, sizeof label, "%s-calls", tag);
+    rc |= expect_int(label, g_scan_activity_calls, expect_calls);
+    if (expect_calls > 0) {
+        DSD_SNPRINTF(label, sizeof label, "%s-target", tag);
+        rc |= expect_int(label, (int)g_scan_activity_target, (int)target);
+        DSD_SNPRINTF(label, sizeof label, "%s-source", tag);
+        rc |= expect_int(label, (int)g_scan_activity_source, (int)source);
+        DSD_SNPRINTF(label, sizeof label, "%s-private", tag);
+        rc |= expect_int(label, g_scan_activity_is_private, expect_private);
+        DSD_SNPRINTF(label, sizeof label, "%s-encrypted", tag);
+        rc |= expect_int(label, g_scan_activity_encrypted, expect_encrypted);
+        DSD_SNPRINTF(label, sizeof label, "%s-data-call", tag);
+        rc |= expect_int(label, g_scan_activity_data_call, 1);
+    }
+
+    dsd_trunk_scan_hooks_set((dsd_trunk_scan_hooks){0});
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
+test_data_call_headers_report_conventional_scan_activity(void) {
+    int rc = 0;
+
+    /* Clear group data call over a DCALL header. */
+    rc |= run_data_header_scan_activity_case("dcall-group", 0x09U, 1U, 1U, 0U, 1234U, 5678U, 1, 0, 0);
+    /* Encrypted private data call: the header's own cipher field is the only classification. */
+    rc |= run_data_header_scan_activity_case("dcall-private-enc", 0x09U, 1U, 4U, 1U, 4321U, 8765U, 1, 1, 1);
+    /* Short data calls carry the same identity and must hold the target too. */
+    rc |= run_data_header_scan_activity_case("sdcall-group", 0x38U, 1U, 1U, 0U, 11U, 22U, 1, 0, 0);
+    /* A header the link layer could not verify must never park the coordinator. */
+    rc |= run_data_header_scan_activity_case("dcall-bad-crc", 0x09U, 0U, 1U, 0U, 1234U, 5678U, 0, 0, 0);
+    rc |= run_data_header_scan_activity_case("sdcall-bad-crc", 0x38U, 0U, 1U, 0U, 11U, 22U, 0, 0, 0);
+    /* Elements without a call identity are not activity reports. */
+    rc |= run_data_header_scan_activity_case("sdcall-iv", 0x3AU, 1U, 1U, 0U, 11U, 22U, 0, 0, 0);
+    rc |= run_data_header_scan_activity_case("dcall-data-block", 0x0BU, 1U, 1U, 0U, 11U, 22U, 0, 0, 0);
+
+    return rc;
+}
+
 static int
 test_adj_site_skips_disabled_entries_for_channel_and_dfa_versions(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
@@ -1918,6 +2027,7 @@ main(void) {
     rc |= test_srv_info_anchors_control_channel_from_rigctl();
     rc |= test_cch_dfa_maps_secondary_channels_and_seeds_control_frequency();
     rc |= test_cch_dfa_control_channel_adoption_pinning();
+    rc |= test_data_call_headers_report_conventional_scan_activity();
     rc |= test_adj_site_skips_disabled_entries_for_channel_and_dfa_versions();
     rc |= test_sdcall_des_data_decrypts_and_resets();
     rc |= test_dcall_aes_data_decrypts_with_manual_key_and_iv();

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -1059,6 +1059,82 @@ test_cch_dfa_maps_secondary_channels_and_seeds_control_frequency(void) {
     return rc;
 }
 
+/*
+ * CCH_INFO DFA control-channel adoption. The site broadcast is the authority on the outbound
+ * control channel: it must override a trunk-scan target's CSV park frequency (which is a guess),
+ * but never an operator-supplied LCN list, and never a target the coordinator shaped for DMR.
+ */
+static int
+run_cch_dfa_adoption_case(const char* tag, int trunk_scan_enabled, long int seeded_lcn0, long int seeded_p25_cc,
+                          long int seeded_trunk_cc, int seeded_lcn_count, int expect_adopt) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    uint8_t bits[128];
+    const uint32_t location_id = (2U << 12U) | 0x021U;
+    const uint16_t ofn1 = 0x1221U;
+    const uint16_t ifn1 = 0x2332U;
+    const long int cc_freq = 852262500L;
+    if (!opts || !state) {
+        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
+        free(state);
+        free(opts);
+        return 1;
+    }
+    DSD_MEMSET(bits, 0, sizeof(bits));
+    reset_assignment_capture();
+
+    state->nxdn_rcn = 1;
+    g_mapped_channel = ofn1;
+    g_mapped_channel_freq = cc_freq;
+
+    opts->trunk_scan_enabled = trunk_scan_enabled;
+    state->trunk_lcn_freq[0] = seeded_lcn0;
+    state->p25_cc_freq = seeded_p25_cc;
+    state->trunk_cc_freq = seeded_trunk_cc;
+    state->lcn_freq_count = seeded_lcn_count;
+
+    set_message_type(bits, 0x1AU);
+    write_bits_u64(bits, 8U, location_id, 24U);
+    write_bits_u64(bits, 32U, 0x13U, 6U);
+    write_bits_u64(bits, 38U, 1U, 2U);
+    write_bits_u64(bits, 40U, ofn1, 16U);
+    write_bits_u64(bits, 56U, ifn1, 16U);
+
+    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+
+    char label[96];
+    int rc = 0;
+    DSD_SNPRINTF(label, sizeof label, "%s-lcn0", tag);
+    rc |= expect_int(label, (int)state->trunk_lcn_freq[0], (int)(expect_adopt ? cc_freq : seeded_lcn0));
+    DSD_SNPRINTF(label, sizeof label, "%s-p25-cc", tag);
+    rc |= expect_int(label, (int)state->p25_cc_freq, (int)(expect_adopt ? cc_freq : seeded_p25_cc));
+    DSD_SNPRINTF(label, sizeof label, "%s-trunk-cc", tag);
+    rc |= expect_int(label, (int)state->trunk_cc_freq, (int)(expect_adopt ? cc_freq : seeded_trunk_cc));
+
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
+test_cch_dfa_control_channel_adoption_pinning(void) {
+    const long int park = 461000000L;
+    int rc = 0;
+
+    /* Plain -T with nothing learned yet: first broadcast seeds the control channel. */
+    rc |= run_cch_dfa_adoption_case("cch-adopt-plain-unseeded", 0, 0, 0, 0, 0, 1);
+    /* Plain -T after adoption (or with an imported LCN list): the existing value is pinned. */
+    rc |= run_cch_dfa_adoption_case("cch-adopt-plain-pinned", 0, park, park, park, 1, 0);
+    /* Trunk scan parks an nxdn-trunk target on its CSV frequency: the site broadcast wins. */
+    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-park", 1, park, park, park, 1, 1);
+    /* A per-target chan_csv with LCN rows is operator intent: pinned even under scan. */
+    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-lcn-list", 1, park, park, park, 2, 0);
+    /* A dmr-trunk target keeps p25_cc_freq at 0: a stray NXDN broadcast must not retune it. */
+    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-dmr-target", 1, park, 0, park, 1, 0);
+
+    return rc;
+}
+
 static int
 test_adj_site_skips_disabled_entries_for_channel_and_dfa_versions(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
@@ -1841,6 +1917,7 @@ main(void) {
     rc |= test_dst_id_info_complete_event();
     rc |= test_srv_info_anchors_control_channel_from_rigctl();
     rc |= test_cch_dfa_maps_secondary_channels_and_seeds_control_frequency();
+    rc |= test_cch_dfa_control_channel_adoption_pinning();
     rc |= test_adj_site_skips_disabled_entries_for_channel_and_dfa_versions();
     rc |= test_sdcall_des_data_decrypts_and_resets();
     rc |= test_dcall_aes_data_decrypts_with_manual_key_and_iv();

--- a/tests/protocol/nxdn/test_nxdn_trunk_diag.c
+++ b/tests/protocol/nxdn/test_nxdn_trunk_diag.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/protocol/nxdn/nxdn_trunk_diag.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -43,6 +44,106 @@ expect_eq_u16(const char* tag, uint16_t got, uint16_t want) {
         return 1;
     }
     return 0;
+}
+
+static const char* g_active_chan_csv;
+
+static const char*
+test_active_chan_csv(const dsd_state* state) {
+    (void)state;
+    return g_active_chan_csv;
+}
+
+static void
+set_scan_chan_csv_hook(const char* path) {
+    g_active_chan_csv = path;
+    dsd_trunk_scan_hooks hooks = {0};
+    hooks.active_chan_csv = test_active_chan_csv;
+    dsd_trunk_scan_hooks_set(hooks);
+}
+
+/*
+ * Under trunk scan the global -C channel map is rejected, so opts->chan_in_file is always empty
+ * and the per-target chan_csv lives in the coordinator. The diagnostics have to ask the
+ * coordinator for it, or they silently never report a missing channel mapping for a scan target.
+ */
+static int
+test_chan_map_path_resolves_under_trunk_scan(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.trunk_scan_enabled = 1;
+    set_scan_chan_csv_hook("targets/site.csv");
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &state, 40, "grant");
+    rc |= expect_eq_size("scan-target-path-records", nxdn_trunk_diag_collect_unmapped_channels(&state, NULL, 0), 1);
+
+    /* A scan target without a chan_csv has no map to report against. */
+    set_scan_chan_csv_hook(NULL);
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &state, 41, "grant");
+    rc |= expect_eq_size("scan-target-no-csv-skipped", nxdn_trunk_diag_collect_unmapped_channels(&state, NULL, 0), 1);
+
+    /* An empty string is the same as no channel map. */
+    set_scan_chan_csv_hook("");
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &state, 42, "grant");
+    rc |=
+        expect_eq_size("scan-target-empty-csv-skipped", nxdn_trunk_diag_collect_unmapped_channels(&state, NULL, 0), 1);
+
+    /* Outside trunk scan the coordinator hook is not the authority; -C alone is. */
+    opts.trunk_scan_enabled = 0;
+    set_scan_chan_csv_hook("targets/site.csv");
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &state, 43, "grant");
+    rc |= expect_eq_size("non-scan-ignores-hook", nxdn_trunk_diag_collect_unmapped_channels(&state, NULL, 0), 1);
+
+    /* A global -C still wins wherever it is set. */
+    (void)DSD_SNPRINTF(opts.chan_in_file, sizeof opts.chan_in_file, "%s", "global.csv");
+    nxdn_trunk_diag_log_missing_channel_once(&opts, &state, 44, "grant");
+    rc |= expect_eq_size("global-chan-map-records", nxdn_trunk_diag_collect_unmapped_channels(&state, NULL, 0), 2);
+
+    dsd_trunk_scan_hooks_set((dsd_trunk_scan_hooks){0});
+    g_active_chan_csv = NULL;
+    dsd_state_ext_free_all(&state);
+    return rc;
+}
+
+/*
+ * The ledger is per decoder-state, but trunk scan rotates several NXDN targets through one state,
+ * so the coordinator has to be able to park and restore each target's ledger.
+ */
+static int
+test_ledger_save_and_restore_round_trip(void) {
+    static dsd_state state;
+    nxdn_trunk_diag_ledger ledger;
+    int rc = 0;
+
+    DSD_MEMSET(&ledger, 0xAB, sizeof(ledger));
+    nxdn_trunk_diag_ledger_save(&state, &ledger);
+    rc |= expect_eq_size("empty-state-saves-empty-ledger", (size_t)ledger.missing_unique, 0);
+
+    rc |= expect_eq_int("note-ch60", nxdn_trunk_diag_note_missing_channel(&state, 60), 1);
+    rc |= expect_eq_int("note-ch61", nxdn_trunk_diag_note_missing_channel(&state, 61), 1);
+    nxdn_trunk_diag_ledger_save(&state, &ledger);
+    rc |= expect_eq_size("saved-two", (size_t)ledger.missing_unique, 2);
+
+    /* Switching to another target starts from that target's (empty) ledger. */
+    nxdn_trunk_diag_ledger empty;
+    DSD_MEMSET(&empty, 0, sizeof(empty));
+    nxdn_trunk_diag_ledger_restore(&state, &empty);
+    rc |= expect_eq_size("restored-empty", nxdn_trunk_diag_collect_unmapped_channels(&state, NULL, 0), 0);
+    rc |= expect_eq_int("note-ch60-again-on-other-target", nxdn_trunk_diag_note_missing_channel(&state, 60), 1);
+
+    /* Switching back restores what the first target had already seen. */
+    nxdn_trunk_diag_ledger_restore(&state, &ledger);
+    uint16_t out[4];
+    DSD_MEMSET(out, 0, sizeof out);
+    rc |= expect_eq_size("restored-two", nxdn_trunk_diag_collect_unmapped_channels(&state, out, 4), 2);
+    rc |= expect_eq_u16("restored-out0", out[0], 60);
+    rc |= expect_eq_u16("restored-out1", out[1], 61);
+    rc |= expect_eq_int("restored-dedup-holds", nxdn_trunk_diag_note_missing_channel(&state, 60), 0);
+
+    dsd_state_ext_free_all(&state);
+    return rc;
 }
 
 int
@@ -120,5 +221,8 @@ main(void) {
     dsd_state_ext_free_all(&state);
     dsd_state_ext_free_all(&log_state);
     dsd_state_ext_free_all(&overflow_state);
+
+    rc |= test_chan_map_path_resolves_under_trunk_scan();
+    rc |= test_ledger_save_and_restore_round_trip();
     return rc;
 }

--- a/tests/protocol/p25/test_p25_frequency_map.c
+++ b/tests/protocol/p25/test_p25_frequency_map.c
@@ -297,6 +297,27 @@ main(void) {
         ns.nxdn_step = 99;
         rc |= expect_eq_long("nxdn dfa unknown verbose", nxdn_channel_to_frequency(&opts, &ns, 10U), 0);
         rc |= expect_eq_long("nxdn dfa unknown quiet", nxdn_channel_to_frequency_quiet(&ns, 10U), 0);
+
+        /* trunk_chan_map has DSD_TRUNK_CHAN_MAP_SIZE entries, so the largest uint16_t channel is
+         * one past the end and a miscorrected 16-bit outbound number reaches here unfiltered. The
+         * map lookup must not read past the array, while the DFA arithmetic stays valid for every
+         * channel number. Under ASan the unguarded read aborts; without it, the adjacent
+         * trunk_chan_map_used[] bytes would be returned as a bogus mapped frequency. */
+        DSD_MEMSET(&ns, 0, sizeof(ns));
+        ns.nxdn_rcn = 1;
+        ns.nxdn_base_freq = 1;
+        ns.nxdn_step = 2;
+        rc |= expect_eq_long("nxdn out-of-range channel falls through to dfa verbose",
+                             nxdn_channel_to_frequency(&opts, &ns, (uint16_t)DSD_TRUNK_CHAN_MAP_SIZE),
+                             100000000L + (long int)DSD_TRUNK_CHAN_MAP_SIZE * 1250L);
+        rc |= expect_eq_long("nxdn out-of-range channel falls through to dfa quiet",
+                             nxdn_channel_to_frequency_quiet(&ns, (uint16_t)DSD_TRUNK_CHAN_MAP_SIZE),
+                             100000000L + (long int)DSD_TRUNK_CHAN_MAP_SIZE * 1250L);
+
+        /* Without a map entry or DFA, an out-of-range channel is simply unknown. */
+        DSD_MEMSET(&ns, 0, sizeof(ns));
+        rc |= expect_eq_long("nxdn out-of-range channel unmapped quiet",
+                             nxdn_channel_to_frequency_quiet(&ns, (uint16_t)DSD_TRUNK_CHAN_MAP_SIZE), 0);
     }
 
     return rc;

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -14,6 +14,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/rdio_export.h>
 #include <errno.h>
 #include <stdio.h>
@@ -1960,12 +1961,134 @@ test_snapshot_mode_inference_tdma_and_auto(void) {
         rc |= 1;
     }
 
+    /* A decoder set no preset reproduces must not be persisted as a preset: saving it as "auto"
+       would reload as every decoder enabled. The snapshot leaves the mode unset so the renderer
+       omits the key and the reload keeps whatever the fresh session established. */
     reset_opts_and_state(opts, state);
     opts.frame_dmr = 1;
     opts.frame_ysf = 1;
     dsd_snapshot_opts_to_user_config(&opts, &state, &snap);
+    if (snap.decode_mode != DSDCFG_MODE_UNSET) {
+        DSD_FPRINTF(stderr, "expected unset mode inference for an unmatched set, got %d\n", (int)snap.decode_mode);
+        rc |= 1;
+    }
+    char unmatched[4096];
+    if (render_config_to_buffer(&snap, unmatched, sizeof unmatched) != 0) {
+        return 1;
+    }
+    if (strstr(unmatched, "decode =") != nullptr) {
+        DSD_FPRINTF(stderr, "unmatched decoder set rendered a decode key:\n%s\n", unmatched);
+        rc |= 1;
+    }
+
+    /* The AUTO set itself still round-trips as "auto". */
+    reset_opts_and_state(opts, state);
+    opts.frame_dstar = 1;
+    opts.frame_x2tdma = 1;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_dpmr = 1;
+    opts.frame_provoice = 1;
+    opts.frame_ysf = 1;
+    opts.frame_m17 = 1;
+    dsd_snapshot_opts_to_user_config(&opts, &state, &snap);
     if (snap.decode_mode != DSDCFG_MODE_AUTO) {
-        DSD_FPRINTF(stderr, "expected AUTO fallback mode inference, got %d\n", (int)snap.decode_mode);
+        DSD_FPRINTF(stderr, "expected AUTO inference for the full decoder set, got %d\n", (int)snap.decode_mode);
+        rc |= 1;
+    }
+    return rc;
+}
+
+/*
+ * A -fa session must come back as a -fa session. The decoder set is persisted as `decode =
+ * "auto"` and reloading it re-enables every decoder; a session that never chose a mode persists
+ * no decode key at all and reloads with the initialization defaults untouched.
+ */
+static int
+test_snapshot_roundtrip_preserves_decoder_set(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    int rc = 0;
+
+    reset_opts_and_state(opts, state);
+    (void)dsd_apply_decode_mode_preset(DSDCFG_MODE_AUTO, DSD_DECODE_PRESET_PROFILE_CLI, &opts, &state);
+
+    dsdneoUserConfig snap;
+    dsd_snapshot_opts_to_user_config(&opts, &state, &snap);
+    char rendered[4096];
+    if (render_config_to_buffer(&snap, rendered, sizeof rendered) != 0) {
+        return 1;
+    }
+    if (strstr(rendered, "decode = \"auto\"") == nullptr) {
+        DSD_FPRINTF(stderr, "-fa session did not persist decode = \"auto\":\n%s\n", rendered);
+        return 1;
+    }
+
+    char path[DSD_TEST_PATH_MAX];
+    if (write_temp_config(rendered, path, sizeof path) != 0) {
+        return 1;
+    }
+    dsdneoUserConfig loaded;
+    int load_rc = dsd_user_config_load(path, &loaded);
+    (void)remove(path);
+    if (load_rc != 0) {
+        DSD_FPRINTF(stderr, "reloading the -fa snapshot failed\n");
+        return 1;
+    }
+
+    reset_opts_and_state(opts, state);
+    dsd_apply_user_config_to_opts(&loaded, &opts, &state);
+    if (!(opts.frame_dstar == 1 && opts.frame_x2tdma == 1 && opts.frame_p25p1 == 1 && opts.frame_p25p2 == 1
+          && opts.frame_nxdn48 == 1 && opts.frame_nxdn96 == 1 && opts.frame_dmr == 1 && opts.frame_dpmr == 1
+          && opts.frame_provoice == 1 && opts.frame_ysf == 1 && opts.frame_m17 == 1)) {
+        DSD_FPRINTF(stderr, "reloaded auto config lost decoders\n");
+        rc |= 1;
+    }
+
+    /* The initialization default set persists no decode key, so a reload cannot widen it. */
+    reset_opts_and_state(opts, state);
+    opts.frame_dstar = 1;
+    opts.frame_x2tdma = 1;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_ysf = 1;
+    dsd_snapshot_opts_to_user_config(&opts, &state, &snap);
+    if (render_config_to_buffer(&snap, rendered, sizeof rendered) != 0) {
+        return 1;
+    }
+    if (strstr(rendered, "decode =") != nullptr) {
+        DSD_FPRINTF(stderr, "default decoder set rendered a decode key:\n%s\n", rendered);
+        return 1;
+    }
+    if (write_temp_config(rendered, path, sizeof path) != 0) {
+        return 1;
+    }
+    load_rc = dsd_user_config_load(path, &loaded);
+    (void)remove(path);
+    if (load_rc != 0) {
+        DSD_FPRINTF(stderr, "reloading the default snapshot failed\n");
+        return 1;
+    }
+
+    reset_opts_and_state(opts, state);
+    opts.frame_dstar = 1;
+    opts.frame_x2tdma = 1;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_ysf = 1;
+    dsd_apply_user_config_to_opts(&loaded, &opts, &state);
+    if (opts.frame_nxdn48 != 0 || opts.frame_nxdn96 != 0 || opts.frame_dpmr != 0 || opts.frame_provoice != 0
+        || opts.frame_m17 != 0) {
+        DSD_FPRINTF(stderr, "reloading a default-set config widened the decoder set\n");
+        rc |= 1;
+    }
+    if (opts.frame_dmr != 1 || opts.frame_p25p1 != 1) {
+        DSD_FPRINTF(stderr, "reloading a default-set config dropped decoders\n");
         rc |= 1;
     }
     return rc;
@@ -1984,11 +2107,14 @@ test_snapshot_roundtrip_dmr_mono_override(void) {
         int frame_p25p1;
         int frame_p25p2;
         int frame_dmr;
+        int all_digital;
         int expected_stereo;
     } cases[] = {
-        {"dmr-only", DSDCFG_MODE_DMR_MONO, 0, 0, 0, 1, 0},
-        {"auto", DSDCFG_MODE_AUTO, 1, 1, 1, 1, 1},
-        {"tdma", DSDCFG_MODE_TDMA, 0, 1, 1, 1, 1},
+        {"dmr-only", DSDCFG_MODE_DMR_MONO, 0, 0, 0, 1, 0, 0},
+        /* Matches no preset, so it persists without a decode key; the override must survive anyway. */
+        {"unmatched-set", DSDCFG_MODE_UNSET, 1, 1, 1, 1, 0, 1},
+        {"auto", DSDCFG_MODE_AUTO, 0, 0, 0, 0, 1, 1},
+        {"tdma", DSDCFG_MODE_TDMA, 0, 1, 1, 1, 0, 1},
     };
 
     for (size_t i = 0; i < sizeof cases / sizeof cases[0]; i++) {
@@ -1997,6 +2123,19 @@ test_snapshot_roundtrip_dmr_mono_override(void) {
         opts.frame_p25p1 = cases[i].frame_p25p1;
         opts.frame_p25p2 = cases[i].frame_p25p2;
         opts.frame_dmr = cases[i].frame_dmr;
+        if (cases[i].all_digital) {
+            opts.frame_dstar = 1;
+            opts.frame_x2tdma = 1;
+            opts.frame_p25p1 = 1;
+            opts.frame_p25p2 = 1;
+            opts.frame_nxdn48 = 1;
+            opts.frame_nxdn96 = 1;
+            opts.frame_dmr = 1;
+            opts.frame_dpmr = 1;
+            opts.frame_provoice = 1;
+            opts.frame_ysf = 1;
+            opts.frame_m17 = 1;
+        }
         opts.dmr_mono = 1;
         opts.dmr_stereo = cases[i].expected_stereo;
         state.dmr_stereo = cases[i].expected_stereo;
@@ -2461,6 +2600,7 @@ main(void) {
     rc |= test_apply_mode_ysf_uses_config_profile_behavior();
     rc |= test_snapshot_staged_file_rate_uses_requested_rate();
     rc |= test_snapshot_mode_inference_tdma_and_auto();
+    rc |= test_snapshot_roundtrip_preserves_decoder_set();
     rc |= test_snapshot_roundtrip_dmr_mono_override();
     rc |= test_radioreference_schema_rows();
     rc |= test_radioreference_config_roundtrip();

--- a/tests/runtime/test_runtime_decode_mode.c
+++ b/tests/runtime/test_runtime_decode_mode.c
@@ -16,6 +16,23 @@
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/runtime/config.h"
 
+/* Every AUTO entry point enables the same decoder set; only the CLI one also resets modulation
+   and the audio layout, which the config and interactive paths own through their own keys. */
+static int
+expect_auto_enables_every_decoder(const char* label, const dsd_opts* opts) {
+    if (!(opts->frame_dstar == 1 && opts->frame_x2tdma == 1 && opts->frame_p25p1 == 1 && opts->frame_p25p2 == 1
+          && opts->frame_nxdn48 == 1 && opts->frame_nxdn96 == 1 && opts->frame_dmr == 1 && opts->frame_dpmr == 1
+          && opts->frame_provoice == 1 && opts->frame_ysf == 1 && opts->frame_m17 == 1)) {
+        DSD_FPRINTF(stderr, "%s AUTO should enable all digital frame flags\n", label);
+        return 1;
+    }
+    if (strcmp(opts->output_name, "AUTO") != 0) {
+        DSD_FPRINTF(stderr, "%s AUTO output_name mismatch: %s\n", label, opts->output_name);
+        return 1;
+    }
+    return 0;
+}
+
 static int
 test_auto_profile_differences(void) {
     static dsd_opts opts = {0};
@@ -30,12 +47,12 @@ test_auto_profile_differences(void) {
         DSD_FPRINTF(stderr, "interactive AUTO apply failed\n");
         return 1;
     }
-    if (opts.frame_dstar != 0 || opts.frame_dmr != 0 || opts.pulse_digi_out_channels != 7 || state.rf_mod != 2) {
-        DSD_FPRINTF(stderr, "interactive AUTO should preserve existing mode flags/channels\n");
+    if (expect_auto_enables_every_decoder("interactive", &opts) != 0) {
         return 1;
     }
-    if (strcmp(opts.output_name, "AUTO") != 0) {
-        DSD_FPRINTF(stderr, "interactive AUTO output_name mismatch: %s\n", opts.output_name);
+    /* Audio layout and modulation stay with the caller on the non-CLI paths. */
+    if (opts.pulse_digi_out_channels != 7 || state.rf_mod != 2) {
+        DSD_FPRINTF(stderr, "interactive AUTO should preserve audio layout and modulation\n");
         return 1;
     }
 
@@ -54,14 +71,14 @@ test_auto_profile_differences(void) {
         DSD_FPRINTF(stderr, "config AUTO apply failed\n");
         return 1;
     }
-    if (!(opts.frame_p25p2 == 1 && opts.frame_nxdn48 == 1 && opts.frame_dstar == 0 && opts.frame_provoice == 0
-          && opts.pulse_digi_out_channels == 3 && state.rf_mod == 2 && state.samplesPerSymbol == 17
-          && state.symbolCenter == 7 && state.sps_hunt_idx == 3)) {
-        DSD_FPRINTF(stderr, "config AUTO should preserve initialized protocol, modulation, and timing state\n");
+    if (expect_auto_enables_every_decoder("config", &opts) != 0) {
         return 1;
     }
-    if (strcmp(opts.output_name, "AUTO") != 0) {
-        DSD_FPRINTF(stderr, "config AUTO output_name mismatch: %s\n", opts.output_name);
+    /* [mode] demod and the output keys are applied after the preset, so it must not touch
+       modulation, the audio layout, or symbol timing on the config path. */
+    if (!(opts.pulse_digi_out_channels == 3 && state.rf_mod == 2 && state.samplesPerSymbol == 17
+          && state.symbolCenter == 7 && state.sps_hunt_idx == 3)) {
+        DSD_FPRINTF(stderr, "config AUTO should preserve modulation, audio layout, and timing state\n");
         return 1;
     }
 
@@ -76,10 +93,7 @@ test_auto_profile_differences(void) {
         DSD_FPRINTF(stderr, "cli AUTO apply failed\n");
         return 1;
     }
-    if (!(opts.frame_dstar == 1 && opts.frame_x2tdma == 1 && opts.frame_p25p1 == 1 && opts.frame_p25p2 == 1
-          && opts.frame_nxdn48 == 1 && opts.frame_nxdn96 == 1 && opts.frame_dmr == 1 && opts.frame_dpmr == 1
-          && opts.frame_provoice == 1 && opts.frame_ysf == 1 && opts.frame_m17 == 1)) {
-        DSD_FPRINTF(stderr, "cli AUTO should enable all digital frame flags\n");
+    if (expect_auto_enables_every_decoder("cli", &opts) != 0) {
         return 1;
     }
     if (opts.pulse_digi_out_channels != 2 || opts.dmr_stereo != 1 || opts.dmr_mono != 0) {
@@ -482,6 +496,52 @@ test_symbol_timing_and_inference(void) {
     opts.dmr_mono = 1;
     if (dsd_infer_decode_mode_preset(&opts) != DSDCFG_MODE_AUTO) {
         DSD_FPRINTF(stderr, "mixed unsupported mono infer should return AUTO\n");
+        return 1;
+    }
+
+    /* The AUTO decoder set is now a mask a preset actually reproduces, so both spellings agree. */
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.frame_dstar = 1;
+    opts.frame_x2tdma = 1;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_dpmr = 1;
+    opts.frame_provoice = 1;
+    opts.frame_ysf = 1;
+    opts.frame_m17 = 1;
+    if (dsd_infer_decode_mode_preset(&opts) != DSDCFG_MODE_AUTO
+        || dsd_infer_decode_mode_preset_exact(&opts) != DSDCFG_MODE_AUTO) {
+        DSD_FPRINTF(stderr, "all-decoder mask should infer AUTO exactly\n");
+        return 1;
+    }
+
+    /* The dsd_init default set matches no preset. The lossy spelling still answers AUTO for the
+       UI's mode label, but the exact one must say UNSET so autosave does not write `decode =
+       "auto"` for it -- reloading that would widen a default session to every decoder. */
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.frame_dstar = 1;
+    opts.frame_x2tdma = 1;
+    opts.frame_p25p1 = 1;
+    opts.frame_p25p2 = 1;
+    opts.frame_dmr = 1;
+    opts.frame_ysf = 1;
+    if (dsd_infer_decode_mode_preset(&opts) != DSDCFG_MODE_AUTO) {
+        DSD_FPRINTF(stderr, "init-default mask should still label as AUTO\n");
+        return 1;
+    }
+    if (dsd_infer_decode_mode_preset_exact(&opts) != DSDCFG_MODE_UNSET) {
+        DSD_FPRINTF(stderr, "init-default mask should not infer an exact preset\n");
+        return 1;
+    }
+
+    /* An exact single-preset match answers the same both ways. */
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.frame_nxdn48 = 1;
+    if (dsd_infer_decode_mode_preset_exact(&opts) != DSDCFG_MODE_NXDN48) {
+        DSD_FPRINTF(stderr, "nxdn48 mask should infer NXDN48 exactly\n");
         return 1;
     }
 

--- a/tools/check_arch_rules.sh
+++ b/tools/check_arch_rules.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+cd "$repo_root"
+
+usage() {
+  cat << 'USAGE'
+Usage: tools/check_arch_rules.sh
+
+Runs the architecture guardrails in cmake/arch_rules.cmake over src/ and
+include/dsd-neo/: module include boundaries (backend vs app-control vs UI vs
+Qt), the frontend/app-control boundary, and forbidden constructs (exit(),
+weak symbols, /alternatename pragmas, direct rtl_stream_* use from the
+terminal UI). Fails with a non-zero exit when any violation is found.
+USAGE
+}
+
+if [[ $# -gt 0 ]]; then
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+fi
+
+if ! command -v cmake > /dev/null 2>&1; then
+  echo "cmake not found in PATH." >&2
+  exit 1
+fi
+
+exec cmake -P cmake/arch_rules.cmake


### PR DESCRIPTION
## Summary

- Adds `nxdn-trunk` and `nxdn-conventional` target types to single-tuner trunk scan (`--trunk-scan targets.csv`), so mixed P25/DMR/NXDN lists rotate in one coordinator. Closes #371.
- Target CSV: `gfsk`/`auto` modulation hints valid for NXDN targets; `chan_csv` valid for `nxdn-trunk` (per-target channel map, same semantics as DMR T3) and rejected on both conventional types.
- Demod: NXDN targets share the DMR-class setup (4800 sym/s, 4-level `4800_4` SPS profile, GFSK `rf_mod`); per-target modulation overrides behave exactly like DMR targets.
- Trunked NXDN: coordinator seeds `p25_cc_freq`/`trunk_cc_freq`/`trunk_lcn_freq[0]` for `nxdn-trunk` so existing grant tuning (SCCH/VCALL via `dsd_trunk_tuning_hook_tune_to_freq`) and return-to-CC work unchanged; retune paths keep `p25_cc_freq` set (unlike DMR trunk); hold keyed on `trunk_is_tuned`.
- Per-target state isolation: full NXDN snapshot (grant chan/freq, RAN, site sys/site code, location category, RCN/base/step/bw) saved/restored alongside the existing DMR/P25 snapshots.
- Conventional NXDN: new runtime hook `dsd_trunk_scan_hook_nxdn_conventional_activity`; `nxdn_element.c` reports CRC-verified VCALL ID (type `0x01`) activity, and the coordinator applies the same allow/block, private-call, data-call, and encrypted-call policy gates as conventional DMR before parking.
- Init-time warning when a target's decoder is disabled by the selected mode preset (e.g. `-ft` does not enable NXDN96; use `-fa` for mixed lists, `-fn` for NXDN-only). Log-only; the coordinator never flips mode-preset frame flags. Emitted once per decoder class, not per target, since scan lists became unbounded in #370.
- Also adds `tools/check_arch_rules.sh` (see *Additional guardrail* below).
- Docs updated (`docs/trunk-scan.md`, `docs/csv-formats.md`, `docs/cli.md`, `docs/config-system.md`), two example rows appended to `examples/trunk_scan_targets.csv`.
- Also adds the `nxdn48-conventional` target type (6.25 kHz / 2400 sym/s) and aligns the `auto` decode preset across its three entry points. Closes #373. Details in *NXDN48 Conventional Targets* and *Decode Mode AUTO Alignment* below.
- Out of scope: NXDN48 **trunk** targets (Type-D control channels) — unverified, tracked in #375.

## Review Follow-Ups (0ba68e2d)

A full review pass over the initial commit found six correctness defects, all fixed in `0ba68e2d`:

- **`nxdn_element.c` — hook fired outside the CRC gate.** The conventional-activity hook ran on any `message_type == 0x01` VCALL, outside the `VCallCrcIsGood` gate that publish, cipher-apply and enc-lockout all sit behind. A CRC-failed VCALL still yields a `destination_id` that TG policy allows by default, so the coordinator parked on a dead channel for a full `activity_hold_ms` per corrupt burst. The DMR counterpart is reached only after the LC's FEC check.
- **`nxdn_element.c` — raw cipher field used as the policy input.** `encrypted` was `info->cipher_type != 0U`, bypassing the classification hysteresis `nxdn_vcall_apply_state()` applies one line above. Under `--enc-lockout`, one trellis-miscorrected 2-bit cipher field would drop the hold mid-call on a clear target. Now passes `state->nxdn_cipher_type`; `is_private` reuses `nxdn_vcall_kind()` instead of re-spelling the `call_type == 4` test.
- **`p25_frequency.c` — out-of-bounds read in both NXDN channel lookups.** `trunk_chan_map[]` holds `DSD_TRUNK_CHAN_MAP_SIZE == 0xFFFF` entries, so an unchecked `uint16_t` channel of `0xFFFF` read one element past the end into `trunk_chan_map_used[]` — an ASan abort, or a bogus tune frequency on release. Guarded with `dsd_state_trunk_chan_valid()`, narrowed to the map lookup so the DFA arithmetic still answers for every channel number. The write path was already guarded; only the reads were not.
- **`trunk_scan.c` — fabricated RAN 0 on never-visited targets.** `trunk_scan_snapshot_clear()` re-establishes every other protocol's non-zero "unknown" sentinel but was not extended for the new NXDN block. RAN 0 is legal, so the zeroed snapshot published `RAN 00` to `nxdn_print_last_ran()`, the ncurses header, and `dsd_events` `sys_id3` for a site whose RAN was never decoded. Restored the `initState()`/`noCarrier()` sentinels; the new test had asserted the wrong values and is corrected.
- **`trunk_scan.c` — P25 decoder check too narrow.** The warning tested `frame_p25p1` alone while the engine's own predicate is `frame_p25p1 || frame_p25p2`. `-f2` on a TDMA control channel warned about a target that decodes fine, and the printed hint (`-f1`) would have broken it by dropping the `6000_4` profile from the SPS hunt.
- **`tests/` — indeterminate `free()` on the parser failure path.** Two new cases left `dsd_trunk_scan_target_list` uninitialized then called `_reset()` unconditionally; `dsd_trunk_scan_load_targets_csv()` is contractually forbidden from writing `*out` on failure, so a parser regression would have crashed or corrupted the heap for every test after it. Zeroed at all four sites that lacked it.

Cleanup in the same commit: extracted `trunk_scan_conventional_activity()` (the DMR and NXDN entry points were byte-for-byte copies differing in one enum constant); rewrote the disabled-decoder warning as an exhaustive `switch` plus a table, so adding a target type fails the build rather than silently classing it as always-decodable; added `trunk_scan_type_is_conventional()` / `_is_gfsk_family()` in place of four inline enum chains; doc comments on the four new public API items.

Docs correction: the branch had claimed `mode.decode = "auto"` in a config file is equivalent to `-fa`. It is not — `decode_mode_apply_auto()` sets the frame flags only under `DSD_DECODE_PRESET_PROFILE_CLI`, so a config-file user got `frame_nxdn96 = 0` and a startup warning on every NXDN target. Corrected, quick-start examples switched to `-fa`, and the new warning documented in both the expected-messages and troubleshooting blocks.

## Known Limitations Closed (9619e6bc, 2912f397, 99eeda09, 56862bcc)

The four limitations this branch previously deferred are fixed here, one commit each.

- **`nxdn-trunk` targets never followed the site control channel** (`9619e6bc`). `nxdn_cch_info_dfa_version()` adopted the DFA outbound CC only while `trunk_lcn_freq[0]` was still zero, and the coordinator seeds that slot with the target's CSV park frequency, so a target parked a few kHz off never self-corrected. The one-shot latch is replaced with an explicit "operator pinned the control channel" predicate mirroring `p25_has_user_lcn_list()`: an imported LCN list pins the CC, the coordinator's single seeded slot does not. `dmr-trunk` targets are excluded through the coordinator's `p25_cc_freq == 0` contract, so a stray NXDN broadcast decoded under `-fa` while parked on a DMR target cannot retune it. Adoption is idempotent and announces only an actual move; plain `-T` is unchanged.
- **`dsd_engine_apply_cc_symbol_timing()` clobbered non-P25 control channels** (`2912f397`). The "is this a P25 CC" question is extracted from `dsd_engine_is_p25_profile_retune()` into `dsd_engine_cc_is_p25()` and now gates the symbol-timing application as well, so one predicate answers it for both RTL profile staging and decoder timing. Skipping is correct rather than merely safe for the others: DMR and NXDN96 are already parked at 4800 sym/s on the four-level profile, and NXDN48/EDACS run rates the function cannot express. The predicate gains one case — under trunk scan the parked target type decides, since an unsynced target reads as P25 by synctype alone (`DSD_SYNC_P25P1_POS` is 0). Deliberately **not** added: `p25_cc_is_tdma` as a positive "P25 known" signal. It would let a P25 CC recover from a false DMR sync, but nothing resets it when a non-P25 CC is adopted, so a stale value from an earlier P25 site would reintroduce this very bug for NXDN.
- **`nxdn_trunk_diag` was unreachable under trunk scan** (`56862bcc`). The channel-map path is now resolved through a new `active_chan_csv` runtime hook that the coordinator answers from the parked target, and the missing-channel ledger became a movable value snapshotted per target alongside the rest of each target's NXDN state. The exit summary grows a ledger/channel-map form so the coordinator logs one line per target at shutdown; the engine's single-system summary is skipped while scanning. A global `-C` map still wins wherever it is set.
- **Data calls never refreshed a conventional hold** (`99eeda09`). Both hook sites reported voice only with `data_call` hardcoded to 0 — the DMR site as well as the NXDN one — so the documented "data-call tuning applies to that decision" was vacuous for both protocols. NXDN SDCALL (`0x38`) and DCALL (`0x09`) headers now report behind the link layer's CRC gate, and DMR data headers report alongside the existing "Data Call" summary, which already excludes the formats without a fresh identity (dpf 1 response, dpf 15 proprietary). The DMR CRC test is explicit because `dmr_dheader()` also admits headers under the relaxed-CRC options. Policy is unchanged: `trunk_tune_data_calls` is off by default and data calls stay exempt from the encrypted-target lockout.

New tests: control-channel adoption pinning across the four scan/plain shapes and end-to-end follow-the-corrected-CC across a rotation; NXDN and EDACS CC returns preserving GFSK timing plus the unsynced-scan-target case; per-target diagnostics path resolution, ledger round trip and cross-target isolation; data-header hook reporting for both protocols including the CRC and no-identity negatives; and coordinator-level data-call hold gating for both conventional types.

## Additional Guardrail (89f66e82)

`cmake/arch_rules.cmake` already encodes the module include boundaries (backend vs app-control vs UI vs Qt), the frontend/app-control split, and the forbidden constructs (`exit()`, weak symbols, `/alternatename` pragmas, direct `rtl_stream_*` use from the terminal UI) — but nothing ran it outside a full configure, so a boundary violation only surfaced when someone happened to reconfigure. `tools/check_arch_rules.sh` runs it standalone via `cmake -P` and is wired into `.githooks/pre-push` (behind a `cmake` availability check, so a missing tool is reported rather than failing the push) and the CI guardrails job. No rules change; the tree passes as-is.

## Review

- [x] Changes were reviewed against the surrounding module design (follows the existing per-type coordinator pattern: parse → classify → demod → seed → retune → hold → snapshot; no new layering).
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. *(Solo-maintainer exception; full `tools/quality_preflight.sh` run, plus a dedicated review pass whose six confirmed correctness findings are fixed in `0ba68e2d` and whose four unfixed findings are listed under Known Limitations.)*
- [x] High-risk areas touched are marked: security / **workflow** / release / **parser** / crypto / dependency / network input / none *(trunk-scan target CSV parser extended — operator-provided local file, not network input. Workflow: `.github/workflows/guardrails.yml` gains one `run:` step invoking a repo-local script; no permission, trigger, or action-pin changes.)*
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions. *(No copied/generated code; new code follows existing trunk-scan patterns.)*
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained. *(`git commit -s` on all three commits.)*

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. *(6 cases in `tests/engine/test_engine_trunk_scan.c` driving the real coordinator: parser accept/reject, control-channel seeding, demod profile rotation, conventional activity hold + allowlist + encrypted lockout, trunk hold while tuned + release, per-target NXDN state isolation — the last now asserting the "no RAN decoded" sentinel. Plus 3 regression cases in `tests/protocol/p25/test_p25_frequency_map.c` pinning the out-of-range channel behaviour of both NXDN lookups.)*
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. *(Protocol touch is one guarded hook call in `nxdn_vcall_process`, now inside the CRC gate and fed the corroborated cipher classification; hook dispatcher is a no-op when trunk scan is not installed, so single-system NXDN behavior is unchanged — covered by the passing NXDN suite.)*
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. *(None added.)*
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification. *(Only `DSD_MEMCPY`/`DSD_SNPRINTF`/`LOG_WARN` wrappers. The new workflow step runs a repo-local script and adds no permissions; `tools/check_arch_rules.sh` is `set -euo pipefail`, takes no arguments beyond `-h`, and `exec`s `cmake -P`.)*

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` *(565/565 pass; two new public-header smoke tests registered)*
- [x] `tools/preflight_ci.sh` *(exit 0)*
- [x] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/check_arch_rules.sh` *(`ARCH_RULES: OK`)*
- [ ] `tools/cmake_format_check.sh` for CMake changes *(N/A — `cmake/arch_rules.cmake` is invoked but not modified; no CMake files touched)*
- [x] `tools/workflow_lint.sh` and `tools/zizmor.sh` for workflow changes *(actionlint clean; zizmor v1.29.0 — no findings)*
- [ ] `tools/osv_scan.sh` for dependency input changes *(N/A — no dependency changes; run anyway as part of quality_preflight)*
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes *(all four ran clean inside `tools/preflight_ci.sh`/`tools/quality_preflight.sh` and the pre-push hook)*

## NXDN48 Conventional Targets (`0f6dd92c`)

Closes #373. NXDN48 and NXDN96 share a sync word, a dispatch handler and every decoded element, so an NXDN48 VCALL/DCALL/SDCALL already reaches the conventional-activity hook: **no protocol code changed**. The two axes that did differ were both hardcoded to the 4800 sym/s answer.

- **Target type axes became exhaustive switches** with no `default`, so the next target type fails the build at every classification site instead of inheriting whichever answer a `type == A || type == B` chain fell through to. `trunk_scan_type_gfsk_symbol_rate()` is the single home for the rate (2400 for NXDN48, 4800 for the rest, 0 for P25) and `trunk_scan_type_is_gfsk_family()` is derived from it.
- **Demod:** parking an NXDN48 target seeds the `2400_4` SPS hunt profile and its timing (20 sps / center 9 at 48 kHz) instead of `4800_4`, and hands the same rate to the retune.
- **RTL chain:** `dsd_engine_prepare_dmr_cc_rtl_chain()` became `dsd_engine_prepare_gfsk_cc_rtl_chain()` and takes the symbol rate, resolving the channel filter through `dsd_rtl_channel_profile_for()` (2400 → 6.25 kHz, 4800 → 12.5 kHz) so the front end and the SPS hunt cannot disagree about which filter a rate wants. The tuning layer learns the parked rate from a new `dsd_engine_trunk_scan_active_gfsk_symbol_rate()` query, because neither `rf_mod` (2 for both rates) nor `sps_hunt_idx` (rotated by the no-sync hunt) can answer it. **Only a 2400 answer changes the chain**; the `rf_mod == 2` gate still selects 4800, so plain `-T` DMR/NXDN96 retunes are byte-for-byte unchanged. This matters because a wrong filter would not self-correct: a pinned hunt stops re-applying the demod profile. Generalizing the gate further is deliberately deferred (#376).
- **Decoder warning** splits NXDN into two classes. `-fn` enables NXDN96 only and `-fi` enables NXDN48 only, so a list holding both rates needs `-fa`. Still log-only; the coordinator never flips frame flags.
- **Activity hook** now claims the hold for either NXDN conventional type via a family predicate — `nxdn_element.c` cannot tell 48 from 96 and must not have to. DMR and NXDN families stay disjoint, asserted both ways.

New tests: parser accept/reject (including the same frequency as both NXDN conventional types, which the `(type, frequency)` duplicate check must keep distinct), the 2400 demod profile and retune sps with round-trip isolation from a neighbouring NXDN96 target, RTL output-rate derivation, the NXDN48 decoder warning in all three flag combinations, NXDN48 activity hold with allow-list and encrypted-lockout cases, data-call gating, and cross-family negatives. `ENGINE_TRUNK_RETUNE_REGRESSION` pins 2400/4/`6K25` for a parked NXDN48 target and 4800/4/`12K5` for the two other shapes.

## Decode Mode AUTO Alignment (`4ed832a3`)

Investigating #373's "decoder-gating design question" showed it was already solved for the CLI: `-fa` enables both `frame_nxdn48` and `frame_nxdn96`, and the DSP resolves the variant from `sps_hunt_idx` (`dsd_frame_sync_active_nxdn_variant()`). So neither per-target frame-flag flipping nor a combined NXDN preset was needed. But the config-file half was broken, and fixing it was a prerequisite for documenting `-fa` as the answer:

- `decode = "auto"` and the first-run wizard's Auto decoded only the `dsd_init` defaults — no NXDN48, NXDN96, dPMR, ProVoice or M17 — because the frame flags sat behind a `p == CLI` check. That was a behavior-preserving carve-out from `e0418756`, not a design decision.
- It also broke the autosave round trip: `snapshot_mode_config()` records `dsd_infer_decode_mode_preset()`, which falls back to AUTO for any set no preset reproduces — including the all-eleven set `-fa` produces. A `-fa` session saved `decode = "auto"` and reloaded decoding six protocols instead of eleven.
- `decode_mode_apply_auto()` now sets the eleven frame flags on every profile. Modulation reset and audio layout stay CLI-only: the config path owns those through `[mode] demod` (applied *after* the preset, so it still wins) and its output keys.
- New `dsd_infer_decode_mode_preset_exact()` reports `DSDCFG_MODE_UNSET` rather than AUTO when no preset reproduces the decoder set, and autosave uses it. Without that, widening AUTO would make every default session reload with every decoder enabled. The AUTO set is now a map row, so `-fa` round-trips exactly. The old spelling is unchanged and still backs the UI mode labels.

Verified by replay: a config whose only content is `decode = "auto"` now decodes `tests/fixtures/iq/nxdn48.iq` (5 VCALLs, `Src=901`) where it previously decoded nothing, while a config with no `decode` key still decodes nothing.

> Note: `-fa` on 2400-class signals does not converge reliably in every case — dPMR decodes under `-fm` but not `-fa`. That is a pre-existing frame-sync hunt issue unrelated to this branch, filed as #374. Trunk scan is insulated from it because the coordinator pins each target's profile directly.

## Risk

- Security/dependency impact: none. No new dependencies; the extended target-CSV parser keeps the same validation posture (duplicate id/type+freq rejection retained, new conventional `chan_csv` rejection, unchanged quoting rules). The out-of-bounds `trunk_chan_map[]` read fixed in `0ba68e2d` predates this branch in the P25/NXDN lookup path and is now bounded on both read and write.
- CLI/UI behavior impact: no new flags or config keys. `--trunk-scan` now accepts three additional `type` values; a log-only init warning appears when a target's decoder is not enabled by the mode preset, now split into NXDN96 and NXDN48 classes. Existing 3-type CSVs parse identically. `nxdn_channel_to_frequency*` now returns the DFA answer instead of an out-of-bounds read for channel `0xFFFF`.
- Decode-mode behavior change (`4ed832a3`), the one deliberate break in this branch: `decode = "auto"` in a config file and the wizard's Auto now enable every digital decoder rather than the initialization defaults, matching `-fa`. Operators who relied on config `auto` meaning "a deliberately narrowed set" must name the narrower preset instead. Autosave no longer writes `decode = "auto"` for a decoder set that matches no preset, so a default session still reloads unchanged; a `-fa` session now reloads as `-fa` rather than silently narrowing.
- Compatibility or packaging impact: none to the shipped artifact. No public API removed; the new hook field is additive to `dsd_trunk_scan_hooks` (zero-initialized struct initializers remain valid); no packaging changes. Developer-facing only: the pre-push hook and the CI guardrails job each gain one check.


