### PR TITLE
fix: give the RTL squelch one off state, and report it as off

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,8 +68,7 @@ Tip: If you run with no arguments and no config is loaded, `dsd-neo` starts the 
   - `rtl:dev:freq:gain:ppm:bw:sql:vol[:bias[=on|off]]`
   - Examples: `rtl:0:851.375M:22:-2:24:0:2`, `rtl:1:450M:0:0:12:0:2`
   - `sql` is a power squelch in dB and is **off** when set to `0`, which is what the examples above use. The startup
-    banner then reads `SQ=-120.0dB`: −120 is the "no measurement" floor, not a threshold that was applied. Give a
-    negative value (`-60`) to actually gate on power.
+    banner and the terminal input line say so (`SQ=off`, `SQL: off`). Give a negative value (`-60`) to gate on power.
 - RTL‑TCP: `-i rtltcp[:host:port[:freq:gain:ppm:bw:sql:vol[:bias[=on|off]]]]`
 - SoapySDR: `-i soapy[:args[:freq[:gain[:ppm[:bw[:sql[:vol]]]]]]]`
 - TCP raw PCM16LE input (mono): `-i tcp[:host:port]` (bare `tcp` connects to `localhost:7355`; sample rate uses `-s`, default 48000)
@@ -412,7 +411,10 @@ Notes
 
 ## RTL‑SDR details (`-i rtl` / `-i rtltcp`)
 
