### PR TITLE
fix(cli): stop announcing an NXDN CRC relaxation -F never performed

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -335,7 +335,8 @@ Notes
 - Disable DMR/dPMR/NXDN/M17 input filtering: `-l`
 - Analog filter bitmap (advanced): `-v <hex>` (bitmask for HPF/LPF/PBF)
 - Modulation optimizations: `-ma` (auto), `-mc` (C4FM), `-mg` (GFSK), `-mq` (QPSK), `-m2` (P25p2 QPSK 6000 sps)
-- Relax CRC checks: `-F` (P25p2 MAC_SIGNAL, DMR RAS/CRC, NXDN SACCH/FACCH/CAC/F2U, M17 LSF/PKT)
+- Relax CRC checks: `-F` (P25p2 MAC_SIGNAL, DMR RAS/CRC, M17 LSF/PKT). No effect on NXDN, which always requires
+  CRC-verified content (see the NXDN note under "Modes & Decoders" above).
 - M17 signed voice-stream verification: `--m17-signature-public-key <hex>` accepts a 64-byte secp256r1 public key as
   raw `X||Y` hex.
 - P25p2 manual WACN/SYSID/CC: `-X <hex>` (e.g., `-X BEE00ABC123`)

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -1883,7 +1883,6 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
             LOG_INFO("NOTICE: %s", KYEL);                                                                              \
             LOG_INFO("NOTICE: Relax P25 Phase 2 MAC_SIGNAL CRC Checksum Pass/Fail\n");                                 \
             LOG_INFO("NOTICE: Relax DMR RAS/CRC CSBK/DATA Pass/Fail\n");                                               \
-            LOG_INFO("NOTICE: Relax NXDN SACCH/FACCH/CAC/F2U CRC Pass/Fail\n");                                        \
             LOG_INFO("NOTICE: Relax M17 LSF/PKT CRC Pass/Fail\n");                                                     \
             LOG_INFO("NOTICE: %s", KNRM);                                                                              \
             break;                                                                                                     \

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -275,7 +275,6 @@ dsd_cli_usage_section_advanced_decoder_options(void) {
     printf("  -F            Relax DMR RAS/CRC CSBK/DATA Pass/Fail\n");
     printf("                 Enabling on some systems could lead to bad channel assignments/site data decoding if bad "
            "or marginal signal\n");
-    printf("  -F            Relax NXDN SACCH/FACCH/CAC/F2U CRC Pass/Fail\n");
     printf("  -F            Relax M17 LSF/PKT CRC Error Checking\n");
     printf("\n");
     printf("      --show-keys  Reveal radio keys and keystream material in CLI/status output for this run.\n");

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -494,6 +494,64 @@ test_compatibility_short_options_use_current_facilities(void) {
     return test_rc;
 }
 
+/*
+ * -F relaxes the CRC gates that actually read the flag, and its startup notice names only those
+ * protocols. NXDN is deliberately absent: dsd-fme disabled its relaxed-CRC fallbacks in 449468f
+ * (2023-08-11) while fighting NXDN false syncs and never restored them, and nothing under
+ * src/protocol/nxdn/ reads aggressive_framesync. Announcing NXDN here sent the reporter of #398
+ * looking for a switch that does not exist, so this locks the notice to what the flag does.
+ */
+static int
+test_F_relaxes_crc_and_notice_omits_nxdn(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        DSD_FPRINTF(stderr, "out of memory\n");
+        return 1;
+    }
+    initOpts(opts);
+    initState(state);
+
+    char arg0[] = "dsd-neo";
+    char arg_F[] = "-F";
+    char* argv[] = {arg0, arg_F, NULL};
+
+    char output[2048];
+    int argc_effective = 0;
+    int exit_rc = -1;
+    int rc = parse_args_capture_stderr(2, argv, opts, state, &argc_effective, &exit_rc, output, sizeof(output));
+
+    int test_rc = 0;
+    if (rc != DSD_PARSE_CONTINUE) {
+        DSD_FPRINTF(stderr, "expected -F to continue, got rc=%d (exit_rc=%d)\n", rc, exit_rc);
+        test_rc = 1;
+    }
+    if (opts->aggressive_framesync != 0 || opts->dmr_crc_relaxed_default != 1) {
+        DSD_FPRINTF(stderr, "expected -F to relax CRC gating, got aggressive=%d dmr_relaxed=%u\n",
+                    (int)opts->aggressive_framesync, (unsigned)opts->dmr_crc_relaxed_default);
+        test_rc = 1;
+    }
+
+    static const char* const announced[] = {"Relax P25 Phase 2", "Relax DMR", "Relax M17"};
+    for (size_t i = 0; i < sizeof announced / sizeof announced[0]; i++) {
+        if (strstr(output, announced[i]) == NULL) {
+            DSD_FPRINTF(stderr, "expected -F notice to contain \"%s\", got \"%s\"\n", announced[i], output);
+            test_rc = 1;
+        }
+    }
+    if (strstr(output, "NXDN") != NULL) {
+        DSD_FPRINTF(stderr, "expected -F notice to omit NXDN (the flag does nothing there), got \"%s\"\n", output);
+        test_rc = 1;
+    }
+
+    freeState(state);
+    free(opts);
+    free(state);
+    return test_rc;
+}
+
 static int
 expect_numeric_parse_error(const char* option, const char* value) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
