### PR TITLE
fix(dsp): derive RTL FSK symbol timing from the SPS hunt profile

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -231,7 +231,13 @@ DirWatch modes keep the WAV and JSON files because the watcher needs stable file
 - `--iq-capture-format <cu8|cf32>` Capture format request (`cu8` default).
 - `--iq-capture-max-mb <n>` Capture byte cap in MiB (`0` unlimited).
 - `--iq-replay <path>` Replay capture metadata/data through the RTL pipeline.
-- `--iq-replay-rate <fast|realtime>` Replay pacing mode (`fast` default).
+- `--iq-replay-rate <fast|realtime>` Replay pacing mode (`fast` default). `fast` lets the front end run ahead of the
+  decoder, bounded only by the output ring (~43 s at 48 kHz), so a short capture can be fully demodulated under the
+  profile the run started with: channel-profile changes the decoder requests mid-replay then land after the samples
+  they were meant to shape, or never at all once the reader hits EOF. Decoder-side symbol timing still follows the SPS
+  hunt either way, but anything that depends on the front end reacting to the decoder -- the Auto hunt narrowing the
+  channel filter onto a candidate, and the stream realignment that comes with it -- only behaves like live hardware
+  under `realtime`. Reproduce hunt and trunking behaviour with `realtime`; `fast` is for throughput over a capture.
 - `--iq-loop` Loop replay when EOF is reached.
 - `--iq-info <path>` Print capture metadata summary and exit.
 
@@ -290,6 +296,14 @@ Notes
 
   A detected sync locks the active rate, level count, timing, and RTL-family channel profile. Passive analog monitoring
   (`-fA`) and already-framed M17 UDP input (`-fU`) are not frame-sync hunt candidates.
+- On RTL-family FSK input the decoder's symbol timing follows the hunt profile from the moment the hunt selects it. The
+  matching front-end channel profile is requested asynchronously and is applied by the demod thread on its next block,
+  so the two are briefly out of step after every hunt step; decoding does not wait for the front end to catch up.
+- The hunt dwells on each candidate profile for a bounded number of buffer passes, so a full rotation over the five
+  profiles takes roughly six seconds at 48 kHz. A transmission that starts mid-rotation and lasts less than one
+  rotation can therefore be missed entirely even though the same capture decodes under its native preset -- Auto
+  converges on signals that persist, such as a control channel or a call of a few seconds, not on isolated short
+  bursts. Name the narrower preset when you already know the mode and cannot afford the search.
 - All three Auto entry points install the complete matrix above: CLI `-fa`, config `decode = "auto"`, and the
   interactive Auto choice select the same decoder set. Only `-fa` also resets the demodulator to C4FM and the audio
   layout to stereo; the config path leaves those to its `demod` and `dmr_mono` keys, and the interactive path to the
@@ -548,7 +562,8 @@ Resampler
 
 CQPSK timing
 
