### PR TITLE
Follow-up to #370: scan-list correctness, protocol count writers, and sparse target snapshots

### DIFF
--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -76,7 +76,7 @@ Notes:
   `number,number` shape.
 - Extra columns are ignored; use them for labels like "default CC".
 - For EDACS-style workflows, DSD-neo also records the `frequency_hz` values in **row order** as an LCN frequency list,
-  so keep rows in the LCN order you want. The LCN list stores at most 26 frequencies.
+  so keep rows in the LCN order you want. The LCN list has no length limit; it is bounded only by memory.
 
 Example:
 

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -76,7 +76,9 @@ Notes:
   `number,number` shape.
 - Extra columns are ignored; use them for labels like "default CC".
 - For EDACS-style workflows, DSD-neo also records the `frequency_hz` values in **row order** as an LCN frequency list,
-  so keep rows in the LCN order you want. The LCN list has no length limit; it is bounded only by memory.
+  so keep rows in the LCN order you want. An imported LCN list has no length limit; it is bounded only by memory.
+  Site broadcasts never write into an imported list or shorten it - the list is positional, so a skipped row's 0
+  holds that LCN's place. Frequencies learned from site broadcasts (with no list imported) are capped at 26.
 
 Example:
 
@@ -120,7 +122,9 @@ Columns:
 
 Validation notes:
 
-- No target-count limit; bounded only by memory.
+- No fixed target-count limit. Each parked target reserves a snapshot of decoder state (~80 KB), and the list is
+  capped by a 256 MB budget for those snapshots - a few thousand targets. A CSV past the cap is rejected while
+  parsing, with an error naming the budget.
 - Duplicate IDs and duplicate `(type, frequency_hz)` rows are rejected. `nxdn-conventional` and
   `nxdn48-conventional` are distinct types, so one frequency may appear once as each.
 - `chan_csv` on conventional (`dmr-conventional`/`nxdn-conventional`/`nxdn48-conventional`) rows is rejected.

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -59,7 +59,9 @@ Column behavior:
 
 Target list limits and validation:
 
-- No target-count limit; bounded only by memory.
+- No fixed target-count limit. Each parked target reserves a snapshot of decoder state (~80 KB), and the list is
+  capped by a 256 MB budget for those snapshots - a few thousand targets. A CSV past the cap is rejected while
+  parsing, with an error naming the budget.
 - Blank rows are skipped.
 - Every data row must contain the seven fields above.
 - The header may have optional columns after `notes`, but the first seven header names must match the required prefix.

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -17,6 +17,7 @@
 #include <dsd-neo/platform/platform.h>
 
 #include <dsd-neo/core/input_level.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/state_fwd.h>
 
@@ -1428,6 +1429,19 @@ int dsd_state_trunk_lcn_reserve(dsd_state* state, size_t count_needed);
  * DSD_TRUNK_LCN_EMBEDDED slots are part of dsd_state and need no release.
  */
 void dsd_state_trunk_lcn_free(dsd_state* state);
