### PR TITLE
fix(dsp): make the SPS hunt's dwell a net symbol budget false syncs cannot starve

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -294,7 +294,8 @@ Notes
   | 3 | 6000 | 4 | P25 Phase 2 (CQPSK), X2-TDMA |
   | 4 | 4800 | 2 | D-STAR |
 
-  A detected sync locks the active rate, level count, timing, and RTL-family channel profile. Passive analog monitoring
+  A sync that a protocol turns into decoded frames locks the active rate, level count, timing, and RTL-family channel
+  profile; a sync on its own does not (see the dwell note below). Passive analog monitoring
   (`-fA`) and already-framed M17 UDP input (`-fU`) are not frame-sync hunt candidates.
 - On RTL-family FSK input the decoder's symbol timing follows the hunt profile from the moment the hunt selects it. The
   matching front-end channel profile is requested asynchronously and is applied by the demod thread on its next block,
@@ -304,10 +305,13 @@ Notes
   rotation can therefore be missed entirely even though the same capture decodes under its native preset -- Auto
   converges on signals that persist, such as a control channel or a call of a few seconds, not on isolated short
   bursts. Name the narrower preset when you already know the mode and cannot afford the search.
-- What holds a profile is decoded frames, not detected syncs. The budget is spent by searching and refunded only when
-  frame handlers consume a pass worth of symbols, so a profile carrying real traffic is never rotated away from, while
-  the occasional sync that no protocol turns into a frame -- the permissive 4800/4 matchers produce these on signals
-  belonging to another profile -- neither holds the profile nor resets the dwell.
+- What holds a profile is decoded frames, not detected syncs. The dwell is a net budget: symbols spent searching for a
+  sync count against it, and symbols a frame handler consumes are credited back. A profile carrying real traffic sits at
+  zero, because a decoded frame costs hundreds of symbols and the next sync follows within a few. Credit is counted per
+  sync, and only once a handler reaches a frame's worth of symbols, so a matcher that recognises a marker and bails --
+  the permissive 4800/4 matchers produce these on signals belonging to another profile -- buys nothing however often it
+  fires, and the dwell does not depend on that cadence. A handler that does swallow a frame's worth on a sync no CRC
+  would accept still delays the hunt, in proportion to the symbols it took; frame sync cannot see a CRC verdict.
 - All three Auto entry points install the complete matrix above: CLI `-fa`, config `decode = "auto"`, and the
   interactive Auto choice select the same decoder set. Only `-fa` also resets the demodulator to C4FM and the audio
   layout to stereo; the config path leaves those to its `demod` and `dmr_mono` keys, and the interactive path to the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -299,11 +299,15 @@ Notes
 - On RTL-family FSK input the decoder's symbol timing follows the hunt profile from the moment the hunt selects it. The
   matching front-end channel profile is requested asynchronously and is applied by the demod thread on its next block,
   so the two are briefly out of step after every hunt step; decoding does not wait for the front end to catch up.
-- The hunt dwells on each candidate profile for a bounded number of buffer passes, so a full rotation over the five
-  profiles takes roughly six seconds at 48 kHz. A transmission that starts mid-rotation and lasts less than one
+- The hunt dwells on each candidate profile for a bounded budget of symbols searched for sync, so a full rotation over
+  the five profiles takes roughly six seconds at 48 kHz. A transmission that starts mid-rotation and lasts less than one
   rotation can therefore be missed entirely even though the same capture decodes under its native preset -- Auto
   converges on signals that persist, such as a control channel or a call of a few seconds, not on isolated short
   bursts. Name the narrower preset when you already know the mode and cannot afford the search.
+- What holds a profile is decoded frames, not detected syncs. The budget is spent by searching and refunded only when
+  frame handlers consume a pass worth of symbols, so a profile carrying real traffic is never rotated away from, while
+  the occasional sync that no protocol turns into a frame -- the permissive 4800/4 matchers produce these on signals
+  belonging to another profile -- neither holds the profile nor resets the dwell.
 - All three Auto entry points install the complete matrix above: CLI `-fa`, config `decode = "auto"`, and the
   interactive Auto choice select the same decoder set. Only `-fa` also resets the demodulator to C4FM and the audio
   layout to stereo; the config path leaves those to its `demod` and `dmr_mono` keys, and the interactive path to the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,6 +68,11 @@ is invertible), so those fixtures exercise the same code path but carry none of
 the original RF impairments. Where a genuine off-air I/Q recording exists (P25
 C4FM/CQPSK, NXDN48/96, dPMR) it is used directly.
 