-RTL-family FSK digital decode selects its own symbol timing and normalization internally. CQPSK uses the OP25-style
+RTL-family FSK digital decode selects its own symbol timing and normalization internally, deriving samples-per-symbol
+from the active SPS hunt profile rather than from the front end's published symbol rate. CQPSK uses the OP25-style
 Gardner/Costas/FLL-band-edge symbol chain.
 
 - `DSD_NEO_TED_GAIN=<float>` — CQPSK/OP25 Gardner timing loop gain override

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -93,6 +93,17 @@ int dsd_frame_sync_suppress_tcp_no_signal_console(const dsd_opts* opts, const ds
 int dsd_frame_sync_sps_hunt_dwell_passes(const dsd_opts* opts, const dsd_state* state);
 
 /**
+ * @brief Return the symbol rate, in Hz, of the SPS hunt profile currently selected.
+ *
+ * The decoder's own timing authority on RTL-family FSK input: the front end applies
+ * a hunt's profile request asynchronously, so its published symbol rate lags the
+ * hunt and must not be what the slicer derives samples-per-symbol from.
+ *
+ * @param state Decoder state; NULL or an out-of-range index yields the 4800/4 default.
+ */
+int dsd_frame_sync_active_profile_symbol_rate_hz(const dsd_state* state);
+
+/**
  * @brief Scan for a valid frame sync pattern and return its type.
  */
 int getFrameSync(dsd_opts* opts, dsd_state* state);

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -68,24 +68,6 @@ enum {
     FRAME_SYNC_HISTORY_CAPACITY = 48,
 };
 
-typedef struct {
-    int symbol_rate_hz;
-    int levels;
-} frame_sync_sps_profile;
-
-/* Keep this order in sync with dsd_state::sps_hunt_idx. */
-static const frame_sync_sps_profile k_frame_sync_sps_profiles[DSD_FRAME_SYNC_SPS_PROFILE_COUNT] = {
-    {4800, 4}, {2400, 4}, {9600, 2}, {6000, 4}, {4800, 2},
-};
-
-static const frame_sync_sps_profile*
-frame_sync_sps_profile_for_index(int index) {
-    if (index < 0 || index >= DSD_FRAME_SYNC_SPS_PROFILE_COUNT) {
-        return &k_frame_sync_sps_profiles[DSD_FRAME_SYNC_SPS_PROFILE_4800_4];
-    }
-    return &k_frame_sync_sps_profiles[index];
-}
-
 static int
 frame_sync_opts_has_4800_four_level_mode(const dsd_opts* opts) {
     if (!opts) {

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -1379,7 +1379,17 @@ symbol_apply_rtl_fsk_discriminator_timing(const dsd_opts* opts, dsd_state* state
         return;
     }
     int output_rate_hz = symbol_rtl_fsk_output_rate_hz(opts);
-    int symbol_rate_hz = symbol_rtl_fsk_symbol_rate_hz(work);
+    /* The SPS hunt's profile, not the front end's published rate. A hunt step only
+     * queues its RTL profile request for the demod thread to apply between input
+     * blocks, so the published rate lags by at least a block -- and under fast I/Q
+     * replay of a fixture that fits the output ring it never moves at all. Slicing
+     * on the lagging rate put the timing back on the old profile after every hunt
+     * step, which frame_sync_ensure_enabled_sps_profile() then read as "the hunt is
+     * on the old profile", cancelling the step and pinning AUTO to 4800/4. */
+    int symbol_rate_hz = dsd_frame_sync_active_profile_symbol_rate_hz(state);
+    if (symbol_rate_hz <= 0) {
+        symbol_rate_hz = symbol_rtl_fsk_symbol_rate_hz(work);
+    }
     (void)symbol_reset_rtl_fsk_timing_if_needed(state, output_rate_hz, symbol_rate_hz, work);
 
     state->samplesPerSymbol = symbol_rtl_fsk_next_sps(state, output_rate_hz, symbol_rate_hz);

--- a/src/dsp/frame_sync_internal.h
+++ b/src/dsp/frame_sync_internal.h
@@ -11,6 +11,15 @@
 extern "C" {
 #endif
 
+/** @brief One entry of the SPS hunt's rate/level table, indexed by dsd_state::sps_hunt_idx. */
+typedef struct {
+    int symbol_rate_hz;
+    int levels;
+} frame_sync_sps_profile;
+
+/** @brief The hunt profile at @p index; an out-of-range index yields the 4800/4 default. */
+const frame_sync_sps_profile* frame_sync_sps_profile_for_index(int index);
+
 void frame_sync_maybe_tick_p25_trunk_sm(dsd_opts* opts, dsd_state* state, time_t now);
 void frame_sync_maybe_auto_switch_modulation(const dsd_opts* opts, dsd_state* state, int t_max, int* lastt);
 int frame_sync_active_profile_modulation(const dsd_opts* opts, const dsd_state* state);

--- a/src/dsp/frame_sync_profile.c
+++ b/src/dsp/frame_sync_profile.c
@@ -8,6 +8,35 @@
 #include <dsd-neo/dsp/frame_sync.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "frame_sync_internal.h"
+
+/* Keep this order in sync with dsd_state::sps_hunt_idx. */
+static const frame_sync_sps_profile k_frame_sync_sps_profiles[DSD_FRAME_SYNC_SPS_PROFILE_COUNT] = {
+    {4800, 4}, {2400, 4}, {9600, 2}, {6000, 4}, {4800, 2},
+};
+
+const frame_sync_sps_profile*
+frame_sync_sps_profile_for_index(int index) {
+    if (index < 0 || index >= DSD_FRAME_SYNC_SPS_PROFILE_COUNT) {
+        return &k_frame_sync_sps_profiles[DSD_FRAME_SYNC_SPS_PROFILE_4800_4];
+    }
+    return &k_frame_sync_sps_profiles[index];
+}
+
+/**
+ * @brief Symbol rate of the SPS hunt profile the decoder is currently slicing for.
+ *
+ * Deliberately the decoder's own view rather than the front end's published rate:
+ * a hunt step only queues its RTL profile request, which the demod thread applies
+ * between input blocks, so the published rate lags the hunt by at least one block
+ * on live input and never catches up at all under fast I/Q replay of a fixture
+ * that fits in the output ring.
+ */
+int
+dsd_frame_sync_active_profile_symbol_rate_hz(const dsd_state* state) {
+    const int profile_index = state ? state->sps_hunt_idx : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    return frame_sync_sps_profile_for_index(profile_index)->symbol_rate_hz;
+}
 
 dsd_nxdn_variant
 dsd_frame_sync_active_nxdn_variant(const dsd_opts* opts, const dsd_state* state) {

--- a/tests/dsp/test_rtl_symbol_cache_generation.c
+++ b/tests/dsp/test_rtl_symbol_cache_generation.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/symbol.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/sockets.h>
@@ -246,6 +247,7 @@ reset_decoder_fixture(dsd_opts* opts, dsd_state* state, void* rtl_context) {
     opts->audio_in_type = AUDIO_IN_RTL;
     opts->symboltiming = 0;
     state->rf_mod = 2;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
     state->rtl_ctx = (struct RtlSdrContext*)rtl_context;
 }
 
@@ -412,6 +414,7 @@ main(void) {
     g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_6K25;
     g_read_base = 2000.0f;
     g_read_base_step = 4.0f;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
     float nxdn_symbol = getSymbol(&opts, &state, 1);
     if (fabsf(nxdn_symbol - 2009.7778f) >= 0.01f) {
         DSD_FPRINTF(stderr, "FSK discriminator generation-change symbol %.4f\n", nxdn_symbol);
@@ -424,6 +427,50 @@ main(void) {
     assert(state.rtl_symbol_cache_channel_profile == RTL_STREAM_CHANNEL_PROFILE_6K25);
     assert(state.rtl_symbol_cache_levels == 2);
 
+    /*
+     * The SPS hunt owns discriminator timing, not the front end's published rate.
+     * A hunt step only queues its RTL profile request for the demod thread, so the
+     * published rate lags it -- and under fast I/Q replay of a fixture that fits in
+     * the output ring it never moves at all. Slicing on the lagging rate put timing
+     * back on the old profile after every hunt step, which
+     * frame_sync_ensure_enabled_sps_profile() then read as "the hunt is on the old
+     * profile", cancelling the step and pinning AUTO to 4800/4 (issue #374).
+     */
+    reset_stream_fixture();
+    reset_decoder_fixture(&opts, &state, &fake_rtl_context);
+    g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+    g_output_rate_hz = 48000U;
+    g_symbol_rate_hz = 4800;
+    g_symbol_levels = 4;
+    g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_12K5;
+    g_read_base = 1000.0f;
+    g_read_base_step = 4.0f;
+
+    (void)getSymbol(&opts, &state, 1);
+    assert(state.samplesPerSymbol == 10);
+
+    /* Hunt steps to 2400/4; the front end has not caught up (same generation, same
+       published 4800/12.5 kHz profile). Timing must follow the hunt regardless. */
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    (void)getSymbol(&opts, &state, 1);
+    assert(state.samplesPerSymbol == 20);
+    assert(state.symbolCenter == dsd_opts_symbol_center(20));
+    assert(g_symbol_rate_hz == 4800);
+
+    /* The front end catching up later changes nothing the hunt did not already ask for. */
+    g_stream_generation++;
+    g_symbol_rate_hz = 2400;
+    g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_6K25;
+    (void)getSymbol(&opts, &state, 1);
+    assert(state.samplesPerSymbol == 20);
+
+    /* And the reverse: a published 2400 rate must not hold timing at 2400 once the
+       hunt has rotated on to a 4800 profile. */
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    (void)getSymbol(&opts, &state, 1);
+    assert(state.samplesPerSymbol == 10);
+    assert(state.symbolCenter == dsd_opts_symbol_center(10));
+
     reset_stream_fixture();
     reset_decoder_fixture(&opts, &state, &fake_rtl_context);
     g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
@@ -433,6 +480,7 @@ main(void) {
     g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_PROVOICE;
     g_read_base = 5000.0f;
     g_read_base_step = 4.0f;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_9600_2;
 
     g_max_read_calls = 2;
     assert(getSymbol(&opts, &state, 0) == 5000.0f);


### PR DESCRIPTION
Refs #374.

## Root cause

On the RTL-family FSK discriminator path the decoder did not own its symbol timing.
`symbol_apply_rtl_fsk_discriminator_timing()` (`src/dsp/dsd_symbol.c`) recomputed
`samplesPerSymbol` on **every symbol** from the front end's *published* symbol rate. But a
hunt step only *queues* its RTL profile request (`rtl_stream_request_demod_profile()`,
consumed by the demod thread between input blocks), so the published rate lags the hunt.

That lag cancelled the hunt:

1. `frame_sync_no_sync_sps_hunt()` steps to `2400_4`, sets `samplesPerSymbol = 20`, queues the request.
2. The next `getSymbol()` sees the published rate still at 4800 and puts timing back to 10 sps.
3. `frame_sync_ensure_enabled_sps_profile()` reads that stale timing as *"the hunt is on profile 0"*,
   re-applies profile 0 and **re-requests the 4800 profile, overwriting the still-pending 2400 request**.

Every step off the starting profile was undone within one pass. The observable result is the
"unexplained" symptom in the issue: the hunt ping-ponged `4800/4 <-> 2400/4` and never printed the
others. The stronger consequence is that **profiles `9600/2` (ProVoice, EDACS), `6000/4` (P25p2,
X2-TDMA) and `4800/2` (D-STAR) were unreachable under `-fa` on RTL FSK input**. On live input the
same cancellation is a race with a one-block window.

## Fix

Derive the slicer's symbol rate from the active hunt profile, falling back to the published rate.

```
SPS hunt: trying 20 sps (sym=2400, demod=48000)
SPS hunt: trying 5 sps (sym=9600, demod=48000)     <- previously never reached
SPS hunt: trying 8 sps (sym=6000, demod=48000)     <- previously never reached
SPS hunt: trying 10 sps (sym=4800, demod=48000)
```

The profile table and `frame_sync_sps_profile_for_index()` move from `dsd_frame_sync.c` to the
existing light `frame_sync_profile.c`, so the new accessor has a single definition and `dsd_symbol.c`
does not drag the whole frame-sync TU (event log, DMR reliability, symbol capture) into hermetic
unit tests.

## What this does *not* fix

Decode counts on the committed fixtures under `-fa` are unchanged: `nxdn48` fast 0 / realtime 5,
`dpmr` 0 both. Measured reason: the NXDN sync patterns in `nxdn48.iq` begin at file time **3.41 s**,
while the 2400 dwell spans **1.12-3.36 s** - it misses by ~50 ms on dwell phase. Pinning the hunt to
2400 decodes the fixture normally (3 matches, same as native `-fi`), confirming the timing fix is
sound and the residual is round-robin duty cycle, not a defect.

Shortening the dwell was the only lever and it is a poor trade - 3->2 passes gives `nxdn48` 1 match,
3->1 gives 2 (native is 3), `dpmr` stays 0 - a fragile partial gain in exchange for changing hunt
behaviour for every live user. Left alone deliberately; see the issue comment for details.

No `DECODE_IQ_*_AUTO` cases are added for that reason (they would fail; the harness uses `fast`).
The regression is locked deterministically at the unit level instead.

## Tests

`tests/dsp/test_rtl_symbol_cache_generation.c`: two existing cases encoded the old
"timing follows the published rate" contract and are updated to set `sps_hunt_idx`; a new case covers
the bug directly - published profile stays 4800/12.5 kHz while the hunt steps to `2400_4`, timing must
become 20 sps; the front end catching up later changes nothing; and the reverse direction. Verified
red/green: fails at line 456 (`state.samplesPerSymbol == 20`) without the fix, passes with it.

## Verification

- `ctest --preset dev-debug` - **100% passed, 565/565**
- `tools/preflight_ci.sh` - clean (clang-tidy, cppcheck, IWYU 0 suggestions, `gcc -fanalyzer` 0 diagnostics, semgrep, arch rules OK)
- Native presets unchanged: `-fi` nxdn48 3, `-fm` dpmr 3, `-fn` nxdn96 37

## Docs

`docs/cli.md`: hunt timing ownership under `-fa`; the rotation-period caveat (a transmission shorter
than one ~6 s rotation can be missed); and the previously undocumented `--iq-replay-rate fast` caveat -
fast replay never exercises the front end reacting to the decoder, which is why `-fa` results differ
between pacings.