+
+/**
+ * Whether the scan list is operator-supplied rather than learned over the air.
+ *
+ * A `-C`/`-Y` channel map, or a per-target chan_csv under trunk scan, is
+ * positional: index i is LCN i+1, and an unparseable row deliberately stores 0
+ * to keep that numbering. Protocol site broadcasts must therefore neither write
+ * into such a list nor lower lcn_freq_count to the handful of slots they know
+ * about. Trunk scan rejects a global chan_in_file at init and seeds slot 0 with
+ * the target's park frequency, so under -Y a count above 1 is the only evidence
+ * a per-target map was imported.
+ */
+int dsd_state_trunk_lcn_user_list_present(const dsd_opts* opts, const dsd_state* state);
 
 static inline int
 dsd_state_minmax_window_size(int requested) {

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -33,6 +33,10 @@ enum DSD_ATTR_PACKED {
     DSD_P25_P2_AUDIO_RING_DEPTH = 4,
     DSD_P25_MAC_FRAGMENT_MAX_OCTETS = 256,
     DSD_TRUNK_CHAN_MAP_SIZE = 0xFFFF,
+    /* Scan-list slots stored inline in dsd_state. Protocol fixed-slot writers raw-index
+     * trunk_lcn_freq[] below this; longer lists spill into the trunk_lcn_freq_ext heap
+     * tail behind dsd_state_trunk_lcn_slot(). */
+    DSD_TRUNK_LCN_EMBEDDED = 26,
     DSD_VERTEX_KS_MAP_MAX = 64,
     DSD_DMR_TG_KEY_MAP_MAX = 256,
     DSD_RTL_SYMBOL_CACHE_CAP = 512,
@@ -414,12 +418,12 @@ struct dsd_state {
     long int p25_vc_freq[2];
     long int trunk_vc_freq[2]; // generic trunk-owner voice-channel frequencies
     // Trunking LCNs and maps
-    long int trunk_lcn_freq[26];
+    long int trunk_lcn_freq[DSD_TRUNK_LCN_EMBEDDED];
     long int trunk_chan_map[DSD_TRUNK_CHAN_MAP_SIZE];
     uint16_t trunk_chan_map_used[DSD_TRUNK_CHAN_MAP_SIZE];
     uint32_t trunk_chan_map_used_count;
     uint64_t trunk_chan_map_seq;
-    /* Scan-list tail beyond the 26 embedded slots (NULL until a longer list is
+    /* Scan-list tail beyond the DSD_TRUNK_LCN_EMBEDDED inline slots (NULL until a longer list is
      * imported). dsd_state_trunk_lcn_slot() abstracts both segments. Never inside
      * a UI_SNAPSHOT_COPY_RANGE: the first range ends at trunk_lcn_freq and members
      * from trunk_chan_map on are copied explicitly. */
@@ -1392,34 +1396,36 @@ dsd_state_set_trunk_chan_freq(dsd_state* state, uint32_t channel, long int freq)
 }
 
 /**
- * Address the scan-list LCN slot at index i. The first 26 slots live in the
- * embedded trunk_lcn_freq array (protocol fixed-slot writers keep raw-indexing
- * those); slots >= 26 live in the heap tail trunk_lcn_freq_ext. Callers must
- * guarantee 0 <= i < lcn_freq_count for reads, or that the index is addressable
- * (trunk_lcn_freq_ext_capacity > i - 26) for writes into the tail.
+ * Address the scan-list LCN slot at index i. The first DSD_TRUNK_LCN_EMBEDDED slots
+ * live in the embedded trunk_lcn_freq array (protocol fixed-slot writers keep
+ * raw-indexing those); higher slots live in the heap tail trunk_lcn_freq_ext. Callers
+ * must guarantee 0 <= i < lcn_freq_count for reads, or that the index is addressable
+ * (trunk_lcn_freq_ext_capacity > i - DSD_TRUNK_LCN_EMBEDDED) for writes into the tail.
  */
 static inline long int*
 dsd_state_trunk_lcn_slot(dsd_state* state, int i) {
-    return i < 26 ? &state->trunk_lcn_freq[i] : &state->trunk_lcn_freq_ext[i - 26];
+    return i < DSD_TRUNK_LCN_EMBEDDED ? &state->trunk_lcn_freq[i]
+                                      : &state->trunk_lcn_freq_ext[i - DSD_TRUNK_LCN_EMBEDDED];
 }
 
 /** Const-qualified dsd_state_trunk_lcn_slot() for read-only contexts. */
 static inline const long int*
 dsd_state_trunk_lcn_slot_const(const dsd_state* state, int i) {
-    return i < 26 ? &state->trunk_lcn_freq[i] : &state->trunk_lcn_freq_ext[i - 26];
+    return i < DSD_TRUNK_LCN_EMBEDDED ? &state->trunk_lcn_freq[i]
+                                      : &state->trunk_lcn_freq_ext[i - DSD_TRUNK_LCN_EMBEDDED];
 }
 
 /**
  * Ensure scan-list indices 0..count_needed-1 are addressable via
  * dsd_state_trunk_lcn_slot(): grows the heap tail by doubling and zero-fills
- * the new tail; no-op when count_needed <= 26. Returns 0 on success, -1 on
- * allocation failure (state left valid, contents preserved).
+ * the new tail; no-op when count_needed <= DSD_TRUNK_LCN_EMBEDDED. Returns 0 on
+ * success, -1 on allocation failure (state left valid, contents preserved).
  */
 int dsd_state_trunk_lcn_reserve(dsd_state* state, size_t count_needed);
 
 /**
  * Free the scan-list heap tail and zero its pointer/capacity. The embedded
- * 26 slots are part of dsd_state and need no release.
+ * DSD_TRUNK_LCN_EMBEDDED slots are part of dsd_state and need no release.
  */
 void dsd_state_trunk_lcn_free(dsd_state* state);
 

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -25,7 +25,22 @@ enum {
     DSD_TRUNK_SCAN_DWELL_MAX_MS = 600000,
     DSD_TRUNK_SCAN_IDLE_DWELL_DEFAULT_MS = 3000,
     DSD_TRUNK_SCAN_ACTIVITY_HOLD_DEFAULT_MS = 1200,
+    /* Ceiling on the memory the parked-target snapshots may occupy. See
+     * dsd_trunk_scan_max_targets(). */
+    DSD_TRUNK_SCAN_TARGET_MEMORY_BUDGET_BYTES = 256 * 1024 * 1024,
 };
+
+/**
+ * @brief Largest number of trunk scan targets that fits in the target memory budget.
+ *
+ * There is no target-count limit as such: each parked target reserves a snapshot of decoder
+ * state, and the cap is DSD_TRUNK_SCAN_TARGET_MEMORY_BUDGET_BYTES divided by that snapshot's
+ * size, so it tracks the struct instead of being a constant that goes stale. Enforced while the
+ * targets CSV is parsed - an unbounded row count would otherwise ask for a single allocation
+ * large enough that Linux overcommit grants it and the process is killed while faulting the
+ * pages in, rather than failing with a message the operator can act on.
+ */
+size_t dsd_trunk_scan_max_targets(void);
 
 typedef enum {
     DSD_TRUNK_SCAN_TARGET_P25_TRUNK = 0,

--- a/include/dsd-neo/protocol/nxdn/nxdn_trunk_diag.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn_trunk_diag.h
@@ -54,9 +54,19 @@ const char* nxdn_trunk_diag_chan_map_path(const dsd_opts* opts, const dsd_state*
  *
  * Lets the scan coordinator report each parked target's own missing channels from its snapshot.
  * No-op without a channel map path or when nothing is missing.
+ *
+ * @p lookup resolves a channel number to its mapped frequency, or 0 when the channel is still
+ * unmapped, and receives @p ctx unchanged. Taking a callback rather than a dense 64K-entry array
+ * lets a caller that stores its channel map sparsely answer the question without materialising
+ * one; pass nxdn_trunk_diag_dense_chan_lookup with a `const long int*` for a dense map.
  */
+typedef long int (*nxdn_trunk_diag_chan_freq_fn)(const void* ctx, uint16_t channel);
+
+/** nxdn_trunk_diag_chan_freq_fn over a dense `const long int[DSD_TRUNK_CHAN_MAP_SIZE]` map. */
+long int nxdn_trunk_diag_dense_chan_lookup(const void* ctx, uint16_t channel);
+
 void nxdn_trunk_diag_log_summary_for(const char* chan_csv, const nxdn_trunk_diag_ledger* ledger,
-                                     const long int* chan_map);
+                                     nxdn_trunk_diag_chan_freq_fn lookup, const void* ctx);
 
 /**
  * @brief Record that a trunked NXDN channel had no known frequency mapping.

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -334,7 +334,14 @@ svc_udp_output_config(dsd_opts* opts, dsd_state* state, const char* host, int po
  */
 static int
 chan_map_adopt(dsd_state* dst, const dsd_state* src) {
-    if (dsd_state_trunk_lcn_reserve(dst, (size_t)src->lcn_freq_count) != 0) {
+    // src is an arbitrary dsd_state*, so the sign and the tail are checked here rather
+    // than inherited from the importer: a negative count would become a huge size_t.
+    const int src_count = src->lcn_freq_count > 0 ? src->lcn_freq_count : 0;
+    if (src_count > DSD_TRUNK_LCN_EMBEDDED && src->trunk_lcn_freq_ext == NULL) {
+        LOG_ERROR("channel map adopt has no scan-list tail for %d entries\n", src_count);
+        return -1;
+    }
+    if (dsd_state_trunk_lcn_reserve(dst, (size_t)src_count) != 0) {
         LOG_ERROR("channel map adopt out of memory\n");
         return -1;
     }
@@ -342,11 +349,11 @@ chan_map_adopt(dsd_state* dst, const dsd_state* src) {
     DSD_MEMCPY(dst->trunk_chan_map_used, src->trunk_chan_map_used, sizeof dst->trunk_chan_map_used);
     dst->trunk_chan_map_used_count = src->trunk_chan_map_used_count;
     DSD_MEMCPY(dst->trunk_lcn_freq, src->trunk_lcn_freq, sizeof dst->trunk_lcn_freq);
-    if (src->lcn_freq_count > 26) {
+    if (src_count > DSD_TRUNK_LCN_EMBEDDED) {
         DSD_MEMCPY(dst->trunk_lcn_freq_ext, src->trunk_lcn_freq_ext,
-                   (size_t)(src->lcn_freq_count - 26) * sizeof(dst->trunk_lcn_freq_ext[0]));
+                   (size_t)(src_count - DSD_TRUNK_LCN_EMBEDDED) * sizeof(dst->trunk_lcn_freq_ext[0]));
     }
-    dst->lcn_freq_count = src->lcn_freq_count;
+    dst->lcn_freq_count = src_count;
     dst->lcn_freq_roll = 0;
     DSD_MEMSET(dst->dmr_lcn_trust, 0, sizeof dst->dmr_lcn_trust);
     dst->trunk_chan_map_seq++;

--- a/src/app_control/ui_snapshot.c
+++ b/src/app_control/ui_snapshot.c
@@ -110,20 +110,39 @@ ui_snapshot_copy_trunk_chan_map(dsd_state* dst, const dsd_state* src) {
     dst->trunk_chan_map_seq = src->trunk_chan_map_seq;
 }
 
-/* The embedded trunk_lcn_freq[26] is a plain array copied by the byte ranges
- * above; the scan-list heap tail past slot 26 needs an explicit deep copy.
+/* The heap tail must stay outside every UI_SNAPSHOT_COPY_RANGE: a raw byte copy of the
+ * pointer would alias the decoder's live buffer into g_pub/g_consume, and the next
+ * reserve() on the snapshot would realloc the decoder's memory out from under it. */
+_Static_assert(offsetof(dsd_state, trunk_lcn_freq_ext) >= UI_SNAPSHOT_FIELD_END(trunk_lcn_freq),
+               "trunk_lcn_freq_ext must sit after the dibit_buf..trunk_lcn_freq copy range");
+_Static_assert(UI_SNAPSHOT_FIELD_END(trunk_lcn_freq_ext_capacity) <= offsetof(dsd_state, audio_out_idx),
+               "trunk_lcn_freq_ext must sit before the audio_out_idx..lastsample copy range");
+/* ui_snapshot_copy_trunk_lcn_freq_ext() writes lcn_freq_count/lcn_freq_roll on its clamp
+ * paths, so the range that carries them has to be copied first or the clamp is undone. */
+_Static_assert(offsetof(dsd_state, lcn_freq_count) >= offsetof(dsd_state, p25_p2_audio_ring_count)
+                   && UI_SNAPSHOT_FIELD_END(lcn_freq_roll) <= UI_SNAPSHOT_FIELD_END(dstar_gps),
+               "lcn_freq_count/roll must ride the range copied before the scan-list tail");
+
+/* The embedded trunk_lcn_freq[] is a plain array copied by the byte ranges
+ * above; the scan-list heap tail past it needs an explicit deep copy.
  * Runs after the range that carries lcn_freq_count/lcn_freq_roll so dst is
  * never left claiming more entries than its tail holds: on reserve failure the
- * count is clamped back to the 26 embedded slots and the roll restarted. */
+ * count is clamped back to the embedded slots and the roll restarted. */
 static void
 ui_snapshot_copy_trunk_lcn_freq_ext(dsd_state* dst, const dsd_state* src) {
     const int count = src->lcn_freq_count > 0 ? src->lcn_freq_count : 0;
-    if (count <= 26) {
+    /* A protocol writer can shrink lcn_freq_count without touching lcn_freq_roll, so the
+     * roll copied by the byte range above may point past the list the snapshot publishes.
+     * Consumers index the list by roll, so make the pair consistent here. */
+    if (dst->lcn_freq_roll > count) {
+        dst->lcn_freq_roll = 0;
+    }
+    if (count <= DSD_TRUNK_LCN_EMBEDDED) {
         return;
     }
-    const size_t ext_count = (size_t)count - 26;
+    const size_t ext_count = (size_t)count - (size_t)DSD_TRUNK_LCN_EMBEDDED;
     if (dsd_state_trunk_lcn_reserve(dst, (size_t)count) != 0) {
-        dst->lcn_freq_count = 26;
+        dst->lcn_freq_count = DSD_TRUNK_LCN_EMBEDDED;
         dst->lcn_freq_roll = 0;
         return;
     }

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -931,6 +931,10 @@ init_state_p25_and_trunk_defaults(dsd_state* state) {
 
     //trunking
     DSD_MEMSET(state->trunk_lcn_freq, 0, sizeof(state->trunk_lcn_freq));
+    // Keep initState() idempotent with respect to the scan-list heap tail: re-initialising a
+    // state that already imported a >26-entry list would otherwise orphan the allocation, and a
+    // state that was not zero-initialised would leave reserve() calling realloc() on garbage.
+    dsd_state_trunk_lcn_free(state);
     DSD_MEMSET(state->trunk_chan_map, 0, sizeof(state->trunk_chan_map));
     DSD_MEMSET(state->trunk_chan_map_used, 0, sizeof(state->trunk_chan_map_used));
     state->trunk_chan_map_used_count = 0;

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -12,6 +12,7 @@
  * without dragging in the full initState/freeState dependency chain.
  */
 
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -60,4 +61,15 @@ dsd_state_trunk_lcn_free(dsd_state* state) {
     free(state->trunk_lcn_freq_ext);
     state->trunk_lcn_freq_ext = NULL;
     state->trunk_lcn_freq_ext_capacity = 0;
+}
+
+int
+dsd_state_trunk_lcn_user_list_present(const dsd_opts* opts, const dsd_state* state) {
+    if (opts && opts->chan_in_file[0] != '\0') {
+        return 1;
+    }
+    if (!opts || !state || opts->trunk_scan_enabled != 1) {
+        return 0;
+    }
+    return (state->lcn_freq_count > 1) ? 1 : 0;
 }

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -16,6 +16,7 @@
 #include <dsd-neo/core/state.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -5,7 +5,7 @@
 
 /**
  * @file
- * @brief Scan-list heap tail (slots past the 26 embedded trunk_lcn_freq[]).
+ * @brief Scan-list heap tail (slots past the embedded trunk_lcn_freq[]).
  *
  * Kept out of dsd_init.c so test targets that link individual core sources
  * (menu services, UI snapshot, trunk scan) can attach the real implementation
@@ -23,10 +23,10 @@ dsd_state_trunk_lcn_reserve(dsd_state* state, size_t count_needed) {
     if (!state) {
         return -1;
     }
-    if (count_needed <= 26) {
+    if (count_needed <= (size_t)DSD_TRUNK_LCN_EMBEDDED) {
         return 0;
     }
-    const size_t ext_needed = count_needed - 26;
+    const size_t ext_needed = count_needed - (size_t)DSD_TRUNK_LCN_EMBEDDED;
     if (ext_needed <= state->trunk_lcn_freq_ext_capacity) {
         return 0;
     }

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -91,7 +91,15 @@ typedef struct {
     dsd_enc_lockout_entry enc_lockout_entries[DSD_ENC_LOCKOUT_MAX];
     time_t p25_aff_last_seen[256];
     time_t p25_ga_last_seen[512];
-    long int trunk_chan_map[DSD_TRUNK_CHAN_MAP_SIZE];
+    /* Sparse channel map: only the channels state->trunk_chan_map_used[] lists, held in the same
+     * ascending order, with chan_map_freq[i] the frequency for chan_map_chan[i]. Dense copies of
+     * trunk_chan_map[] and trunk_chan_map_used[] were 655 KB of the 738 KB every parked target
+     * cost, and each rotation memcpy'd all of it; real sites map a few hundred channels. Grown on
+     * demand by trunk_scan_snapshot_chan_map_reserve() and released by trunk_scan_snapshot_clear()
+     * and trunk_scan_coord_free(). trunk_chan_map_used_count is the number of valid entries. */
+    uint16_t* chan_map_chan;
+    long int* chan_map_freq;
+    size_t chan_map_capacity;
     uint32_t trunk_chan_map_used_count;
     uint32_t p25_sys_services_available;
     uint32_t p25_sys_services_supported;
@@ -136,7 +144,6 @@ typedef struct {
     uint16_t p25_patch_key[8];
     uint16_t p25_patch_wgid[8][8];
     uint16_t p25_ga_tg[512];
-    uint16_t trunk_chan_map_used[DSD_TRUNK_CHAN_MAP_SIZE];
     uint8_t p25_prot_valid;
     uint8_t p25_prot_algid;
     uint8_t p25_cc_prot_valid;
@@ -194,6 +201,18 @@ typedef struct {
     uint64_t tune_request_id;
     int tune_pending;
 } dsd_trunk_scan_target_runtime;
+
+/*
+ * Enforced while parsing, not only where the array is allocated: an unbounded row count would ask
+ * for one calloc large enough that Linux overcommit grants it and the process is OOM-killed while
+ * faulting the pages in, instead of failing with a message. It also bounds the parser's per-row
+ * duplicate scans, which are linear in the rows accepted so far.
+ */
+size_t
+dsd_trunk_scan_max_targets(void) {
+    const size_t max = (size_t)DSD_TRUNK_SCAN_TARGET_MEMORY_BUDGET_BYTES / sizeof(dsd_trunk_scan_target_runtime);
+    return max > 0 ? max : 1U;
+}
 
 typedef struct {
     dsd_trunk_scan_target_runtime* targets;
@@ -663,6 +682,14 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
         return -1;
     }
 
+    if (parsed->count >= dsd_trunk_scan_max_targets()) {
+        scan_set_error(parse->err, parse->err_sz,
+                       "row %u exceeds the trunk scan target budget: each target reserves %zu KB of "
+                       "decoder state, so %zu targets is the most that fits in %d MB",
+                       parse->row, sizeof(dsd_trunk_scan_target_runtime) / 1024U, dsd_trunk_scan_max_targets(),
+                       DSD_TRUNK_SCAN_TARGET_MEMORY_BUDGET_BYTES / (1024 * 1024));
+        return -1;
+    }
     if (scan_target_list_reserve(parsed, parsed->count + 1) != 0) {
         scan_set_error(parse->err, parse->err_sz, "out of memory loading trunk scan targets");
         return -1;
@@ -845,9 +872,139 @@ trunk_scan_snapshot_lcn_ext_reserve(dsd_trunk_scan_snapshot* snapshot, size_t ex
     return 0;
 }
 
+/*
+ * Grow the sparse channel-map arrays to hold at least @p needed entries, doubling like
+ * trunk_scan_snapshot_lcn_ext_reserve(). Both arrays are grown together so an index is valid in
+ * either or in neither; on failure the snapshot keeps the arrays it already had.
+ */
+static int
+trunk_scan_snapshot_chan_map_reserve(dsd_trunk_scan_snapshot* snapshot, size_t needed) {
+    if (needed <= snapshot->chan_map_capacity) {
+        return 0;
+    }
+    size_t capacity = snapshot->chan_map_capacity > 0 ? snapshot->chan_map_capacity : 64;
+    while (capacity < needed) {
+        if (capacity > SIZE_MAX / 2) {
+            capacity = needed;
+            break;
+        }
+        capacity *= 2;
+    }
+    if (capacity > SIZE_MAX / sizeof(long int)) {
+        return -1;
+    }
+    uint16_t* chans = (uint16_t*)realloc(snapshot->chan_map_chan, capacity * sizeof *chans);
+    if (!chans) {
+        return -1;
+    }
+    snapshot->chan_map_chan = chans;
+    long int* freqs = (long int*)realloc(snapshot->chan_map_freq, capacity * sizeof *freqs);
+    if (!freqs) {
+        /* chan_map_chan already grew; capacity stays at the old value so the two arrays are
+         * never both indexed past the shorter one. */
+        return -1;
+    }
+    snapshot->chan_map_freq = freqs;
+    snapshot->chan_map_capacity = capacity;
+    return 0;
+}
+
+/*
+ * Capture state's channel map as (channel, frequency) pairs. state->trunk_chan_map_used[] is
+ * already the exact sorted set of mapped channels, so this walks it directly rather than
+ * scanning 64K slots.
+ */
+static void
+trunk_scan_save_chan_map_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* snapshot) {
+    uint32_t used = state->trunk_chan_map_used_count;
+    if (used > (uint32_t)DSD_TRUNK_CHAN_MAP_SIZE) {
+        used = (uint32_t)DSD_TRUNK_CHAN_MAP_SIZE;
+    }
+    if (used > 0 && trunk_scan_snapshot_chan_map_reserve(snapshot, (size_t)used) != 0) {
+        LOG_WARN("trunk scan: could not capture %u mapped channels for the parked target; its "
+                 "channel map will be relearned\n",
+                 (unsigned int)used);
+        used = 0;
+    }
+    for (uint32_t i = 0; i < used; i++) {
+        const uint16_t chan = state->trunk_chan_map_used[i];
+        snapshot->chan_map_chan[i] = chan;
+        snapshot->chan_map_freq[i] = state->trunk_chan_map[chan];
+    }
+    snapshot->trunk_chan_map_used_count = used;
+    snapshot->trunk_chan_map_seq = state->trunk_chan_map_seq;
+}
+
+/*
+ * Reinstate a saved channel map. Only the outgoing target's mapped channels are cleared - a
+ * DSD_MEMSET of the whole 64K-entry map would cost half a megabyte on every rotation.
+ */
+static void
+trunk_scan_restore_chan_map_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot* snapshot) {
+    uint32_t stale = state->trunk_chan_map_used_count;
+    if (stale > (uint32_t)DSD_TRUNK_CHAN_MAP_SIZE) {
+        stale = (uint32_t)DSD_TRUNK_CHAN_MAP_SIZE;
+    }
+    for (uint32_t i = 0; i < stale; i++) {
+        state->trunk_chan_map[state->trunk_chan_map_used[i]] = 0;
+    }
+
+    /* Bounded by all three of: what the snapshot claims, what it actually allocated, and what
+     * state->trunk_chan_map_used[] can hold - this loop writes into that fixed-size array. */
+    size_t used = snapshot->trunk_chan_map_used_count;
+    if (!snapshot->chan_map_chan || !snapshot->chan_map_freq) {
+        used = 0;
+    }
+    if (used > snapshot->chan_map_capacity) {
+        used = snapshot->chan_map_capacity;
+    }
+    if (used > (size_t)DSD_TRUNK_CHAN_MAP_SIZE) {
+        used = (size_t)DSD_TRUNK_CHAN_MAP_SIZE;
+    }
+    for (size_t i = 0; i < used; i++) {
+        const uint16_t chan = snapshot->chan_map_chan[i];
+        state->trunk_chan_map[chan] = snapshot->chan_map_freq[i];
+        state->trunk_chan_map_used[i] = chan;
+    }
+    state->trunk_chan_map_used_count = (uint32_t)used;
+    state->trunk_chan_map_seq = snapshot->trunk_chan_map_seq;
+}
+
+/*
+ * nxdn_trunk_diag_chan_freq_fn over a snapshot's sparse channel map. chan_map_chan[] is kept in
+ * the ascending order state->trunk_chan_map_used[] maintains, so this binary-searches it.
+ */
+static long int
+trunk_scan_snapshot_chan_lookup(const void* ctx, uint16_t channel) {
+    const dsd_trunk_scan_snapshot* snapshot = (const dsd_trunk_scan_snapshot*)ctx;
+    if (!snapshot || !snapshot->chan_map_chan || !snapshot->chan_map_freq) {
+        return 0;
+    }
+    size_t lo = 0;
+    size_t hi = snapshot->trunk_chan_map_used_count;
+    if (hi > snapshot->chan_map_capacity) {
+        hi = snapshot->chan_map_capacity;
+    }
+    while (lo < hi) {
+        const size_t mid = lo + ((hi - lo) / 2U);
+        const uint16_t at = snapshot->chan_map_chan[mid];
+        if (at == channel) {
+            return snapshot->chan_map_freq[mid];
+        }
+        if (at < channel) {
+            lo = mid + 1U;
+        } else {
+            hi = mid;
+        }
+    }
+    return 0;
+}
+
 static void
 trunk_scan_snapshot_clear(dsd_trunk_scan_snapshot* snapshot) {
     free(snapshot->trunk_lcn_freq_ext);
+    free(snapshot->chan_map_chan);
+    free(snapshot->chan_map_freq);
     DSD_MEMSET(snapshot, 0, sizeof(*snapshot));
     snapshot->dmr_mfid = -1;
     snapshot->dmr_color_code = 16;
@@ -978,10 +1135,7 @@ trunk_scan_save_p25_identity_snapshot(const dsd_state* state, dsd_trunk_scan_sna
     } else {
         snapshot->trunk_lcn_freq_ext_count = 0;
     }
-    DSD_MEMCPY(snapshot->trunk_chan_map, state->trunk_chan_map, sizeof(snapshot->trunk_chan_map));
-    DSD_MEMCPY(snapshot->trunk_chan_map_used, state->trunk_chan_map_used, sizeof(snapshot->trunk_chan_map_used));
-    snapshot->trunk_chan_map_used_count = state->trunk_chan_map_used_count;
-    snapshot->trunk_chan_map_seq = state->trunk_chan_map_seq;
+    trunk_scan_save_chan_map_snapshot(state, snapshot);
     DSD_MEMCPY(snapshot->dmr_lcn_trust, state->dmr_lcn_trust, sizeof(snapshot->dmr_lcn_trust));
     DSD_MEMCPY(snapshot->p25_chan_tdma_explicit, state->p25_chan_tdma_explicit,
                sizeof(snapshot->p25_chan_tdma_explicit));
@@ -1012,10 +1166,7 @@ trunk_scan_restore_p25_identity_snapshot(dsd_state* state, const dsd_trunk_scan_
     DSD_MEMCPY(state->trunk_vc_freq, snapshot->trunk_vc_freq, sizeof(state->trunk_vc_freq));
     trunk_scan_restore_enc_lockout_snapshot(state, snapshot);
     DSD_MEMCPY(state->trunk_lcn_freq, snapshot->trunk_lcn_freq, sizeof(state->trunk_lcn_freq));
-    DSD_MEMCPY(state->trunk_chan_map, snapshot->trunk_chan_map, sizeof(state->trunk_chan_map));
-    DSD_MEMCPY(state->trunk_chan_map_used, snapshot->trunk_chan_map_used, sizeof(state->trunk_chan_map_used));
-    state->trunk_chan_map_used_count = snapshot->trunk_chan_map_used_count;
-    state->trunk_chan_map_seq = snapshot->trunk_chan_map_seq;
+    trunk_scan_restore_chan_map_snapshot(state, snapshot);
     DSD_MEMCPY(state->dmr_lcn_trust, snapshot->dmr_lcn_trust, sizeof(state->dmr_lcn_trust));
     DSD_MEMCPY(state->p25_chan_tdma_explicit, snapshot->p25_chan_tdma_explicit, sizeof(state->p25_chan_tdma_explicit));
     state->p25_chan_iden = snapshot->p25_chan_iden;
@@ -2230,8 +2381,12 @@ trunk_scan_coord_free(dsd_trunk_scan_coord* coord) {
     }
     for (size_t i = 0; i < coord->count; i++) {
         free(coord->targets[i].snapshot.trunk_lcn_freq_ext);
+        free(coord->targets[i].snapshot.chan_map_chan);
+        free(coord->targets[i].snapshot.chan_map_freq);
     }
     free(coord->scratch_snapshot.trunk_lcn_freq_ext);
+    free(coord->scratch_snapshot.chan_map_chan);
+    free(coord->scratch_snapshot.chan_map_freq);
     free(coord->targets);
     free(coord);
 }
@@ -2286,6 +2441,13 @@ trunk_scan_coord_create(const dsd_trunk_scan_target_list* list, const dsd_opts* 
     dsd_trunk_scan_coord* coord = (dsd_trunk_scan_coord*)calloc(1, sizeof(*coord));
     if (!coord) {
         scan_set_error(err, err_sz, "failed to allocate trunk scan coordinator");
+        return NULL;
+    }
+    if (list->count > dsd_trunk_scan_max_targets()) {
+        scan_set_error(err, err_sz, "%zu trunk scan targets exceed the %d MB target budget (%zu KB each; %zu maximum)",
+                       list->count, DSD_TRUNK_SCAN_TARGET_MEMORY_BUDGET_BYTES / (1024 * 1024),
+                       sizeof(dsd_trunk_scan_target_runtime) / 1024U, dsd_trunk_scan_max_targets());
+        trunk_scan_coord_free(coord);
         return NULL;
     }
     /* count is what trunk_scan_coord_free() walks, so publish it only once the array
@@ -2367,7 +2529,8 @@ trunk_scan_log_nxdn_diag_summaries(dsd_trunk_scan_coord* coord, const dsd_state*
         if (rt->target.type != DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
             continue;
         }
-        nxdn_trunk_diag_log_summary_for(rt->target.chan_csv, &rt->snapshot.nxdn_diag, rt->snapshot.trunk_chan_map);
+        nxdn_trunk_diag_log_summary_for(rt->target.chan_csv, &rt->snapshot.nxdn_diag, trunk_scan_snapshot_chan_lookup,
+                                        &rt->snapshot);
     }
 }
 

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -78,7 +78,7 @@ typedef struct {
     long int p25_vc_freq[2];
     long int trunk_vc_freq[2];
     time_t p25_patch_last_update[8];
-    long int trunk_lcn_freq[26];
+    long int trunk_lcn_freq[DSD_TRUNK_LCN_EMBEDDED];
     long int* trunk_lcn_freq_ext;
     size_t trunk_lcn_freq_ext_count;
     size_t trunk_lcn_freq_ext_capacity;
@@ -838,6 +838,8 @@ trunk_scan_snapshot_lcn_ext_reserve(dsd_trunk_scan_snapshot* snapshot, size_t ex
     if (!ext) {
         return -1;
     }
+    DSD_MEMSET(ext + snapshot->trunk_lcn_freq_ext_capacity, 0,
+               (capacity - snapshot->trunk_lcn_freq_ext_capacity) * sizeof *ext);
     snapshot->trunk_lcn_freq_ext = ext;
     snapshot->trunk_lcn_freq_ext_capacity = capacity;
     return 0;
@@ -962,15 +964,15 @@ trunk_scan_save_p25_identity_snapshot(const dsd_state* state, dsd_trunk_scan_sna
     DSD_MEMCPY(snapshot->trunk_vc_freq, state->trunk_vc_freq, sizeof(snapshot->trunk_vc_freq));
     trunk_scan_save_enc_lockout_snapshot(state, snapshot);
     DSD_MEMCPY(snapshot->trunk_lcn_freq, state->trunk_lcn_freq, sizeof(snapshot->trunk_lcn_freq));
-    if (state->lcn_freq_count > 26) {
-        const size_t ext_count = (size_t)state->lcn_freq_count - 26;
+    if (state->lcn_freq_count > DSD_TRUNK_LCN_EMBEDDED) {
+        const size_t ext_count = (size_t)state->lcn_freq_count - (size_t)DSD_TRUNK_LCN_EMBEDDED;
         if (trunk_scan_snapshot_lcn_ext_reserve(snapshot, ext_count) == 0) {
             DSD_MEMCPY(snapshot->trunk_lcn_freq_ext, state->trunk_lcn_freq_ext,
                        ext_count * sizeof(snapshot->trunk_lcn_freq_ext[0]));
             snapshot->trunk_lcn_freq_ext_count = ext_count;
         } else {
             /* Tail capture failed; the dmr save clamps the snapshot count to
-             * the 26 embedded slots so the snapshot stays self-consistent. */
+             * the embedded slots so the snapshot stays self-consistent. */
             snapshot->trunk_lcn_freq_ext_count = 0;
         }
     } else {
@@ -1177,8 +1179,12 @@ trunk_scan_save_dmr_snapshot(const dsd_state* state, dsd_trunk_scan_snapshot* sn
     snapshot->dmr_rest_channel = state->dmr_rest_channel;
     snapshot->lcn_freq_count = state->lcn_freq_count;
     snapshot->lcn_freq_roll = state->lcn_freq_roll;
-    if (snapshot->lcn_freq_count > 26 && snapshot->trunk_lcn_freq_ext_count == 0) {
-        snapshot->lcn_freq_count = 26;
+    /* Compare against the tail actually captured rather than testing it for 0: the clamp then
+     * holds whatever order the per-protocol savers run in, instead of depending on
+     * trunk_scan_save_p25_identity_snapshot() having refreshed ext_count first. */
+    if (snapshot->lcn_freq_count > DSD_TRUNK_LCN_EMBEDDED
+        && snapshot->trunk_lcn_freq_ext_count < (size_t)(snapshot->lcn_freq_count - DSD_TRUNK_LCN_EMBEDDED)) {
+        snapshot->lcn_freq_count = DSD_TRUNK_LCN_EMBEDDED;
         snapshot->lcn_freq_roll = 0;
     }
     snapshot->is_con_plus = state->is_con_plus;
@@ -1199,12 +1205,19 @@ trunk_scan_restore_dmr_snapshot(dsd_state* state, const dsd_trunk_scan_snapshot*
     state->dmr_rest_channel = snapshot->dmr_rest_channel;
     state->lcn_freq_roll = snapshot->lcn_freq_roll;
     state->lcn_freq_count = snapshot->lcn_freq_count;
-    if (state->lcn_freq_count > 26) {
-        if (dsd_state_trunk_lcn_reserve(state, (size_t)state->lcn_freq_count) == 0) {
+    if (state->lcn_freq_count > DSD_TRUNK_LCN_EMBEDDED) {
+        /* The tail the snapshot actually captured is authoritative, not lcn_freq_count:
+         * the save path clamps the count when the capture failed, but bounding the copy
+         * here means no save ordering can make this read past the snapshot buffer. */
+        const size_t ext_count = (size_t)state->lcn_freq_count - (size_t)DSD_TRUNK_LCN_EMBEDDED;
+        if (snapshot->trunk_lcn_freq_ext != NULL && ext_count <= snapshot->trunk_lcn_freq_ext_count
+            && dsd_state_trunk_lcn_reserve(state, (size_t)state->lcn_freq_count) == 0) {
             DSD_MEMCPY(state->trunk_lcn_freq_ext, snapshot->trunk_lcn_freq_ext,
-                       (size_t)(state->lcn_freq_count - 26) * sizeof(state->trunk_lcn_freq_ext[0]));
+                       ext_count * sizeof(state->trunk_lcn_freq_ext[0]));
         } else {
-            state->lcn_freq_count = 26;
+            LOG_WARN("WARNING: Trunk scan could not restore %d scan-list entries; keeping the first %d\n",
+                     snapshot->lcn_freq_count, (int)DSD_TRUNK_LCN_EMBEDDED);
+            state->lcn_freq_count = DSD_TRUNK_LCN_EMBEDDED;
             state->lcn_freq_roll = 0;
         }
     }
@@ -1668,7 +1681,10 @@ trunk_scan_build_target_runtime(dsd_trunk_scan_coord* coord, dsd_opts* opts, dsd
     trunk_scan_seed_empty_snapshot(empty_snapshot, opts, state);
     double now_m = trunk_scan_now_m();
 
-    for (size_t i = 0; i < list->count; i++) {
+    /* coord->count is what coord->targets was sized to, so it -- not the caller's list --
+     * bounds the fill. */
+    const size_t build_count = list->count < coord->count ? list->count : coord->count;
+    for (size_t i = 0; i < build_count; i++) {
         dsd_trunk_scan_target_runtime* rt = &coord->targets[i];
         rt->target = list->targets[i];
         trunk_scan_restore_snapshot(state, empty_snapshot);
@@ -2272,13 +2288,15 @@ trunk_scan_coord_create(const dsd_trunk_scan_target_list* list, const dsd_opts* 
         scan_set_error(err, err_sz, "failed to allocate trunk scan coordinator");
         return NULL;
     }
-    coord->count = list->count;
+    /* count is what trunk_scan_coord_free() walks, so publish it only once the array
+     * it indexes exists. */
     coord->targets = (dsd_trunk_scan_target_runtime*)calloc(list->count, sizeof *coord->targets);
     if (!coord->targets) {
         scan_set_error(err, err_sz, "failed to allocate trunk scan targets");
-        free(coord);
+        trunk_scan_coord_free(coord);
         return NULL;
     }
+    coord->count = list->count;
     trunk_scan_capture_saved_opts(coord, opts);
     return coord;
 }

--- a/src/protocol/dmr/dmr_csbk.c
+++ b/src/protocol/dmr/dmr_csbk.c
@@ -1251,12 +1251,44 @@ dmr_cspdu_pf0_c_bcast_print_unknown_cdef(const dmr_cspdu_pf0_c_bcast_fields* f, 
     DSD_FPRINTF(stderr, " RES2: %X;", f->mbc_res2);
 }
 
+/*
+ * Ceiling on frequencies learned from site broadcasts. Held at the embedded slot count so
+ * over-the-air data can never drive a heap allocation; the reserve call below keeps the
+ * function correct if that ever changes.
+ */
+enum { DMR_CSBK_LEARNED_LCN_MAX = DSD_TRUNK_LCN_EMBEDDED };
+
+/*
+ * Remember a frequency announced by C_BCAST Chan_Freq as a control-channel hunt candidate.
+ *
+ * Appends distinct frequencies rather than writing modulo a fixed window: the scan list is no
+ * longer capped at a handful of slots, so a modular write would clobber a learned entry and
+ * assigning the count would truncate the list to the window size. An operator-supplied map is
+ * left untouched entirely - it is positional (index i is LCN i+1), so appending site-announced
+ * frequencies to it would break that numbering, and the announced channel is already recorded
+ * in the sparse channel map by the caller either way.
+ */
 static void
-dmr_cspdu_pf0_c_bcast_track_freq(dsd_state* state, long freqr) {
-    state->trunk_lcn_freq[state->lcn_freq_count++ % 25] = freqr;
-    if (state->lcn_freq_count > 25) {
-        state->lcn_freq_count = 25;
+dmr_cspdu_pf0_c_bcast_track_freq(const dsd_opts* opts, dsd_state* state, long freqr) {
+    if (freqr == 0 || dsd_state_trunk_lcn_user_list_present(opts, state)) {
+        return;
     }
+    if (state->lcn_freq_count < 0) {
+        state->lcn_freq_count = 0;
+    }
+    for (int i = 0; i < state->lcn_freq_count; i++) {
+        if (*dsd_state_trunk_lcn_slot_const(state, i) == freqr) {
+            return;
+        }
+    }
+    if (state->lcn_freq_count >= DMR_CSBK_LEARNED_LCN_MAX) {
+        return;
+    }
+    if (dsd_state_trunk_lcn_reserve(state, (size_t)state->lcn_freq_count + 1U) != 0) {
+        return;
+    }
+    *dsd_state_trunk_lcn_slot(state, state->lcn_freq_count) = freqr;
+    state->lcn_freq_count++;
 }
 
 static void
@@ -1265,7 +1297,7 @@ dmr_cspdu_pf0_c_bcast_maybe_store_channel(dsd_opts* opts, dsd_state* state, uint
         return;
     }
     dsd_state_set_trunk_chan_freq(state, (uint32_t)a_channel, freqr);
-    dmr_cspdu_pf0_c_bcast_track_freq(state, freqr);
+    dmr_cspdu_pf0_c_bcast_track_freq(opts, state, freqr);
     const long cand[1] = {freqr};
     dmr_sm_on_neighbor_update(opts, state, cand, 1);
 }

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -1733,6 +1733,30 @@ nxdn_cc_is_operator_pinned(const dsd_opts* opts, const dsd_state* state) {
     return (state->lcn_freq_count > 1 || state->p25_cc_freq == 0) ? 1 : 0;
 }
 
+/*
+ * Follow the control channel a CCH_INFO element announces, unless the operator pinned it.
+ */
+static void
+nxdn_cch_info_adopt_control_channel(const dsd_opts* opts, dsd_state* state, long int freq1) {
+    if (freq1 == 0 || nxdn_cc_is_operator_pinned(opts, state)) {
+        return;
+    }
+    const long int previous_cc = state->trunk_cc_freq;
+    state->trunk_lcn_freq[0] = freq1;
+    state->p25_cc_freq = freq1;
+    state->trunk_cc_freq = freq1;
+    // Raise, never assign: reaching here means no operator list is present, but the count can
+    // still be above 1 from learned entries that must not be discarded.
+    if (state->lcn_freq_count < 1) {
+        state->lcn_freq_count = 1;
+    }
+    // Announce only a real move: under trunk scan this runs on every CCH_INFO, and once the park
+    // frequency has been corrected the adoption is idempotent.
+    if (previous_cc != 0 && previous_cc != freq1) {
+        LOG_INFO("NOTICE: NXDN trunking: site control channel is %.6lf MHz; following it\n", (double)freq1 / 1000000.0);
+    }
+}
+
 static int
 nxdn_cch_info_dfa_version(dsd_opts* opts, dsd_state* state, const uint8_t* Message, size_t message_bits,
                           uint32_t location_id, uint8_t channel1sts) {
@@ -1780,23 +1804,7 @@ nxdn_cch_info_dfa_version(dsd_opts* opts, dsd_state* state, const uint8_t* Messa
 
     const long int freq1 = nxdn_channel_to_frequency(opts, state, OFN1);
     nxdn_channel_to_frequency(opts, state, IFN1);
-    if (freq1 != 0 && !nxdn_cc_is_operator_pinned(opts, state)) {
-        const long int previous_cc = state->trunk_cc_freq;
-        state->trunk_lcn_freq[0] = freq1;
-        state->p25_cc_freq = freq1;
-        state->trunk_cc_freq = freq1;
-        // Raise, never assign: reaching here means no operator list is present, but the
-        // count can still be above 1 from learned entries that must not be discarded.
-        if (state->lcn_freq_count < 1) {
-            state->lcn_freq_count = 1;
-        }
-        // Announce only a real move: under trunk scan this runs on every CCH_INFO, and once the
-        // park frequency has been corrected the adoption is idempotent.
-        if (previous_cc != 0 && previous_cc != freq1) {
-            LOG_INFO("NOTICE: NXDN trunking: site control channel is %.6lf MHz; following it\n",
-                     (double)freq1 / 1000000.0);
-        }
-    }
+    nxdn_cch_info_adopt_control_channel(opts, state, freq1);
 
     return 1;
 }

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -1707,8 +1707,11 @@ nxdn_cch_info_channel_version(dsd_state* state, uint32_t location_id, uint8_t ch
  */
 static int
 nxdn_cc_is_operator_pinned(const dsd_opts* opts, const dsd_state* state) {
+    // Tested by count, not by trunk_lcn_freq[0]: an imported map is positional, so an
+    // unparseable row 1 deliberately stores 0 to keep LCN numbering, and reading slot 0
+    // alone would mistake that whole list for "nothing imported".
     if (opts->trunk_scan_enabled != 1) {
-        return state->trunk_lcn_freq[0] != 0;
+        return state->lcn_freq_count > 0;
     }
 
     // Only the parked target's own control channel may move, and only an nxdn-trunk target has one
@@ -1723,7 +1726,7 @@ nxdn_cc_is_operator_pinned(const dsd_opts* opts, const dsd_state* state) {
     if (opts->trunk_enable != 1 || dsd_trunk_scan_hook_p25_ctx() != NULL || dsd_trunk_scan_hook_dmr_ctx() != NULL) {
         return 1;
     }
-    if (state->trunk_lcn_freq[0] == 0) {
+    if (state->lcn_freq_count == 0) {
         return 0;
     }
     // More entries than the single seeded slot mean a per-target chan_csv supplied real LCNs.
@@ -1782,7 +1785,11 @@ nxdn_cch_info_dfa_version(dsd_opts* opts, dsd_state* state, const uint8_t* Messa
         state->trunk_lcn_freq[0] = freq1;
         state->p25_cc_freq = freq1;
         state->trunk_cc_freq = freq1;
-        state->lcn_freq_count = 1;
+        // Raise, never assign: reaching here means no operator list is present, but the
+        // count can still be above 1 from learned entries that must not be discarded.
+        if (state->lcn_freq_count < 1) {
+            state->lcn_freq_count = 1;
+        }
         // Announce only a real move: under trunk scan this runs on every CCH_INFO, and once the
         // park frequency has been corrected the adoption is idempotent.
         if (previous_cc != 0 && previous_cc != freq1) {

--- a/src/protocol/nxdn/nxdn_trunk_diag.c
+++ b/src/protocol/nxdn/nxdn_trunk_diag.c
@@ -72,10 +72,16 @@ nxdn_trunk_diag_note_missing_channel(dsd_state* state, uint16_t channel) {
     return 1;
 }
 
+long int
+nxdn_trunk_diag_dense_chan_lookup(const void* ctx, uint16_t channel) {
+    const long int* chan_map = (const long int*)ctx;
+    return chan_map ? chan_map[channel] : 0;
+}
+
 static size_t
-nxdn_trunk_diag_collect_from(const nxdn_trunk_diag_ledger* ledger, const long int* chan_map, uint16_t* out,
-                             size_t out_cap) {
-    if (!ledger || !chan_map || ledger->missing_unique == 0) {
+nxdn_trunk_diag_collect_from(const nxdn_trunk_diag_ledger* ledger, nxdn_trunk_diag_chan_freq_fn lookup, const void* ctx,
+                             uint16_t* out, size_t out_cap) {
+    if (!ledger || !lookup || ledger->missing_unique == 0) {
         return 0;
     }
 
@@ -88,7 +94,7 @@ nxdn_trunk_diag_collect_from(const nxdn_trunk_diag_ledger* ledger, const long in
         if ((ledger->missing_seen[byte_idx] & bit_mask) == 0) {
             continue;
         }
-        if (chan_map[ch] != 0) {
+        if (lookup(ctx, (uint16_t)ch) != 0) {
             continue;
         }
 
@@ -106,7 +112,8 @@ nxdn_trunk_diag_collect_unmapped_channels(const dsd_state* state, uint16_t* out,
     if (!state) {
         return 0;
     }
-    return nxdn_trunk_diag_collect_from(nxdn_trunk_diag_get(state), state->trunk_chan_map, out, out_cap);
+    return nxdn_trunk_diag_collect_from(nxdn_trunk_diag_get(state), nxdn_trunk_diag_dense_chan_lookup,
+                                        state->trunk_chan_map, out, out_cap);
 }
 
 void
@@ -232,15 +239,18 @@ nxdn_trunk_diag_summary_finalize(char* msg, size_t msg_cap, size_t used) {
     }
 }
 
+// Cppcheck 2.21 loses the final prototype name after a callback typedef parameter.
+// cppcheck-suppress-begin funcArgNamesDifferentUnnamed
 void
-nxdn_trunk_diag_log_summary_for(const char* chan_csv, const nxdn_trunk_diag_ledger* ledger, const long int* chan_map) {
+nxdn_trunk_diag_log_summary_for(const char* chan_csv, const nxdn_trunk_diag_ledger* ledger,
+                                nxdn_trunk_diag_chan_freq_fn lookup, const void* ctx) {
     if (!chan_csv || chan_csv[0] == '\0') {
         return;
     }
 
     uint16_t missing[16];
     const size_t cap = sizeof(missing) / sizeof(missing[0]);
-    const size_t total = nxdn_trunk_diag_collect_from(ledger, chan_map, missing, cap);
+    const size_t total = nxdn_trunk_diag_collect_from(ledger, lookup, ctx, missing, cap);
     if (total == 0) {
         return;
     }
@@ -262,11 +272,13 @@ nxdn_trunk_diag_log_summary_for(const char* chan_csv, const nxdn_trunk_diag_ledg
     LOG_INFO("NOTICE: %s", msg);
 }
 
+// cppcheck-suppress-end funcArgNamesDifferentUnnamed
+
 void
 nxdn_trunk_diag_log_summary(const dsd_opts* opts, const dsd_state* state) {
     if (!opts || !state) {
         return;
     }
     nxdn_trunk_diag_log_summary_for(nxdn_trunk_diag_chan_map_path(opts, state), nxdn_trunk_diag_get(state),
-                                    state->trunk_chan_map);
+                                    nxdn_trunk_diag_dense_chan_lookup, state->trunk_chan_map);
 }

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -4900,17 +4900,10 @@ next_lcn_freq(dsd_state* state, long* out_freq) {
 
 static int
 p25_has_user_lcn_list(const dsd_opts* opts, const dsd_state* state) {
-    if (opts && opts->chan_in_file[0] != '\0') {
-        return 1;
-    }
-    if (!opts || !state || opts->trunk_scan_enabled != 1) {
-        return 0;
-    }
-
     // Trunk-scan seeds entry 0 with the target CC. Additional entries mean a
     // per-target chan_csv was imported; learned grant caches only populate the
     // sparse channel map and must not disable current-site CC candidate hunts.
-    return (state->lcn_freq_count > 1) ? 1 : 0;
+    return dsd_state_trunk_lcn_user_list_present(opts, state);
 }
 
 static int

--- a/src/protocol/p25/phase2/p25p2_vpdu.c
+++ b/src/protocol/p25/phase2/p25p2_vpdu.c
@@ -294,9 +294,21 @@ p25p2_sccb_implicit_channel_b_valid(int bridged_p1, int channel1, int channel2, 
     return sysclass2 != 0;
 }
 
+/*
+ * Seed the low scan-list slots with secondary control channels announced for the current site.
+ *
+ * Only ever raises lcn_freq_count: an operator-supplied list is positional and may be far longer
+ * than the three slots this touches, so assigning the count here would discard the rest of it.
+ * Such a list is left alone entirely - a deliberate 0 placeholder holding an LCN position is not
+ * a free slot.
+ */
 static void
-p25p2_seed_secondary_lcn_fallback(dsd_state* state, int rfssid, int siteid, const long* freqs, int count) {
+p25p2_seed_secondary_lcn_fallback(const dsd_opts* opts, dsd_state* state, int rfssid, int siteid, const long* freqs,
+                                  int count) {
     if (!state || !freqs || count <= 0 || !p25p2_sccb_matches_current_site(state, rfssid, siteid)) {
+        return;
+    }
+    if (dsd_state_trunk_lcn_user_list_present(opts, state)) {
         return;
     }
 
@@ -2953,7 +2965,7 @@ p25p2_vpdu_iter_block_34(p25p2_vpdu_ctx* ctx) {
         const long scc_freqs[2] = {freq1, freq2};
 
         //place the cc freq into the list at index 0 if 0 is empty so we can hunt for rotating CCs without user LCN list
-        p25p2_seed_secondary_lcn_fallback(state, rfssid, siteid, scc_freqs, channel2_valid ? 2 : 1);
+        p25p2_seed_secondary_lcn_fallback(opts, state, rfssid, siteid, scc_freqs, channel2_valid ? 2 : 1);
     }
 
     if (len_b < 0) {
@@ -4039,13 +4051,8 @@ p25p2_vpdu_iter_block_53(p25p2_vpdu_ctx* ctx) {
         long int sccf = process_channel_to_freq(opts, state, channelt);
         (void)process_channel_to_freq(opts, state, channelr);
         // Add to CC candidate list for hunting
-        if (sccf > 0 && p25p2_sccb_matches_current_site(state, rfssid, siteid) && state->trunk_lcn_freq[1] == 0) {
-            state->trunk_lcn_freq[1] = sccf;
-            state->lcn_freq_count = 2;
-        } else if (sccf > 0 && p25p2_sccb_matches_current_site(state, rfssid, siteid) && state->trunk_lcn_freq[2] == 0
-                   && sccf != state->trunk_lcn_freq[1]) {
-            state->trunk_lcn_freq[2] = sccf;
-            state->lcn_freq_count = 3;
+        if (sccf > 0) {
+            p25p2_seed_secondary_lcn_fallback(opts, state, rfssid, siteid, &sccf, 1);
         }
         (void)p25_announce_secondary_cc_channel(opts, state, (uint16_t)channelt, (uint8_t)rfssid, (uint8_t)siteid,
                                                 (uint8_t)sysclass);

--- a/src/runtime/radioreference/rr_generate.c
+++ b/src/runtime/radioreference/rr_generate.c
@@ -684,7 +684,6 @@ rr_warn_skips(const rr_skip_counts* skips, const char* label, const char* range,
 typedef struct {
     size_t unusable;
     size_t duplicate;
-    size_t truncated;
 } rr_p25_skips;
 
 /**
@@ -699,51 +698,45 @@ typedef struct {
  * probes never get the cooldown a failed candidate-array entry gets.
  *
  * @param site  Site.
- * @param order Receives frequency indexes, ranked.
- * @param max   Capacity of `order`.
+ * @param order Receives frequency indexes, ranked. Sized for site->freq_count,
+ *              which every ranked entry consumes exactly one of, so the write
+ *              can never run past it.
  * @param skips Receives per-reason drop counts.
  * @return Number of indexes written.
  */
 static size_t
-rr_p25_rank_freqs(const dsd_rr_site* site, size_t* order, size_t max, rr_p25_skips* skips) {
-    long long* chosen = (long long*)calloc(site->freq_count > 0U ? site->freq_count : 1U, sizeof *chosen);
+rr_p25_rank_freqs(const dsd_rr_site* site, size_t* order, rr_p25_skips* skips) {
     size_t count = 0;
 
-    if (chosen) {
-
-        for (int pass = 0; pass < 3; pass++) {
-            for (size_t i = 0; i < site->freq_count; i++) {
-                const dsd_rr_site_freq* freq = &site->freqs[i];
-                const int rank = freq->is_control ? 0 : (freq->is_alt_control ? 1 : 2);
-                if (rank != pass) {
-                    continue;
-                }
-                if (!rr_freq_usable(freq->freq_hz)) {
-                    skips->unusable++;
-                    continue;
-                }
-                int duplicate = 0;
-                for (size_t k = 0; k < count; k++) {
-                    if (chosen[k] == freq->freq_hz) {
-                        duplicate = 1;
-                        break;
-                    }
-                }
-                if (duplicate) {
-                    skips->duplicate++;
-                    continue;
-                }
-                if (count >= max) {
-                    skips->truncated++;
-                    continue;
-                }
-                chosen[count] = freq->freq_hz;
-                order[count] = i;
-                count++;
+    for (int pass = 0; pass < 3; pass++) {
+        for (size_t i = 0; i < site->freq_count; i++) {
+            const dsd_rr_site_freq* freq = &site->freqs[i];
+            const int rank = freq->is_control ? 0 : (freq->is_alt_control ? 1 : 2);
+            if (rank != pass) {
+                continue;
             }
+            if (!rr_freq_usable(freq->freq_hz)) {
+                skips->unusable++;
+                continue;
+            }
+            /* The kept frequencies are exactly site->freqs[order[0..count-1]], so
+             * the dedup reads them back through `order` rather than carrying a
+             * second copy of the list. */
+            int duplicate = 0;
+            for (size_t k = 0; k < count; k++) {
+                if (site->freqs[order[k]].freq_hz == freq->freq_hz) {
+                    duplicate = 1;
+                    break;
+                }
+            }
+            if (duplicate) {
+                skips->duplicate++;
+                continue;
+            }
+            order[count] = i;
+            count++;
         }
     }
-    free(chosen);
     return count;
 }
 
@@ -764,15 +757,19 @@ rr_p25_rank_freqs(const dsd_rr_site* site, size_t* order, size_t max, rr_p25_ski
  */
 static int
 rr_p25_identifiers_usable(const dsd_rr_site* site, const size_t* order, size_t count) {
-    long* seen = (long*)calloc(count > 0U ? count : 1U, sizeof *seen);
+    if (count == 0U) {
+        return 0;
+    }
+    long* seen = (long*)calloc(count, sizeof *seen);
     if (!seen) {
         return 0;
     }
-    int usable = (count > 0U) ? 1 : 0;
-    for (size_t i = 0; i < count && usable; i++) {
+    int usable = 1;
+    for (size_t i = 0; i < count; i++) {
         const long chan = rr_freq_channel(&site->freqs[order[i]], 1);
         if (chan < RR_P25_IDENTIFIER_MIN || chan > RR_CHAN_NUMBER_MAX) {
             usable = 0;
+            break;
         }
         for (size_t k = 0; k < i; k++) {
             if (seen[k] == chan) {
@@ -780,9 +777,10 @@ rr_p25_identifiers_usable(const dsd_rr_site* site, const size_t* order, size_t c
                 break;
             }
         }
-        if (usable) {
-            seen[i] = chan;
+        if (!usable) {
+            break;
         }
+        seen[i] = chan;
     }
     free(seen);
     return usable;
@@ -794,26 +792,25 @@ rr_p25_identifiers_usable(const dsd_rr_site* site, const size_t* order, size_t c
  * @param site     Site.
  * @param text     Output buffer.
  * @param warnings Warning list, or NULL.
+ * @return 0 on success, -1 on allocation failure.
  */
-static void
+static int
 rr_chan_p25(const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warnings) {
-    size_t* order = (size_t*)calloc(site->freq_count > 0U ? site->freq_count : 1U, sizeof *order);
+    if (site->freq_count == 0U) {
+        rr_warn(warnings, "This P25 site lists no usable frequencies, so no channel map was generated.");
+        return 0;
+    }
+    size_t* order = (size_t*)calloc(site->freq_count, sizeof *order);
     if (!order) {
         rr_warn(warnings, "could not allocate the scan list");
-        return;
+        return -1;
     }
-    rr_p25_skips skips = {0U, 0U, 0U};
-    size_t count = rr_p25_rank_freqs(site, order, site->freq_count, &skips);
-    /* The ranked indexes reference site->freqs, so the count never exceeds the
-     * site's frequency list by construction; clamping keeps that invariant
-     * visible where the heap allocation is sized. */
-    if (count > site->freq_count) {
-        count = site->freq_count;
-    }
+    rr_p25_skips skips = {0U, 0U};
+    const size_t count = rr_p25_rank_freqs(site, order, &skips);
     if (count == 0U) {
         free(order);
         rr_warn(warnings, "This P25 site lists no usable frequencies, so no channel map was generated.");
-        return;
+        return 0;
     }
 
     char msg[DSD_RR_WARNING_TEXT_MAX];
@@ -824,12 +821,6 @@ rr_chan_p25(const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warning
     }
     if (skips.duplicate > 0U) {
         (void)DSD_SNPRINTF(msg, sizeof(msg), "%zu duplicate site frequency/frequencies were dropped.", skips.duplicate);
-        rr_warn(warnings, msg);
-    }
-    if (skips.truncated > 0U) {
-        (void)DSD_SNPRINTF(msg, sizeof(msg),
-                           "%zu site frequency/frequencies past the 26-slot control-channel hunt list were dropped.",
-                           skips.truncated);
         rr_warn(warnings, msg);
     }
 
@@ -846,6 +837,7 @@ rr_chan_p25(const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warning
         rr_text_chan_row(text, chan, freq->freq_hz, NULL);
     }
     free(order);
+    return 0;
 }
 
 /**
@@ -1043,13 +1035,14 @@ rr_chan_edacs(const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warni
  * @param site_count Number of repeaters.
  * @param text       Output buffer.
  * @param warnings   Warning list, or NULL.
+ * @return 0 on success, -1 on allocation failure.
  */
-static void
+static int
 rr_chan_conventional(const dsd_rr_site* sites, size_t site_count, rr_text* text, dsd_rr_warning_list* warnings) {
     long long* chosen = (long long*)calloc(site_count > 0U ? site_count : 1U, sizeof *chosen);
     if (!chosen) {
         rr_warn(warnings, "could not allocate the scan list");
-        return;
+        return -1;
     }
     size_t count = 0;
     size_t duplicates = 0;
@@ -1095,7 +1088,7 @@ rr_chan_conventional(const dsd_rr_site* sites, size_t site_count, rr_text* text,
      * already on at every hangtime expiry, which is pure churn. */
     if (count < 2U) {
         free(chosen);
-        return;
+        return 0;
     }
 
     for (size_t i = 0; i < count; i++) {
@@ -1104,6 +1097,7 @@ rr_chan_conventional(const dsd_rr_site* sites, size_t site_count, rr_text* text,
     rr_warn(warnings, "Scanning across repeaters needs an RTL-SDR or a rigctl-controlled radio; on any other input the "
                       "session stays on the first frequency.");
     free(chosen);
+    return 0;
 }
 
 /**
@@ -1118,7 +1112,7 @@ rr_chan_conventional(const dsd_rr_site* sites, size_t site_count, rr_text* text,
 static int
 rr_chan_trunked(dsd_rr_protocol protocol, const dsd_rr_site* site, rr_text* text, dsd_rr_warning_list* warnings) {
     switch (protocol) {
-        case DSD_RR_PROTO_P25: rr_chan_p25(site, text, warnings); return 0;
+        case DSD_RR_PROTO_P25: return rr_chan_p25(site, text, warnings);
         case DSD_RR_PROTO_DMR_CONPLUS:
         case DSD_RR_PROTO_DMR_TIER3: return rr_chan_dmr_lcn(protocol, site, text, warnings);
         case DSD_RR_PROTO_DMR_CAPPLUS:
@@ -1149,8 +1143,7 @@ dsd_rr_generate_chan_csv(dsd_rr_protocol protocol, const dsd_rr_site* sites, siz
 
     int rc;
     if (dsd_rr_protocol_is_conventional(protocol)) {
-        rr_chan_conventional(sites, site_count, &text, warnings);
-        rc = 0;
+        rc = rr_chan_conventional(sites, site_count, &text, warnings);
     } else {
         if (site_count > 1U) {
             rr_warn(warnings, "This system is trunked, so only the first selected site was used.");

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -848,7 +848,12 @@ static void
 ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* state) {
     if (opts->scanner_mode == 1) {
         printw("| Scan Mode: ");
-        if (state->lcn_freq_roll != 0) {
+        // lcn_freq_roll is advanced past the entry just tuned, so the displayed slot is roll - 1.
+        // Bound it by lcn_freq_count the way every other scan-list consumer does: a protocol writer
+        // that shrinks the count (nxdn_element.c, p25p2_vpdu.c, dmr_csbk.c) leaves roll pointing
+        // past the end, and slots >= 26 resolve into the heap tail, which is only as long as the
+        // count that reserved it.
+        if (state->lcn_freq_roll > 0 && state->lcn_freq_roll <= state->lcn_freq_count) {
             printw(" Frequency: %.06lf MHz",
                    (double)*dsd_state_trunk_lcn_slot_const(state, state->lcn_freq_roll - 1) / 1000000);
         }

--- a/src/ui/terminal/rr_panel.c
+++ b/src/ui/terminal/rr_panel.c
@@ -799,11 +799,16 @@ rr_panel_draw_heading(WINDOW* win, int body_w, const dsd_rr_system_info* info, c
     }
     RrPanelCounter counter;
     rr_panel_counter_state(sites->items, sites->count, rr_panel_core_site_selected, g_rr_panel.core, &counter);
-    const int cx = 2 + body_w - (int)strlen(counter.text);
+    const char* label = counter.text;
+    int cx = 2 + body_w - (int)strlen(label);
+    if (cx <= (int)strlen(line) + 2) {
+        label = counter.short_text;
+        cx = 2 + body_w - (int)strlen(label);
+    }
     if (cx <= (int)strlen(line) + 2) {
         return;
     }
-    mvwaddnstr(win, 2, cx, counter.text, (int)strlen(counter.text));
+    mvwaddnstr(win, 2, cx, label, (int)strlen(label));
 }
 
 static void

--- a/src/ui/terminal/rr_panel_format.c
+++ b/src/ui/terminal/rr_panel_format.c
@@ -88,6 +88,7 @@ rr_panel_counter_state(const dsd_rr_site* sites, size_t site_count, rr_panel_sit
         long long* chosen = (long long*)calloc(site_count, sizeof *chosen);
         if (chosen == NULL) {
             (void)DSD_SNPRINTF(out->text, sizeof out->text, "[ selection unavailable ]");
+            (void)DSD_SNPRINTF(out->short_text, sizeof out->short_text, "[ ? ]");
             return;
         }
         for (size_t i = 0; i < site_count; i++) {
@@ -119,6 +120,9 @@ rr_panel_counter_state(const dsd_rr_site* sites, size_t site_count, rr_panel_sit
     }
     out->kept = (int)count;
     (void)DSD_SNPRINTF(out->text, sizeof out->text, "[ %d distinct frequencies ]", out->kept);
+    /* The heading right-aligns the counter beside a ~38-column title; the full label needs a
+     * 66-column body before it fits, so narrower terminals get this instead of nothing. */
+    (void)DSD_SNPRINTF(out->short_text, sizeof out->short_text, "[ %d freqs ]", out->kept);
 }
 
 // cppcheck-suppress-end funcArgNamesDifferentUnnamed

--- a/src/ui/terminal/rr_panel_format.c
+++ b/src/ui/terminal/rr_panel_format.c
@@ -81,13 +81,15 @@ rr_panel_counter_state(const dsd_rr_site* sites, size_t site_count, rr_panel_sit
         return;
     }
     DSD_MEMSET(out, 0, sizeof *out);
-    long long* chosen = (long long*)calloc(site_count > 0U ? site_count : 1U, sizeof *chosen);
-    if (chosen == NULL) {
-        (void)DSD_SNPRINTF(out->text, sizeof out->text, "[ selection unavailable ]");
-        return;
-    }
     size_t count = 0;
-    if (sites != NULL && is_selected != NULL) {
+    if (sites != NULL && is_selected != NULL && site_count > 0U) {
+        // Runs on the panel redraw path, so nothing is allocated for the empty
+        // list the screen shows before a system is loaded.
+        long long* chosen = (long long*)calloc(site_count, sizeof *chosen);
+        if (chosen == NULL) {
+            (void)DSD_SNPRINTF(out->text, sizeof out->text, "[ selection unavailable ]");
+            return;
+        }
         for (size_t i = 0; i < site_count; i++) {
             if (!is_selected(user, i)) {
                 continue;
@@ -113,9 +115,9 @@ rr_panel_counter_state(const dsd_rr_site* sites, size_t site_count, rr_panel_sit
             chosen[count] = hz;
             count++;
         }
+        free(chosen);
     }
     out->kept = (int)count;
-    free(chosen);
     (void)DSD_SNPRINTF(out->text, sizeof out->text, "[ %d distinct frequencies ]", out->kept);
 }
 

--- a/src/ui/terminal/rr_panel_format.h
+++ b/src/ui/terminal/rr_panel_format.h
@@ -20,10 +20,11 @@
 #include <dsd-neo/runtime/radioreference_import.h>
 
 typedef struct {
-    int kept;       /* distinct usable frequencies kept, no cap */
-    int empty;      /* selected sites whose first usable frequency is 0 */
-    int duplicates; /* selected sites repeating an already-kept frequency */
-    char text[40];  /* "[ 3 distinct frequencies ]" */
+    int kept;            /* distinct usable frequencies kept, no cap */
+    int empty;           /* selected sites whose first usable frequency is 0 */
+    int duplicates;      /* selected sites repeating an already-kept frequency */
+    char text[40];       /* "[ 3 distinct frequencies ]" */
+    char short_text[16]; /* "[ 3 freqs ]" - for a heading too narrow for text */
 } RrPanelCounter;
 
 typedef int (*rr_panel_site_selected_fn)(const void* user, size_t index);

--- a/src/ui/terminal/rr_wizard_core.c
+++ b/src/ui/terminal/rr_wizard_core.c
@@ -222,9 +222,9 @@ typedef struct {
 /*
  * Matches what dsd_rr_provenance::site_ids can actually hold: 2048 bytes fits
  * 341 five-digit ids plus their commas, which is the width RadioReference
- * issues. Ids beyond the cap are ignored, which is harmless: the conventional
- * generator caps at 26 distinct frequencies and a trunked one uses only the
- * first site.
+ * issues. Ids beyond the cap are ignored, which only affects a system listing
+ * more than 341 sites: a trunked one uses only the first site, and a
+ * conventional one keeps every distinct frequency among the ids it did read.
  */
 #define RR_REFRESH_MAX_SITE_IDS 341
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6036,6 +6036,7 @@ add_executable(
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk_parse.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk_tables.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
 )
 target_include_directories(
     dsd-neo_test_dmr_t3_cmove
@@ -6059,6 +6060,7 @@ add_executable(
     dsd-neo_test_dmr_t3_force_release
     protocol/dmr/test_dmr_t3_force_release.c
     ${PROJECT_SOURCE_DIR}/src/core/time/dsd_time_state.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
     ${PROJECT_SOURCE_DIR}/src/core/util/talkgroup_policy.c
     ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
     ${PROJECT_SOURCE_DIR}/tests/test_support/csv_import_stub.c
@@ -6096,6 +6098,7 @@ add_executable(
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk_parse.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_csbk_tables.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
 )
 target_include_directories(
     dsd-neo_test_dmr_t3_move_release
@@ -6119,6 +6122,7 @@ add_executable(
     dsd-neo_test_dmr_t3_ann_wd_tscc
     protocol/dmr/test_dmr_t3_ann_wd_tscc.c
     ${PROJECT_SOURCE_DIR}/src/core/time/dsd_time_state.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
     ${PROJECT_SOURCE_DIR}/src/core/util/talkgroup_policy.c
     ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
     ${PROJECT_SOURCE_DIR}/tests/test_support/csv_import_stub.c

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -983,7 +983,7 @@ test_coordinator_idle_rotation_and_state_restore(void) {
     }
 
     state.p25_iden_fdma[1].base_freq = 12345;
-    state.trunk_chan_map[99] = 851012500;
+    dsd_state_set_trunk_chan_freq(&state, 99U, 851012500);
     state.dmr_rest_channel = 4;
     state.dmr_lcn_trust[4] = 2;
     seed_target0_p25_state(&state);
@@ -1003,7 +1003,7 @@ test_coordinator_idle_rotation_and_state_restore(void) {
     test_rc |= expect_empty_target_p25_state(&state);
 
     state.p25_iden_fdma[1].base_freq = 99999;
-    state.trunk_chan_map[99] = 852012500;
+    dsd_state_set_trunk_chan_freq(&state, 99U, 852012500);
     state.dmr_rest_channel = 8;
     state.dmr_lcn_trust[4] = 0;
     state.dmr_lcn_trust[8] = 2;
@@ -1107,6 +1107,193 @@ test_coordinator_preserves_long_lcn_list_across_rotation(void) {
 
     dsd_engine_trunk_scan_shutdown(&opts, &state);
     dsd_state_trunk_lcn_free(&state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * Write a targets CSV of @p rows generated rows. Streamed rather than formatted into a buffer:
+ * a budget-sized list is far past write_targets_file()'s 8 KB body limit.
+ */
+static int
+write_generated_targets_file(const char* dir, size_t rows, char* out_path, size_t out_sz) {
+    if (dsd_test_path_join(out_path, out_sz, dir, "targets.csv") != 0) {
+        return -1;
+    }
+    FILE* fp = dsd_fopen_private(out_path, "wb");
+    if (!fp) {
+        return -1;
+    }
+    int rc = (fputs(k_header, fp) >= 0) ? 0 : -1;
+    for (size_t i = 0; rc == 0 && i < rows; i++) {
+        if (DSD_FPRINTF(fp, "t%zu,p25-trunk,%lu,,250,,\n", i, 851000000UL + (unsigned long)(i * 12500U)) < 0) {
+            rc = -1;
+        }
+    }
+    if (fclose(fp) != 0) {
+        rc = -1;
+    }
+    return rc;
+}
+
+/*
+ * The target count is bounded by a memory budget rather than a fixed limit. One row past the
+ * derived cap must be rejected while parsing, with an error naming the budget - not accepted into
+ * an allocation that overcommit grants and the OOM killer later reclaims. Exactly the cap must
+ * still load: the budget bounds the list, it does not shrink it.
+ */
+static int
+test_targets_csv_rejects_rows_past_the_memory_budget(void) {
+    const size_t max = dsd_trunk_scan_max_targets();
+    if (max == 0U || max > 100000U) {
+        DSD_FPRINTF(stderr, "implausible trunk scan target cap %zu\n", max);
+        return 1;
+    }
+
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+
+    int test_rc = 0;
+    char err[256] = {0};
+
+    if (write_generated_targets_file(dir, max + 1U, target_path, sizeof target_path) != 0) {
+        DSD_FPRINTF(stderr, "could not write a %zu-row targets CSV\n", max + 1U);
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    dsd_trunk_scan_target_list over = {0};
+    if (dsd_trunk_scan_load_targets_csv(target_path, &opts, &over, err, sizeof err) == 0) {
+        DSD_FPRINTF(stderr, "a %zu-row targets CSV was accepted over a cap of %zu\n", max + 1U, max);
+        test_rc = 1;
+    } else if (strstr(err, "budget") == NULL) {
+        DSD_FPRINTF(stderr, "budget rejection did not explain itself: %s\n", err);
+        test_rc = 1;
+    }
+    dsd_trunk_scan_target_list_reset(&over);
+
+    if (write_generated_targets_file(dir, max, target_path, sizeof target_path) != 0) {
+        DSD_FPRINTF(stderr, "could not write a %zu-row targets CSV\n", max);
+        cleanup_paths(dir, target_path, NULL);
+        return 1;
+    }
+    err[0] = '\0';
+    dsd_trunk_scan_target_list at_cap = {0};
+    if (dsd_trunk_scan_load_targets_csv(target_path, &opts, &at_cap, err, sizeof err) != 0 || at_cap.count != max) {
+        DSD_FPRINTF(stderr, "a targets CSV exactly at the cap (%zu) was refused: %s\n", max, err);
+        test_rc = 1;
+    }
+    dsd_trunk_scan_target_list_reset(&at_cap);
+
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * The parked-target snapshot stores the channel map sparsely, indexed through
+ * state->trunk_chan_map_used[]. A map far larger than the old dense copy's practical working set
+ * must survive a rotation entry for entry, and must not leak into the next target.
+ */
+static int
+test_coordinator_preserves_large_chan_map_across_rotation(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,p25-trunk,851000000,,250,,\n"
+                             "b,p25-trunk,852000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0
+        || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "large chan map scan init failed err=%s\n", err);
+        dsd_engine_trunk_scan_shutdown(&opts, &state);
+        trunk_scan_test_clear_now();
+        cleanup_paths(dir, target_path, NULL);
+        return 1;
+    }
+
+    /* Channels are deliberately non-contiguous and not in ascending insertion order, so the
+     * snapshot cannot pass by accident: it has to carry the channel numbers, not just a run. */
+    enum { CHAN_COUNT = 300 };
+
+#define TARGET0_CHAN(i) ((uint32_t)(((CHAN_COUNT - 1 - (i)) * 7) + 3))
+#define TARGET0_FREQ(i) (851000000L + 12500L * (long)(i))
+
+    for (int i = 0; i < CHAN_COUNT; i++) {
+        dsd_state_set_trunk_chan_freq(&state, TARGET0_CHAN(i), TARGET0_FREQ(i));
+    }
+    if (state.trunk_chan_map_used_count != (uint32_t)CHAN_COUNT) {
+        DSD_FPRINTF(stderr, "seeded %u mapped channels, want %d\n", state.trunk_chan_map_used_count, (int)CHAN_COUNT);
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "large chan map scan did not rotate to target 1\n");
+        test_rc = 1;
+    }
+    if (state.trunk_chan_map_used_count != 0) {
+        DSD_FPRINTF(stderr, "target 0's channel map leaked into target 1 (%u entries)\n",
+                    state.trunk_chan_map_used_count);
+        test_rc = 1;
+    }
+    for (int i = 0; i < CHAN_COUNT; i++) {
+        if (state.trunk_chan_map[TARGET0_CHAN(i)] != 0) {
+            DSD_FPRINTF(stderr, "channel %u still mapped on target 1\n", TARGET0_CHAN(i));
+            test_rc = 1;
+            break;
+        }
+    }
+
+    /* Give target 1 a map of its own so the restore has stale entries to clear. */
+    dsd_state_set_trunk_chan_freq(&state, 4097U, 852000000L);
+
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "large chan map scan did not rotate back to target 0\n");
+        test_rc = 1;
+    }
+    if (state.trunk_chan_map_used_count != (uint32_t)CHAN_COUNT) {
+        DSD_FPRINTF(stderr, "channel map restored with %u entries, want %d\n", state.trunk_chan_map_used_count,
+                    (int)CHAN_COUNT);
+        test_rc = 1;
+    }
+    if (state.trunk_chan_map[4097] != 0) {
+        DSD_FPRINTF(stderr, "target 1's channel 4097 survived the rotation back to target 0\n");
+        test_rc = 1;
+    }
+    for (int i = 0; i < CHAN_COUNT; i++) {
+        if (state.trunk_chan_map[TARGET0_CHAN(i)] != TARGET0_FREQ(i)) {
+            DSD_FPRINTF(stderr, "channel %u restored as %ld, want %ld\n", TARGET0_CHAN(i),
+                        state.trunk_chan_map[TARGET0_CHAN(i)], TARGET0_FREQ(i));
+            test_rc = 1;
+            break;
+        }
+    }
+
+#undef TARGET0_CHAN
+#undef TARGET0_FREQ
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
     trunk_scan_test_clear_now();
     cleanup_paths(dir, target_path, NULL);
     return test_rc;
@@ -4695,6 +4882,8 @@ main(void) {
     rc |= run_with_default_tune_hook(test_coordinator_idle_rotation_and_state_restore);
     rc |= run_with_default_tune_hook(test_coordinator_rotation_past_32_targets);
     rc |= run_with_default_tune_hook(test_coordinator_preserves_long_lcn_list_across_rotation);
+    rc |= run_with_default_tune_hook(test_coordinator_preserves_large_chan_map_across_rotation);
+    rc |= test_targets_csv_rejects_rows_past_the_memory_budget();
     rc |= run_with_default_tune_hook(test_call_identity_state_isolated_per_target);
     rc |= run_with_default_tune_hook(test_call_event_lifecycle_isolated_per_target);
     rc |= run_with_default_tune_hook(test_call_event_current_rows_isolated_per_target);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -718,6 +718,7 @@ make_runtime_targets(const char* body, char* out_path, size_t out_sz, char* out_
 static void
 reset_scan_opts_state(dsd_opts* opts, dsd_state* state) {
     dsd_state_ext_free_all(state);
+    dsd_state_trunk_lcn_free(state);
     DSD_MEMSET(opts, 0, sizeof(*opts));
     DSD_MEMSET(state, 0, sizeof(*state));
     opts->trunk_scan_enabled = 1;
@@ -1022,6 +1023,90 @@ test_coordinator_idle_rotation_and_state_restore(void) {
     test_rc |= expect_target0_p25_state(&state);
 
     dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* A per-target scan list longer than the embedded slots lives in dsd_state's heap tail, so
+ * the snapshot has to carry that tail across a rotation and hand it back intact. Nothing
+ * else in the suite drives trunk_scan_snapshot_lcn_ext_reserve() or the bounded restore. */
+static int
+test_coordinator_preserves_long_lcn_list_across_rotation(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,p25-trunk,851000000,,250,,\n"
+                             "b,p25-trunk,852000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0
+        || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "long lcn list scan init failed err=%s\n", err);
+        dsd_engine_trunk_scan_shutdown(&opts, &state);
+        trunk_scan_test_clear_now();
+        cleanup_paths(dir, target_path, NULL);
+        return 1;
+    }
+
+    enum { LONG_LCN_COUNT = 40 };
+
+    if (dsd_state_trunk_lcn_reserve(&state, (size_t)LONG_LCN_COUNT) != 0) {
+        DSD_FPRINTF(stderr, "could not reserve a %d-entry scan list\n", (int)LONG_LCN_COUNT);
+        test_rc = 1;
+    } else {
+        for (int i = 0; i < LONG_LCN_COUNT; i++) {
+            *dsd_state_trunk_lcn_slot(&state, i) = 851000000L + 12500L * (long)i;
+        }
+        state.lcn_freq_count = LONG_LCN_COUNT;
+        state.lcn_freq_roll = 30;
+    }
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "long lcn list scan did not rotate to target 1\n");
+        test_rc = 1;
+    }
+    if (state.lcn_freq_count > DSD_TRUNK_LCN_EMBEDDED) {
+        DSD_FPRINTF(stderr, "target 0's scan list leaked into target 1 (count=%d)\n", state.lcn_freq_count);
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "long lcn list scan did not rotate back to target 0\n");
+        test_rc = 1;
+    }
+    if (state.lcn_freq_count != LONG_LCN_COUNT || state.lcn_freq_roll != 30) {
+        DSD_FPRINTF(stderr, "scan list was truncated across the rotation: count=%d roll=%d\n", state.lcn_freq_count,
+                    state.lcn_freq_roll);
+        test_rc = 1;
+    } else {
+        for (int i = 0; i < LONG_LCN_COUNT; i++) {
+            const long want = 851000000L + 12500L * (long)i;
+            if (*dsd_state_trunk_lcn_slot(&state, i) != want) {
+                DSD_FPRINTF(stderr, "scan list slot %d restored as %ld, want %ld\n", i,
+                            *dsd_state_trunk_lcn_slot(&state, i), want);
+                test_rc = 1;
+                break;
+            }
+        }
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_state_trunk_lcn_free(&state);
     trunk_scan_test_clear_now();
     cleanup_paths(dir, target_path, NULL);
     return test_rc;
@@ -4609,6 +4694,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_parser_accepts_100_targets);
     rc |= run_with_default_tune_hook(test_coordinator_idle_rotation_and_state_restore);
     rc |= run_with_default_tune_hook(test_coordinator_rotation_past_32_targets);
+    rc |= run_with_default_tune_hook(test_coordinator_preserves_long_lcn_list_across_rotation);
     rc |= run_with_default_tune_hook(test_call_identity_state_isolated_per_target);
     rc |= run_with_default_tune_hook(test_call_event_lifecycle_isolated_per_target);
     rc |= run_with_default_tune_hook(test_call_event_current_rows_isolated_per_target);

--- a/tests/fuzz/fuzz_core_csv_import.c
+++ b/tests/fuzz/fuzz_core_csv_import.c
@@ -68,6 +68,7 @@ LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     }
 
     dsd_state_ext_free_all(state);
+    dsd_state_trunk_lcn_free(state);
     free(state);
     free(opts);
     (void)remove(path);

--- a/tests/protocol/dmr/test_dmr_grant_policy.c
+++ b/tests/protocol/dmr/test_dmr_grant_policy.c
@@ -1026,6 +1026,45 @@ main(void) {
     dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
     rc |= expect_true("c_bcast channel frequency learned", pf0_st.trunk_chan_map[77] == 451012500L);
     rc |= expect_true("c_bcast channel frequency tracked", pf0_st.trunk_lcn_freq[0] == 451012500L);
+    rc |= expect_true("c_bcast first learned frequency sets count", pf0_st.lcn_freq_count == 1);
+
+    /* Distinct announcements append rather than writing modulo a fixed window, and a repeat of
+     * an already-tracked frequency is not appended twice. */
+    build_c_bcast_chan_freq(bits, bytes, 78U, 451U, 300U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("c_bcast second frequency appended", pf0_st.trunk_lcn_freq[1] == 451037500L);
+    rc |= expect_true("c_bcast second frequency raises count", pf0_st.lcn_freq_count == 2);
+    build_c_bcast_chan_freq(bits, bytes, 79U, 451U, 300U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("c_bcast duplicate frequency not appended", pf0_st.lcn_freq_count == 2);
+    dsd_state_ext_free_all(&pf0_st);
+
+    /* An imported channel map is positional operator intent: a site broadcast must neither write
+     * into it nor lower lcn_freq_count to the handful of slots the broadcast knows about. Slot 1
+     * holds the deliberate 0 an unparseable CSV row leaves behind to keep LCN numbering. */
+    init_env(&pf0_opts, &pf0_st);
+    DSD_SNPRINTF(pf0_opts.chan_in_file, sizeof pf0_opts.chan_in_file, "%s", "imported.csv");
+    for (int i = 0; i < 40; i++) {
+        rc |= expect_true("imported list reserve", dsd_state_trunk_lcn_reserve(&pf0_st, (size_t)i + 1U) == 0);
+        *dsd_state_trunk_lcn_slot(&pf0_st, i) = (i == 1) ? 0L : (460000000L + (long)i * 12500L);
+    }
+    pf0_st.lcn_freq_count = 40;
+    build_c_bcast_chan_freq(bits, bytes, 77U, 451U, 100U);
+    dmr_cspdu(&pf0_opts, &pf0_st, bits, bytes, 1U, 0U);
+    rc |= expect_true("imported map still learns the channel", pf0_st.trunk_chan_map[77] == 451012500L);
+    rc |= expect_true("imported map keeps its length", pf0_st.lcn_freq_count == 40);
+    int imported_intact = 1;
+    for (int i = 0; i < 40; i++) {
+        const long want = (i == 1) ? 0L : (460000000L + (long)i * 12500L);
+        if (*dsd_state_trunk_lcn_slot(&pf0_st, i) != want) {
+            DSD_FPRINTF(stderr, "imported map slot %d clobbered: got %ld want %ld\n", i,
+                        *dsd_state_trunk_lcn_slot(&pf0_st, i), want);
+            imported_intact = 0;
+        }
+    }
+    rc |= expect_true("imported map entries untouched", imported_intact);
+    pf0_opts.chan_in_file[0] = '\0';
+    dsd_state_trunk_lcn_free(&pf0_st);
     dsd_state_ext_free_all(&pf0_st);
 
     init_env(&pf0_opts, &pf0_st);

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -1137,6 +1137,11 @@ run_cch_dfa_adoption_case(const char* tag, int trunk_scan_enabled, int trunk_ena
     rc |= expect_int(label, (int)state->p25_cc_freq, (int)(expect_adopt ? cc_freq : seeded_p25_cc));
     DSD_SNPRINTF(label, sizeof label, "%s-trunk-cc", tag);
     rc |= expect_int(label, (int)state->trunk_cc_freq, (int)(expect_adopt ? cc_freq : seeded_trunk_cc));
+    /* Adoption seeds slot 0, so it may only raise lcn_freq_count - never assign it down over an
+     * operator-supplied list that is longer than the one slot this writer knows about. */
+    DSD_SNPRINTF(label, sizeof label, "%s-lcn-count", tag);
+    rc |= expect_int(label, state->lcn_freq_count,
+                     seeded_lcn_count > 1 ? seeded_lcn_count : (expect_adopt ? 1 : seeded_lcn_count));
 
     set_parked_scan_target_ctx(0);
     free(state);
@@ -1164,6 +1169,12 @@ test_cch_dfa_control_channel_adoption_pinning(void) {
     rc |= run_cch_dfa_adoption_case("cch-adopt-scan-p25-target", 1, 1, 1, park, park, park, 1, 0);
     /* Conventional targets run with trunk_enable == 0 and have no control channel to adopt. */
     rc |= run_cch_dfa_adoption_case("cch-adopt-scan-conventional-target", 1, 0, 0, 0, 0, 0, 0, 0);
+    /* An imported map is positional: an unparseable row 1 stores 0 on purpose to keep LCN
+     * numbering, so slot 0 alone cannot be read as "nothing imported". The list is operator
+     * intent and must survive the broadcast intact. */
+    rc |= run_cch_dfa_adoption_case("cch-adopt-plain-placeholder-row", 0, 1, 0, 0, 0, 0, 40, 0);
+    /* A long learned list must not be truncated to the single slot this writer seeds. */
+    rc |= run_cch_dfa_adoption_case("cch-adopt-scan-long-list", 1, 1, 0, park, park, park, 40, 0);
 
     return rc;
 }

--- a/tests/protocol/p25/test_p25_p2_vpdu_core.c
+++ b/tests/protocol/p25/test_p25_p2_vpdu_core.c
@@ -681,6 +681,86 @@ run_native_sccb_zero_channel_b_case(void) {
     return rc;
 }
 
+/*
+ * SCCB-Explicit (0x69) seeds the low scan-list slots for control-channel hunting. It must only
+ * ever raise lcn_freq_count, and must leave an operator-supplied list alone: such a list is
+ * positional, so a 0 in slot 1 is an unparseable CSV row holding LCN 2's place, not a free slot.
+ */
+static int
+run_sccb_explicit_scan_list_case(int imported, int seeded_count, const char* tag) {
+    static dsd_opts opts;
+    dsd_state* state = NULL;
+    int rc = 0;
+    char label[96];
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!state) {
+        return 1;
+    }
+
+    state->p25_iden_fdma[1].chan_type = 1;
+    state->p25_iden_fdma[1].chan_spac = 100;
+    state->p25_iden_fdma[1].base_freq = 851000000 / 5;
+    state->p25_iden_fdma[1].populated = 1;
+    state->p25_chan_tdma_explicit[1] = 1;
+    state->p2_rfssid = 0x02;
+    state->p2_siteid = 0x03;
+
+    if (imported) {
+        DSD_SNPRINTF(opts.chan_in_file, sizeof opts.chan_in_file, "%s", "imported.csv");
+    }
+    for (int i = 0; i < seeded_count; i++) {
+        if (dsd_state_trunk_lcn_reserve(state, (size_t)i + 1U) != 0) {
+            DSD_FPRINTF(stderr, "%s: scan-list reserve failed at %d\n", tag, i);
+            free(state);
+            return 1;
+        }
+        /* Slot 1 is the deliberate placeholder an unparseable row leaves behind. */
+        *dsd_state_trunk_lcn_slot(state, i) = (i == 1) ? 0L : (851000000L + (long)i * 12500L);
+    }
+    state->lcn_freq_count = seeded_count;
+
+    unsigned long long int MAC[24] = {0};
+    MAC[0] = 0x07; /* P1 TSBK bridge marker this decoder path requires */
+    MAC[1] = 0x69;
+    MAC[2] = 0x02; /* RFSS matches the current site */
+    MAC[3] = 0x03; /* SITE matches the current site */
+    MAC[4] = 0x10; /* CHAN-T iden 1, channel 0x00A */
+    MAC[5] = 0x0A;
+    MAC[6] = 0x10; /* CHAN-R 0x1005 (uplink) */
+    MAC[7] = 0x05;
+    MAC[8] = 0x01; /* service class */
+
+    process_MAC_VPDU(&opts, state, 0 /* FACCH */, P25_MAC_PDU_ACTIVE, MAC);
+
+    DSD_SNPRINTF(label, sizeof label, "%s_count_not_lowered", tag);
+    rc |= expect_true(label, state->lcn_freq_count >= seeded_count);
+    if (imported) {
+        DSD_SNPRINTF(label, sizeof label, "%s_count_preserved", tag);
+        rc |= expect_eq_long(label, state->lcn_freq_count, seeded_count);
+        int intact = 1;
+        for (int i = 0; i < seeded_count; i++) {
+            const long want = (i == 1) ? 0L : (851000000L + (long)i * 12500L);
+            if (*dsd_state_trunk_lcn_slot(state, i) != want) {
+                DSD_FPRINTF(stderr, "%s: slot %d clobbered: got %ld want %ld\n", tag, i,
+                            *dsd_state_trunk_lcn_slot(state, i), want);
+                intact = 0;
+            }
+        }
+        DSD_SNPRINTF(label, sizeof label, "%s_entries_untouched", tag);
+        rc |= expect_true(label, intact);
+    } else {
+        /* No operator list: the announced frequency still lands in the first free low slot. */
+        DSD_SNPRINTF(label, sizeof label, "%s_seeded_slot1", tag);
+        rc |= expect_eq_long(label, state->trunk_lcn_freq[1], 851000000L + 10L * 100L * 125L);
+    }
+
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    return rc;
+}
+
 static void
 put_iden_base(unsigned char* mac, int pos, long base_freq) {
     mac[pos + 0] = (unsigned char)((base_freq >> 24) & 0xFF);
@@ -1747,6 +1827,10 @@ run_cases(void) {
     }
 
     rc |= run_bridged_sccb_zero_channel_b_case();
+    /* A long imported map survives an SCCB-Explicit broadcast intact; a learned list is only
+     * ever extended, never truncated to the two slots this writer knows about. */
+    rc |= run_sccb_explicit_scan_list_case(1, 200, "sccb_explicit_imported");
+    rc |= run_sccb_explicit_scan_list_case(0, 5, "sccb_explicit_learned");
     rc |= run_native_sccb_zero_channel_b_case();
 
     // Case 9: SCCB candidates are site-scoped when current RFSS/SITE are known.

--- a/tests/ui/test_ui_rr_panel.c
+++ b/tests/ui/test_ui_rr_panel.c
@@ -98,6 +98,9 @@ test_counter_counts_distinct_frequencies(void) {
     assert(counter.empty == 0);
     assert(counter.duplicates == 0);
     assert(strcmp(counter.text, "[ 3 distinct frequencies ]") == 0);
+    /* The heading falls back to this when the body is too narrow for the full label. */
+    assert(strcmp(counter.short_text, "[ 3 freqs ]") == 0);
+    assert(strlen(counter.short_text) < strlen(counter.text));
 }
 
 static void
@@ -115,6 +118,7 @@ test_counter_keeps_every_distinct_frequency(void) {
     rr_panel_counter_state(sites, 27, select_all, NULL, &counter);
     assert(counter.kept == 27);
     assert(strcmp(counter.text, "[ 27 distinct frequencies ]") == 0);
+    assert(strcmp(counter.short_text, "[ 27 freqs ]") == 0);
 }
 
 static void
@@ -135,6 +139,7 @@ test_counter_skips_empty_and_duplicates(void) {
     assert(counter.duplicates == 1);
     assert(counter.empty == 1);
     assert(strcmp(counter.text, "[ 2 distinct frequencies ]") == 0);
+    assert(strcmp(counter.short_text, "[ 2 freqs ]") == 0);
 }
 
 static void


### PR DESCRIPTION
Follow-up review of the unbounded scan-list work in #370, in three commits.

## 1. Correctness fixes for the unbounded LCN scan list (`b61f1342`)

Bounds, error-propagation and lifetime issues that the heap tail introduced or made reachable.

- **`dsd_ncurses_printer.c`** indexed the scan list by `lcn_freq_roll - 1` with no bound against `lcn_freq_count`. Past the embedded slots that resolved into the heap tail, or into `NULL` when no tail was reserved.
- **`ui_snapshot.c`** could publish a `lcn_freq_roll` pointing past the count it shipped alongside it.
- **`rr_generate.c`**: `rr_chan_p25()` and `rr_chan_conventional()` kept `void` returns after the calloc conversion, so an allocation failure reached the caller as a successful import with an empty channel map. `rr_p25_rank_freqs()` reported OOM as "this site lists no usable frequencies". The dead 26-slot truncation branch and its stale warning are gone.
- **`trunk_scan.c`**: the snapshot restore copied `lcn_freq_count - 26` longs without consulting `trunk_lcn_freq_ext_count` or NULL-checking the tail; the save-side clamp tested the captured tail for zero instead of comparing against it; the reserve helper did not zero the region it grew. `coord->count` was published before `coord->targets` was allocated.
- **`initState()`** did not reset the heap tail, so it was not idempotent.
- **fuzz/test leaks**: `fuzz_core_csv_import` and the trunk-scan test's state reset both leaked the tail once a CSV exceeded the embedded slots (LSan-confirmed).

Adds the first coverage of the snapshot heap-tail path, and replaces the magic `26` with `DSD_TRUNK_LCN_EMBEDDED`.

## 2. Site broadcasts no longer truncate or clobber the scan list (`782e2229`)

Three protocol writers seeded fixed low slots and then *assigned* `lcn_freq_count` to the handful of slots they knew about — harmless at 26 entries, but a single broadcast could drop an imported 200-row map to 2. Each writer's "is this list populated" guard also tested a fixed slot for zero rather than the count, so an imported map's deliberate 0 placeholder read as "nothing imported" and got overwritten.

- New `dsd_state_trunk_lcn_user_list_present()` is the single answer to "did the operator supply this list?"; `p25_has_user_lcn_list()` delegates to it.
- The SCCB-Explicit (`0x69`) handler duplicated, less correctly, what `p25p2_seed_secondary_lcn_fallback()` already does 3,700 lines above; it now calls that helper.
- `nxdn_cc_is_operator_pinned()` tests the count; the CCH_INFO adoption raises it.
- `dmr_cspdu_pf0_c_bcast_track_freq()` appends distinct frequencies instead of writing modulo a 25-slot window. Learned entries are capped at the embedded slot count so over-the-air data can never drive an allocation.

Regression coverage in all three existing protocol harnesses, each checked against the pre-fix implementation.

## 3. Sparse target snapshots and a bounded target list (`0bee0b34`)

Dense copies of `trunk_chan_map[0xFFFF]` and `trunk_chan_map_used[0xFFFF]` were 655 KB of the 738 KB each parked target cost, and every rotation memcpy'd all of it. A 4,000-row targets CSV asked for 2.9 GB in one calloc — which overcommit grants, so the promised allocation error never fired and the process was OOM-killed while faulting the pages in.

The snapshot now stores only the channels `trunk_chan_map_used[]` lists, as `(channel, frequency)` pairs:

| | before | after |
|---|---|---|
| per target | 738,216 B | 82,888 B |
| per-rotation copy | 660 KB | `used_count` x 10 B |

`dsd_trunk_scan_max_targets()` publishes a cap derived from a 256 MB budget divided by the snapshot size, so it tracks the struct rather than being a constant that goes stale. It is enforced while the CSV is parsed, which turns the OOM kill into a message naming the budget and bounds the parser's per-row duplicate scans.

Also: the RR panel counter gained a short form so it stops vanishing below ~66 columns, and a stale "the conventional generator caps at 26 distinct frequencies" rationale in `rr_wizard_core.c` is corrected.

## Verification

- `cmake --build --preset dev-debug` clean; **573/573 ctest pass**
- `tools/preflight_ci.sh` exit 0 (clang-tidy, cppcheck, IWYU, `gcc -fanalyzer`, lizard, guardrails, format checks)
- `tools/semgrep.sh --strict` 0 findings; `tools/check_arch_rules.sh` OK
- Touched tests pass under `asan-ubsan-debug`
- Every new test was mutation-checked against the pre-fix implementation