### PR TITLE
fix: let a parked GFSK scan target's symbol rate drive the RTL chain

### DIFF
--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -207,7 +207,9 @@ During scanning:
 - `nxdn48-conventional` targets park at 2400 sym/s with the 6.25 kHz channel filter; every other GFSK-family target
   parks at 4800 sym/s with the 12.5 kHz filter. Set `modulation = gfsk` on NXDN48 rows: that pins the symbol-rate
   hunt to the 2400 profile for the whole dwell, whereas an empty or `auto` column lets the hunt rotate through the
-  other enabled rates during dead air, which also swings the channel filter.
+  other enabled rates during dead air, which also swings the channel filter. The parked target's type selects the
+  symbol rate and channel filter even under a global `-m` modulation lock; the lock still governs symbol slicing, so
+  DMR and NXDN rows under `-mc` or `-mq` need `modulation = gfsk` (or `auto`) to decode.
 - When a retune fails, DSD-neo logs a warning, briefly cools that target down, and tries another eligible target.
 
 Expected log messages include:

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -143,6 +143,10 @@ int dsd_engine_trunk_scan_active_p25_cqpsk_request(const dsd_state* state, int* 
  * is rotated by the no-sync SPS hunt, so a plain `-T` session can be sitting on the 2400 profile
  * during dead air. The coordinator's own target type is the only stable answer.
  *
+ * The tuning layer treats a non-zero answer as authoritative for the RTL chain regardless of
+ * `rf_mod`, so a target whose modulation column is empty under a global `-m` lock still gets its
+ * own symbol rate and channel filter.
+ *
  * @param state Decoder state owning the scan coordinator.
  * @return 2400 or 4800 for a parked GFSK-family target; 0 when trunk scan is not installed or the
  *         parked target is P25.

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -321,14 +321,21 @@ dsd_engine_prepare_gfsk_cc_rtl_chain(const dsd_opts* opts, const dsd_state* stat
 /*
  * Symbol rate for a four-level GFSK retune, or 0 when this is not one.
  *
- * Only NXDN48 needs the coordinator's answer: every other GFSK-family target runs 4800 sym/s,
- * which state->rf_mod == 2 already selects. Keeping the rf_mod gate for those leaves plain -T
- * DMR/NXDN96 retune behavior byte-for-byte unchanged, including under a modulation lock.
+ * Under trunk scan the coordinator's parked target type is authoritative. The symbol rate and the
+ * channel filter belong to the target's channel, not to the modulation lock, which keeps owning
+ * symbol slicing through rf_mod and is left alone here. Deriving the rate from rf_mod == 2 instead
+ * loses every GFSK target whose modulation column is empty under a global -mc/-mq lock, because the
+ * coordinator then leaves rf_mod at the locked value: the retune falls through to re-queuing
+ * whatever chain the previous target left on the front end -- after an nxdn48-conventional dwell, a
+ * 2400 sym/s 6.25 kHz chain on a 12.5 kHz channel -- and a locked SPS hunt never re-applies over it,
+ * since it only rotates among equal-timing profiles. Outside trunk scan the coordinator answers 0
+ * and the rf_mod gate keeps plain -T retunes unchanged.
  */
 static int
 dsd_engine_gfsk_cc_symbol_rate(const dsd_state* state) {
-    if (dsd_engine_trunk_scan_active_gfsk_symbol_rate(state) == 2400) {
-        return 2400;
+    const int scan_rate = dsd_engine_trunk_scan_active_gfsk_symbol_rate(state);
+    if (scan_rate > 0) {
+        return scan_rate;
     }
     return (state && state->rf_mod == 2) ? 4800 : 0;
 }

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -894,6 +894,94 @@ main(void) {
     assert(g_rtl_ted_sps == 10);
     rtl_stream_clear_pending_retune_profile();
 
+    /* A global -mc lock with an empty per-target modulation column leaves rf_mod at the locked C4FM
+     * value, so the coordinator's answer is the only thing that can pick the chain for a parked
+     * DMR/NXDN96 target. Without it the retune re-queues whatever the front end already had -- after
+     * an nxdn48-conventional dwell, a 2400 sym/s 6.25 kHz chain on a 12.5 kHz channel -- and the
+     * locked SPS hunt never re-applies over it, because it only rotates among equal-timing profiles. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_scan_enabled = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 0;
+    g_trunk_scan_target_count = 2;
+    g_trunk_scan_active_p25_target = 0;
+    g_trunk_scan_active_gfsk_symbol_rate = 4800;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 0;
+    g_rtl_symbol_rate_hz = 2400;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_6K25;
+    g_rtl_ted_sps = 20;
+    g_rtl_ted_sps_override = 0;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_scan_tune_to_freq(opts, state, 461112500, 10, NULL) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_cqpsk_enable == 0);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_symbol_levels == 4);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_12K5);
+    assert(g_rtl_ted_sps == 10);
+    assert(g_rtl_ted_sps_override == 0);
+    /* The chain follows the parked target; the lock keeps owning symbol slicing. */
+    assert(state->rf_mod == 0);
+    rtl_stream_clear_pending_retune_profile();
+
+    /* Same on the trunk-CC path under -mq: a parked GFSK target must not inherit the previous P25
+     * target's CQPSK demod and C4FM-family filter. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    opts->trunk_scan_enabled = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 1;
+    g_trunk_scan_target_count = 2;
+    g_trunk_scan_active_p25_target = 0;
+    g_trunk_scan_active_gfsk_symbol_rate = 4800;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 1;
+    g_rtl_symbol_rate_hz = 4800;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    g_rtl_ted_sps = 10;
+    g_rtl_ted_sps_override = 0;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_trunk_tune_to_cc_request(opts, state, 452000000, 10, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_cqpsk_enable == 0);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_symbol_levels == 4);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_12K5);
+    assert(g_rtl_ted_sps == 10);
+    assert(state->rf_mod == 1);
+    rtl_stream_clear_pending_retune_profile();
+
+    /* Outside trunk scan the fall-through still owns a locked non-GFSK session: the coordinator
+     * answers 0, rf_mod != 2, and the retune re-queues the front end's current chain unchanged. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 0;
+    g_trunk_scan_target_count = 0;
+    g_trunk_scan_active_p25_target = 0;
+    g_trunk_scan_active_gfsk_symbol_rate = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 0;
+    g_rtl_symbol_rate_hz = 4800;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_C4FM;
+    g_rtl_ted_sps = 8;
+    g_rtl_ted_sps_override = 0;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_scan_tune_to_freq(opts, state, 461112500, 10, NULL) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_cqpsk_enable == 0);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_symbol_levels == 4);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
+    assert(g_rtl_ted_sps == 10);
+    rtl_stream_clear_pending_retune_profile();
+
     /* Trunk-scan RTL retunes queue the active target/global gain with the
      * demod profile so gain changes happen at the retune boundary. */
     DSD_MEMSET(opts, 0, sizeof(*opts));


### PR DESCRIPTION
Closes #376.

## The concrete case

#376 was filed as "close as `wontfix` unless a concrete case turns up", with the stated trigger being *a bug report where a locked-modulation DMR/NXDN96 scan target lands on the wrong channel filter*. Code reading produces exactly that, no report needed.

`dsd_engine_gfsk_cc_symbol_rate()` consulted the coordinator only to recognise 2400 sym/s (NXDN48); every other GFSK-family target depended on the `state->rf_mod == 2` gate that predates trunk scan. Under a global `-mc`/`-mq` lock with an empty per-target `modulation` column the coordinator deliberately leaves `rf_mod` at the locked value (`trunk_scan_apply_gfsk_class_target_demod()`, pinned by `test_locked_demod_mode_preserved_when_seeding_targets`), so the query returned 0 for a parked DMR/NXDN96 target and the retune fell through to `dsd_engine_prepare_current_cc_rtl_chain()` — which re-queues **whatever chain the previous target left on the front end**:

- scan list `[nxdn48-conventional, dmr-* or nxdn-* with an empty column]` under `-mc`: the DMR/NXDN96 row inherits the NXDN48 dwell's 2400 sym/s 6.25 kHz chain on a 12.5 kHz channel;
- a P25 row before a GFSK row under `-mq`: the GFSK row inherits the CQPSK demod and the C4FM-family filter.

It never self-corrects. Under a lock the SPS hunt only rotates among equal-timing profiles (`frame_sync_sps_hunt_next_index_matching_timing`) and `frame_sync_apply_sps_hunt_profile()` returns before `rtl_maybe_apply_demod_profile()` when the profile does not change.

## The change

Make any non-zero coordinator answer authoritative:

```c
const int scan_rate = dsd_engine_trunk_scan_active_gfsk_symbol_rate(state);
if (scan_rate > 0) {
    return scan_rate;
}
return (state && state->rf_mod == 2) ? 4800 : 0;
```

The symbol rate and channel filter are properties of the parked target's channel; the modulation lock keeps owning symbol slicing through `rf_mod`, which this does not touch. NXDN48 already set that precedent. `dsd_engine_prepare_gfsk_cc_rtl_chain()` already resolves the filter through `dsd_rtl_channel_profile_for()`, so nothing else in the chain path changes — no coordinator or frame-sync changes.

## Blast radius

| Scenario | Before | After |
| --- | --- | --- |
| Plain `-T` (no scan) | rf_mod gate | unchanged (coordinator answers 0) |
| `-mg` / unlocked scan | 4800 / 12K5 | unchanged (`rf_mod == 2` already agreed) |
| `-mc`/`-mq` + empty column, GFSK row | inherits previous target's chain | cqpsk off, 4800 sym/s, 4-level, 12.5 kHz |

## Tests

Three cases added to `ENGINE_TRUNK_RETUNE_REGRESSION`, each verified to fail or pass on the pre-fix tree individually:

1. **locked C4FM, conventional path** — parked 4800 target after an NXDN48 dwell. Fails pre-fix (`g_rtl_symbol_rate_hz == 4800`, got 2400/6K25); also asserts `rf_mod` is left alone.
2. **locked QPSK, trunk-CC path** — parked GFSK target after a P25 CQPSK dwell. Fails pre-fix (`g_rtl_cqpsk_enable == 0`).
3. **locked non-scan fall-through** — the behaviour #376 notes nothing pinned. Passes pre-fix and post-fix; it is the guard that this change does not widen past trunk scan.

`ENGINE_TRUNK_SCAN` still passes, confirming the coordinator's lock handling is untouched.

## Verification

- `ctest --preset dev-debug --output-on-failure` → **565/565 pass**
- `tools/format.sh`, `tools/preflight_ci.sh` → clean (arch rules OK, clang-tidy clean, cppcheck passed, IWYU 0 suggestions, gcc `-fanalyzer` clean, semgrep clean, lizard no thresholds exceeded)

## Docs

`docs/trunk-scan.md` gains a sentence that the parked target's type selects the rate and filter even under a global `-m` lock, and that DMR/NXDN rows under `-mc`/`-mq` still need `modulation = gfsk` (or `auto`) to decode. The header doc comment records that a non-zero answer is authoritative for the RTL chain regardless of `rf_mod`.