-- Fields: `dev` (device index), `freq` (Hz/MHz), `gain` (0–49), `ppm`, `bw` (kHz: 4, 6, 8, 12, 16, 24, 48), `sql` (dB or linear), `vol` (monitor gain, 0–3; typical 1–3), optional `bias[=on|off]`.
+- Fields: `dev` (device index), `freq` (Hz/MHz), `gain` (0–49), `ppm`, `bw` (kHz: 4, 6, 8, 12, 16, 24, 48), `sql` (negative = threshold in dB, `0` = off, positive = linear mean power), `vol` (monitor gain, 0–3; typical 1–3), optional `bias[=on|off]`.
+- A `sql` value that is not a number leaves the squelch as it was rather than switching it off. A disabled squelch is
+  reported as `off` everywhere it is shown — the startup banner, the terminal input line, the DSP panel — so it is
+  never mistaken for a threshold gating at the −120 dB display floor.
 - For DMR data/LRRP on direct RTL input, use `bw=48` when possible, or at least `bw=24`; lower basebands may still decode voice but corrupt data PDUs.
 - Note: For EDACS analog voice follow, `sql <= 0` now uses a bounded fallback watchdog to avoid indefinite VC hold when no release marker is detected.
 - RTL USB, RTL-TCP, SoapySDR, and IQ replay digital decode run in the symbol domain. The digital decoder receives one

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -283,7 +283,7 @@ small subset is exposed as config keys for convenience (for example
 | `rtl_gain` | INT (0-49) | RTL-SDR gain in dB | `0` |
 | `rtl_ppm` | INT (-1000-1000) | Frequency correction | `0` |
 | `rtl_bw_khz` | INT (4-48) | DSP bandwidth | `48` |
-| `rtl_sql` | INT (-100-0) | Squelch level | `0` |
+| `rtl_sql` | INT (-100-0) | Squelch threshold in dB; `0` switches squelch off (a disabled squelch is saved as `0`) | `0` |
 | `rtl_volume` | INT (1-3) | RTL monitor/non-symbol gain multiplier | `2` |
 | `auto_ppm` | BOOL | Enable carrier/error-based RTL auto-PPM correction | `false` |
 | `rtl_auto_ppm` | BOOL | Deprecated read alias for `auto_ppm` | `false` |

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -347,7 +347,8 @@ The input section shows a persistent advisory line when recent input-level metri
 samples measured before demodulation. The line is advisory only; DSD-neo never changes input volume, RF gain, AGC, or
 filtering automatically.
 
-The default RTL input line shows the SQL threshold but does not duplicate channel power. Enable the DSP panel when you
+The default RTL input line shows the SQL threshold, reading `off` when the squelch is disabled, but does not
+duplicate channel power. Enable the DSP panel when you
 need to inspect post-channel-filter squelch power. `RF Level` and `Squelch` are measured at different stages and are not
 expected to match exactly.
 

--- a/include/dsd-neo/core/power.h
+++ b/include/dsd-neo/core/power.h
@@ -5,13 +5,16 @@
 
 /**
  * @file
- * @brief Mean power and dB conversion helpers.
+ * @brief Mean power and dB conversion helpers, and the RTL squelch contract.
  *
  * These helpers are used by the RTL squelch/VOX paths and UI displays.
  */
 
 #ifndef DSD_NEO_INCLUDE_DSD_NEO_CORE_POWER_H_H
 #define DSD_NEO_INCLUDE_DSD_NEO_CORE_POWER_H_H
+
+#include <math.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,6 +23,77 @@ extern "C" {
 double raw_pwr(const short* samples, int len, int step);
 double pwr_to_dB(double mean_power);
 double dB_to_pwr(double dB);
+
+/**
+ * @brief Whether a stored squelch threshold gates anything.
+ *
+ * A threshold of zero or below never closes the gate: every consumer tests
+ * `level > 0` before comparing channel power against it (see
+ * `demod_pipeline.cpp` and `dsd_frame_sync.c`). Displaying such a level as
+ * decibels reads as a very low threshold rather than as "not gating", which is
+ * exactly the confusion this predicate exists to prevent.
+ *
+ * @param mean_power Stored threshold in mean-power units.
+ * @return Non-zero when the squelch is off.
+ */
+static inline int
+dsd_squelch_is_off(double mean_power) {
+    return !(mean_power > 0.0);
+}
+
+/**
+ * @brief Map a user-facing `sql` setting onto a stored threshold.
+ *
+ * One definition for every entry point that accepts the setting: the `sql` field
+ * of an `rtl:`/`rtltcp:`/`soapy:` input string, the `[input] rtl_sql` config key,
+ * and the runtime squelch commands. Negative values are decibels, zero switches
+ * the squelch off, and a positive value is a linear mean power taken as given
+ * (the legacy CLI contract).
+ *
+ * The decibel branch is the same computation as dB_to_pwr(), inlined here so the
+ * runtime library — which does not link the core object that defines it — shares
+ * one implementation instead of keeping private copies.
+ *
+ * @param sql Setting as the user wrote it.
+ * @return Threshold in mean-power units; 0.0 when squelch is off.
+ */
+static inline double
+dsd_squelch_level_from_sql(double sql) {
+    if (!(sql < 0.0)) {
+        /* Zero is off, and a positive value is already a mean power. NaN lands
+         * here too, and off is the safe reading of a value that is not a number. */
+        return (sql > 0.0) ? sql : 0.0;
+    }
+    if (sql < -200.0) {
+        sql = -200.0; /* avoid denormals, matching dB_to_pwr() */
+    }
+    /* exp(dB * ln(10)/10) instead of pow(10, dB/10) to avoid generic pow overhead. */
+    const double kLn10_over_10 = 2.302585092994046 / 10.0;
+    double pwr = exp(sql * kLn10_over_10);
+    if (pwr < 0.0) {
+        pwr = 0.0;
+    }
+    if (pwr > 1.0) {
+        pwr = 1.0;
+    }
+    return pwr;
+}
+
+/**
+ * @brief Render a squelch threshold for display.
+ *
+ * Writes `off` when the threshold gates nothing, otherwise the level in decibels
+ * to one place followed by @p unit. The unit is the caller's so each surface
+ * keeps its own spacing for a real threshold ("dB" for `SQ=-47.0dB`, " dB" for
+ * `SQL: -47.0 dB`).
+ *
+ * @param mean_power Stored threshold in mean-power units.
+ * @param unit       Text appended after the number; may be empty, not NULL.
+ * @param out        Destination buffer.
+ * @param out_size   Capacity of @p out in bytes.
+ * @return 0 on success, -1 when @p out is NULL or @p out_size is zero.
+ */
+int dsd_squelch_format(double mean_power, const char* unit, char* out, size_t out_size);
 
 #ifdef __cplusplus
 }

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -19,6 +19,7 @@
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/frontend_types.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
@@ -1157,7 +1158,12 @@ ui_cmd_handle_rtl_set_sql_db(dsd_opts* opts, dsd_state* state, const struct dsd_
         int rc = svc_rtl_set_sql_db(opts, d);
         result = ui_cmd_apply_status_from_service_rc(rc);
         if (rc == 0) {
-            ui_set_toast(state, 3, "Applied: RTL squelch -> %.1f dB", d);
+            /* Report the threshold that was stored rather than the number that was
+             * asked for: a request of 0 dB switches the squelch off, and echoing
+             * "0.0 dB" would describe a gate at full scale instead. */
+            char sql[24];
+            (void)dsd_squelch_format(opts->rtl_squelch_level, " dB", sql, sizeof sql);
+            ui_set_toast(state, 3, "Applied: RTL squelch -> %s", sql);
         } else if (ui_rc_is_not_supported(rc)) {
             ui_set_toast(state, 3, "Unsupported: squelch control not available on active backend");
         } else {
@@ -1945,14 +1951,13 @@ apply_cfg_rtl_common(dsd_opts* opts, const dsdneoUserConfig* cfg) {
     if (cfg->rtl_bw_khz) {
         opts->rtl_dsp_bw_khz = cfg->rtl_bw_khz;
     }
-    if (cfg->rtl_sql) {
-        double sql = (double)cfg->rtl_sql;
-        if (sql > 1.0) {
-            sql /= (32768.0 * 32768.0);
-        }
-        opts->rtl_squelch_level = sql;
-        rtl_stream_set_channel_squelch((float)sql);
-    }
+    /* rtl_sql is the same setting the CLI `sql` field carries, so it converts the
+     * same way: negative is decibels, 0 is off. Storing the raw integer put a
+     * -50 dB request in as a power of -50, which switches the squelch off.
+     * Unlike the sibling keys below, 0 is a real value here rather than "key
+     * omitted", so this applies unconditionally — as the startup loader does. */
+    opts->rtl_squelch_level = dsd_squelch_level_from_sql((double)cfg->rtl_sql);
+    rtl_stream_set_channel_squelch((float)opts->rtl_squelch_level);
     if (cfg->rtl_gain) {
         opts->rtl_gain_value = cfg->rtl_gain;
     }

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -729,7 +729,11 @@ svc_rtl_set_sql_db(dsd_opts* opts, double dB) {
     if (!opts) {
         return -1;
     }
-    opts->rtl_squelch_level = dB_to_pwr(dB);
+    /* 0 dB is full scale, so as a threshold it would close the gate on every
+     * signal there is. Spending that value on "off" instead gives both UIs a way
+     * to switch the squelch off, and matches what 0 already means in the `sql`
+     * CLI field and the rtl_sql config key. */
+    opts->rtl_squelch_level = (dB >= 0.0) ? 0.0 : dsd_squelch_level_from_sql(dB);
     /* Sync the demod state for channel-based squelching */
     rtl_stream_set_channel_squelch((float)opts->rtl_squelch_level);
     return 0;

--- a/src/app_control/services.h
+++ b/src/app_control/services.h
@@ -182,7 +182,13 @@ int svc_rtl_set_freq(dsd_opts* opts, dsd_state* state, uint32_t hz);
 int svc_rtl_set_gain(dsd_opts* opts, dsd_state* state, int value);
 /** @brief Set RTL DSP baseband bandwidth (kHz: 4,6,8,12,16,24,48), clamping and restarting if needed. */
 int svc_rtl_set_bandwidth(dsd_opts* opts, dsd_state* state, int khz);
-/** @brief Set RTL squelch threshold in dB, converting to power units. */
+/**
+ * @brief Set the RTL squelch threshold from a decibel value.
+ *
+ * Negative values are a threshold in dB. Zero or above switches the squelch off,
+ * the same meaning 0 carries in the `sql` field of an input string and in the
+ * `rtl_sql` config key; a 0 dB threshold is full scale and would never open.
+ */
 int svc_rtl_set_sql_db(dsd_opts* opts, double dB);
 /** @brief Set RTL monitor/non-symbol gain multiplier (clamped to 0–3). */
 int svc_rtl_set_volume_mult(dsd_opts* opts, int mult);

--- a/src/core/util/dsd_misc.c
+++ b/src/core/util/dsd_misc.c
@@ -615,3 +615,24 @@ dB_to_pwr(double dB) {
     }
     return pwr;
 }
+
+/*
+ * Render a squelch threshold for display, saying "off" when it gates nothing.
+ *
+ * Kept next to pwr_to_dB() because it is that function's display counterpart for
+ * the one case pwr_to_dB() cannot express: its -120 dB result means both "a
+ * measurement of zero" and "a threshold that was never applied", and only the
+ * caller's context separates them. For a threshold, this function does.
+ */
+int
+dsd_squelch_format(double mean_power, const char* unit, char* out, size_t out_size) {
+    if (!out || out_size == 0U) {
+        return -1;
+    }
+    if (dsd_squelch_is_off(mean_power)) {
+        DSD_SNPRINTF(out, out_size, "off");
+        return 0;
+    }
+    DSD_SNPRINTF(out, out_size, "%.1f%s", pwr_to_dB(mean_power), unit ? unit : "");
+    return 0;
+}

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -500,11 +500,13 @@ dsd_engine_setup_parse_sql_token_or_default(const char* token, double fallback) 
         return fallback;
     }
     double sq_val = 0.0;
-    (void)dsd_parse_double_arg(token, &sq_val);
-    if (sq_val < 0.0) {
-        return dB_to_pwr(sq_val);
+    if (dsd_parse_double_arg(token, &sq_val) != 0) {
+        /* A token that is not a number says nothing about the squelch. Treating a
+         * failed parse as the zero left in sq_val switched the squelch off, which
+         * is a setting the user never asked for. */
+        return fallback;
     }
-    return sq_val;
+    return dsd_squelch_level_from_sql(sq_val);
 }
 
 static void
@@ -799,9 +801,11 @@ dsd_engine_setup_parse_soapy_input(dsd_opts* opts) {
         LOG_INFO("NOTICE: : default device args\n");
     }
     if (tuning_applied) {
-        LOG_INFO("NOTICE: SoapySDR tuning: Freq=%u Gain=%d PPM=%d DSP-BW=%dkHz SQ=%.1fdB VOL=%d\n",
-                 opts->rtlsdr_center_freq, opts->rtl_gain_value, opts->rtlsdr_ppm_error, opts->rtl_dsp_bw_khz,
-                 pwr_to_dB(opts->rtl_squelch_level), opts->rtl_volume_multiplier);
+        char sql[24];
+        (void)dsd_squelch_format(opts->rtl_squelch_level, "dB", sql, sizeof sql);
+        LOG_INFO("NOTICE: SoapySDR tuning: Freq=%u Gain=%d PPM=%d DSP-BW=%dkHz SQ=%s VOL=%d\n",
+                 opts->rtlsdr_center_freq, opts->rtl_gain_value, opts->rtlsdr_ppm_error, opts->rtl_dsp_bw_khz, sql,
+                 opts->rtl_volume_multiplier);
     }
     opts->rtltcp_enabled = 0;
     opts->audio_in_type = AUDIO_IN_RTL;
@@ -963,9 +967,11 @@ dsd_engine_setup_configure_local_rtl(dsd_opts* opts, dsd_state* state, char* ven
     if (opts->rtl_volume_multiplier > 3 || opts->rtl_volume_multiplier < 0) {
         opts->rtl_volume_multiplier = 1;
     }
-    LOG_INFO("NOTICE: RTL #%d: Freq=%d Gain=%d PPM=%d DSP-BW=%dkHz SQ=%.1fdB VOL=%d%s\n", opts->rtl_dev_index,
-             opts->rtlsdr_center_freq, opts->rtl_gain_value, opts->rtlsdr_ppm_error, opts->rtl_dsp_bw_khz,
-             pwr_to_dB(opts->rtl_squelch_level), opts->rtl_volume_multiplier, opts->rtl_bias_tee ? " BIAS=on" : "");
+    char sql[24];
+    (void)dsd_squelch_format(opts->rtl_squelch_level, "dB", sql, sizeof sql);
+    LOG_INFO("NOTICE: RTL #%d: Freq=%d Gain=%d PPM=%d DSP-BW=%dkHz SQ=%s VOL=%d%s\n", opts->rtl_dev_index,
+             opts->rtlsdr_center_freq, opts->rtl_gain_value, opts->rtlsdr_ppm_error, opts->rtl_dsp_bw_khz, sql,
+             opts->rtl_volume_multiplier, opts->rtl_bias_tee ? " BIAS=on" : "");
     opts->audio_in_type = AUDIO_IN_RTL;
     return 1;
 #else

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -5327,7 +5327,9 @@ setup_initial_freq_and_rate(dsd_opts* opts) {
     }
     dongle.dev_index = opts->rtl_dev_index;
     LOG_INFO("Setting DSP baseband to %d Hz\n", rtl_dsp_bw_hz);
-    LOG_INFO("Setting RTL Power Squelch Level to %.1f dB\n", pwr_to_dB(opts->rtl_squelch_level));
+    char sql[24];
+    (void)dsd_squelch_format(opts->rtl_squelch_level, " dB", sql, sizeof sql);
+    LOG_INFO("Setting RTL Power Squelch Level to %s\n", sql);
     port = 0;
     if (opts->rtl_udp_port != 0) {
         int p = opts->rtl_udp_port;

--- a/src/protocol/edacs/edacs-fme.c
+++ b/src/protocol/edacs/edacs-fme.c
@@ -498,7 +498,11 @@ edacs_print_analog_status(const dsd_opts* opts, const dsd_state* state, int afs,
     } else {
         DSD_FPRINTF(stderr, "%s", KRED);
     }
-    DSD_FPRINTF(stderr, " Analog PWR: %.1f dB SQL: %.1f dB", pwr_to_dB(pwr), pwr_to_dB(sql));
+    /* The measurement is always a number; the threshold says "off" when this
+     * channel is not being gated at all (the watchdog case below). */
+    char sql_text[24];
+    (void)dsd_squelch_format(sql, " dB", sql_text, sizeof sql_text);
+    DSD_FPRINTF(stderr, " Analog PWR: %.1f dB SQL: %s", pwr_to_dB(pwr), sql_text);
 
     if (state->ea_mode == 0) {
         int a = (afs >> state->edacs_a_shift) & state->edacs_a_mask;

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -149,7 +149,7 @@ dsd_cli_usage_section_radio_and_encoder(void) {
     printf("                   Note: This is the DSP baseband used to derive capture rate;\n");
     printf("                         it is NOT the tuner IF filter.\n");
     printf("  sq   <val>    RTL-SDR Squelch Threshold (Optional)\n");
-    printf("                 (Negative = dB; Positive/Zero = linear mean power)\n");
+    printf("                 (Negative = dB; 0 = off; Positive = linear mean power)\n");
     printf("  vol  <num>    RTL-SDR Sample 'Volume' Multiplier (default = 2)(1,2,3)\n");
     printf("  bias [on|off] Enable 5V bias tee on compatible dongles (default off)\n");
     printf(" Example: dsd-neo -fs -i rtl -C cap_plus_channel.csv -T\n");

--- a/src/runtime/config_user.cpp
+++ b/src/runtime/config_user.cpp
@@ -16,6 +16,7 @@
 #include <dsd-neo/core/frontend_types.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/parse.h>
+#include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/posix_compat.h>
@@ -169,26 +170,6 @@ local_pwr_to_dB(double mean_power) {
         dB = -120.0;
     }
     return dB;
-}
-
-// Local helper to convert dB to linear power (avoids dependency on dsd_misc.c)
-static double
-local_dB_to_pwr(double dB) {
-    if (dB >= 0.0) {
-        return 1.0;
-    }
-    if (dB < -200.0) {
-        dB = -200.0;
-    }
-    const double k_ln10_over_10 = 2.302585092994046 / 10.0;
-    double pwr = std::exp(dB * k_ln10_over_10);
-    if (pwr < 0.0) {
-        pwr = 0.0;
-    }
-    if (pwr > 1.0) {
-        pwr = 1.0;
-    }
-    return pwr;
 }
 
 void
@@ -410,11 +391,7 @@ apply_shared_radio_tuning_from_config(const dsdneoUserConfig* cfg, dsd_opts* opt
     opts->rtl_gain_value = gain;
     opts->rtlsdr_ppm_error = ppm;
     opts->rtl_dsp_bw_khz = bw;
-    if (sql < 0) {
-        opts->rtl_squelch_level = local_dB_to_pwr((double)sql);
-    } else {
-        opts->rtl_squelch_level = (double)sql;
-    }
+    opts->rtl_squelch_level = dsd_squelch_level_from_sql((double)sql);
     opts->rtl_volume_multiplier = vol;
 }
 
@@ -480,7 +457,10 @@ snapshot_apply_live_rtl_values(const dsd_opts* opts, dsdneoUserConfig* cfg) {
     cfg->rtl_ppm = opts->rtlsdr_ppm_error;
     cfg->rtl_ppm_is_set = 1;
     cfg->rtl_bw_khz = opts->rtl_dsp_bw_khz;
-    cfg->rtl_sql = (int)local_pwr_to_dB(opts->rtl_squelch_level);
+    /* Off is a setting in its own right, and 0 is how the CLI and the config key
+     * both spell it. Rendering it through pwr_to_dB() saved -120, which reloaded
+     * as a real threshold and is outside the key's own -100..0 range. */
+    cfg->rtl_sql = dsd_squelch_is_off(opts->rtl_squelch_level) ? 0 : (int)local_pwr_to_dB(opts->rtl_squelch_level);
     cfg->rtl_volume = opts->rtl_volume_multiplier;
     if (opts->rtlsdr_center_freq > 0) {
         DSD_SNPRINTF(cfg->rtl_freq, sizeof cfg->rtl_freq, "%u", opts->rtlsdr_center_freq);

--- a/src/runtime/input_spec.c
+++ b/src/runtime/input_spec.c
@@ -4,12 +4,12 @@
  */
 
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/freq_parse.h>
 #include <dsd-neo/runtime/input_spec.h>
 #include <errno.h>
 #include <limits.h>
-#include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -19,11 +19,6 @@
 static int
 is_valid_rtl_bw_khz(int bw) {
     return (bw == 4 || bw == 6 || bw == 8 || bw == 12 || bw == 16 || bw == 24 || bw == 48);
-}
-
-static double
-local_dB_to_pwr(double dB) {
-    return pow(10.0, dB / 10.0);
 }
 
 static int
@@ -235,7 +230,7 @@ parse_soapy_optional_tail(char* tok[SOFTY_TOK_MAX], size_t n, size_t* cur, doubl
         return -1;
     }
     if (rc > 0) {
-        *sql = (dv < 0.0) ? local_dB_to_pwr(dv) : dv;
+        *sql = dsd_squelch_level_from_sql(dv);
     }
 
     int iv = 0;

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -189,8 +189,11 @@ MetricsModel::fillDecoderView(View& next, const dsd_opts* opts_snapshot, const d
     next.tuner_gain_db = next.radio_input ? opts_snapshot->rtl_gain_value : 0;
     /* rtl_squelch_level is a mean-power threshold, not decibels — the same
      * conversion the engine's own status line uses. Publishing the raw value
-     * would put "0" on screen for a squelch of -120 dB. */
+     * would put "0" on screen for a squelch of -120 dB. A level that gates
+     * nothing is published separately, because pwr_to_dB() renders it as -120
+     * too and the panel would otherwise show a threshold that is not in force. */
     next.squelch_db = next.radio_input ? pwr_to_dB(opts_snapshot->rtl_squelch_level) : 0.0;
+    next.squelch_off = next.radio_input && dsd_squelch_is_off(opts_snapshot->rtl_squelch_level);
     next.ppm = next.radio_input ? opts_snapshot->rtlsdr_ppm_error : 0;
 }
 

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -75,6 +75,7 @@ class MetricsModel : public QObject {
     Q_PROPERTY(int modulation READ modulation NOTIFY controlChanged)
     Q_PROPERTY(int tunerGainDb READ tunerGainDb NOTIFY controlChanged)
     Q_PROPERTY(double squelchDb READ squelchDb NOTIFY controlChanged)
+    Q_PROPERTY(bool squelchOff READ squelchOff NOTIFY controlChanged)
     Q_PROPERTY(int ppm READ ppm NOTIFY controlChanged)
     Q_PROPERTY(QString uiMessage READ uiMessage NOTIFY uiMessageChanged)
 
@@ -259,6 +260,18 @@ class MetricsModel : public QObject {
     double
     squelchDb() const {
         return m_view.squelch_db;
+    }
+
+    /**
+     * @brief Whether the squelch is switched off rather than set low.
+     *
+     * squelchDb() bottoms out at the -120 dB display floor, which a threshold
+     * genuinely set that low shares with a squelch that is not gating at all.
+     * The panel needs to name the second case rather than print a number for it.
+     */
+    bool
+    squelchOff() const {
+        return m_view.squelch_off;
     }
 
     /**
@@ -517,6 +530,7 @@ class MetricsModel : public QObject {
         int modulation = 0;
         int tuner_gain_db = 0;
         double squelch_db = 0.0;
+        bool squelch_off = false;
         int ppm = 0;
         bool audio_muted = false;
         qulonglong held_tg = 0;
@@ -550,7 +564,8 @@ class MetricsModel : public QObject {
                    && enc_lockout_count == other.enc_lockout_count && tuner_controlled == other.tuner_controlled
                    && trunking_enabled == other.trunking_enabled && scanner_mode == other.scanner_mode
                    && decode_mode == other.decode_mode && modulation == other.modulation
-                   && tuner_gain_db == other.tuner_gain_db && squelch_db == other.squelch_db && ppm == other.ppm;
+                   && tuner_gain_db == other.tuner_gain_db && squelch_db == other.squelch_db
+                   && squelch_off == other.squelch_off && ppm == other.ppm;
         }
     };
 

--- a/src/ui/qt/qml/RadioSheet.qml
+++ b/src/ui/qt/qml/RadioSheet.qml
@@ -42,6 +42,10 @@ ModalSheet {
     readonly property int gainDb: isNaN(pendingGain) ? metrics.tunerGainDb : pendingGain
     readonly property int ppm: isNaN(pendingPpm) ? metrics.ppm : pendingPpm
     readonly property real squelchDb: isNaN(pendingSquelch) ? metrics.squelchDb : pendingSquelch
+    // Off is a state of its own, not a very low threshold: squelchDb bottoms out
+    // at the -120 dB display floor either way. A pending request speaks for
+    // itself, since 0 is what the engine reads as "switch it off".
+    readonly property bool squelchOff: isNaN(pendingSquelch) ? metrics.squelchOff : pendingSquelch >= 0
 
     // 0 dB is the tuner's automatic gain, not silence — worth saying, because
     // "0" next to a signal that vanished reads as a mistake otherwise.
@@ -102,19 +106,26 @@ ModalSheet {
     /**
      * Nudge the squelch. Coarse steps: this is a threshold, not a measurement.
      *
-     * The floor is the readback's own: pwr_to_dB() clamps what comes back at
-     * -120 dB, so a step below that submits a value the display can never show
-     * and the button reads as broken while still restating the threshold.
+     * Off sits one step below the floor. The floor itself is the readback's own:
+     * pwr_to_dB() clamps what comes back at -120 dB, so a threshold below that
+     * cannot be displayed. Stepping down from the floor therefore switches the
+     * squelch off — which the engine spells 0 — rather than pinning at a value
+     * the button can no longer move, and stepping up from off lands back on the
+     * floor. Above it, -5 dB is the last real threshold, because 0 is off.
      */
     function stepSquelch(delta) {
-        var next = squelchDb + delta
-        if (next < -120)
-            next = -120
-        if (next > 0)
+        var cur = squelchOff ? -125 : squelchDb
+        var next = cur + delta
+        if (next < -120) {
+            if (squelchOff)
+                return
             next = 0
+        } else if (next > -5) {
+            next = -5
+        }
         // The reading is a float that has been through dB_to_pwr and back, so
         // "already there" is a tolerance, not an equality.
-        if (Math.abs(next - squelchDb) < 0.001)
+        if (!squelchOff && Math.abs(next - squelchDb) < 0.001)
             return
         pendingSquelch = next
         squelchTtl.restart()
@@ -218,7 +229,7 @@ ModalSheet {
                 anchors.verticalCenter: parent.verticalCenter
                 width: 74
                 horizontalAlignment: Text.AlignRight
-                text: Math.round(sheet.squelchDb) + " dB"
+                text: sheet.squelchOff ? qsTr("off") : Math.round(sheet.squelchDb) + " dB"
                 font.family: Theme.mono
                 font.pixelSize: 14
                 color: Theme.textPrimary

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -367,7 +367,9 @@ ui_render_rtl_input_source(dsd_opts* opts, dsd_state* state) {
         ui_print_rtl_gain_field(opts);
         printw(" Mon: %iX;", opts->rtl_volume_multiplier);
         ui_print_rtl_ppm_field(opts);
-        printw(" SQL: %.1f dB;", pwr_to_dB(opts->rtl_squelch_level));
+        char sql[24];
+        (void)dsd_squelch_format(opts->rtl_squelch_level, " dB", sql, sizeof sql);
+        printw(" SQL: %s;", sql);
         printw(" DSP-BW: %i kHz;", opts->rtl_dsp_bw_khz);
         printw(" FRQ: %i;", opts->rtlsdr_center_freq);
         ui_print_rtl_auto_ppm_status();
@@ -566,7 +568,11 @@ ui_render_m17_encoder_status(const dsd_opts* opts, const dsd_state* state) {
             printw("  |");
         }
         if (opts->audio_in_type != AUDIO_IN_RTL && state->m17_vox == 1) {
-            printw(" SQL: %.1f : %.1f dB;", pwr_to_dB(opts->rtl_pwr), pwr_to_dB(opts->rtl_squelch_level));
+            /* Measured power then threshold: the first is always a reading, the
+             * second says "off" when it is not gating. */
+            char vox_sql[24];
+            (void)dsd_squelch_format(opts->rtl_squelch_level, " dB", vox_sql, sizeof vox_sql);
+            printw(" SQL: %.1f : %s;", pwr_to_dB(opts->rtl_pwr), vox_sql);
         }
         printw("\n");
     }

--- a/src/ui/terminal/menu_actions.c
+++ b/src/ui/terminal/menu_actions.c
@@ -1249,7 +1249,11 @@ rtl_set_bw(void* v) {
 void
 rtl_set_sql(void* v) {
     UiCtx* c = (UiCtx*)v;
-    ui_prompt_open_double_async("Squelch (dB, negative)", pwr_to_dB(c->opts->rtl_squelch_level), cb_rtl_sql, c);
+    /* Offer 0 for a squelch that is off rather than pwr_to_dB()'s -120 floor:
+     * accepting the value shown must not turn a disabled squelch into a real
+     * threshold. 0 is also how the `sql` CLI field and rtl_sql spell "off". */
+    const double shown = dsd_squelch_is_off(c->opts->rtl_squelch_level) ? 0.0 : pwr_to_dB(c->opts->rtl_squelch_level);
+    ui_prompt_open_double_async("Squelch (dB; 0 = off)", shown, cb_rtl_sql, c);
 }
 
 void

--- a/src/ui/terminal/menu_items.c
+++ b/src/ui/terminal/menu_items.c
@@ -121,7 +121,7 @@ static const NcMenuItem RTL_MENU_ITEMS[] = {
      .on_select = rtl_set_bw},
     {.id = "rtl.sql",
      .label = "Squelch (dB)...",
-     .help = "Post-filter squelch threshold in dB; more negative opens more.",
+     .help = "Post-filter squelch threshold in dB; more negative opens more; 0 switches squelch off.",
      .on_select = rtl_set_sql},
     /* 'v' is here as well as on Input > Input volume: the key drives whichever of the
        two multipliers matches the live input type, and on RTL that is this row. */

--- a/src/ui/terminal/ncurses_dsp_status_format.c
+++ b/src/ui/terminal/ncurses_dsp_status_format.c
@@ -13,8 +13,12 @@ ui_dsp_format_squelch_status(double channel_power, double squelch_power, char* o
     if (!out || out_size == 0U) {
         return -1;
     }
-    const int gate_closed = (squelch_power > 0.0 && channel_power < squelch_power);
+    const int gate_closed = (!dsd_squelch_is_off(squelch_power) && channel_power < squelch_power);
     const char* gate = gate_closed ? "Closed" : "Open";
-    DSD_SNPRINTF(out, out_size, "%s ch:%.1f dB sql:%.1f dB", gate, pwr_to_dB(channel_power), pwr_to_dB(squelch_power));
+    /* The threshold and the measurement are different things: a disabled threshold
+     * says so, while the channel power is always a reading and always a number. */
+    char sql[24];
+    (void)dsd_squelch_format(squelch_power, " dB", sql, sizeof sql);
+    DSD_SNPRINTF(out, out_size, "%s ch:%.1f dB sql:%s", gate, pwr_to_dB(channel_power), sql);
     return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4345,6 +4345,7 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--wrap=rtl_stream_stop"
             "-Wl,--wrap=rtl_stream_destroy"
             "-Wl,--wrap=rtl_stream_set_channel_squelch"
+            "-Wl,--wrap=rtl_stream_output_rate"
     )
 else()
     target_link_libraries(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1563,6 +1563,11 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}/src/ui/terminal
 )
 target_compile_definitions(dsd-neo_test_ui_menu_services PRIVATE USE_RADIO)
+# The squelch contract's dB conversion is a header inline over exp().
+target_link_libraries(
+    dsd-neo_test_ui_menu_services
+    PRIVATE ${DSD_NEO_TEST_MATH_LIB}
+)
 add_test(NAME UI_MENU_SERVICES COMMAND dsd-neo_test_ui_menu_services)
 
 if(DSD_ENABLE_TERMINAL_UI)
@@ -1917,6 +1922,12 @@ if(DSD_ENABLE_TERMINAL_UI)
             ${PROJECT_SOURCE_DIR}/include
             ${PROJECT_SOURCE_DIR}/src/app_control
             ${PROJECT_SOURCE_DIR}/src/ui/terminal
+    )
+    # USE_RADIO so the RTL rows (squelch among them) are compiled and testable.
+    target_compile_definitions(dsd-neo_test_ui_menu_actions PRIVATE USE_RADIO)
+    target_link_libraries(
+        dsd-neo_test_ui_menu_actions
+        PRIVATE ${DSD_NEO_TEST_MATH_LIB}
     )
     add_test(NAME UI_MENU_ACTIONS COMMAND dsd-neo_test_ui_menu_actions)
 
@@ -4315,6 +4326,12 @@ set(_DSD_RUNTIME_CONFIG_APPLY_LIBS
     ${_DSD_RUNTIME_CLI_PARSE_LIBS}
 )
 if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+    # The RTL hot restart replaces the stream, so a config re-apply is only
+    # reachable with the stream entry points wrapped.
+    target_compile_definitions(
+        dsd-neo_test_runtime_config_apply
+        PRIVATE DSD_NEO_TEST_RTL_WRAP=1
+    )
     target_link_libraries(
         dsd-neo_test_runtime_config_apply
         PRIVATE
@@ -4323,6 +4340,11 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
             "-Wl,--end-group"
             ${LIBS}
             dsd-neo_test_support
+            "-Wl,--wrap=rtl_stream_create"
+            "-Wl,--wrap=rtl_stream_start"
+            "-Wl,--wrap=rtl_stream_stop"
+            "-Wl,--wrap=rtl_stream_destroy"
+            "-Wl,--wrap=rtl_stream_set_channel_squelch"
     )
 else()
     target_link_libraries(

--- a/tests/core/test_core_misc_power_filters.c
+++ b/tests/core/test_core_misc_power_filters.c
@@ -10,8 +10,8 @@
 #include <dsd-neo/fec/trellis.h>
 #include <dsd-neo/fec/viterbi.h>
 #include <math.h>
-#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -73,6 +73,53 @@ test_power_helpers(void) {
 }
 
 static void
+test_squelch_contract_helpers(void) {
+    /* A stored threshold gates nothing when it is <= 0: this is the same test every
+     * consumer makes before comparing channel power against it. */
+    assert(dsd_squelch_is_off(0.0));
+    assert(dsd_squelch_is_off(-37.5));
+    assert(!dsd_squelch_is_off(dB_to_pwr(-47.0)));
+    assert(!dsd_squelch_is_off(1.0e-30));
+
+    /* The one mapping from a user-facing `sql` setting to a stored threshold:
+     * negative is dB, 0 is off, positive is linear mean power taken as given. */
+    assert(dsd_squelch_level_from_sql(0.0) == 0.0);
+    assert(fabs(dsd_squelch_level_from_sql(-47.0) - dB_to_pwr(-47.0)) < 1.0e-12);
+    assert(fabs(pwr_to_dB(dsd_squelch_level_from_sql(-47.0)) + 47.0) < 0.001);
+    assert(fabs(dsd_squelch_level_from_sql(-250.0) - dB_to_pwr(-250.0)) < 1.0e-12);
+    assert(dsd_squelch_level_from_sql(-250.0) >= 0.0);
+    assert(dsd_squelch_level_from_sql(0.25) == 0.25);
+
+    /* Display: "off" when it gates nothing, so a reader can tell a disabled squelch
+     * from one gating at an extremely low threshold. The unit is the caller's, so a
+     * real threshold keeps each surface's existing spacing. */
+    char out[32];
+    assert(dsd_squelch_format(0.0, "dB", out, sizeof out) == 0);
+    assert(strcmp(out, "off") == 0);
+    assert(dsd_squelch_format(-1.0, " dB", out, sizeof out) == 0);
+    assert(strcmp(out, "off") == 0);
+    assert(dsd_squelch_format(dB_to_pwr(-47.0), "dB", out, sizeof out) == 0);
+    assert(strcmp(out, "-47.0dB") == 0);
+    assert(dsd_squelch_format(dB_to_pwr(-47.0), " dB", out, sizeof out) == 0);
+    assert(strcmp(out, "-47.0 dB") == 0);
+    assert(dsd_squelch_format(1.0, " dB", out, sizeof out) == 0);
+    assert(strcmp(out, "0.0 dB") == 0);
+
+    /* A threshold so low that pwr_to_dB() floors it is still a threshold, and still
+     * prints as a number: only "gates nothing" reads as off. */
+    assert(dsd_squelch_format(1.0e-30, " dB", out, sizeof out) == 0);
+    assert(strcmp(out, "-120.0 dB") == 0);
+
+    assert(dsd_squelch_format(0.0, " dB", NULL, sizeof out) == -1);
+    assert(dsd_squelch_format(0.0, " dB", out, 0U) == -1);
+
+    char tiny[4];
+    assert(dsd_squelch_format(dB_to_pwr(-47.0), " dB", tiny, sizeof tiny) == 0);
+    assert(tiny[3] == '\0');
+    assert(strcmp(tiny, "-47") == 0);
+}
+
+static void
 test_audio_filter_helpers(void) {
     static dsd_state state;
     DSD_MEMSET(&state, 0, sizeof(state));
@@ -130,6 +177,7 @@ int
 main(void) {
     test_trellis_and_viterbi_helpers();
     test_power_helpers();
+    test_squelch_contract_helpers();
     test_audio_filter_helpers();
     return 0;
 }

--- a/tests/engine/test_engine_run_setup.c
+++ b/tests/engine/test_engine_run_setup.c
@@ -17,6 +17,7 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/io/rtl_stream_fwd.h"
+#include "test_support.h"
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -400,6 +401,39 @@ test_unavailable_radio_inputs_are_rejected(void) {
 #endif
 
 static int
+expect_contains(const char* tag, const char* haystack, const char* needle) {
+    if (strstr(haystack, needle) == NULL) {
+        DSD_FPRINTF(stderr, "%s failed: %s not in [%s]\n", tag, needle, haystack);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_omits(const char* tag, const char* haystack, const char* needle) {
+    if (strstr(haystack, needle) != NULL) {
+        DSD_FPRINTF(stderr, "%s failed: %s present in [%s]\n", tag, needle, haystack);
+        return 1;
+    }
+    return 0;
+}
+
+/* Run the setup with the startup banners captured, so what the user is told about
+ * the squelch is assertable and not merely inferred from the stored value. */
+static int
+run_lifecycle_capturing_banner(dsd_opts* opts, dsd_state* state, char* buf, size_t buf_size, int* rc_out) {
+    dsd_test_capture_stderr cap;
+    if (dsd_test_capture_stderr_begin(&cap, "engine_banner") != 0) {
+        return 1;
+    }
+    *rc_out = dsd_engine_run_with_lifecycle(opts, state, NULL);
+    if (dsd_test_capture_stderr_end(&cap) != 0) {
+        return 1;
+    }
+    return dsd_test_capture_stderr_read(&cap, buf, buf_size) != 0;
+}
+
+static int
 test_rtltcp_tuning_tokens_and_bias(void) {
     dsd_opts* opts = NULL;
     dsd_state* state = NULL;
@@ -462,6 +496,21 @@ test_rtltcp_invalid_and_partial_tuning_tokens(void) {
     if (init_test_runtime(&opts, &state) != 0) {
         return 1;
     }
+    /* An unparseable squelch token is not a request to switch the squelch off:
+     * the setting the session already had has to survive it. */
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "rtltcp:sql.example:1234:450M:11:0:24:loud:5");
+    opts->rtl_squelch_level = 0.25;
+    rc = dsd_engine_run_with_lifecycle(opts, state, NULL);
+    test_rc |= expect_true("rtltcp unparseable sql run ok", rc == 0);
+    test_rc |=
+        expect_double_near("rtltcp unparseable sql keeps previous threshold", opts->rtl_squelch_level, 0.25, 1e-12);
+    test_rc |= expect_true("rtltcp unparseable sql still parses volume", opts->rtl_volume_multiplier == 5);
+
+    free_test_runtime(opts, state);
+
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
     DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "rtltcp:short.example:7777:450M:11:bias=on");
     opts->rtl_bias_tee = 0;
     rc = dsd_engine_run_with_lifecycle(opts, state, NULL);
@@ -487,7 +536,12 @@ test_soapy_setup_normalizes_args_and_tuning(void) {
 
     DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s",
                  "soapy:driver=test,serial=ABC:450.5M:7:2:12:-33:3");
-    int rc = dsd_engine_run_with_lifecycle(opts, state, NULL);
+    char banner[4096] = {0};
+    int rc = 0;
+    if (run_lifecycle_capturing_banner(opts, state, banner, sizeof banner, &rc) != 0) {
+        free_test_runtime(opts, state);
+        return 1;
+    }
 
     int test_rc = 0;
     test_rc |= expect_true("soapy run ok", rc == 0);
@@ -497,6 +551,26 @@ test_soapy_setup_normalizes_args_and_tuning(void) {
                                                          && opts->rtlsdr_ppm_error == 2 && opts->rtl_dsp_bw_khz == 12
                                                          && opts->rtl_volume_multiplier == 3);
     test_rc |= expect_double_near("soapy squelch", opts->rtl_squelch_level, dB_to_pwr(-33.0), 1e-12);
+    test_rc |= expect_contains("soapy banner states the threshold", banner, "SQ=-33.0dB");
+
+    free_test_runtime(opts, state);
+
+    /* sql=0 is what every documented example uses, and it switches the squelch
+     * off. Reported as -120.0 dB it read as a threshold that had been applied,
+     * which is the confusion this case pins down. */
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "soapy:driver=test:450.5M:7:2:12:0:3");
+    banner[0] = '\0';
+    if (run_lifecycle_capturing_banner(opts, state, banner, sizeof banner, &rc) != 0) {
+        free_test_runtime(opts, state);
+        return 1;
+    }
+    test_rc |= expect_true("soapy disabled-squelch run ok", rc == 0);
+    test_rc |= expect_true("soapy sql=0 stores no threshold", opts->rtl_squelch_level == 0.0);
+    test_rc |= expect_contains("soapy banner names a disabled squelch", banner, "SQ=off");
+    test_rc |= expect_omits("soapy banner does not invent a threshold", banner, "SQ=-120");
 
     free_test_runtime(opts, state);
     return test_rc;

--- a/tests/runtime/test_runtime_config_apply.cpp
+++ b/tests/runtime/test_runtime_config_apply.cpp
@@ -545,6 +545,8 @@ test_output_config_without_frontend_preserves_active_frontend(void) {
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
 /* The RTL hot restart tears the stream down and builds a new one, so a config
  * re-apply can only be exercised with the stream calls faked out. */
+/* The fake stands in for a real RtlSdrContext, so nothing may dereference it:
+ * every entry point that would is wrapped below. */
 static int g_wrap_fake_ctx = 0;
 static float g_wrap_last_channel_squelch = -1.0f;
 
@@ -581,6 +583,14 @@ int
 __wrap_rtl_stream_set_channel_squelch(float level) {
     g_wrap_last_channel_squelch = level;
     return 0;
+}
+
+/* Read back off the context after a restart. Wrapped because the real one walks
+ * into the fake context, which is not an RtlSdrContext. */
+uint32_t
+__wrap_rtl_stream_output_rate(const RtlSdrContext* ctx) {
+    (void)ctx;
+    return 48000U;
 }
 
 // NOLINTEND(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)

--- a/tests/runtime/test_runtime_config_apply.cpp
+++ b/tests/runtime/test_runtime_config_apply.cpp
@@ -54,6 +54,7 @@
 
 #include "dsd-neo/core/dibit.h"
 #include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/io/rtl_stream_fwd.h"
 #include "dsd-neo/platform/file_compat.h"
 #include "dsd-neo/platform/posix_compat.h"
 #include "dsd-neo/runtime/call_alert.h"
@@ -540,6 +541,104 @@ test_output_config_without_frontend_preserves_active_frontend(void) {
     (void)remove(path);
     return rc;
 }
+
+#if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
+/* The RTL hot restart tears the stream down and builds a new one, so a config
+ * re-apply can only be exercised with the stream calls faked out. */
+static int g_wrap_fake_ctx = 0;
+static float g_wrap_last_channel_squelch = -1.0f;
+
+// GNU ld --wrap entry points must keep the reserved __wrap_* symbol names.
+// NOLINTBEGIN(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+int
+__wrap_rtl_stream_create(dsd_opts* opts, RtlSdrContext** out_ctx) {
+    (void)opts;
+    if (out_ctx) {
+        *out_ctx = (RtlSdrContext*)&g_wrap_fake_ctx;
+    }
+    return 0;
+}
+
+int
+__wrap_rtl_stream_start(RtlSdrContext* ctx) {
+    (void)ctx;
+    return 0;
+}
+
+int
+__wrap_rtl_stream_stop(RtlSdrContext* ctx) {
+    (void)ctx;
+    return 0;
+}
+
+int
+__wrap_rtl_stream_destroy(RtlSdrContext* ctx) {
+    (void)ctx;
+    return 0;
+}
+
+int
+__wrap_rtl_stream_set_channel_squelch(float level) {
+    g_wrap_last_channel_squelch = level;
+    return 0;
+}
+
+// NOLINTEND(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+
+/*
+ * A config re-applied mid-run carries rtl_sql in decibels, exactly as the CLI
+ * `sql` field and the startup loader do. Stored as the raw integer, a -50 dB
+ * request became a threshold of -50 mean power, which gates nothing: asking for
+ * a squelch through the config switched the squelch off instead.
+ */
+static int
+test_config_reapply_converts_rtl_squelch_from_db(void) {
+    test_runtime runtime;
+    if (alloc_test_runtime(&runtime) != 0) {
+        return 1;
+    }
+    dsd_opts* opts = runtime.opts;
+    dsd_state* state = runtime.state;
+
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->rtl_squelch_level = 0.0;
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof opts->audio_in_dev, "%s", "rtl:0:851375000:22:0:24:0:2");
+
+    dsdneoUserConfig cfg;
+    DSD_MEMSET(&cfg, 0, sizeof cfg);
+    cfg.has_input = 1;
+    cfg.input_source = DSDCFG_INPUT_RTL;
+    cfg.rtl_device = 0;
+    DSD_SNPRINTF(cfg.rtl_freq, sizeof cfg.rtl_freq, "%s", "460.125M");
+    cfg.rtl_gain = 22;
+    cfg.rtl_bw_khz = 24;
+    cfg.rtl_sql = -50;
+    cfg.rtl_volume = 2;
+
+    g_wrap_last_channel_squelch = -1.0f;
+    dsd_app_command_submit(DSD_APP_CMD_CONFIG_APPLY, &cfg, sizeof cfg);
+    (void)dsd_app_drain_cmds(opts, state);
+
+    int rc = 0;
+    rc |= expect_true("config re-apply converts rtl_sql from dB",
+                      fabs(opts->rtl_squelch_level - pow(10.0, -5.0)) < 1e-12);
+    rc |= expect_float_near("config re-apply pushes the threshold to the demod", g_wrap_last_channel_squelch,
+                            (float)pow(10.0, -5.0), 1e-9f);
+
+    /* And rtl_sql = 0 still means off, rather than "key omitted". */
+    cfg.rtl_sql = 0;
+    DSD_SNPRINTF(cfg.rtl_freq, sizeof cfg.rtl_freq, "%s", "461.125M");
+    g_wrap_last_channel_squelch = -1.0f;
+    dsd_app_command_submit(DSD_APP_CMD_CONFIG_APPLY, &cfg, sizeof cfg);
+    (void)dsd_app_drain_cmds(opts, state);
+    rc |= expect_true("config re-apply of rtl_sql 0 switches squelch off", opts->rtl_squelch_level == 0.0);
+    rc |= expect_float_near("config re-apply of rtl_sql 0 opens the demod gate", g_wrap_last_channel_squelch, 0.0f,
+                            1e-9f);
+
+    free_test_runtime(&runtime);
+    return rc;
+}
+#endif
 
 static int
 test_ui_command_queue_applies_fifo(void) {
@@ -2766,6 +2865,21 @@ test_ui_rtl_setting_commands_stage_without_live_restart(void) {
     rc |= expect_true("RTL setting commands leave restart staged", opts->rtl_needs_restart == 1);
     rc |= expect_true("RTL auto PPM command writes final toast", strstr(state->ui_msg, "Auto PPM -> On") != NULL);
 
+    /* Switching the squelch off has to be reportable as off. The toast echoed the
+     * number it was handed, so switching the squelch off said "-> 0.0 dB", which
+     * reads as a threshold at full scale rather than as no gating at all. */
+    double sql_off = 0.0;
+    dsd_app_command_submit(DSD_APP_CMD_RTL_SET_SQL_DB, &sql_off, sizeof sql_off);
+    (void)dsd_app_drain_cmds(opts, state);
+    rc |= expect_true("RTL squelch command accepts off", opts->rtl_squelch_level == 0.0);
+    rc |= expect_true("RTL squelch off toast names it off", strstr(state->ui_msg, "RTL squelch -> off") != NULL);
+
+    double sql_back = -55.0;
+    dsd_app_command_submit(DSD_APP_CMD_RTL_SET_SQL_DB, &sql_back, sizeof sql_back);
+    (void)dsd_app_drain_cmds(opts, state);
+    rc |= expect_true("RTL squelch toast still states a real threshold",
+                      strstr(state->ui_msg, "RTL squelch -> -55.0 dB") != NULL);
+
     free_test_runtime(&runtime);
     return rc;
 }
@@ -2819,6 +2933,9 @@ main(void) {
     rc |= test_zero_rtl_ppm_apply_updates_live_request();
     rc |= test_omitted_rtl_ppm_apply_preserves_live_request();
     rc |= test_ui_rtl_setting_commands_stage_without_live_restart();
+#ifdef DSD_NEO_TEST_RTL_WRAP
+    rc |= test_config_reapply_converts_rtl_squelch_from_db();
+#endif
 #endif
     return rc ? 1 : 0;
 }

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -17,6 +17,7 @@
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/rdio_export.h>
 #include <errno.h>
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
@@ -1524,6 +1525,91 @@ test_snapshot_rtl_and_rtltcp_device_specs(void) {
     return rc;
 }
 
+/*
+ * A squelch that is off has to survive being saved and loaded again. Serialized
+ * through pwr_to_dB() it came back as rtl_sql = -120, which the loader then
+ * applied as a real threshold: the session that had no squelch acquired one, and
+ * the startup banner reported a gate that had never been asked for. -120 is also
+ * outside the schema's own -100..0 range for the key.
+ */
+/*
+ * A squelch that is off has to survive being saved and loaded again. Serialized
+ * through pwr_to_dB() it came back as rtl_sql = -120, which then reached the
+ * decoder as a real threshold: the session that had no squelch acquired one, and
+ * the startup banner reported a gate nobody asked for. -120 is also outside the
+ * schema's own -100..0 range for the key.
+ *
+ * The two input families store the setting differently. RTL and RTL-TCP render a
+ * device string that the engine parses, so the assertion there is on the `sql`
+ * field of that string; SoapySDR applies the tuning to opts directly.
+ */
+static int
+test_snapshot_disabled_squelch_roundtrips_as_off(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    dsdneoUserConfig snap;
+    int rc = 0;
+
+    reset_opts_and_state(opts, state);
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "rtl:0:851.375M:22:-2:24:0:2");
+    opts.rtlsdr_center_freq = 851375000U;
+    opts.rtl_gain_value = 22;
+    opts.rtl_dsp_bw_khz = 24;
+    opts.rtl_squelch_level = 0.0;
+    opts.rtl_volume_multiplier = 2;
+
+    dsd_snapshot_opts_to_user_config(&opts, &state, &snap);
+    if (snap.rtl_sql != 0) {
+        DSD_FPRINTF(stderr, "snapshot of a disabled squelch expected rtl_sql 0, got %d\n", snap.rtl_sql);
+        rc |= 1;
+    }
+
+    dsd_apply_user_config_to_opts(&snap, &opts, &state);
+    if (strcmp(opts.audio_in_dev, "rtl:0:851375000:22:0:24:0:2") != 0) {
+        DSD_FPRINTF(stderr, "reloaded disabled squelch expected sql field 0, got %s\n", opts.audio_in_dev);
+        rc |= 1;
+    }
+
+    /* A real threshold still round-trips through decibels. */
+    reset_opts_and_state(opts, state);
+    DSD_SNPRINTF(opts.audio_in_dev, sizeof opts.audio_in_dev, "%s", "rtl:0:851.375M:22:-2:24:-50:2");
+    opts.rtlsdr_center_freq = 851375000U;
+    opts.rtl_gain_value = 22;
+    opts.rtl_dsp_bw_khz = 24;
+    opts.rtl_squelch_level = pow(10.0, -5.0);
+    opts.rtl_volume_multiplier = 2;
+    dsd_snapshot_opts_to_user_config(&opts, &state, &snap);
+    if (snap.rtl_sql != -50) {
+        DSD_FPRINTF(stderr, "snapshot of a -50 dB threshold expected rtl_sql -50, got %d\n", snap.rtl_sql);
+        rc |= 1;
+    }
+
+    /* SoapySDR applies the shared tuning straight to opts, so the stored
+     * threshold is assertable there without going through the engine. */
+    reset_opts_and_state(opts, state);
+    dsdneoUserConfig cfg;
+    DSD_MEMSET(&cfg, 0, sizeof cfg);
+    cfg.has_input = 1;
+    cfg.input_source = DSDCFG_INPUT_SOAPY;
+    DSD_SNPRINTF(cfg.soapy_args, sizeof cfg.soapy_args, "%s", "driver=test");
+    cfg.rtl_sql = 0;
+    opts.rtl_squelch_level = 12.0; /* clobber, so the apply has to write it */
+    dsd_apply_user_config_to_opts(&cfg, &opts, &state);
+    if (opts.rtl_squelch_level != 0.0) {
+        DSD_FPRINTF(stderr, "soapy apply of rtl_sql 0 expected 0.0, got %g\n", opts.rtl_squelch_level);
+        rc |= 1;
+    }
+
+    cfg.rtl_sql = -50;
+    dsd_apply_user_config_to_opts(&cfg, &opts, &state);
+    if (fabs(opts.rtl_squelch_level - pow(10.0, -5.0)) > 1e-12) {
+        DSD_FPRINTF(stderr, "soapy apply of rtl_sql -50 expected 1e-5, got %g\n", opts.rtl_squelch_level);
+        rc |= 1;
+    }
+
+    return rc;
+}
+
 static int
 test_load_and_apply_rtltcp_regression(void) {
     static const char* ini = "[input]\n"
@@ -2592,6 +2678,7 @@ main(void) {
     rc |= test_snapshot_roundtrip_soapy_args();
     rc |= test_snapshot_roundtrip_zero_rtl_ppm();
     rc |= test_snapshot_rtl_and_rtltcp_device_specs();
+    rc |= test_snapshot_disabled_squelch_roundtrips_as_off();
     rc |= test_load_and_apply_rtltcp_regression();
     rc |= test_snapshot_roundtrip();
     rc |= test_apply_demod_lock();

--- a/tests/runtime/test_runtime_input_spec.c
+++ b/tests/runtime/test_runtime_input_spec.c
@@ -134,7 +134,10 @@ test_soapy_args_with_full_tuning(void) {
         free(opts);
         return 1;
     }
-    if (!(opts->rtl_squelch_level > 0.0 && opts->rtl_squelch_level < 1.0e-4)) {
+    /* The `sql` field means the same thing here as in an rtl: string: a negative
+     * value is decibels. This path had its own copy of the conversion, so the
+     * exact mapping is pinned rather than just its order of magnitude. */
+    if (fabs(opts->rtl_squelch_level - pow(10.0, -5.0)) > 1.0e-12) {
         DSD_FPRINTF(stderr, "soapy full tuning squelch expected dB->power mapping, got %.12f\n",
                     opts->rtl_squelch_level);
         free(opts);

--- a/tests/ui/qml/tst_spectrum_screen.qml
+++ b/tests/ui/qml/tst_spectrum_screen.qml
@@ -650,6 +650,34 @@ Item {
             findChild(screen, "radioSquelchUp").clicked()
             verify(Math.abs(testContext.lastSquelchDb() - (-115)) < 0.001)
 
+            // A squelch that is off has to say so. Rendered as "-120 dB" there was
+            // no way to tell it from a threshold set at the display floor, and no
+            // way to ask for it back once stepped away from.
+            panel.forgetRequests()
+            testContext.setMetric("squelchOff", true)
+            tryVerify(function () { return metrics.squelchOff === true })
+            var squelchReadout = findChild(screen, "radioSquelchValue")
+            compare(squelchReadout.text, "off")
+
+            var atOff = testContext.squelchCalls()
+            findChild(screen, "radioSquelchDown").clicked()
+            compare(testContext.squelchCalls(), atOff,
+                    "a step below off asked the dongle for something")
+
+            findChild(screen, "radioSquelchUp").clicked()
+            verify(Math.abs(testContext.lastSquelchDb() - (-120)) < 0.001)
+
+            // And stepping down past the floor asks for off, rather than pinning
+            // at a threshold the user cannot get out of.
+            panel.forgetRequests()
+            testContext.setMetric("squelchOff", false)
+            tryVerify(function () { return metrics.squelchOff === false })
+            compare(squelchReadout.text, "-120 dB")
+            findChild(screen, "radioSquelchDown").clicked()
+            compare(testContext.lastSquelchDb(), 0)
+            compare(squelchReadout.text, "off")
+            panel.forgetRequests()
+
             // PPM is chosen once, by someone with no way to tell if it was right.
             findChild(screen, "radioPpmUp").clicked()
             compare(testContext.lastPpm(), 1)

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -175,6 +175,7 @@ class CommandRecorder : public QObject {
     Q_INVOKABLE bool
     setSquelchDb(double db) {
         m_last_squelch_db = db;
+        m_squelch_calls++;
         return true;
     }
 
@@ -220,6 +221,7 @@ class CommandRecorder : public QObject {
         m_gain_calls = 0;
         m_last_gain_db = -1;
         m_last_squelch_db = 0.0;
+        m_squelch_calls = 0;
         m_last_modulation = -1;
         m_last_decode_mode = -1;
         m_last_ppm = 9999;
@@ -238,6 +240,12 @@ class CommandRecorder : public QObject {
     double
     lastSquelchDb() const {
         return m_last_squelch_db;
+    }
+
+    /* Lets a case assert that a step which cannot move made no request at all. */
+    Q_INVOKABLE int
+    squelchCalls() const {
+        return m_squelch_calls;
     }
 
     int
@@ -290,6 +298,7 @@ class CommandRecorder : public QObject {
     int m_gain_calls = 0;
     int m_last_gain_db = -1;
     double m_last_squelch_db = 0.0;
+    int m_squelch_calls = 0;
     int m_last_modulation = -1;
     int m_last_decode_mode = -1;
     int m_last_ppm = 9999;
@@ -612,6 +621,11 @@ class Setup : public QObject {
     }
 
     Q_INVOKABLE int
+    squelchCalls() const {
+        return (m_commands != nullptr) ? m_commands->squelchCalls() : -1;
+    }
+
+    Q_INVOKABLE int
     lastModulation() const {
         return (m_commands != nullptr) ? m_commands->lastModulation() : -1;
     }
@@ -793,6 +807,7 @@ class Setup : public QObject {
         metrics[QStringLiteral("modulation")] = 0;
         metrics[QStringLiteral("tunerGainDb")] = 30;
         metrics[QStringLiteral("squelchDb")] = -120.0;
+        metrics[QStringLiteral("squelchOff")] = false;
         metrics[QStringLiteral("ppm")] = 0;
         m_metrics = metrics;
         m_engine = engine;

--- a/tests/ui/test_ui_dsp_squelch_status.c
+++ b/tests/ui/test_ui_dsp_squelch_status.c
@@ -22,11 +22,24 @@ test_squelch_status_closed(void) {
     assert(strcmp(out, "Closed ch:-80.0 dB sql:-40.0 dB") == 0);
 }
 
+/*
+ * A disabled squelch has to say so. Rendered as a number it read as a threshold
+ * gating at -120 dB, which is why a reporter concluded squelch was applied and
+ * very low when it was switched off entirely.
+ */
 static void
 test_squelch_status_open_when_disabled(void) {
     char out[64];
     assert(ui_dsp_format_squelch_status(0.0, 0.0, out, sizeof(out)) == 0);
-    assert(strcmp(out, "Open ch:-120.0 dB sql:-120.0 dB") == 0);
+    assert(strcmp(out, "Open ch:-120.0 dB sql:off") == 0);
+}
+
+/* The channel measurement is unaffected: only the threshold reads as off. */
+static void
+test_squelch_status_reports_power_while_disabled(void) {
+    char out[64];
+    assert(ui_dsp_format_squelch_status(dB_to_pwr(-60.0), 0.0, out, sizeof(out)) == 0);
+    assert(strcmp(out, "Open ch:-60.0 dB sql:off") == 0);
 }
 
 static void
@@ -46,6 +59,7 @@ main(void) {
     test_squelch_status_open();
     test_squelch_status_closed();
     test_squelch_status_open_when_disabled();
+    test_squelch_status_reports_power_while_disabled();
     test_squelch_status_open_at_threshold();
     test_squelch_status_rejects_missing_output();
     return 0;

--- a/tests/ui/test_ui_menu_actions.c
+++ b/tests/ui/test_ui_menu_actions.c
@@ -9,7 +9,9 @@
 
 #include <assert.h>
 #include <dsd-neo/app_control/commands.h>
+#include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/platform/audio.h>
@@ -18,6 +20,7 @@
 #include <dsd-neo/runtime/call_alert.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
+#include <math.h>
 #include <sndfile.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -204,6 +207,23 @@ capture_command(int cmd_id, const void* payload, size_t payload_sz) {
         DSD_MEMCPY(g_cmd.data, payload, payload_sz);
     }
     g_cmd.calls++;
+    return 0;
+}
+
+double
+pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
+    if (mean_power <= 0.0) {
+        return -120.0;
+    }
+    return 10.0 * log10(mean_power);
+}
+
+int
+dsd_app_frontend_get_metrics(dsd_frontend_metrics* out) { // NOLINT(misc-use-internal-linkage)
+    if (!out) {
+        return -1;
+    }
+    DSD_MEMSET(out, 0, sizeof *out);
     return 0;
 }
 
@@ -470,6 +490,57 @@ dsd_audio_enumerate_devices(dsd_audio_device* inputs, dsd_audio_device* outputs,
         outputs[1] = g_audio_outputs[1];
     }
     return 0;
+}
+
+/* The RTL rows hand their prompt results to these; the rows themselves are what
+ * is under test, so the callbacks only have to exist. */
+void
+cb_rtl_dev(void* u, int ok, int i) {
+    (void)u;
+    (void)ok;
+    (void)i;
+}
+
+void
+cb_rtl_freq(void* u, int ok, int f) {
+    (void)u;
+    (void)ok;
+    (void)f;
+}
+
+void
+cb_rtl_gain(void* u, int ok, int g) {
+    (void)u;
+    (void)ok;
+    (void)g;
+}
+
+void
+cb_rtl_ppm(void* u, int ok, int p) {
+    (void)u;
+    (void)ok;
+    (void)p;
+}
+
+void
+cb_rtl_bw(void* u, int ok, int bw) {
+    (void)u;
+    (void)ok;
+    (void)bw;
+}
+
+void
+cb_rtl_sql(void* u, int ok, double dB) {
+    (void)u;
+    (void)ok;
+    (void)dB;
+}
+
+void
+cb_rtl_vol(void* u, int ok, int m) {
+    (void)u;
+    (void)ok;
+    (void)m;
 }
 
 void
@@ -1260,6 +1331,20 @@ test_additional_prompt_and_toggle_actions(void) {
     reset_capture();
     act_set_input_warn(NULL);
     rc |= expect_int("input warn env fallback", g_prompt.initial_double == 12.5, 1);
+
+    /* The squelch row has to be able to express "off". The prompt offered
+     * pwr_to_dB() of a disabled squelch, which is -120: retyping what was shown
+     * would have turned a squelch that was off into a real threshold. */
+    reset_capture();
+    opts.rtl_squelch_level = 0.0;
+    rtl_set_sql(&ctx);
+    rc |= expect_str("rtl squelch prompt", g_prompt.title, "Squelch (dB; 0 = off)");
+    rc |= expect_int("rtl squelch off prompt offers off", g_prompt.initial_double == 0.0, 1);
+
+    reset_capture();
+    opts.rtl_squelch_level = pow(10.0, -5.0);
+    rtl_set_sql(&ctx);
+    rc |= expect_int("rtl squelch prompt states a real threshold", fabs(g_prompt.initial_double - (-50.0)) < 0.001, 1);
 
 #if defined(__SSE__) || defined(__SSE2__)
     reset_capture();

--- a/tests/ui/test_ui_menu_services.c
+++ b/tests/ui/test_ui_menu_services.c
@@ -13,7 +13,6 @@
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
-#include <dsd-neo/core/power.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/talkgroup_policy.h>
@@ -203,11 +202,6 @@ dsd_tg_policy_clear(dsd_state* state) {
 void
 dsd_state_ext_free_all(dsd_state* state) {
     (void)state;
-}
-
-double
-dB_to_pwr(double dB) {
-    return dB;
 }
 
 int
@@ -680,7 +674,15 @@ test_rtl_service_option_contracts(void) {
     rc |= expect_int("rtl bandwidth exact stored", opts.rtl_dsp_bw_khz, 12);
 
     rc |= expect_int("rtl squelch stores converted threshold", svc_rtl_set_sql_db(&opts, -12.5), 0);
-    rc |= expect_double("rtl squelch level stored", opts.rtl_squelch_level, -12.5);
+    rc |= expect_double("rtl squelch level stored", opts.rtl_squelch_level, pow(10.0, -1.25));
+
+    /* 0 dB is full scale: as a threshold it closes the gate forever, so it is the
+     * natural spelling of "off" and matches what 0 means in the CLI and config.
+     * Without it neither UI could switch the squelch off at all. */
+    rc |= expect_int("rtl squelch accepts zero", svc_rtl_set_sql_db(&opts, 0.0), 0);
+    rc |= expect_double("rtl squelch zero switches off", opts.rtl_squelch_level, 0.0);
+    rc |= expect_int("rtl squelch accepts positive", svc_rtl_set_sql_db(&opts, 3.0), 0);
+    rc |= expect_double("rtl squelch positive switches off", opts.rtl_squelch_level, 0.0);
     rc |= expect_int("rtl volume invalid defaults", svc_rtl_set_volume_mult(&opts, -1), 0);
     rc |= expect_int("rtl volume default stored", opts.rtl_volume_multiplier, 1);
     rc |= expect_int("rtl volume valid stored", svc_rtl_set_volume_mult(&opts, 3), 0);

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -237,6 +237,22 @@ pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
     return mean_power;
 }
 
+/* Mirrors the real formatter's shape over the identity pwr_to_dB() above, so the
+ * rendered field is checkable without linking core. */
+int
+dsd_squelch_format(double mean_power, const char* unit, char* out,
+                   size_t out_size) { // NOLINT(misc-use-internal-linkage)
+    if (!out || out_size == 0U) {
+        return -1;
+    }
+    if (dsd_squelch_is_off(mean_power)) {
+        DSD_SNPRINTF(out, out_size, "off");
+        return 0;
+    }
+    DSD_SNPRINTF(out, out_size, "%.1f%s", pwr_to_dB(mean_power), unit ? unit : "");
+    return 0;
+}
+
 const char*
 dsd_input_level_status_label(dsd_input_level_status status) { // NOLINT(misc-use-internal-linkage)
     (void)status;
@@ -581,7 +597,9 @@ test_rtl_and_soapy_input_source_rendering(void) {
     opts.rtl_volume_multiplier = 3;
     opts.rtlsdr_ppm_error = -7;
     g_requested_ppm = opts.rtlsdr_ppm_error;
-    opts.rtl_squelch_level = -37.5f;
+    /* A stored threshold is a mean power, so a real one is positive; the dB stub
+     * above is the identity, which is why this reads back as "37.5 dB". */
+    opts.rtl_squelch_level = 37.5f;
     opts.rtl_dsp_bw_khz = 24;
     opts.rtlsdr_center_freq = 851012500;
     opts.rtl_udp_port = 5555;
@@ -593,11 +611,18 @@ test_rtl_and_soapy_input_source_rendering(void) {
     assert_capture_contains(" G: 21dB;");
     assert_capture_contains(" Mon: 3X;");
     assert_capture_contains(" PPM: -7;");
-    assert_capture_contains(" SQL: -37.5 dB;");
+    assert_capture_contains(" SQL: 37.5 dB;");
     assert_capture_contains(" DSP-BW: 24 kHz;");
     assert_capture_contains(" FRQ: 851012500;");
     assert_capture_contains("| Auto PPM: Off");
     assert_capture_contains("| External RTL Tuning on UDP: 127.0.0.1:5555");
+
+    /* Squelch off is the default every documented example uses. Printed as a
+     * number it read as a threshold that had been applied. */
+    opts.rtl_squelch_level = 0.0;
+    reset_printw_capture();
+    ui_render_rtl_input_source(&opts, &state);
+    assert_capture_contains(" SQL: off;");
 
     DSD_MEMSET(&opts, 0, sizeof(opts));
     opts.audio_in_type = AUDIO_IN_RTL;

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -164,6 +164,19 @@ main(int argc, char** argv) {
      * or a -120 dB threshold renders as 0. */
     expect("gain is reported", model.tunerGainDb() == 30);
     expect("squelch is reported in dB", std::fabs(model.squelchDb() - (-120.0)) < 0.5);
+
+    /* A threshold at the display floor is still a threshold. Only a level that
+     * gates nothing is off, and the panel has to be able to tell them apart --
+     * both rendered as "-120 dB" there was no way to see which one was in force. */
+    expect("a -120 dB threshold is not off", !model.squelchOff());
+
+    opts.rtl_squelch_level = 0.0;
+    model.refresh(&opts, &state);
+    expect("a squelch that gates nothing reads as off", model.squelchOff());
+
+    opts.rtl_squelch_level = dB_to_pwr(-120.0);
+    model.refresh(&opts, &state);
+    expect("a restored threshold stops reading as off", !model.squelchOff());
     expect("c4fm reads as modulation 0", model.modulation() == 0);
 
     opts.mod_qpsk = 1;


### PR DESCRIPTION
Fixes #409.

## What was happening

`sql` is off when set to `0` — which is what every example in `--help` and `docs/cli.md` uses — because every consumer tests `level > 0` before gating. But every readout ran the stored level through `pwr_to_dB()`, whose `mean_power <= 0` branch returns the **-120 dB display floor**. So a squelch that was switched off reported itself as `SQ=-120.0dB`, and the #398 reporter reasonably read that as a threshold applied at a very low level.

Tracing it turned up that the same setting is converted in four different places, and that there was no coherent "off" on the UI side at all. Rather than fix the banner and leave the rest, this replaces all of it with one contract.

## The contract

Three helpers in `include/dsd-neo/core/power.h`:

| helper | what it settles |
|---|---|
| `dsd_squelch_is_off()` | the test the consumers already make (`level > 0`), named once |
| `dsd_squelch_level_from_sql()` | negative = dB, `0` = off, positive = linear mean power |
| `dsd_squelch_format()` | renders `off`, or the dB value plus the caller's unit |

The first two are header inlines because `dsd-neo_runtime` does not link the core object that defines `dB_to_pwr()` — which is exactly why `config_user.cpp` and `input_spec.c` had grown private copies of the conversion (one of them without the clamps). `pwr_to_dB()`/`dB_to_pwr()` are untouched: they are measurement-domain helpers, and the -120 floor is correct for a *measured* zero. `dsd_squelch_format()` takes the unit as a parameter so each surface keeps its spacing byte-for-byte for a real threshold.

## The five things fixed

**1. Readouts say `off`.** Both startup banners (`engine.c`), `Setting RTL Power Squelch Level` (`rtl_sdr_fm.cpp`), the ncurses input line and M17 VOX line, the DSP panel (`ncurses_dsp_status_format.c`), the EDACS analog line, the runtime toast, and the Qt RadioSheet.

**2. Config autosave.** `snapshot_apply_live_rtl_values()` wrote a disabled squelch as `rtl_sql = -120`, which the loader then applied as a real threshold — a session with no squelch acquired one across a save/reload, and `-120` is outside the key's own `-100..0` schema range. Now it writes `0`, and `0` reloads as off.

**3. The hot-restart config re-apply.** `apply_cfg_rtl_common()` stored `cfg->rtl_sql` as a raw power with no dB conversion, so a `-50` dB request became a threshold of `-50` mean power — which gates nothing. Asking for a squelch through a mid-run config apply switched the squelch *off*. It now converts from decibels, and applies unconditionally because `0` is a real value here rather than "key omitted" (unlike the sibling gain/bandwidth/volume keys, which keep their guards).

**4. Neither UI could switch the squelch off.** `svc_rtl_set_sql_db(0)` was `dB_to_pwr(0) = 1.0` — a gate at full scale that never opens. `0` dB now means off, matching what `0` already means in the `sql` field and the `rtl_sql` key. The terminal prompt becomes `Squelch (dB; 0 = off)` and offers `0` rather than `-120` for a disabled squelch (accepting the value shown used to turn an off squelch into a real threshold). The Qt stepper gains an off position one step below the -120 dB floor, so stepping down from the floor asks for off instead of pinning, and `-5 dB` becomes the top of the real-threshold range.

**5. An unparseable `sql` token.** `dsd_engine_setup_parse_sql_token_or_default()` discarded the result of `dsd_parse_double_arg()`, so a token like `loud` left `sq_val` at its initialized `0` and switched the squelch off. It now returns the fallback.

Storage semantics are unchanged (`level <= 0` is off; negative `sql` is dB; positive is linear mean power), and output for a real threshold is byte-identical.

## Coverage

Every change was driven from a failing test first.

| test | what it pins |
|---|---|
| `CORE_MISC_POWER_FILTERS` | the three helpers: off-ness, the dB mapping and its -200 dB clamp, `off` vs a floored-but-real `-120.0 dB`, truncation, NULL/zero-size |
| `UI_DSP_SQUELCH_STATUS` | `Open ch:-120.0 dB sql:off`, and that the channel measurement stays a number |
| `UI_NCURSES_PRINTER_HELPERS` | ` SQL: off;` on the input line |
| `ENGINE_RUN_SETUP` | the banner itself, captured off stderr: `SQ=-33.0dB` for a threshold, `SQ=off` and *not* `SQ=-120` for `sql=0`; plus the unparseable-token case |
| `RUNTIME_CONFIG_USER` | `rtl_sql = 0` on snapshot, the reloaded spec's `sql` field, and a `-50 dB` threshold still round-tripping |
| `RUNTIME_CONFIG_APPLY` | the toast saying `off`; and the hot-restart re-apply converting `rtl_sql` from dB — reachable now that the target wraps the `rtl_stream_*` entry points |
| `UI_MENU_SERVICES` | `0` and a positive dB switch the squelch off; `-12.5` stores `10^-1.25` |
| `UI_MENU_ACTIONS` | the prompt title and its default (the target gains `USE_RADIO`, so the RTL rows are compiled and testable for the first time) |
| `UI_QT_METRICS_MODEL` | a `-120 dB` threshold is not off; a level that gates nothing is |
| `UI_QT_QML_CALL_LISTS` | the readout showing `off`, a step below off making no request, stepping up landing on `-120`, stepping down from the floor asking for `0` |

Negative controls, each confirmed to fail:

- remove the `off` branch from `dsd_squelch_format()` → `CORE_MISC_POWER_FILTERS`, `UI_DSP_SQUELCH_STATUS`, `ENGINE_RUN_SETUP`, `RUNTIME_CONFIG_APPLY`
- restore the discarded parse result → `ENGINE_RUN_SETUP`
- restore `(int)local_pwr_to_dB(...)` in the serializer → `RUNTIME_CONFIG_USER`
- restore the raw-integer store in `apply_cfg_rtl_common()` → `RUNTIME_CONFIG_APPLY` (`config re-apply converts rtl_sql from dB`)

## Verification

```
ctest --preset dev-debug --output-on-failure                      # 571 passed
cmake --preset dev-debug -DDSD_ENABLE_QT_UI=ON && ctest ...       # 579 passed
tools/preflight_ci.sh                                             # clean
```

Manual, against the issue's reproduction shape:

```
$ dsd-neo -i soapy:driver=test:465.975M:43:0:48:0:1 -o null -fa
NOTICE: SoapySDR tuning: Freq=465975000 Gain=43 PPM=0 DSP-BW=48kHz SQ=off VOL=1
Setting RTL Power Squelch Level to off

$ dsd-neo -i soapy:driver=test:465.975M:43:0:48:-60:1 -o null -fa
NOTICE: SoapySDR tuning: Freq=465975000 Gain=43 PPM=0 DSP-BW=48kHz SQ=-60.0dB VOL=1
Setting RTL Power Squelch Level to -60.0 dB
```

## Risk

**CLI/UI behavior impact:** readouts say `off` for a disabled squelch (real-threshold output is byte-identical); autosave writes `rtl_sql = 0` rather than `-120`; a mid-run config re-apply now honours `rtl_sql` in decibels where it previously switched the squelch off; `0` dB from the menu or Qt switches the squelch off instead of closing the gate permanently; the Qt stepper's top is now `-5 dB`; an unparseable CLI `sql` token keeps the previous setting.

The docs note added by #406 to describe the `-120` reading is replaced, since the banner no longer produces it.