@@ -6776,6 +6834,7 @@ main(void) {
     rc |= test_bootstrap_cli_file_override_ignores_config_file_rate_timing();
     rc |= test_bootstrap_cli_file_override_uses_cli_rate_for_headerless_open();
     rc |= test_bootstrap_cli_rate_override_uses_cli_rate_for_headerless_open();
+    rc |= test_F_relaxes_crc_and_notice_omits_nxdn();
     return rc;
 }
 


### PR DESCRIPTION
Fixes #408.

## What

`-F` prints `Relax NXDN SACCH/FACCH/CAC/F2U CRC Pass/Fail`, and the same claim appears in `-h` (`usage.c`) and `docs/cli.md`. Nothing under `src/protocol/nxdn/` reads `opts->aggressive_framesync` — its consumers are DMR (`dmr_dburst.c`, `dmr_block.c`), P25 (`p25p1_mdpu.c`, `p25p2_xcch.c`) and M17 (`m17.c`). Every NXDN CRC gate is unconditional, so the flag is inert there.

This drops the claim from all three surfaces and adds CLI-layer coverage for what `-F` actually does.

## Was it dropped from the fork by accident?

No. Traced in dsd-fme (HEAD `198f0ea`):

| commit | date | change |
|---|---|---|
| `44ad75e` | 2023-03-02 | added live `else if (opts->aggressive_framesync == 0) NXDN_Elements_Content_decode(..., 0, ...)` fallbacks at FACCH1, SACCH-NSF, F2U, CAC and full SACCH |
| `20f0c85` | 2023-06-07 | commented out the SACCH-NSF fallback ("NXDN Frame Print Tweaks; #123") |
| `449468f` | 2023-08-11 | commented out all remaining fallbacks |
| `56b491e` | 2026-01-30 | soft-decision Viterbi rewrite; left them commented |

At upstream HEAD all four references (`nxdn_deperm.c:499,703,914`, `nxdn_element.c:49`) are still `//` comments, and upstream's own runtime notice is equally stale (its `-h` never listed NXDN). Upstream issue #123 is lwvmobile's NXDN false-sync write-up — 10-symbol FSW matching noise, one-bit LICH parity, "use squelch" — i.e. the context the relaxation was switched off in, and the same problem as #398 here.

Our import (`300644e9`) carried the already-commented lines; #95 deleted them as dead code, changing no behaviour. The fork then *widened* the stale claim: the `-h` line and the `docs/cli.md` bullet were added later, so the promise ended up in three places instead of one.

## Should we implement it instead?

No.

- #406 moved NXDN the other way: a frame must prove its content with a CRC before it refreshes a scan hold, synthesizes voice, publishes a RAN or opens a call record, because receiver noise clears both NXDN gates on an open squelch.
- NXDN's CRCs are short — SACCH 6-bit, SCCH 7-bit, FACCH1 12-bit, CAC 16-bit. Relaxing a 6-bit CRC that noise already clears about once every 64 frames means acting on data with no integrity check at all. P25p2 MAC_SIGNAL and DMR's RAS-masked CRCs have a rationale for relaxation; NXDN does not.
- This is precisely the #398 failure mode. That reporter was running `-F` and reasonably read the notice as the explanation for their fictional decodes.
- Even a print-only variant (the DMR rule: relaxed CRC prints but never parks the scan) would need per-handler gating across every `nxdn_element_dispatch_handler()` target — `NXDN_Elements_Content_decode()` stores `VCallCrcIsGood` but only a handful of consumers check it, while grant, site-info, adjacent-site and alias handlers run unconditionally. That is a large audit for a feature nobody asked for, on the one protocol where stricter is demonstrably better.

## Changes

- `src/runtime/cli/args.c` — drop the NXDN NOTICE line (P25p2/DMR/M17 lines unchanged).
- `src/runtime/cli/usage.c` — drop the NXDN `-F` help line.
- `docs/cli.md` — `-F` bullet now lists P25p2/DMR/M17 and states the flag has no effect on NXDN, pointing at the existing NXDN CRC-confirmation note under "Modes & Decoders".
- `tests/runtime/test_runtime_cli_parse.c` — new `test_F_relaxes_crc_and_notice_omits_nxdn()`: asserts `-F` sets `aggressive_framesync = 0` and `dmr_crc_relaxed_default = 1` (untested at the CLI layer until now), that the notice names P25p2, DMR and M17, and that it does not mention NXDN.

No behaviour change to any decoder.

## Verification

```
ctest --preset dev-debug -R '^RUNTIME_CLI_PARSE$' --output-on-failure   # passes
dsd-neo -h | grep -- '-F '                                             # three lines, no NXDN
dsd-neo -F -i /dev/null -o null 2>&1 | grep -i relax                   # three NOTICE lines, no NXDN
grep -rn 'NXDN SACCH/FACCH/CAC/F2U' src docs tests apps include         # empty
tools/preflight_ci.sh                                                  # clean
```

Negative control: restoring the NXDN NOTICE line makes the new test fail with `expected -F notice to omit NXDN`, so it is not vacuous.