+`DECODE_IQ_*_AUTO_HUNT` cases assert on an `SPS hunt:` rotation line rather than a decoded payload. The `dstar` (4 s)
+and `p25p2_cc` (2 s) fixtures are shorter than one full hunt rotation (~6 s at 48 kHz), so under `-fa` they cannot be
+expected to decode; what they can prove is that the hunt is not pinned on its starting profile, which is the defect
+those cases cover.
+
 Known gaps and caveats:
 
 - **ProVoice** and **X2-TDMA** have no usable public sample and are untested here.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,10 +40,12 @@ begins after the demodulator, this covers the DSP front end as well.
 ctest --preset dev-debug -L iq-decode --output-on-failure
 ```
 
-Each case asserts on a decoded payload field (NAC, WACN/SYS, colour code, RAN,
-callsign, site ID) rather than a sync count, so a silent framing or protocol
-regression fails the test instead of merely moving a counter. The whole set runs
-in about 7 seconds because I/Q replay defaults to `--iq-replay-rate fast`.
+Each decode case asserts on a decoded payload field (NAC, WACN/SYS, colour code,
+RAN, callsign, site ID) rather than a sync count, so a silent framing or protocol
+regression fails the test instead of merely moving a counter. The
+`DECODE_IQ_*_AUTO_HUNT` cases are the documented exception, described below. The
+whole set runs in about 7 seconds because I/Q replay defaults to
+`--iq-replay-rate fast`.
 
 Covered: P25 Phase 1 C4FM (control and voice), P25 Phase 1 CQPSK/LSM (control and
 voice, plus a two-ray simulcast-impaired control channel), P25 Phase 2, DMR

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -540,10 +540,19 @@ struct dsd_state {
      * Set when preamble detected; overridden if user specifies -xz. */
     int m17_polarity;
     /* Multi-rate sync hunting: cycle through symbol-rate candidates when no sync found.
-     * sps_hunt_counter: symbols searched without valid sync
+     * The hunt spends a symbol budget rather than counting sync attempts, because an
+     * isolated sync that no protocol turns into a frame must not buy the profile more
+     * time (see frame_sync_no_sync_sps_hunt()).
+     * sps_hunt_counter: symbols searched for sync since the budget was last reset
+     * sps_hunt_consumed: symbols frame handlers consumed over the same window; reaching
+     *   one no-sync pass means something is decoding here, and resets the budget
+     * sps_hunt_symbolcnt_mark: dsd_state::symbolcnt as getFrameSync() last returned, so
+     *   the next call can measure what the handler consumed in between
      * sps_hunt_idx: current rate/profile index
      * (0=4800/4-level, 1=2400/4-level, 2=9600/binary, 3=6000/4-level, 4=4800/binary) */
     int sps_hunt_counter;
+    int sps_hunt_consumed;
+    int sps_hunt_symbolcnt_mark;
     int sps_hunt_idx;
     int lastsynctype;
     int lastp25type;

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -543,15 +543,17 @@ struct dsd_state {
      * The hunt spends a symbol budget rather than counting sync attempts, because an
      * isolated sync that no protocol turns into a frame must not buy the profile more
      * time (see frame_sync_no_sync_sps_hunt()).
-     * sps_hunt_counter: symbols searched for sync since the budget was last reset
-     * sps_hunt_consumed: symbols frame handlers consumed over the same window; reaching
-     *   one no-sync pass means something is decoding here, and resets the budget
+     * sps_hunt_counter: symbols the search burned that no frame handler claimed. Symbols
+     *   spent looking for a sync count up; symbols a handler consumed on one sync are
+     *   debited back, floored at zero, so a profile carrying traffic sits at zero and a
+     *   profile matching nothing reaches its dwell. Zeroing this alone is a complete reset.
      * sps_hunt_symbolcnt_mark: dsd_state::symbolcnt as getFrameSync() last returned, so
-     *   the next call can measure what the handler consumed in between
+     *   the next call can measure what the handler consumed in between. Credit is per sync
+     *   and only counts once it reaches a frame's worth, which is what keeps the dwell
+     *   independent of how often an unproductive matcher fires.
      * sps_hunt_idx: current rate/profile index
      * (0=4800/4-level, 1=2400/4-level, 2=9600/binary, 3=6000/4-level, 4=4800/binary) */
     int sps_hunt_counter;
-    int sps_hunt_consumed;
     int sps_hunt_symbolcnt_mark;
     int sps_hunt_idx;
     int lastsynctype;

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -43,6 +43,7 @@
 #include <dsd-neo/runtime/frame_sync_hooks.h>
 #include <dsd-neo/runtime/shutdown.h>
 #include <dsd-neo/runtime/telemetry.h>
+#include <limits.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -1944,9 +1945,6 @@ frame_sync_maybe_auto_switch_modulation(const dsd_opts* opts, dsd_state* state, 
     }
 
     *lastt = 0;
-    if (state->carrier == 1) {
-        state->sps_hunt_counter = 0;
-    }
     if (opts->mod_cli_lock) {
         return;
     }
@@ -2733,6 +2731,11 @@ dsd_frame_sync_test_eval_window(dsd_opts* opts, dsd_state* state, const char* sy
 
 static void
 frame_sync_advance_sync_window(dsd_opts* opts, dsd_state* state, frame_sync_runtime_ctx* rt) {
+    /* One more symbol spent looking for a sync on this profile. Unlike synctest_pos this
+     * lives in dsd_state, so returning a sync does not hand the profile a fresh budget. */
+    if (state->sps_hunt_counter < INT_MAX) {
+        state->sps_hunt_counter++;
+    }
     if (rt->synctest_pos < 10200) {
         rt->synctest_pos++;
         return;
@@ -2930,17 +2933,52 @@ frame_sync_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* state) {
     }
 }
 
-void
+/** @brief Symbols a profile is owed before the hunt may leave it. */
+static int
+frame_sync_sps_hunt_dwell_symbols(const dsd_opts* opts, const dsd_state* state) {
+    int passes = dsd_frame_sync_sps_hunt_dwell_passes(opts, state);
+    if (passes < 1) {
+        passes = 1;
+    }
+    return passes * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
+}
+
+/**
+ * @brief Fold what the last frame handler consumed into the hunt's budget.
+ *
+ * Called on entry to getFrameSync(), where dsd_state::symbolcnt has advanced by exactly
+ * the symbols a protocol handler took since the previous return. A handler that consumed
+ * a whole no-sync pass is decoding something here, so the profile keeps its place; the
+ * eight dibits an unproductive sync costs never add up to that.
+ */
+static void
+frame_sync_sps_hunt_note_handler_consumption(dsd_state* state) {
+    const unsigned int delta = (unsigned int)state->symbolcnt - (unsigned int)state->sps_hunt_symbolcnt_mark;
+    const unsigned int pass = (unsigned int)DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
+    unsigned int consumed = (unsigned int)state->sps_hunt_consumed;
+    consumed = (delta >= pass || consumed >= pass - delta) ? pass : consumed + delta;
+    if (consumed >= pass) {
+        state->sps_hunt_counter = 0;
+        consumed = 0;
+    }
+    state->sps_hunt_consumed = (int)consumed;
+    state->sps_hunt_symbolcnt_mark = state->symbolcnt;
+}
+
+/** @brief Remember where the handler starts consuming, so the next call can measure it. */
+static void
+frame_sync_sps_hunt_mark_return(dsd_state* state) {
+    state->sps_hunt_symbolcnt_mark = state->symbolcnt;
+}
+
+int
 frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
     const int preserve_modulation = opts->mod_cli_lock ? 1 : 0;
-    if (state->carrier != 0) {
-        return;
-    }
-    state->sps_hunt_counter++;
-    if (state->sps_hunt_counter < dsd_frame_sync_sps_hunt_dwell_passes(opts, state)) {
-        return;
+    if (state->sps_hunt_counter < frame_sync_sps_hunt_dwell_symbols(opts, state)) {
+        return 0;
     }
     state->sps_hunt_counter = 0;
+    state->sps_hunt_consumed = 0;
 
     /* Generic modulation locks retain their demodulator while rotating equal-timing protocol gates. A P25p2-specific
      * lock retains whichever P25 profile was selected explicitly by the helper or by a CC retune. This keeps a known
@@ -2954,7 +2992,9 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
                        ? state->sps_hunt_idx
                        : (preserve_modulation ? frame_sync_sps_hunt_next_index_matching_timing(opts, state)
                                               : frame_sync_sps_hunt_next_index(opts, state));
+    const int previous_idx = state->sps_hunt_idx;
     frame_sync_apply_sps_hunt_profile(opts, state, next_idx, preserve_modulation);
+    return state->sps_hunt_idx != previous_idx;
 }
 
 double
@@ -3018,7 +3058,7 @@ frame_sync_no_sync_try_p25_release(dsd_opts* opts, dsd_state* state, time_t now)
 
 static int
 frame_sync_handle_no_sync_timeout(dsd_opts* opts, dsd_state* state, const frame_sync_runtime_ctx* rt, time_t now) {
-    if (state->lastsynctype == DSD_SYNC_P25P1_NEG || rt->synctest_pos < 1800) {
+    if (state->lastsynctype == DSD_SYNC_P25P1_NEG || rt->synctest_pos < DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS) {
         return 0;
     }
 
@@ -3027,7 +3067,7 @@ frame_sync_handle_no_sync_timeout(dsd_opts* opts, dsd_state* state, const frame_
         DSD_FPRINTF(stderr, "Sync: no sync\n");
     }
 
-    frame_sync_no_sync_sps_hunt(opts, state);
+    (void)frame_sync_no_sync_sps_hunt(opts, state);
     dsd_frame_sync_hook_p25_sm_vc_no_sync(opts, state);
     frame_sync_no_sync_try_p25_release(opts, state, now);
     dsd_frame_sync_hook_no_carrier(opts, state);
@@ -3087,6 +3127,7 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
     const double nowm = dsd_time_now_monotonic_s();
     frame_sync_maybe_tick_p25_trunk_sm(opts, state, now);
     frame_sync_apply_cli_mod_lock(opts, state);
+    frame_sync_sps_hunt_note_handler_consumption(state);
     frame_sync_ensure_enabled_sps_profile(opts, state);
 
     frame_sync_runtime_ctx rt;
@@ -3112,6 +3153,7 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
             int sync_type = frame_sync_eval_window(opts, state, &rt, now, nowm);
             if (sync_type != DSD_SYNC_NONE) {
                 g_unsynced_dmr_dump_symbols = 0;
+                frame_sync_sps_hunt_mark_return(state);
                 return sync_type;
             }
         }
@@ -3119,11 +3161,23 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
 
         if (dsd_exitflag_load() == 1) {
             dsd_request_shutdown(opts, state);
+            frame_sync_sps_hunt_mark_return(state);
             return DSD_SYNC_NONE;
         }
 
         frame_sync_advance_sync_window(opts, state, &rt);
         if (frame_sync_handle_no_sync_timeout(opts, state, &rt, now)) {
+            frame_sync_sps_hunt_mark_return(state);
+            return -1;
+        }
+
+        /* The timeout above is the usual trigger, but it needs 1800 matchless symbols
+         * inside one call. Syncs arriving more often than that -- the permissive 4800/4
+         * matchers do, on signals belonging to another profile entirely -- would otherwise
+         * keep the hunt from ever running. The budget spans calls, so they cannot. */
+        if (frame_sync_no_sync_sps_hunt(opts, state)) {
+            dsd_frame_sync_hook_no_carrier(opts, state);
+            frame_sync_sps_hunt_mark_return(state);
             return -1;
         }
     }

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -3082,6 +3082,21 @@ frame_sync_no_sync_try_p25_release(dsd_opts* opts, dsd_state* state, time_t now)
     }
 }
 
+/**
+ * @brief The accounting every no-sync return from getFrameSync() owes, in contract order.
+ *
+ * The P25 trunk SM counts VC no-sync passes and decides releases off these, and expects
+ * the VC no-sync note before the no-carrier teardown (the ordering is asserted in
+ * tests/dsp/test_frame_sync_internal_helpers.c). Both no-sync exits -- the timeout and
+ * the SPS hunt's budget exit -- go through here so they cannot drift apart (#393).
+ */
+static void
+frame_sync_no_sync_run_hooks(dsd_opts* opts, dsd_state* state, time_t now) {
+    dsd_frame_sync_hook_p25_sm_vc_no_sync(opts, state);
+    frame_sync_no_sync_try_p25_release(opts, state, now);
+    dsd_frame_sync_hook_no_carrier(opts, state);
+}
+
 static int
 frame_sync_handle_no_sync_timeout(dsd_opts* opts, dsd_state* state, const frame_sync_runtime_ctx* rt, time_t now) {
     if (state->lastsynctype == DSD_SYNC_P25P1_NEG || rt->synctest_pos < DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS) {
@@ -3094,9 +3109,7 @@ frame_sync_handle_no_sync_timeout(dsd_opts* opts, dsd_state* state, const frame_
     }
 
     (void)frame_sync_no_sync_sps_hunt(opts, state);
-    dsd_frame_sync_hook_p25_sm_vc_no_sync(opts, state);
-    frame_sync_no_sync_try_p25_release(opts, state, now);
-    dsd_frame_sync_hook_no_carrier(opts, state);
+    frame_sync_no_sync_run_hooks(opts, state, now);
     return 1;
 }
 
@@ -3204,10 +3217,13 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
          *
          * One pass is the smallest dwell frame_sync_sps_hunt_dwell_symbols() can return, so
          * the compare below is a necessary condition for the step and keeps the policy call
-         * out of the per-symbol path. */
+         * out of the per-symbol path.
+         *
+         * This is a no-sync exit like the timeout above and owes the P25 SM the same
+         * accounting, in the same order. */
         if (state->sps_hunt_counter >= DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS
             && frame_sync_no_sync_sps_hunt(opts, state)) {
-            dsd_frame_sync_hook_no_carrier(opts, state);
+            frame_sync_no_sync_run_hooks(opts, state, now);
             frame_sync_sps_hunt_mark_return(state);
             return -1;
         }

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -2944,24 +2944,44 @@ frame_sync_sps_hunt_dwell_symbols(const dsd_opts* opts, const dsd_state* state) 
 }
 
 /**
- * @brief Fold what the last frame handler consumed into the hunt's budget.
+ * @brief Debit what the last frame handler consumed from the hunt's budget.
  *
- * Called on entry to getFrameSync(), where dsd_state::symbolcnt has advanced by exactly
- * the symbols a protocol handler took since the previous return. A handler that consumed
- * a whole no-sync pass is decoding something here, so the profile keeps its place; the
- * eight dibits an unproductive sync costs never add up to that.
+ * Called on entry to getFrameSync(), where dsd_state::symbolcnt has advanced by exactly the
+ * symbols one protocol handler took since the previous return. The budget is a net count of
+ * symbols the search burned that no frame handler claimed. A profile carrying traffic sits
+ * at zero -- its handlers take a frame's worth between syncs that arrive a few symbols
+ * apart -- while a profile matching nothing spends its dwell at one symbol per symbol.
+ *
+ * Credit is per sync and floored at DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS. A handler that returns
+ * inside that did not decode a frame; it recognised a marker and bailed, and buys nothing.
+ * The floor is what keeps the rule independent of how often an unproductive matcher fires.
+ * Crediting an accumulator instead made the dwell a function of that cadence -- a matcher
+ * firing every few symbols, the shape an alternating bit-sync run on any other protocol
+ * presents, banked a refund faster than the search could spend the budget and pinned the
+ * profile for good (#388).
+ *
+ * A handler that does consume a frame's worth on a sync no CRC would accept is still
+ * credited, because frame sync cannot see a CRC verdict. What it buys is bounded by what it
+ * actually took rather than the whole budget, so it delays the hunt in proportion to the
+ * stream it swallowed instead of resetting it.
  */
 static void
 frame_sync_sps_hunt_note_handler_consumption(dsd_state* state) {
-    const unsigned int delta = (unsigned int)state->symbolcnt - (unsigned int)state->sps_hunt_symbolcnt_mark;
-    const unsigned int pass = (unsigned int)DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
-    unsigned int consumed = (unsigned int)state->sps_hunt_consumed;
-    consumed = (delta >= pass || consumed >= pass - delta) ? pass : consumed + delta;
-    if (consumed >= pass) {
-        state->sps_hunt_counter = 0;
+    unsigned int consumed = (unsigned int)state->symbolcnt - (unsigned int)state->sps_hunt_symbolcnt_mark;
+    if (consumed > (unsigned int)INT_MAX) {
+        /* symbolcnt went backwards, so an unrelated subsystem zeroed it rather than a
+         * handler having consumed 4 billion symbols (nxdn_reset_after_cac_fail(),
+         * initState() on an in-process restart). Credit nothing; the mark below re-anchors
+         * the measurement on the next call. */
         consumed = 0;
     }
-    state->sps_hunt_consumed = (int)consumed;
+    if (consumed >= (unsigned int)DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS) {
+        /* dsd_state::sps_hunt_counter only ever counts up from zero, so this is exact.
+         * Sites outside the hunt park a profile by zeroing it; the floor at zero means
+         * consumption measured across such a reset cannot drive it negative. */
+        const unsigned int counter = (unsigned int)state->sps_hunt_counter;
+        state->sps_hunt_counter = (int)(consumed >= counter ? 0U : counter - consumed);
+    }
     state->sps_hunt_symbolcnt_mark = state->symbolcnt;
 }
 
@@ -2973,12 +2993,11 @@ frame_sync_sps_hunt_mark_return(dsd_state* state) {
 
 int
 frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
-    const int preserve_modulation = opts->mod_cli_lock ? 1 : 0;
     if (state->sps_hunt_counter < frame_sync_sps_hunt_dwell_symbols(opts, state)) {
         return 0;
     }
     state->sps_hunt_counter = 0;
-    state->sps_hunt_consumed = 0;
+    const int preserve_modulation = opts->mod_cli_lock ? 1 : 0;
 
     /* Generic modulation locks retain their demodulator while rotating equal-timing protocol gates. A P25p2-specific
      * lock retains whichever P25 profile was selected explicitly by the helper or by a CC retune. This keeps a known
@@ -2993,8 +3012,15 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
                        : (preserve_modulation ? frame_sync_sps_hunt_next_index_matching_timing(opts, state)
                                               : frame_sync_sps_hunt_next_index(opts, state));
     const int previous_idx = state->sps_hunt_idx;
+    const int previous_mod = state->rf_mod;
     frame_sync_apply_sps_hunt_profile(opts, state, next_idx, preserve_modulation);
-    return state->sps_hunt_idx != previous_idx;
+    /* A repeated binary profile is a step too: frame_sync_apply_sps_hunt_profile() normalises
+     * dsd_state::rf_mod and resets the modulation vote state without the index moving, and the
+     * caller's sync window -- its level ring, its min/max, its history -- was captured under the
+     * old modulation. Say so, so the window is rebuilt rather than matched across the change.
+     * The two comparisons are exact: the helper mutates nothing else once it is past its own
+     * no-op guard. */
+    return state->sps_hunt_idx != previous_idx || state->rf_mod != previous_mod;
 }
 
 double
@@ -3171,11 +3197,16 @@ getFrameSync(dsd_opts* opts, dsd_state* state) {
             return -1;
         }
 
-        /* The timeout above is the usual trigger, but it needs 1800 matchless symbols
+        /* The timeout above is the usual trigger, but it needs a whole matchless pass
          * inside one call. Syncs arriving more often than that -- the permissive 4800/4
          * matchers do, on signals belonging to another profile entirely -- would otherwise
-         * keep the hunt from ever running. The budget spans calls, so they cannot. */
-        if (frame_sync_no_sync_sps_hunt(opts, state)) {
+         * keep the hunt from ever running. The budget spans calls, so they cannot.
+         *
+         * One pass is the smallest dwell frame_sync_sps_hunt_dwell_symbols() can return, so
+         * the compare below is a necessary condition for the step and keeps the policy call
+         * out of the per-symbol path. */
+        if (state->sps_hunt_counter >= DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS
+            && frame_sync_no_sync_sps_hunt(opts, state)) {
             dsd_frame_sync_hook_no_carrier(opts, state);
             frame_sync_sps_hunt_mark_return(state);
             return -1;

--- a/src/dsp/frame_sync_internal.h
+++ b/src/dsp/frame_sync_internal.h
@@ -11,6 +11,14 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Symbols one no-sync pass is worth.
+ *
+ * The no-sync timeout fires after this many consecutive matchless symbols, and the SPS
+ * hunt's dwell is a whole number of these (see dsd_frame_sync_sps_hunt_dwell_passes()).
+ */
+#define DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS 1800
+
 /** @brief One entry of the SPS hunt's rate/level table, indexed by dsd_state::sps_hunt_idx. */
 typedef struct {
     int symbol_rate_hz;
@@ -31,7 +39,8 @@ int frame_sync_best_nxdn_scaled_ham(const char* symbols10, int best_start);
 int frame_sync_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state);
 void frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx, int preserve_modulation);
 void frame_sync_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* state);
-void frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state);
+/** @brief Step the SPS hunt if the active profile has spent its symbol budget; 1 if it moved. */
+int frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state);
 double frame_sync_elapsed_seconds(double nowm, time_t now, double mono_stamp, time_t wall_stamp);
 void frame_sync_p25_slot_activity(const dsd_opts* opts, const dsd_state* state, time_t now, double nowm,
                                   double mac_hold, double ring_hold, double dt, int* left_active, int* right_active);

--- a/src/dsp/frame_sync_internal.h
+++ b/src/dsp/frame_sync_internal.h
@@ -19,6 +19,18 @@ extern "C" {
  */
 #define DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS 1800
 
+/**
+ * @brief Symbols a frame handler must consume on one sync for that sync to count as a frame.
+ *
+ * The SPS hunt credits a profile for symbols its handlers take (see
+ * frame_sync_no_sync_sps_hunt()), and this is what separates decoding from recognising a
+ * marker and bailing. It sits between the two costs it has to tell apart: above the 8
+ * dibits dispatch_m17.c skips on a bare preamble -- the only path in src/engine/dispatch
+ * that returns without reading a frame -- and below the 28 dibits of P25p1's TDU
+ * (processTDU(), the shortest frame any protocol here decodes).
+ */
+#define DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS    16
+
 /** @brief One entry of the SPS hunt's rate/level table, indexed by dsd_state::sps_hunt_idx. */
 typedef struct {
     int symbol_rate_hz;
@@ -39,7 +51,13 @@ int frame_sync_best_nxdn_scaled_ham(const char* symbols10, int best_start);
 int frame_sync_sps_hunt_next_index(const dsd_opts* opts, const dsd_state* state);
 void frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx, int preserve_modulation);
 void frame_sync_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* state);
-/** @brief Step the SPS hunt if the active profile has spent its symbol budget; 1 if it moved. */
+/**
+ * @brief Step the SPS hunt if the active profile has spent its symbol budget.
+ *
+ * @return 1 when the step changed the profile index or the modulation -- the caller's sync
+ *         window is then stale and must be rebuilt -- and 0 when the profile still owes
+ *         symbols, or when spending the budget left the timing and modulation untouched.
+ */
 int frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state);
 double frame_sync_elapsed_seconds(double nowm, time_t now, double mono_stamp, time_t wall_stamp);
 void frame_sync_p25_slot_activity(const dsd_opts* opts, const dsd_state* state, time_t now, double nowm,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7687,6 +7687,34 @@ add_test(
     COMMAND dsd-neo_test_frame_sync_internal_helpers
 )
 
+# SPS hunt progress across sync returns: false syncs must not pin the hunt, decoded
+# frames must hold their profile (issue #388).
+add_executable(
+    dsd-neo_test_frame_sync_sps_hunt_false_sync
+    dsp/test_frame_sync_sps_hunt_false_sync.c
+)
+if(DSD_HAS_RADIO)
+    target_compile_definitions(
+        dsd-neo_test_frame_sync_sps_hunt_false_sync
+        PRIVATE USE_RADIO
+    )
+endif()
+target_include_directories(
+    dsd-neo_test_frame_sync_sps_hunt_false_sync
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/dsp
+)
+target_link_libraries(
+    dsd-neo_test_frame_sync_sps_hunt_false_sync
+    PRIVATE
+        dsd-neo_dsp_private_test_support
+        ${DSD_NEO_TEST_MATH_LIB}
+        ${LIBSNDFILE_LIBRARIES}
+)
+add_test(
+    NAME FRAME_SYNC_SPS_HUNT_FALSE_SYNC
+    COMMAND dsd-neo_test_frame_sync_sps_hunt_false_sync
+)
+
 # Frame sync level-window estimator parity with the established sync scanner.
 add_executable(
     dsd-neo_test_frame_sync_level_window
@@ -8995,6 +9023,22 @@ if(DSD_HAS_RADIO)
         "Site ID \\[02\\]\\[002\\]"
     )
     dsd_neo_add_iq_decode_test(DECODE_IQ_M17 m17 -fz "SRC: N0CALL")
+
+    # Auto must not be pinned on its starting profile by syncs no protocol turns into a
+    # frame (issue #388). Both fixtures are shorter than one full hunt rotation, so the
+    # assertion is that the hunt moves, not that the capture decodes -- see docs/testing.md.
+    dsd_neo_add_iq_decode_test(
+        DECODE_IQ_DSTAR_AUTO_HUNT
+        dstar
+        "-fa -v 3"
+        "SPS hunt: trying 20 sps"
+    )
+    dsd_neo_add_iq_decode_test(
+        DECODE_IQ_P25P2_CC_AUTO_HUNT
+        p25p2_cc
+        "-fa -v 3"
+        "SPS hunt: trying 20 sps"
+    )
 
     # Restart safety: bootstrap + engine lifecycle twice inside one process, the
     # shape an embedding host (Android service, GUI shell) uses. Lives here

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -313,7 +313,7 @@ test_sps_hunt_profile_updates_timing(void) {
     opts.frame_dstar = 1;
     opts.mod_cli_lock = 1;
     state.sps_hunt_idx = 4;
-    state.sps_hunt_counter = 100;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
     state.samplesPerSymbol = 10;
     state.symbolCenter = 4;
     frame_sync_no_sync_sps_hunt(&opts, &state);
@@ -334,7 +334,7 @@ test_sps_hunt_profile_updates_timing(void) {
     opts.mod_gfsk = 1;
     state.rf_mod = 2;
     state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
-    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) - 1;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
     state.samplesPerSymbol = 10;
     state.symbolCenter = 4;
     state.min = -3.0f;
@@ -360,7 +360,7 @@ test_sps_hunt_profile_updates_timing(void) {
     opts.mod_c4fm = 1;
     state.rf_mod = 0;
     state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
-    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) - 1;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
     state.samplesPerSymbol = 10;
     state.symbolCenter = 4;
     state.min = -3.0f;
@@ -385,7 +385,7 @@ test_sps_hunt_profile_updates_timing(void) {
     opts.mod_p25p2_profile_lock = 1;
     state.rf_mod = 1;
     state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
-    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) - 1;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
     state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 6000, 0);
     state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
     state.min = -3.0f;
@@ -410,7 +410,7 @@ test_sps_hunt_profile_updates_timing(void) {
     opts.mod_p25p2_profile_lock = 1;
     state.rf_mod = 1;
     state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
-    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) - 1;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
     state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 4800, 0);
     state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
     state.min = -3.0f;
@@ -430,7 +430,7 @@ test_sps_hunt_profile_updates_timing(void) {
     opts.mod_qpsk = 1;
     state.rf_mod = 1;
     state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
-    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) - 1;
+    state.sps_hunt_counter = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
     state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 6000, 0);
     state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
     frame_sync_no_sync_sps_hunt(&opts, &state);
@@ -450,6 +450,55 @@ test_sps_hunt_profile_updates_timing(void) {
     assert(state.sps_hunt_idx == 3);
     assert(state.samplesPerSymbol == 20);
     assert(state.symbolCenter == 8);
+}
+
+/*
+ * The hunt's dwell is a symbol budget that survives sync returns (issue #388). A sync that
+ * raises carrier but yields no frame used to stop the hunt outright: it blocked the step and
+ * zeroed the dwell. Only symbols a frame handler actually consumes buy the profile more time.
+ */
+static void
+test_sps_hunt_budget_is_spent_in_symbols(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    reset(&opts, &state);
+    opts.frame_dmr = 1;
+    opts.frame_dstar = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    const int dwell = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
+
+    /* One symbol short of the budget the profile keeps its place. */
+    state.sps_hunt_counter = dwell - 1;
+    assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 0);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state.sps_hunt_counter == dwell - 1);
+
+    /* Carrier is not a veto. An unproductive sync raises it, and the hunt still steps. */
+    state.carrier = 1;
+    state.sps_hunt_counter = dwell;
+    assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 1);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
+    assert(state.sps_hunt_counter == 0);
+    assert(state.sps_hunt_consumed == 0);
+}
+
+/* Carrier no longer wipes the hunt's progress from the modulation-switch path. */
+static void
+test_carrier_does_not_reset_the_hunt_budget(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    reset(&opts, &state);
+    opts.frame_dmr = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_c4fm = 1;
+    state.carrier = 1;
+    state.sps_hunt_counter = 1234;
+
+    int lastt = 0;
+    for (int i = 0; i < 48; i++) {
+        frame_sync_maybe_auto_switch_modulation(&opts, &state, 24, &lastt);
+    }
+    assert(state.sps_hunt_counter == 1234);
 }
 
 static void
@@ -1682,6 +1731,8 @@ main(void) {
     test_sps_hunt_skips_disabled_protocol_rates();
     test_sps_hunt_profile_updates_timing();
     test_sps_hunt_reconciles_external_timing();
+    test_sps_hunt_budget_is_spent_in_symbols();
+    test_carrier_does_not_reset_the_hunt_budget();
     test_binary_profiles_override_unlocked_qpsk();
     test_four_level_profiles_reset_inherited_modulation();
     test_nxdn_variant_follows_active_profile();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -479,7 +479,6 @@ test_sps_hunt_budget_is_spent_in_symbols(void) {
     assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 1);
     assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
     assert(state.sps_hunt_counter == 0);
-    assert(state.sps_hunt_consumed == 0);
 }
 
 /* Carrier no longer wipes the hunt's progress from the modulation-switch path. */

--- a/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
+++ b/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
@@ -335,6 +335,11 @@ drive_hunt(const HuntCase* tc) {
 
     result.final_idx = state.sps_hunt_idx;
     free_state_buffers(&state);
+    if (result.stepped != tc->expect_step) {
+        DSD_FPRINTF(stderr, "%s: gap %d, handler %d -> stepped=%d after %ld symbols (%d syncs)\n", tc->label,
+                    tc->marker_gap, tc->handler_symbols, result.stepped, g_symbols_emitted, result.syncs_seen);
+    }
+    assert(result.stepped == tc->expect_step);
     return result;
 }
 
@@ -361,6 +366,64 @@ test_false_syncs_do_not_starve_the_hunt(void) {
     const long dwell_symbols = (long)DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS * 3;
     assert(r.symbols_at_step >= dwell_symbols);
     assert(r.symbols_at_step < dwell_symbols * 2);
+}
+
+/* #388, the density half: an unproductive matcher that fires every few symbols must not
+ * hold the profile any longer than one that fires every few hundred. A refund that
+ * accumulates across syncs makes the dwell a function of the false-sync cadence, so a
+ * dense matcher pins the profile forever while a sparse one does not. */
+static void
+test_dense_false_syncs_do_not_starve_the_hunt(void) {
+    /* An alternating bit-sync run matches the M17 preamble at nearly every offset, so a
+     * near-zero gap is the realistic shape here, not a contrived one. These span the cliff
+     * an accumulating refund put at gap = handler cost x dwell passes (8 x 3): below it the
+     * refund outran the budget and pinned the profile for good, above it the hunt stepped
+     * normally. The dwell must not know which side of that line the cadence fell on. */
+    static const int gaps[] = {0, 8, 16, 24, 40};
+
+    for (size_t i = 0; i < sizeof(gaps) / sizeof(gaps[0]); i++) {
+        const HuntCase tc = {
+            .label = "dense false syncs at 4800/4",
+            .marker = FALSE_SYNC_MARKER,
+            .marker_gap = gaps[i],
+            .handler_symbols = 8, /* dispatch_m17.c skipDibit(8): a preamble, never a frame */
+            .symbol_budget = 400000,
+            .expect_step = 1,
+        };
+        const HuntResult r = drive_hunt(&tc);
+
+        assert(r.syncs_seen > 10);
+        assert(r.stepped == 1);
+        assert(r.final_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+        /* The dwell the idle case gets, regardless of how often the matcher fired. */
+        const long dwell_symbols = (long)DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS * 3;
+        assert(r.symbols_at_step >= dwell_symbols);
+        assert(r.symbols_at_step < dwell_symbols * 2);
+    }
+}
+
+/* The floor is the whole of the density fix, so state where it sits. One symbol short of a
+ * frame's worth, at the densest cadence the stream can produce, is the worst case an
+ * unproductive matcher can present -- and it still gets exactly the idle dwell. */
+static void
+test_sub_frame_consumption_never_buys_dwell(void) {
+    const HuntCase tc = {
+        .label = "sub-frame handler at the densest cadence",
+        .marker = FALSE_SYNC_MARKER,
+        .marker_gap = 0,
+        .handler_symbols = DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS - 1,
+        .symbol_budget = 400000,
+        .expect_step = 1,
+    };
+    const HuntResult r = drive_hunt(&tc);
+
+    assert(r.stepped == 1);
+    assert(r.final_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    /* The budget is spent in searched symbols; symbols_at_step also counts what the
+     * handler swallowed, which at this cadence is nearly one per symbol searched. */
+    const long dwell_symbols = (long)DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS * 3;
+    assert(r.symbols_at_step >= dwell_symbols);
+    assert(r.symbols_at_step < dwell_symbols * 3);
 }
 
 /* The other side of the contract: a signal being decoded holds its profile. */
@@ -408,6 +471,8 @@ test_idle_rotation_period_is_unchanged(void) {
 int
 main(void) {
     test_false_syncs_do_not_starve_the_hunt();
+    test_dense_false_syncs_do_not_starve_the_hunt();
+    test_sub_frame_consumption_never_buys_dwell();
     test_consumed_frames_hold_the_profile();
     test_idle_rotation_period_is_unchanged();
     return 0;

--- a/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
+++ b/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
@@ -28,6 +28,7 @@
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/sync_calibration.h>
 #include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/runtime/frame_sync_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -286,11 +287,12 @@ init_auto_opts_state(dsd_opts* opts, dsd_state* state) {
 
 typedef struct {
     const char* label;
-    const char* marker;  /* sync marker injected into the stream ("" = never syncs) */
-    int marker_gap;      /* filler symbols between markers */
-    int handler_symbols; /* symbols the "protocol handler" consumes per returned sync */
-    long symbol_budget;  /* stop after this many symbols leave the source */
-    int expect_step;     /* 1 = the hunt must leave its starting profile */
+    const char* marker;                                  /* sync marker injected into the stream ("" = never syncs) */
+    int marker_gap;                                      /* filler symbols between markers */
+    int handler_symbols;                                 /* symbols the "protocol handler" consumes per returned sync */
+    long symbol_budget;                                  /* stop after this many symbols leave the source */
+    int expect_step;                                     /* 1 = the hunt must leave its starting profile */
+    void (*configure)(dsd_opts* opts, dsd_state* state); /* optional setup on top of the AUTO defaults */
 } HuntCase;
 
 typedef struct {
@@ -309,6 +311,9 @@ drive_hunt(const HuntCase* tc) {
     HuntResult result = {0, 0, 0, 0};
 
     init_auto_opts_state(&opts, &state);
+    if (tc->configure) {
+        tc->configure(&opts, &state);
+    }
     if (!init_state_buffers(&state)) {
         DSD_FPRINTF(stderr, "%s: failed to allocate frame-sync state buffers\n", tc->label);
         return result;
@@ -468,6 +473,80 @@ test_idle_rotation_period_is_unchanged(void) {
     assert(r.symbols_at_step < dwell_symbols + 200);
 }
 
+/* Frame-sync hook fakes that record the order they were called in. */
+static int g_hook_order = 0;
+static int g_vc_no_sync_order = 0;
+static int g_release_order = 0;
+static int g_no_carrier_order = 0;
+
+static void
+fake_p25_sm_vc_no_sync(dsd_opts* opts, const dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_vc_no_sync_order = ++g_hook_order;
+}
+
+static void
+fake_p25_sm_release(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_release_order = ++g_hook_order;
+}
+
+static void
+fake_no_carrier(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_no_carrier_order = ++g_hook_order;
+}
+
+/* A P25 voice channel the trunk SM has tuned, whose hangtime has already run out: the
+ * shape in which frame_sync_no_sync_try_p25_release() has a release to make. */
+static void
+configure_tuned_vc_past_hangtime(dsd_opts* opts, dsd_state* state) {
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->trunk_hangtime = 0;
+    state->last_vc_sync_time = 0;
+    state->last_vc_sync_time_m = 0.0;
+    state->p25_last_vc_tune_time = 0;
+    state->p25_last_vc_tune_time_m = 0.0;
+}
+
+/* #393: the budget exit is a no-sync exit like the timeout, so it owes the P25 SM the
+ * same accounting in the same order -- VC no-sync pass, release check, then no-carrier.
+ * Markers every 8 symbols keep the 1800-symbol timeout from ever arming, so only the
+ * budget exit can step here. */
+static void
+test_budget_exit_runs_the_no_sync_hooks(void) {
+    g_hook_order = 0;
+    g_vc_no_sync_order = 0;
+    g_release_order = 0;
+    g_no_carrier_order = 0;
+    dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){
+        .p25_sm_release = fake_p25_sm_release,
+        .p25_sm_vc_no_sync = fake_p25_sm_vc_no_sync,
+        .no_carrier = fake_no_carrier,
+    });
+
+    const HuntCase tc = {
+        .label = "budget exit hooks",
+        .marker = FALSE_SYNC_MARKER,
+        .marker_gap = 0,
+        .handler_symbols = 8,
+        .symbol_budget = 40000,
+        .expect_step = 1,
+        .configure = configure_tuned_vc_past_hangtime,
+    };
+    const HuntResult r = drive_hunt(&tc);
+    dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){0});
+
+    assert(r.stepped == 1);
+    assert(g_vc_no_sync_order > 0);
+    assert(g_release_order > g_vc_no_sync_order);
+    assert(g_no_carrier_order > g_release_order);
+}
+
 int
 main(void) {
     test_false_syncs_do_not_starve_the_hunt();
@@ -475,6 +554,7 @@ main(void) {
     test_sub_frame_consumption_never_buys_dwell();
     test_consumed_frames_hold_the_profile();
     test_idle_rotation_period_is_unchanged();
+    test_budget_exit_runs_the_no_sync_hooks();
     return 0;
 }
 

--- a/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
+++ b/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief SPS hunt progress across sync returns (issue #388).
+ *
+ * Under AUTO, permissive matchers on the 4800/4 profile return isolated syncs that no
+ * protocol ever turns into a frame. Each one used to pin the hunt twice over: it discarded
+ * the per-call `synctest_pos` that armed the no-sync timeout, and it raised `state->carrier`,
+ * which both blocked `frame_sync_no_sync_sps_hunt()` and zeroed the dwell counter. A signal
+ * sitting on any other profile could then never be found.
+ *
+ * These cases drive `getFrameSync()` the way `live_scanner_*()` in src/engine/engine.c does:
+ * every returned sync is "handled" by consuming symbols, exactly as a protocol dispatch
+ * handler consumes dibits. What separates a false sync from a real one is how many symbols
+ * the handler takes, so that is what the hunt is asked to measure.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/sync_patterns.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/core/time_format.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/dsp/sync_calibration.h>
+#include <dsd-neo/platform/sockets.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "dsd-neo/core/dibit.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "frame_sync_internal.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+/* An exact doubled M17 preamble: what AUTO accepts as a preamble marker, and the
+ * shape an alternating bit-sync run on any other protocol presents. */
+#define FALSE_SYNC_MARKER M17_PRE M17_PRE
+
+/* Symbol source: `gap` filler symbols, then the marker, repeating. A zero-length
+ * marker makes the stream pure filler (the idle case). */
+static const char* g_marker = "";
+static int g_marker_gap = 0;
+static int g_stream_pos = 0;
+static long g_symbols_emitted = 0;
+
+static void
+stream_reset(const char* marker, int gap) {
+    g_marker = marker ? marker : "";
+    g_marker_gap = gap;
+    g_stream_pos = 0;
+    g_symbols_emitted = 0;
+}
+
+static char
+stream_next_dibit(void) {
+    const int marker_len = (int)strlen(g_marker);
+    const int period = g_marker_gap + marker_len;
+    char dibit = '1';
+    if (period > 0) {
+        const int phase = g_stream_pos % period;
+        if (phase >= g_marker_gap) {
+            dibit = g_marker[phase - g_marker_gap];
+        }
+    }
+    g_stream_pos++;
+    g_symbols_emitted++;
+    return dibit;
+}
+
+dsd_socket_t
+Connect(char* hostname, int portno) { // NOLINT(misc-use-internal-linkage)
+    (void)hostname;
+    (void)portno;
+    return (dsd_socket_t)0;
+}
+
+int
+openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    return -1;
+}
+
+int
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    return 0;
+}
+
+void
+dsd_request_shutdown(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
+    (void)state;
+    (void)old_rate_hz;
+    (void)new_rate_hz;
+}
+
+int
+dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out,
+                          size_t out_size) { // NOLINT(misc-use-internal-linkage)
+    (void)timestamp;
+    (void)format;
+    return out ? DSD_SNPRINTF(out, out_size, "%s", "00:00:00") >= 0 : 0;
+}
+
+void
+printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+}
+
+void
+dsd_mark_cc_sync(dsd_state* state) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+}
+
+void
+dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+void
+write_symbol_capture_record(dsd_opts* opts, dsd_state* state, int dibit, float symbol, const dsd_dibit_soft_t* soft) {
+    (void)opts;
+    (void)state;
+    (void)dibit;
+    (void)symbol;
+    (void)soft;
+}
+
+uint8_t
+dmr_compute_reliability(const dsd_state* st, float sym) {
+    (void)st;
+    (void)sym;
+    return 255;
+}
+
+double
+pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
+    (void)mean_power;
+    return 0.0;
+}
+
+void
+lpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+hpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+pbf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+/* Mirrors the production slicer's bookkeeping: history push plus the symbol counter
+ * that src/dsp/dsd_symbol.c bumps on every getSymbol() path. */
+float
+getSymbol(dsd_opts* opts, dsd_state* state, int have_sync) { // NOLINT(misc-use-internal-linkage)
+    (void)opts;
+    (void)have_sync;
+
+    const char dibit = stream_next_dibit();
+    const float symbol = (dibit == '3') ? -3.0f : 3.0f;
+    dsd_symbol_history_push(state, symbol);
+    state->symbolcnt++;
+    return symbol;
+}
+
+static void
+free_state_buffers(dsd_state* state) {
+    free(state->dibit_buf);
+    free(state->dmr_payload_buf);
+    free(state->dmr_soft_buf);
+    free(state->symbol_history);
+    state->dibit_buf = NULL;
+    state->dmr_payload_buf = NULL;
+    state->dmr_soft_buf = NULL;
+    state->symbol_history = NULL;
+}
+
+static int
+init_state_buffers(dsd_state* state) {
+    state->dibit_buf = (int*)calloc(1000000U, sizeof(int));
+    state->dmr_payload_buf = (int*)calloc(1000000U, sizeof(int));
+    state->dmr_soft_buf = (dsd_dibit_soft_t*)calloc(1000000U, sizeof(dsd_dibit_soft_t));
+    state->symbol_history = (float*)calloc(DSD_SYMBOL_HISTORY_SIZE, sizeof(float));
+    if (!state->dibit_buf || !state->dmr_payload_buf || !state->dmr_soft_buf || !state->symbol_history) {
+        free_state_buffers(state);
+        return 0;
+    }
+    state->dibit_buf_p = state->dibit_buf + 200;
+    state->dmr_payload_p = state->dmr_payload_buf + 200;
+    state->dmr_soft_p = state->dmr_soft_buf + 200;
+    state->symbol_history_size = DSD_SYMBOL_HISTORY_SIZE;
+    state->symbol_history_head = 0;
+    state->symbol_history_count = 0;
+    return 1;
+}
+
+/* AUTO (-fa): every digital candidate enabled, C4FM pinned so the run stays
+ * deterministic (the hunt then rotates among equal-timing profiles). */
+static void
+init_auto_opts_state(dsd_opts* opts, dsd_state* state) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 96000;
+    opts->wav_decimator = 48000;
+    opts->mod_cli_lock = 1;
+    opts->mod_c4fm = 1;
+    opts->msize = 1;
+    opts->ssize = 128;
+    opts->frame_dstar = 1;
+    opts->frame_x2tdma = 1;
+    opts->frame_p25p1 = 1;
+    opts->frame_p25p2 = 1;
+    opts->frame_nxdn48 = 1;
+    opts->frame_nxdn96 = 1;
+    opts->frame_dmr = 1;
+    opts->frame_dpmr = 1;
+    opts->frame_provoice = 1;
+    opts->frame_ysf = 1;
+    opts->frame_m17 = 1;
+
+    state->rf_mod = 0;
+    state->p25_p2_active_slot = -1;
+    state->center = 0.0f;
+    state->min = -3.0f;
+    state->max = 3.0f;
+    state->lmid = -2.0f;
+    state->umid = 2.0f;
+    state->minref = -2.4f;
+    state->maxref = 2.4f;
+
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    const int demod_rate = dsd_opts_current_input_timing_rate(opts);
+    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, 4800, demod_rate);
+    state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+}
+
+typedef struct {
+    const char* label;
+    const char* marker;  /* sync marker injected into the stream ("" = never syncs) */
+    int marker_gap;      /* filler symbols between markers */
+    int handler_symbols; /* symbols the "protocol handler" consumes per returned sync */
+    long symbol_budget;  /* stop after this many symbols leave the source */
+    int expect_step;     /* 1 = the hunt must leave its starting profile */
+} HuntCase;
+
+typedef struct {
+    int stepped;
+    long symbols_at_step;
+    int syncs_seen;
+    int final_idx;
+} HuntResult;
+
+/* The engine's shape: getFrameSync() in a loop, each sync handed to a handler that
+ * consumes symbols, until the hunt steps or the symbol budget runs out. */
+static HuntResult
+drive_hunt(const HuntCase* tc) {
+    static dsd_opts opts;
+    static dsd_state state;
+    HuntResult result = {0, 0, 0, 0};
+
+    init_auto_opts_state(&opts, &state);
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "%s: failed to allocate frame-sync state buffers\n", tc->label);
+        return result;
+    }
+    const int start_idx = state.sps_hunt_idx;
+    stream_reset(tc->marker, tc->marker_gap);
+    dsd_frame_sync_reset_mod_state();
+
+    while (g_symbols_emitted < tc->symbol_budget) {
+        const int sync = getFrameSync(&opts, &state);
+        if (state.sps_hunt_idx != start_idx) {
+            result.stepped = 1;
+            result.symbols_at_step = g_symbols_emitted;
+            break;
+        }
+        if (sync == DSD_SYNC_NONE) {
+            continue;
+        }
+        result.syncs_seen++;
+        for (int i = 0; i < tc->handler_symbols; i++) {
+            (void)getSymbol(&opts, &state, 1);
+        }
+    }
+
+    result.final_idx = state.sps_hunt_idx;
+    free_state_buffers(&state);
+    return result;
+}
+
+/* #388: isolated syncs that no handler turns into a frame must not pin the hunt. */
+static void
+test_false_syncs_do_not_starve_the_hunt(void) {
+    /* One marker per ~300 symbols is far more often than the 1800-symbol no-sync
+     * timeout, so before the fix the timeout never armed and the hunt never ran. */
+    const HuntCase tc = {
+        .label = "false syncs at 4800/4",
+        .marker = FALSE_SYNC_MARKER,
+        .marker_gap = 284,
+        .handler_symbols = 8, /* what an M17 preamble costs: dispatch_m17.c skipDibit(8) */
+        .symbol_budget = 40000,
+        .expect_step = 1,
+    };
+    const HuntResult r = drive_hunt(&tc);
+
+    assert(r.syncs_seen > 10);
+    assert(r.stepped == 1);
+    assert(r.final_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    /* The hunt owes the profile one full dwell before it may leave, and must not
+     * need much more than that. */
+    const long dwell_symbols = (long)DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS * 3;
+    assert(r.symbols_at_step >= dwell_symbols);
+    assert(r.symbols_at_step < dwell_symbols * 2);
+}
+
+/* The other side of the contract: a signal being decoded holds its profile. */
+static void
+test_consumed_frames_hold_the_profile(void) {
+    /* Same marker, same cadence -- only the handler's appetite differs. A protocol
+     * reading real frames consumes far more than it searches (NXDN96 spends 182
+     * symbols per frame, P25p1 408, M17 184). */
+    const HuntCase tc = {
+        .label = "decoded frames at 4800/4",
+        .marker = FALSE_SYNC_MARKER,
+        .marker_gap = 84,
+        .handler_symbols = 400,
+        .symbol_budget = 60000,
+        .expect_step = 0,
+    };
+    const HuntResult r = drive_hunt(&tc);
+
+    assert(r.syncs_seen > 50);
+    assert(r.stepped == 0);
+    assert(r.final_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+}
+
+/* No signal at all: the rotation period is the one docs/cli.md documents. */
+static void
+test_idle_rotation_period_is_unchanged(void) {
+    const HuntCase tc = {
+        .label = "idle hunt",
+        .marker = "",
+        .marker_gap = 0,
+        .handler_symbols = 0,
+        .symbol_budget = 40000,
+        .expect_step = 1,
+    };
+    const HuntResult r = drive_hunt(&tc);
+
+    assert(r.syncs_seen == 0);
+    assert(r.stepped == 1);
+    /* Three no-sync passes of 1800 symbols, as before this change. */
+    const long dwell_symbols = (long)DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS * 3;
+    assert(r.symbols_at_step >= dwell_symbols);
+    assert(r.symbols_at_step < dwell_symbols + 200);
+}
+
+int
+main(void) {
+    test_false_syncs_do_not_starve_the_hunt();
+    test_consumed_frames_hold_the_profile();
+    test_idle_rotation_period_is_unchanged();
+    return 0;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
## Summary

Fixes consequence A of #388: under AUTO the SPS hunt performed **zero** rotations on `dstar`, `p25p2_cc` and `m17`, so
D-STAR (`4800_2`) and P25p2 (`6000_4`) could not be reached at all.

Two commits:

- `9dfb5461` moves the hunt's dwell from a per-call sync counter to a symbol budget carried in `dsd_state`, and drops
  the carrier gate.
- `da5fb2a7` replaces the refund rule that commit shipped, which still let a *dense* false sync starve the hunt, and
  fixes three defects found reviewing the first commit.

Two independent mechanisms starve the hunt on `main`, both driven by syncs that no protocol turns into a frame:

1. **Per-call reset.** The hunt's only trigger was the no-sync timeout, gated on `synctest_pos`, which lives in the
   stack-allocated `frame_sync_runtime_ctx`. Every `return sync_type` threw that progress away, so a sync arriving more
   often than once per 1800 symbols meant the timeout never armed.
2. **Carrier gate.** `state->carrier` both blocked `frame_sync_no_sync_sps_hunt()` outright and zeroed the dwell counter
   from the modulation-switch path -- and carrier is raised by the *matchers* (`frame_sync_set_basic_lock()` from the
   M17 preamble; `nxdn_mark_carrier_sync_active()` after an 8-dibit LICH parity check), not by a decoded frame.
   `noCarrier()` runs only in the engine's outer loop (`engine.c:2422`), so carrier persists across the inner
   synced-frame loop.

The issue text retracts the carrier half. That retraction is wrong -- its premise (only `frame_sync_set_basic_lock()`
sets carrier) is right, but that helper has 26 call sites, one per accepted sync. Fixing only (1) would not have
restored rotation. Evidence in
[this comment](https://github.com/arancormonk/dsd-neo/issues/388#issuecomment-5464576735).

### Approach

The dwell is a **symbol budget carried in `dsd_state`** rather than a count of hunt calls, and the budget is a **net**
count of symbols the search burned that no frame handler claimed:

- `sps_hunt_counter` counts up once per symbol searched for sync, and survives sync returns.
- What a handler consumed on one sync is measured from a `symbolcnt` delta (`sps_hunt_symbolcnt_mark` is stamped at
  every `getFrameSync()` return) and **debited back**, floored at zero.
- Credit is per sync and gated on `DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS`. A handler that returns inside that recognised a
  marker and bailed rather than decoding a frame, and buys nothing.
- Carrier no longer gates the hunt. The idle rotation period is unchanged at three 1800-symbol passes per profile.

So a profile carrying traffic sits at zero -- its handlers take a frame's worth between syncs that arrive a few symbols
apart -- while a profile matching nothing spends its dwell at one symbol per symbol.

**Why the floor, and why not an accumulator.** `9dfb5461` accumulated consumption and, on reaching one no-sync pass,
zeroed the counter outright. Both halves of that are wrong. The accumulator makes the dwell a function of *how often*
the matcher fires, and the reset is an unbounded exchange -- any amount of search bought back for a fixed 1800 symbols.
A matcher firing more often than once per `dwell_passes * handler_cost` symbols banked the refund faster than the
search could spend the budget, and pinned the profile permanently. An alternating bit-sync run matches the M17 preamble
at nearly every offset, so that is the shape a real signal on another profile presents, not a contrived one. The
coupling also ran backwards: `dwell_passes = 5`, which this issue's own trunked-P25 scenario selects, made starvation
*easier*.

The floor sits between the two costs it has to tell apart: above the 8 dibits `dispatch_m17.c` skips on a bare preamble
-- the only path in `src/engine/dispatch` that returns without reading a frame -- and below the 28 dibits of P25p1's
TDU, the shortest frame any protocol here decodes.

Frame sync cannot see a CRC verdict, so a handler that *does* swallow a frame's worth on a sync no CRC would accept is
still credited. What it buys is now bounded by what it actually took rather than the whole budget. Tracked as #391.

The timeout keeps priority and its full hook ordering; the new per-symbol budget check sits after it and only fires when
syncs keep cutting passes short -- i.e. exactly the starvation case.

### Also fixed in `da5fb2a7`

Three defects in `9dfb5461`, found reviewing it:

- **`symbolcnt` is not monotonic.** `nxdn_reset_after_cac_fail()` zeroes it after 11 consecutive CAC CRC failures --
  the repeated-false-sync condition this issue is about -- and `initState()` does the same on an in-process restart.
  The unsigned delta wrapped to ~2^32 and granted a full refund. A backwards jump now credits nothing.
- **Stale sync window on a modulation-only step.** `frame_sync_apply_sps_hunt_profile()` normalises `rf_mod` and resets
  the modulation vote state without the index moving, on single-candidate profiles such as `-fd` and `-fp`. The old
  `return sps_hunt_idx != previous_idx` reported no step, so `getFrameSync()` kept matching a window whose level ring,
  min/max and history were captured under the previous modulation. The return now compares `rf_mod` too.
- **Per-symbol PLT chain.** The bottom-of-loop hunt call ran a two-deep non-inlinable call chain on *every* demodulated
  symbol to recompute a constant budget before an early return (`frame_sync_policy.c` is a separate TU and LTO is off
  in `dev-debug`). A counter compare against one no-sync pass -- the smallest dwell the policy can return -- now guards
  it.

### Also fixed after review: #393

The SPS hunt's budget exit is a no-sync return from `getFrameSync()` like the timeout, but it ran only
`dsd_frame_sync_hook_no_carrier()`. It now goes through the same three-step sequence as the timeout -- VC no-sync pass,
P25 release check, then no-carrier -- via one shared helper (`frame_sync_no_sync_run_hooks()`), so the two exits cannot
drift apart again. `FRAME_SYNC_SPS_HUNT_FALSE_SYNC` gains `test_budget_exit_runs_the_no_sync_hooks`: markers every 8
symbols so the timeout can never arm, fake hooks recording call order, a tuned VC past its hangtime so the release path
is reachable; it asserts VC-no-sync < release < no-carrier. Verified red before the fix (`g_vc_no_sync_order > 0`
failed) and green after.

## Measured results

Hunt rotations under `-fa`, counting `SPS hunt: trying` lines (the startup `Decoding AUTO` notice is not a rotation):

| Fixture | `main` | this PR |
|---|---:|---:|
| `dstar` | 0 | 1 |
| `p25p2_cc` | 0 | 1 |
| `m17` | 0 | 3 |

Rotation is the whole of consequence A -- on `main` these profiles are never searched at all. None of the three
fixtures *decodes* under `-fa` at any commit, `main` included: they are shorter than one full rotation, which is why
the `DECODE_IQ_*_AUTO_HUNT` cases assert a rotation line rather than a payload (documented in `docs/testing.md`).

Native single-protocol presets are unaffected: **13 of the 15 `iq-decode` fixtures produce byte-identical output to
`main`** under their native preset. The two exceptions, `p25p1_c4fm_vc` and `p25p1_cqpsk_vc`, are nondeterministic
run-to-run **on `main` as well** (2-3 distinct outputs over 5 runs each), so they cannot be compared byte-wise in
either direction; both pass their `DECODE_IQ_*` payload assertions.

### Off-air P25 LSM control channel (added after review, 2026-08-29)

A 119 s off-air capture of a live P25 Phase 1 CQPSK/LSM control channel (769.76875 MHz, NAC 006, RTL-SDR at
1.536 MS/s cu8, 0 drops) replayed through `main` and this PR, three runs per cell, counting `TSBK` lines and
`SPS hunt: trying` lines:

| Mode | `main` TSBK | this PR TSBK | rotations `main` / PR |
|---|---:|---:|---|
| default preset (no `-f`) | 2885-2887 | 2882-2887 | 0 / 0 |
| `-ft`, `-f1`, and each with `-T` | 2885-2887 | 2882-2887 | 0 / 0 |
| **`-fa`** | 580-583 | **432-519** | 0 / **15-20** |

Every mode but `-fa` is unchanged within the same run-to-run jitter `main` shows. A live `-T` run against the same site
(180 s, 10 VC tunes, 9 releases, 131 P25p2 MACs) had no rotation on the control channel; its three rotations were all on
a voice channel after the call's TDULC terminator, via the timeout path with the full P25 SM hooks
(`[P25 SM] frame-sync-no-sync`), which is `main`'s behaviour on a dead channel too.

**`-fa` is a second measured regression on a live control channel: -11% to -26% TSBKs (mean -17%).** The hunt leaves
the control channel three to four times per two minutes, each excursion ~4.8 s across the other four profiles. The
mechanism is the design's stated trade-off, not an accounting fault -- verified with a temporary per-entry trace that
the counter is charged exactly one symbol per symbol searched and credited exactly what the handler consumed:

- Under `-fa` on this signal the M17 preamble and NXDN96 matchers fire ~955 times per 120 s **on `main` as well**
  (505 `+M17`, 211 `-M17`, 239 `NXDN96`), which is why `main` itself decodes only 583 of the ~2887 TSBKs the default
  preset gets. Their modulation votes flap the demodulator, and P25p1 syncs then arrive with failing NIDs:
  876 `duid:EE` against 583 `TSBK` on `main` under `-fa`, versus 0 under the default preset.
- Measured handler consumption on one sync: TSBK handler **134** symbols of a 180-symbol TSDU slot, LDU **840**,
  TDULC **192**, failed NID **33**. A decoded 1-TSBK TSDU therefore nets -88 (clipped at zero), a failed-NID frame
  +114 and a missed frame +180, so a P25p1 control channel breaks even at roughly 45% NID failures or 33% missed
  frames. Under `-fa` this channel runs at ~60% failures, and every run of failures longer than the 5400-symbol dwell
  is a rotation.

The same missing per-protocol productivity signal that #391 describes for the opposite direction (false credit) is
the fix here (false charge); the matcher side is #398 (NXDN) and #399 (M17). Tracked as #400.

## What this deliberately does not do

Consequence B of #388 is **not** caused by NXDN false syncs, so no matcher was touched and the NXDN 5-variant matcher
is left alone. Instrumenting `frame_sync_try_m17_preamble()` on `m17.iq.json`: under `-fa` it is evaluated 4000x on the
correct profile and accepts **0**; under `-fz` it accepts **23** in its first 2000 evaluations despite a *less*
alternating stream. The difference is entirely AUTO's acceptance rule (`max_hamming = 0` plus a required repeated
marker) rather than stream availability -- and M17 is tried 4th vs NXDN 10th, so NXDN cannot pre-empt an acceptable
preamble. Full evidence in the issue comment above. B is an AUTO M17 *acquisition* question, now split out as **#399**
-- the same rule that accepts nothing on `m17.iq.json` accepts 57 false preambles on `dstar.iq.json`, so it is
discriminating on the wrong axis and relaxing it toward the `-fz` rule is not safe.

**#388 therefore stays open on merge** -- it documents both consequences and only A is addressed here, so this PR
carries `Refs`, not `Fixes`.

### Follow-ups filed

Review of both commits produced seven issues, none of them blocking:

| Issue | |
|---|---|
| #391 | An unproductive handler that consumes a frame's worth still buys dwell (D-STAR 1992/2652, EDACS 1920, all pre-CRC) |
| #392 | Dispatch gates that consume no symbols let the hunt rotate off a just-tuned channel (the mirror image of #388) |
| #393 | This PR's new no-sync exit omits the paired P25 SM no-sync hooks -- **fixed in this PR** (third commit, see below) |
| #394 | `frame_sync_ensure_enabled_sps_profile()` adopts a profile without resetting its dwell |
| #395 | `dsd_state::symbolcnt` is a signed `int` that overflows during ordinary uptime (pre-existing on `main`) |
| #396 | The hunt unit suite sets `mod_cli_lock`, so it never exercises the `-fa` rotation it documents |
| #397 | The frame-sync DSP link-stub block is duplicated across five test files |
| #399 | Consequence B of #388, split out: M17 never acquires under `-fa` on its own profile |
| #398 | NXDN/dPMR false-detect on noise at low squelch (field report; constrains #391's proposed fix) |
| #400 | Under `-fa` the hunt leaves a live P25 control channel when matcher false syncs degrade it (-17% TSBKs off-air; measured after review) |

#392 was the one worth a look before merge (it can affect a live call; verified benign against a live site, see
*Measured results*), and #393 is now fixed here. #389 also has a
[comment](https://github.com/arancormonk/dsd-neo/issues/389#issuecomment-5465355005): this PR's new trigger does not
consult the `DSD_SYNC_P25P1_NEG` carve-out, which inverts that issue's conclusion rather than leaving it intact.

## Review

- [ ] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / **none**. Change is confined to the DSP frame-sync hunt policy; no security, workflow, release, crypto, dependency or network-input surface.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

> Authored by Claude Code. The three human-review boxes are left unchecked deliberately — maintainer review is pending
> and I cannot check them on a reviewer's behalf.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. *(None added.)*
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` -- **568/568 passed**
- [x] `tools/preflight_ci.sh` -- exit 0; IWYU `suggested=0 fatal=0`, gcc `-fanalyzer` 0 diagnostics, cppcheck passed, `ARCH_RULES: OK`
- [x] `tools/quality_preflight.sh` for broad or high-risk changes -- exit 0 (adds scan-build, OSV, gitleaks, zizmor, fuzz smoke)
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes -- no workflow changes (ran anyway via `quality_preflight.sh`)
- [ ] `tools/osv_scan.sh` for dependency input changes -- no dependency changes (ran anyway via `quality_preflight.sh`)
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` -- all run by preflight

Also re-ran the whole suite under `asan-ubsan-debug`: **568/568**, no sanitizer reports.

### Test changes

- `tests/dsp/test_frame_sync_sps_hunt_false_sync.c` (`FRAME_SYNC_SPS_HUNT_FALSE_SYNC`) drives `getFrameSync()` in an
  engine-shaped loop, handing each returned sync to a handler that consumes symbols.
  - **Sparse false syncs** (every ~300 symbols): the hunt never stepped before `9dfb5461` and steps within one dwell
    after it; the *same* marker at the *same* cadence holds the profile when the handler consumes a frame's worth;
    idle rotation is pinned at three passes.
  - **Dense false syncs** (`da5fb2a7`): the same 8-symbol handler at gaps 0, 8, 16, 24 and 40, spanning the cliff the
    accumulating refund put at `handler_cost * dwell_passes`. Verified red/green -- before `da5fb2a7`, gap 0 pinned the
    hunt for 400,008 symbols across 16,667 syncs; after it, every gap steps within one dwell.
  - **The floor itself**: one symbol short of a frame's worth, at the densest cadence the stream can produce.
  - A failed expectation now prints the cadence that produced it.
- Swept handler cost against gap (11 x 10) to confirm the boundary is the floor and nothing else: at 8 and 12 symbols
  per sync the hunt steps at every gap including 0, while at 400 and 1992 -- a real frame's worth -- it holds the
  profile at every gap.
- `DECODE_IQ_DSTAR_AUTO_HUNT` and `DECODE_IQ_P25P2_CC_AUTO_HUNT` cover it end to end. Both were confirmed to fail
  without `9dfb5461`, and were run 10x to confirm determinism.
- `test_frame_sync_internal_helpers.c` states the dwell in symbols rather than hunt calls (a deliberate contract
  change), and gains cases for carrier no longer vetoing a step or wiping the budget.

## Risk

- **Security/dependency impact:** none. No new dependencies, no parsing of untrusted input, no allocation changes.
- **CLI/UI behavior impact:** confined to multi-profile modes (`-fa`, `-ft`). Native single-protocol presets cannot
  rotate at all (`frame_sync_sps_hunt_next_index()` returns the current index when nothing else is a candidate) and are
  measurably unchanged. `docs/cli.md` states the net rule, its per-sync floor, and the limitation tracked as #391;
  `docs/testing.md` carves the two `AUTO_HUNT` cases out of the rule that every `iq-decode` case asserts on a payload
  field.
  **One measured regression, accepted by the maintainer:** `p25p1_cqpsk_cc_simulcast` under `-ft` drops from **11 real
  P25p1 decodes on `main` to 8** (`NAC/CC: 0D6` lines; deterministic over 5 runs), because the hunt now correctly
  rotates away from a marginal signal. `9dfb5461` alone dropped it to 6; the net refund in `da5fb2a7` recovers 2 of
  those 5, because every real frame is now credited back rather than having to reach an 1800-symbol threshold it never
  met. No threshold within this design can close the remaining gap -- the false-sync captures consume *more* than that
  real one, so consumption cannot separate them. The robust discriminator is per-protocol frame validation, which no
  reusable signal exists for today; that is #391. The `DECODE_IQ_P25P1_CQPSK_SIMULCAST_CC` regression test uses `-f1`
  and is unaffected.
  **A second, `-fa`-only regression** was measured after review on an off-air P25 LSM control channel: **-17% TSBKs**
  with 15-20 hunt rotations per two minutes, where `main` holds the profile. Numbers, mechanism and the live `-T`
  control run are in *Measured results*; tracked as #400. Every other mode measured identical to `main`.
- **Compatibility or packaging impact:** none externally. One `int` field is added to `dsd_state`
  (`sps_hunt_symbolcnt_mark`, `include/dsd-neo/core/state.h`), which is built from source with the rest of the tree; no
  packaging or config format changes. `9dfb5461` added two; `da5fb2a7` removes `sps_hunt_consumed` along with the
  accumulator it served.

Refs #388.
Fixes #393.


