### PR TITLE
fix(nxdn): drop the CRC flag the element decoder could only ever set to 1

### DIFF
--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -318,6 +318,9 @@ Private per-protocol modules worth knowing about:
   verdicts to it, and `nxdn_frame.c` consults it before refreshing the scan hold or synthesizing voice, as
   `nxdn_deperm.c`/`nxdn_element.c` do before publishing a RAN or a call. The engine clears it with the carrier through
   `nxdn_confirm_reset()`, the one entry point exported in `<dsd-neo/protocol/nxdn/nxdn.h>`.
+  `NXDN_Elements_Content_decode()` carries no CRC verdict of its own: the channel decoders in `nxdn_deperm.c` and
+  `NXDN_SACCH_Full_decode()` hand it CRC-verified content only, so the gate lives in those callers, with
+  `nxdn_confirm_is_confirmed()` as the frame-level check at the sites that publish a call or refresh a scan hold.
 
 Build files: `src/protocol/CMakeLists.txt` and per‑protocol `src/protocol/<name>/CMakeLists.txt`
 

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -241,21 +241,15 @@ typedef struct {
     uint16_t DestinationID; /* May be a Group ID or a Unit ID */
     uint8_t CipherType;
     uint8_t KeyID;
-    uint8_t VCallCrcIsGood;
 
     /*******************************/
     /***** VCALL_IV parameters *****/
     /*******************************/
     uint8_t IV[8];
-    uint8_t VCallIvCrcIsGood;
 
     /*****************************/
     /***** Custom parameters *****/
     /*****************************/
-
-    /* Specifies if the "CipherType" and the "KeyID" parameter are valid
-   * 1 = Valid ; 0 = CRC error */
-    uint8_t CipherParameterValidity;
 
     /* Used on DES and AES encrypted frames */
     uint8_t PartOfCurrentEncryptedFrame; /* Could be 1 or 2 */

--- a/include/dsd-neo/protocol/nxdn/nxdn_alias_decode.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn_alias_decode.h
@@ -29,12 +29,12 @@ void nxdn_alias_reset(dsd_state* state);
 /**
  * Decode/assemble a standard NXDN alias block (message type 0x3F).
  */
-void nxdn_alias_decode_prop(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok);
+void nxdn_alias_decode_prop(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits);
 
 /**
  * Decode/assemble an ARIB-style segmented alias payload.
  */
-void nxdn_alias_decode_arib(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok);
+void nxdn_alias_decode_arib(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits);
 
 /**
  * Best-effort Shift-JIS style text decode to UTF-8.

--- a/include/dsd-neo/protocol/nxdn/nxdn_deperm.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn_deperm.h
@@ -50,7 +50,20 @@ const char* nxdn_message_type_label(uint8_t message_type);
 void nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType);
 
 void NXDN_SACCH_Full_decode(dsd_opts* opts, dsd_state* state);
-void NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, uint8_t CrcCorrect, const uint8_t* ElementsContent,
+
+/**
+ * @brief Decode an NXDN element content block and dispatch it by message type.
+ *
+ * Carries no CRC verdict of its own: callers pass CRC-verified content only. Every channel
+ * decoder in `nxdn_deperm.c` checks its own CRC -- SACCH CRC-6, FACCH1 CRC-12, FACCH2/UDCH
+ * CRC-15, CAC CRC-16, FACCH3/UDCH2 -- and reports it to `nxdn_confirm_note_evidence()` before
+ * calling here, as does `NXDN_SACCH_Full_decode()` for an assembled superframe. The gate lives
+ * in those callers; `nxdn_confirm_is_confirmed()` is the frame-level check at the sites that
+ * publish a call or refresh a scan hold. The one deliberate exception is the synthesized
+ * disconnect in `nxdn_vcall_run_enc_lockout()`, which fabricates a DISC element locally to drive
+ * the same teardown a received one would.
+ */
+void NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, const uint8_t* ElementsContent,
                                   size_t elements_bits);
 void NXDN_decode_scch(dsd_opts* opts, dsd_state* state, const uint8_t* Message, uint8_t direction);
 void NXDN_decode_VCALL_ASSGN(dsd_opts* opts, dsd_state* state, const uint8_t* Message);

--- a/src/protocol/nxdn/nxdn_alias_decode.c
+++ b/src/protocol/nxdn/nxdn_alias_decode.c
@@ -182,14 +182,11 @@ nxdn_alias_decode_shift_jis_fallback(const uint8_t* in, size_t in_len, size_t ef
 }
 
 static void
-nxdn_alias_log_prop_segment(const dsd_opts* opts, uint8_t block_number, uint8_t total_blocks, uint8_t crc_ok) {
+nxdn_alias_log_prop_segment(const dsd_opts* opts, uint8_t block_number, uint8_t total_blocks) {
     if (opts == NULL || opts->payload != 1) {
         return;
     }
     DSD_FPRINTF(stderr, " Alias segment %u/%u", (unsigned)block_number, (unsigned)total_blocks);
-    if (crc_ok == 0U) {
-        DSD_FPRINTF(stderr, " (CRC ERR)");
-    }
 }
 
 static void
@@ -221,14 +218,11 @@ nxdn_alias_collect_prop_alias(const dsd_state* state, uint8_t total_blocks, char
 }
 
 static void
-nxdn_alias_log_arib_segment(const dsd_opts* opts, uint8_t seg_num, uint8_t seg_total, uint8_t crc_ok) {
+nxdn_alias_log_arib_segment(const dsd_opts* opts, uint8_t seg_num, uint8_t seg_total) {
     if (opts == NULL || opts->payload != 1) {
         return;
     }
     DSD_FPRINTF(stderr, " ARIB alias segment %u/%u", (unsigned)seg_num, (unsigned)seg_total);
-    if (crc_ok == 0U) {
-        DSD_FPRINTF(stderr, " (CRC ERR)");
-    }
 }
 
 static int
@@ -352,18 +346,15 @@ nxdn_alias_reset(dsd_state* state) {
 }
 
 void
-nxdn_alias_decode_prop(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+nxdn_alias_decode_prop(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits) {
     if (state == NULL || message_bits == NULL) {
         return;
     }
 
     uint8_t block_number = (uint8_t)convert_bits_into_output(&message_bits[32U], 4U);
     uint8_t total_blocks = (uint8_t)convert_bits_into_output(&message_bits[36U], 4U);
-    nxdn_alias_log_prop_segment(opts, block_number, total_blocks, crc_ok);
+    nxdn_alias_log_prop_segment(opts, block_number, total_blocks);
 
-    if (crc_ok == 0U) {
-        return;
-    }
     if (block_number < 1U || block_number > 4U) {
         return;
     }
@@ -384,18 +375,15 @@ nxdn_alias_decode_prop(const dsd_opts* opts, dsd_state* state, const uint8_t* me
 }
 
 void
-nxdn_alias_decode_arib(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+nxdn_alias_decode_arib(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits) {
     if (state == NULL || message_bits == NULL) {
         return;
     }
 
     uint8_t seg_num = (uint8_t)convert_bits_into_output(&message_bits[16U], 4U);
     uint8_t seg_total = (uint8_t)convert_bits_into_output(&message_bits[20U], 4U);
-    nxdn_alias_log_arib_segment(opts, seg_num, seg_total, crc_ok);
+    nxdn_alias_log_arib_segment(opts, seg_num, seg_total);
 
-    if (crc_ok == 0U) {
-        return;
-    }
     if (!nxdn_alias_valid_arib_segment(seg_num, seg_total)) {
         return;
     }

--- a/src/protocol/nxdn/nxdn_deperm.c
+++ b/src/protocol/nxdn/nxdn_deperm.c
@@ -267,7 +267,7 @@ nxdn_handle_sacch_non_superframe(dsd_opts* opts, dsd_state* state, const uint8_t
         state->nxdn_part_of_frame = 3;
         DSD_FPRINTF(stderr, "PF 1/1");
         nxdn_reset_payload_seed_if_forced(state);
-        NXDN_Elements_Content_decode(opts, state, 1, nsf_sacch, sizeof(nsf_sacch));
+        NXDN_Elements_Content_decode(opts, state, nsf_sacch, sizeof(nsf_sacch));
     } else {
         state->nxdn_part_of_frame = 0;
         DSD_FPRINTF(stderr, "PF X/1");
@@ -529,7 +529,7 @@ nxdn_handle_facch2_udch(dsd_opts* opts, dsd_state* state, const uint8_t* trellis
 
     if (crc == check) {
         state->data_header_format[0] = 1;
-        NXDN_Elements_Content_decode(opts, state, 1, f2u_message_buffer, (size_t)(199 - 8 - 15));
+        NXDN_Elements_Content_decode(opts, state, f2u_message_buffer, (size_t)(199 - 8 - 15));
     }
     if (type == 0 && crc == check) {
         nxdn_print_udch_data(m_data);
@@ -637,7 +637,7 @@ nxdn_handle_cac(dsd_opts* opts, dsd_state* state, const uint8_t* trellis_buf, co
     nxdn_update_cac_fail_state(state, crc);
 
     if (crc == 0) {
-        NXDN_Elements_Content_decode(opts, state, 1, cac_message_buffer, sizeof(cac_message_buffer));
+        NXDN_Elements_Content_decode(opts, state, cac_message_buffer, sizeof(cac_message_buffer));
     }
     nxdn_print_cac_payload(opts, m_data);
     rotate_symbol_out_file(opts, state);
@@ -945,7 +945,7 @@ nxdn_decode_facch3_udch2_content(dsd_opts* opts, dsd_state* state, const struct 
     nxdn_confirm_note_evidence(state, NXDN_EVIDENCE_STRONG);
 
     state->data_header_format[0] = 1;
-    NXDN_Elements_Content_decode(opts, state, 1, message->bits, 160U);
+    NXDN_Elements_Content_decode(opts, state, message->bits, 160U);
 }
 
 static void
@@ -1158,7 +1158,7 @@ nxdn_deperm_facch_soft(dsd_opts* opts, dsd_state* state, uint8_t bits[144], cons
         nxdn_confirm_note_evidence(state, NXDN_EVIDENCE_STRONG);
     }
     if (crc == check && !duplicate) {
-        NXDN_Elements_Content_decode(opts, state, 1, trellis_buf, sizeof(trellis_buf));
+        NXDN_Elements_Content_decode(opts, state, trellis_buf, sizeof(trellis_buf));
     }
 
     if (opts->payload == 1) {
@@ -1235,10 +1235,12 @@ nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType) {
     }
     DSD_FPRINTF(stderr, "%s", KNRM);
 
-    //End the canonical call on explicit release or disconnect signaling. CRC-verified release
-    //decoded over the air is positive end evidence -- the terminator reason lets the event layer
-    //keep an audible epoch whose call identity never decoded, where EXPLICIT reads as a retune.
-    if (state->NxdnElementsContent.VCallCrcIsGood != 0U && nxdn_message_type_resets_call(MessageType)) {
+    //End the canonical call on explicit release or disconnect signaling. A release or disconnect
+    //reaches here only through NXDN_Elements_Content_decode(), which the channel decoders hand
+    //CRC-verified content alone, so this is positive end evidence decoded over the air -- the
+    //terminator reason lets the event layer keep an audible epoch whose call identity never
+    //decoded, where EXPLICIT reads as a retune.
+    if (nxdn_message_type_resets_call(MessageType)) {
         if (dsd_call_state_end_ex(state, 0U, 0.0, DSD_CALL_END_TERMINATOR) > 0) {
             dsd_event_sync_slot((dsd_opts*)opts, state, 0U);
         }

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -60,7 +60,6 @@ struct nxdn_element_dispatch_entry {
     nxdn_element_handler_fn handler;
 };
 
-static uint8_t nxdn_alias_crc_ok(const dsd_state* state);
 static void nxdn_reset_data_call_state(dsd_state* state);
 static void nxdn_data_call_option_to_str(uint8_t data_call_option, char* duplex, size_t duplex_sz, char* mode,
                                          size_t mode_sz);
@@ -186,7 +185,7 @@ NXDN_SACCH_Full_decode(dsd_opts* opts, dsd_state* state) {
     // currently only going to run this if all four CRCs are good
     if (CrcCorrect == 1) {
         nxdn_confirm_note_evidence(state, NXDN_EVIDENCE_STRONG);
-        NXDN_Elements_Content_decode(opts, state, CrcCorrect, SACCH, sizeof(SACCH));
+        NXDN_Elements_Content_decode(opts, state, SACCH, sizeof(SACCH));
     }
 
     //reset the sacch field -- Github Issue #118
@@ -289,7 +288,7 @@ nxdn_element_handle_alias(const dsd_opts* opts, dsd_state* state, const uint8_t*
     DSD_FPRINTF(stderr, "%s", KYEL);
     DSD_FPRINTF(stderr, " ALIAS");
     DSD_FPRINTF(stderr, "%s", KNRM);
-    nxdn_alias_decode_prop(opts, state, elements, nxdn_alias_crc_ok(state));
+    nxdn_alias_decode_prop(opts, state, elements);
 }
 
 static const char*
@@ -469,8 +468,7 @@ nxdn_element_dispatch_handler(uint8_t message_type) {
 }
 
 void
-NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, uint8_t CrcCorrect, const uint8_t* ElementsContent,
-                             size_t elements_bits) {
+NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, const uint8_t* ElementsContent, size_t elements_bits) {
     enum { NXDN_ELEMENTS_MIN_MESSAGE_TYPE_BITS = 8U };
 
     if (opts == NULL || state == NULL || ElementsContent == NULL) {
@@ -503,13 +501,10 @@ NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, uint8_t CrcCorrec
     /* Save the "Message Type" field */
     state->NxdnElementsContent.MessageType = MessageType;
 
-    /* Set the CRC state */
-    state->NxdnElementsContent.VCallCrcIsGood = CrcCorrect;
-
     nxdn_message_type(opts, state, MessageTypeExt);
 
     if (MessageTypeExt == 0xE7U) {
-        nxdn_alias_decode_arib(opts, state, ElementsContent, nxdn_alias_crc_ok(state));
+        nxdn_alias_decode_arib(opts, state, ElementsContent);
         return;
     }
 
@@ -663,17 +658,17 @@ nxdn_sdcall_iv(dsd_opts* opts, dsd_state* state, const uint8_t* Message) {
  * target keeps its activity hold for data traffic and not only for voice. A header is the only
  * data element carrying a call identity; the blocks that follow it carry none.
  *
- * Held behind the link layer's CRC gate for the same reason the VCALL site is: an unverified
- * header carries a garbage identity, and acting on one parks the coordinator on noise for a full
- * activity_hold_ms. The header's own two-bit cipher field is the encryption classification --
- * data calls have no equivalent of the voice hysteresis in nxdn_enc_class.c -- and a misread
- * costs at most one hold refresh, because talkgroup policy exempts data calls from the
- * encrypted-target lockout ledger.
+ * A header reaches here only through a channel decoder whose CRC passed, and is held behind the
+ * frame's confirmation for the same reason the VCALL site is: an unverified header carries a
+ * garbage identity, and acting on one parks the coordinator on noise for a full activity_hold_ms.
+ * The header's own two-bit cipher field is the encryption classification -- data calls have no
+ * equivalent of the voice hysteresis in nxdn_enc_class.c -- and a misread costs at most one hold
+ * refresh, because talkgroup policy exempts data calls from the encrypted-target lockout ledger.
  */
 static void
 nxdn_data_header_report_scan_activity(const dsd_opts* opts, const dsd_state* state, uint8_t call_type, uint16_t source,
                                       uint16_t target, uint8_t cipher) {
-    if (state->NxdnElementsContent.VCallCrcIsGood == 0U || !nxdn_confirm_is_confirmed(state)) {
+    if (!nxdn_confirm_is_confirmed(state)) {
         return;
     }
     // call_type 4 is the individual/private call, spelled the same way as the trunked data-grant
@@ -2318,14 +2313,13 @@ nxdn_vcall_publish(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_inf
 static void
 nxdn_vcall_apply_state(dsd_state* state, const struct nxdn_vcall_info* info) {
     if (info->message_type == 0x01U) {
-        // Only a CRC-verified VCALL may mutate the live cipher, and even then through the
-        // classification hysteresis: trellis miscorrections that survive the short CRCs are
-        // exactly one element away from muting a clear call -- or unmuting an encrypted one --
-        // and, under lockout, permanently blocking the talkgroup.
-        if (state->NxdnElementsContent.VCallCrcIsGood != 0U) {
-            state->nxdn_key = info->key_id;
-            state->nxdn_cipher_type = nxdn_cipher_observe(state, info->cipher_type, 0);
-        }
+        // A VCALL reaches here only through a channel decoder whose CRC passed -- the element
+        // decoder is never handed unverified content -- and even then mutates the live cipher only
+        // through the classification hysteresis: trellis miscorrections that survive the short
+        // CRCs are exactly one element away from muting a clear call -- or unmuting an encrypted
+        // one -- and, under lockout, permanently blocking the talkgroup.
+        state->nxdn_key = info->key_id;
+        state->nxdn_cipher_type = nxdn_cipher_observe(state, info->cipher_type, 0);
     } else {
         DSD_SNPRINTF(state->generic_talker_alias[0], sizeof(state->generic_talker_alias[0]), "%s", "");
         nxdn_alias_reset(state);
@@ -2351,16 +2345,17 @@ nxdn_vcall_run_enc_lockout(dsd_opts* opts, dsd_state* state, const struct nxdn_v
         const int established_recoverable =
             nxdn_cipher_established_clear(state)
             || (nxdn_cipher_established_enc(state) && nxdn_vcall_has_key(state, (uint8_t)state->nxdn_cipher_type));
-        if (state->NxdnElementsContent.VCallCrcIsGood != 0U && established_recoverable) {
+        if (established_recoverable) {
             (void)dsd_enc_lockout_release(state, info->destination_id, is_group);
         }
         return;
     }
     // The lockout entry is permanent for the session and the synthesized disconnect drops the
-    // channel, so the lockout acts only on CRC-verified, corroborated evidence: a lone
-    // non-clear observation stays tentative (or quarantined) in the hysteresis above and must
-    // repeat -- one superframe -- before it may lock the talkgroup out.
-    if (state->NxdnElementsContent.VCallCrcIsGood == 0U || !nxdn_cipher_established_enc(state)) {
+    // channel, so the lockout acts only on corroborated evidence. The element was CRC-verified by
+    // the channel decoder that handed it over, and a lone non-clear observation stays tentative
+    // (or quarantined) in the hysteresis above and must repeat -- one superframe -- before it may
+    // lock the talkgroup out.
+    if (!nxdn_cipher_established_enc(state)) {
         return;
     }
 
@@ -2380,11 +2375,15 @@ nxdn_vcall_run_enc_lockout(dsd_opts* opts, dsd_state* state, const struct nxdn_v
     // disconnect fires per corroborated VCALL): retrying the synthesized
     // disconnect until the trunking layer actually drops the channel is what
     // lets an already-locked target still force a release.
+    //
+    // This fabricated DISC is the one element content no CRC ever covered, and deliberately so: it
+    // exists to drive the same teardown a received DISC would -- nxdn_message_type()'s call and
+    // alias reset, and nxdn_element_handle_disc()'s return to the control channel.
     uint8_t dbits[96];
     DSD_MEMSET(dbits, 0, sizeof(dbits));
     dbits[3] = 1;
     dbits[7] = 1;
-    NXDN_Elements_Content_decode(opts, state, 1, dbits, sizeof(dbits));
+    NXDN_Elements_Content_decode(opts, state, dbits, sizeof(dbits));
 }
 
 // Release and disconnect variants that reach nxdn_vcall_process. TX_REL_EX (0x07) ends the epoch
@@ -2397,10 +2396,11 @@ nxdn_vcall_message_type_is_release(uint8_t message_type) {
 
 static void
 nxdn_vcall_process(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_info* info) {
-    if (info->message_type != 0x01U && state->NxdnElementsContent.VCallCrcIsGood != 0U) {
-        // A CRC-verified release decoded over the air is positive end evidence -- the terminator
-        // reason lets the event layer keep an audible epoch whose call identity never decoded,
-        // where EXPLICIT reads as a retune and drops the row.
+    if (info->message_type != 0x01U) {
+        // A release reaching here was CRC-verified by the channel decoder that handed it over, so
+        // it is positive end evidence decoded over the air -- the terminator reason lets the event
+        // layer keep an audible epoch whose call identity never decoded, where EXPLICIT reads as a
+        // retune and drops the row.
         const dsd_call_end_reason reason =
             nxdn_vcall_message_type_is_release(info->message_type) ? DSD_CALL_END_TERMINATOR : DSD_CALL_END_EXPLICIT;
         if (dsd_call_state_end_ex(state, 0U, 0.0, reason) > 0) {
@@ -2411,11 +2411,11 @@ nxdn_vcall_process(dsd_opts* opts, dsd_state* state, const struct nxdn_vcall_inf
     nxdn_vcall_load_key(opts, state, info);
     nxdn_vcall_print_cipher(opts, state, info);
     nxdn_vcall_apply_state(state, info);
-    if (info->message_type == 0x01U && state->NxdnElementsContent.VCallCrcIsGood != 0U
-        && nxdn_confirm_is_confirmed(state)) {
-        // Held behind the same CRC gate as the publish below: a miscorrected VCALL carries a
-        // garbage destination_id, and letting it refresh the conventional scan hold would park
-        // the coordinator on noise for a full activity_hold_ms per corrupt burst. The encryption
+    if (info->message_type == 0x01U && nxdn_confirm_is_confirmed(state)) {
+        // Held, like the publish below, until the frame's content has confirmed the transmission:
+        // a miscorrected VCALL carries a garbage destination_id, and letting it refresh the
+        // conventional scan hold would park the coordinator on noise for a full activity_hold_ms
+        // per corrupt burst. The encryption
         // flag is the corroborated classification nxdn_vcall_apply_state() just applied, not the
         // raw element field -- a lone flipped cipher_type would otherwise drop the hold mid-call
         // under --enc-lockout, the exact defect nxdn_enc_class.c exists to prevent.
@@ -2932,18 +2932,3 @@ NXDN_Cipher_Type_To_Str(uint8_t CipherType) {
 
     return Ptr;
 } /* End NXDN_Cipher_Type_To_Str() */
-
-static uint8_t
-nxdn_alias_crc_ok(const dsd_state* state) {
-    if (state == NULL) {
-        return 0U;
-    }
-
-    /* FACCH1/SACCH superframe CRC drives alias acceptance when available. */
-    if (!state->nxdn_sacch_non_superframe) {
-        return (uint8_t)((state->NxdnElementsContent.VCallCrcIsGood != 0U) ? 1U : 0U);
-    }
-
-    /* Standalone SACCH frames do not carry the same assembled CRC context. */
-    return 1U;
-}

--- a/tests/protocol/nxdn/test_nxdn_alias_decode.c
+++ b/tests/protocol/nxdn/test_nxdn_alias_decode.c
@@ -110,27 +110,24 @@ main(void) {
      * sequence arrives, which catches stale-fragment mixing regressions.
      */
     build_prop_msg(bits, 2U, 2U, "NAME");
-    nxdn_alias_decode_prop(&opts, &state, bits, 1U);
+    nxdn_alias_decode_prop(&opts, &state, bits);
     rc |= expect_str("prop-partial", state.generic_talker_alias[0], "NAME");
 
     build_prop_msg(bits, 1U, 2U, "TEST");
-    nxdn_alias_decode_prop(&opts, &state, bits, 1U);
+    nxdn_alias_decode_prop(&opts, &state, bits);
     rc |= expect_str("prop-assembled", state.generic_talker_alias[0], "TESTNAME");
 
     DSD_SNPRINTF(state.generic_talker_alias[0], sizeof(state.generic_talker_alias[0]), "%s", "KEEP");
-    build_prop_msg(bits, 1U, 1U, "FAIL");
-    nxdn_alias_decode_prop(&opts, &state, bits, 0U);
-    rc |= expect_str("prop-crc-gate", state.generic_talker_alias[0], "KEEP");
 
     {
         uint8_t packed[12];
         build_arib_packed_alias8(packed, "ARIBTEST", 0x84201F67U);
         build_arib_msg(bits, 1U, 2U, &packed[0]);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
         rc |= expect_str("arib-partial", state.generic_talker_alias[0], "KEEP");
 
         build_arib_msg(bits, 2U, 2U, &packed[6]);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
     }
     rc |= expect_str("arib-assembled", state.generic_talker_alias[0], "ARIBTEST");
     rc |= expect_u8("arib-seen-reset", state.nxdn_alias_arib_seen_mask, 0U);
@@ -143,16 +140,16 @@ main(void) {
         build_arib_packed_alias8(fresh_packed, "GOOD1234", 0x51265003U);
 
         build_arib_msg(bits, 2U, 2U, stale_seg2);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
         rc |= expect_str("arib-restart-stale-seed", state.generic_talker_alias[0], "BASE");
 
         build_arib_msg(bits, 1U, 2U, &fresh_packed[0]);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
         rc |= expect_str("arib-restart-no-mix", state.generic_talker_alias[0], "BASE");
         rc |= expect_u8("arib-restart-mask", state.nxdn_alias_arib_seen_mask, 0x01U);
 
         build_arib_msg(bits, 2U, 2U, &fresh_packed[6]);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
     }
     rc |= expect_str("arib-restart-assembled", state.generic_talker_alias[0], "GOOD1234");
     rc |= expect_u8("arib-restart-reset-mask", state.nxdn_alias_arib_seen_mask, 0U);
@@ -164,11 +161,11 @@ main(void) {
         static const uint8_t total2_seg2[6] = {'A', 'S', 0x11, 0x22, 0x33, 0x44};
 
         build_arib_msg(bits, 1U, 3U, total3_seg1);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
         rc |= expect_str("arib-total-mismatch-seed", state.generic_talker_alias[0], "STABLE");
 
         build_arib_msg(bits, 2U, 2U, total2_seg2);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
     }
     rc |= expect_str("arib-total-mismatch-no-mix", state.generic_talker_alias[0], "STABLE");
     rc |= expect_u8("arib-total-mismatch-mask", state.nxdn_alias_arib_seen_mask, 0x02U);
@@ -184,21 +181,21 @@ main(void) {
         build_arib_packed_alias8(fresh_packed, "FRESH222", 0x5FD0F4FDU);
 
         build_arib_msg(bits, 1U, 2U, &stale_packed[0]);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
         rc |= expect_str("arib-midseq-seed", state.generic_talker_alias[0], "HOLD");
 
         build_arib_msg(bits, 2U, 2U, &fresh_packed[6]);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
         rc |= expect_str("arib-midseq-no-mix", state.generic_talker_alias[0], "HOLD");
         rc |= expect_u8("arib-midseq-reset-mask", state.nxdn_alias_arib_seen_mask, 0U);
         rc |= expect_u8("arib-midseq-reset-total", state.nxdn_alias_arib_total_segments, 0U);
 
         build_arib_msg(bits, 1U, 2U, &fresh_packed[0]);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
         rc |= expect_str("arib-midseq-clean-partial", state.generic_talker_alias[0], "HOLD");
 
         build_arib_msg(bits, 2U, 2U, &fresh_packed[6]);
-        nxdn_alias_decode_arib(&opts, &state, bits, 1U);
+        nxdn_alias_decode_arib(&opts, &state, bits);
     }
     rc |= expect_str("arib-midseq-clean-assembled", state.generic_talker_alias[0], "FRESH222");
 

--- a/tests/protocol/nxdn/test_nxdn_crc32_bits.c
+++ b/tests/protocol/nxdn/test_nxdn_crc32_bits.c
@@ -60,11 +60,9 @@ CNXDNConvolution_chainback(unsigned char* out, unsigned int nBits) {
 }
 
 void
-NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, uint8_t CrcCorrect, const uint8_t* ElementsContent,
-                             size_t elements_bits) {
+NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, const uint8_t* ElementsContent, size_t elements_bits) {
     (void)opts;
     (void)state;
-    (void)CrcCorrect;
     (void)ElementsContent;
     (void)elements_bits;
 }
@@ -185,7 +183,6 @@ seed_call_state(dsd_opts* opts, dsd_state* state) {
     state->nxdn_cipher_type = 1;
     state->keyloader = 1;
     state->R = 42;
-    state->NxdnElementsContent.VCallCrcIsGood = 1U;
     DSD_MEMSET(state->nxdn_sacch_frame_segcrc, 0, sizeof(state->nxdn_sacch_frame_segcrc));
     DSD_MEMSET(state->nxdn_sacch_frame_segment, 0, sizeof(state->nxdn_sacch_frame_segment));
 }
@@ -257,17 +254,6 @@ test_message_type_reset_contract(void) {
     rc |= expect_int("idle-r-kept", state.R, 42);
     rc |= expect_int("idle-sacch-kept", all_sacch_segments_are(0U, &state), 1);
 
-    seed_call_state(&opts, &state);
-    g_alias_reset_calls = 0;
-    state.NxdnElementsContent.VCallCrcIsGood = 0U;
-    nxdn_message_type(&opts, &state, 0x08U);
-    rc |= expect_int("bad-crc-release-no-alias-reset", g_alias_reset_calls, 0);
-    rc |= expect_int("bad-crc-release-call-present", dsd_call_state_get(&state, 0U, &call), 1);
-    rc |= expect_int("bad-crc-release-call-active", call.phase, DSD_CALL_PHASE_ACTIVE);
-    rc |= expect_u32("bad-crc-release-target-kept", (uint32_t)call.ota_target_id, 5678U);
-    rc |= expect_int("bad-crc-release-cipher-kept", state.nxdn_cipher_type, 1);
-    rc |= expect_int("bad-crc-release-r-kept", state.R, 42);
-    rc |= expect_int("bad-crc-release-sacch-kept", all_sacch_segments_are(0U, &state), 1);
     dsd_state_ext_free_all(&state);
     return rc;
 }

--- a/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
+++ b/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
@@ -484,10 +484,27 @@ test_sacch_state_update(void) {
     state.payload_miN = 0x11U;
     make_sacch_trellis(trellis, 3U, 0x3FU);
 
+    /* A failed SACCH CRC must keep the frame out of the element decoder entirely: the caller is
+     * the gate, since the decoder itself carries no CRC verdict (issue #411). The sentinel is
+     * what the decoder would overwrite with the real message type had it run. */
+    state.NxdnElementsContent.MessageType = 0x22U;
+
     nxdn_handle_sacch(&opts, &state, trellis, m_data, 0x01U, 0x00U);
     rc |= expect_int("sacch-nsf-bad-crc-part-reset", state.nxdn_part_of_frame, 0);
     rc |= expect_int("sacch-nsf-bad-crc-forced-seed", (int)state.payload_miN, 0x2468);
+    rc |= expect_u8_at("sacch-nsf-bad-crc-skips-elements", 0U, state.NxdnElementsContent.MessageType, 0x22U);
     rc |= expect_sacch_reset_to_ones(&state);
+
+    /* The same frame with a passing CRC does reach the decoder. IDLE (0x10) sits at bits 2..7 of
+     * the 24-bit NSF payload the handler copies from trellis[8..31]. */
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.nxdn_sacch_non_superframe = 1;
+    make_sacch_trellis(trellis, 3U, 0x3FU);
+    write_bits_msb(trellis, 10U, 6U, 0x10U);
+    state.NxdnElementsContent.MessageType = 0x22U;
+
+    nxdn_handle_sacch(&opts, &state, trellis, m_data, 0x2AU, 0x2AU);
+    rc |= expect_u8_at("sacch-nsf-good-message-type", 0U, state.NxdnElementsContent.MessageType, 0x10U);
     return rc;
 }
 
@@ -624,9 +641,14 @@ test_cac_crc_failure_reset(void) {
     state.payload_mi = 0xCCCCU;
     state.aes_ivR[0] = 0x5AU;
 
+    /* Same caller-gate contract as SACCH above: a non-zero CAC CRC remainder never reaches the
+     * element decoder (issue #411). */
+    state.NxdnElementsContent.MessageType = 0x22U;
+
     for (int i = 0; i < 10; i++) {
         nxdn_handle_cac(&opts, &state, trellis, m_data, 1U);
     }
+    rc |= expect_u8_at("cac-bad-crc-skips-elements", 0U, state.NxdnElementsContent.MessageType, 0x22U);
     rc |= expect_int("cac-before-threshold-carrier", state.carrier, 1);
     rc |= expect_int("cac-before-threshold-format", state.data_header_format[0], 9);
 
@@ -649,6 +671,16 @@ test_cac_crc_failure_reset(void) {
 
     nxdn_handle_cac(&opts, &state, trellis, m_data, 1U);
     rc |= expect_int("cac-counter-cleared-after-reset", state.carrier, 0);
+
+    /* A clean CAC (zero remainder) does reach the decoder: IDLE sits at bits 2..7 of the 147-bit
+     * element buffer the handler copies from trellis[8..154]. */
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(trellis, 0, sizeof(trellis));
+    write_bits_msb(trellis, 10U, 6U, 0x10U);
+    state.NxdnElementsContent.MessageType = 0x22U;
+
+    nxdn_handle_cac(&opts, &state, trellis, m_data, 0U);
+    rc |= expect_u8_at("cac-good-message-type", 0U, state.NxdnElementsContent.MessageType, 0x10U);
     return rc;
 }
 
@@ -685,6 +717,91 @@ test_pich_tch_dcr_csm_alias_state(void) {
     return rc;
 }
 
+/*
+ * Build the 144 soft bits an over-the-air FACCH1 burst would present, by running the decoder's
+ * own transform chain backwards: CRC-12 over the 80-bit payload, rate-1/2 K=5 convolutional
+ * encode, 16/9 puncture, then permute. The decoder has no encoder to borrow -- trellis_encode()
+ * in src/core/util/dsd_misc.c is static and nxdn_convolution.h is decode-only -- so the eight
+ * lines of the rate-1/2 encoder are restated here. nxdn_hard_fallback_decode() runs
+ * trellis_decode() over the very stream nxdn_conv_decode_soft() consumes, so both speak this code.
+ */
+static void
+make_facch1_soft_bits(uint8_t bits[144], const uint8_t payload[80], int corrupt_crc) {
+    static const uint8_t PARITY[32] = {0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0,
+                                       1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1};
+    uint8_t trellis[96];
+    uint8_t coded[192];
+    uint8_t deperm[144];
+
+    DSD_MEMSET(trellis, 0, sizeof(trellis));
+    for (size_t i = 0U; i < 80U; i++) {
+        trellis[i] = (uint8_t)(payload[i] & 1U);
+    }
+
+    /* CRC-12 over the payload, MSB first, exactly where the decoder reads its check field. */
+    uint16_t crc = crc12f(trellis, 80);
+    if (corrupt_crc) {
+        crc ^= 1U;
+    }
+    write_bits_msb(trellis, 80U, 12U, crc);
+    /* trellis[92..95] stay zero: the chainback returns 92 data bits and four flush bits. */
+
+    unsigned int reg = 0U;
+    for (size_t i = 0U; i < sizeof(coded); i += 2U) {
+        reg = ((reg << 1U) | trellis[i >> 1U]) & 0x1FU;
+        coded[i] = PARITY[reg & 0x19U];
+        coded[i + 1U] = PARITY[reg & 0x17U];
+    }
+
+    /* Puncture: nxdn_depuncture_16_9_rel() reinserts a zero at each 4k+1, so drop it here. */
+    size_t out = 0U;
+    for (size_t k = 0U; k < 48U; k++) {
+        deperm[out++] = coded[(k * 4U) + 0U];
+        deperm[out++] = coded[(k * 4U) + 2U];
+        deperm[out++] = coded[(k * 4U) + 3U];
+    }
+
+    /* Permute: nxdn_depermute_rel_u8() does deperm[PERM_16_9[i]] = bits[i]. */
+    for (size_t i = 0U; i < 144U; i++) {
+        bits[i] = deperm[PERM_16_9[i]];
+    }
+}
+
+/*
+ * FACCH1 carries call setup, so it is the most consequential of the caller gates: the element
+ * decoder records no CRC verdict of its own, and a frame whose CRC-12 failed must never reach it
+ * (issue #411).
+ */
+static int
+test_facch1_crc_gates_element_decode(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t payload[80];
+    uint8_t bits[144];
+    uint8_t reliab[144];
+    int rc = 0;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(payload, 0, sizeof(payload));
+    DSD_MEMSET(reliab, 255, sizeof(reliab));
+    write_bits_msb(payload, 2U, 6U, 0x10U); /* IDLE */
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.NxdnElementsContent.MessageType = 0x22U;
+    make_facch1_soft_bits(bits, payload, 0);
+    nxdn_deperm_facch_soft(&opts, &state, bits, reliab, 1U);
+    rc |= expect_u8_at("facch1-good-message-type", 0U, state.NxdnElementsContent.MessageType, 0x10U);
+    rc |= expect_int("facch1-good-confirmed", nxdn_confirm_is_confirmed(&state), 1);
+
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.NxdnElementsContent.MessageType = 0x22U;
+    make_facch1_soft_bits(bits, payload, 1);
+    nxdn_deperm_facch_soft(&opts, &state, bits, reliab, 1U);
+    rc |= expect_u8_at("facch1-bad-crc-skips-elements", 0U, state.NxdnElementsContent.MessageType, 0x22U);
+    rc |= expect_int("facch1-bad-crc-unconfirmed", nxdn_confirm_is_confirmed(&state), 0);
+    return rc;
+}
+
 static int
 test_facch2_udch_crc_state_update(void) {
     static const uint8_t m_data[26] = {0};
@@ -702,13 +819,11 @@ test_facch2_udch_crc_state_update(void) {
     rc |= expect_int("facch2-good-part", state.nxdn_part_of_frame, 2);
     rc |= expect_u8_at("facch2-good-format", 0U, state.data_header_format[0], 1U);
     rc |= expect_u8_at("facch2-good-message-type", 0U, state.NxdnElementsContent.MessageType, 0x10U);
-    rc |= expect_u8_at("facch2-good-crc", 0U, state.NxdnElementsContent.VCallCrcIsGood, 1U);
 
     state.nxdn_last_ran = 0x33U;
     state.nxdn_part_of_frame = 7;
     state.data_header_format[0] = 9U;
     state.NxdnElementsContent.MessageType = 0x22U;
-    state.NxdnElementsContent.VCallCrcIsGood = 0U;
 
     nxdn_handle_facch2_udch(&opts, &state, trellis, m_data, 0x456U, 0x457U, 1U);
     rc |= expect_int("facch2-bad-keeps-ran", (int)state.nxdn_last_ran, 0x33);
@@ -739,17 +854,14 @@ test_facch3_udch2_crc_state_update(void) {
     nxdn_handle_facch3_udch2_soft(&opts, &state, &message, 1U);
     rc |= expect_u8_at("facch3-good-format", 0U, state.data_header_format[0], 1U);
     rc |= expect_u8_at("facch3-good-message-type", 0U, state.NxdnElementsContent.MessageType, 0x10U);
-    rc |= expect_u8_at("facch3-good-crc", 0U, state.NxdnElementsContent.VCallCrcIsGood, 1U);
 
     state.data_header_format[0] = 9U;
     state.NxdnElementsContent.MessageType = 0x22U;
-    state.NxdnElementsContent.VCallCrcIsGood = 0U;
 
     message.check[0] = 0x124U;
     nxdn_handle_facch3_udch2_soft(&opts, &state, &message, 0U);
     rc |= expect_u8_at("udch2-bad-keeps-format", 0U, state.data_header_format[0], 9U);
     rc |= expect_u8_at("udch2-bad-skips-elements", 0U, state.NxdnElementsContent.MessageType, 0x22U);
-    rc |= expect_u8_at("udch2-bad-keeps-crc", 0U, state.NxdnElementsContent.VCallCrcIsGood, 0U);
     return rc;
 }
 
@@ -804,16 +916,13 @@ test_facch3_udch2_split_block_storage_and_crc_gate(void) {
     nxdn_handle_facch3_udch2_soft(&opts, &state, &message, 1U);
     rc |= expect_u8_at("facch3-split-good-format", 0U, state.data_header_format[0], 1U);
     rc |= expect_u8_at("facch3-split-good-message-type", 0U, state.NxdnElementsContent.MessageType, 0x10U);
-    rc |= expect_u8_at("facch3-split-good-crc", 0U, state.NxdnElementsContent.VCallCrcIsGood, 1U);
 
     state.data_header_format[0] = 9U;
     state.NxdnElementsContent.MessageType = 0x22U;
-    state.NxdnElementsContent.VCallCrcIsGood = 0U;
     message.check[1] = 0x223U;
     nxdn_handle_facch3_udch2_soft(&opts, &state, &message, 0U);
     rc |= expect_u8_at("udch2-split-bad-keeps-format", 0U, state.data_header_format[0], 9U);
     rc |= expect_u8_at("udch2-split-bad-keeps-message-type", 0U, state.NxdnElementsContent.MessageType, 0x22U);
-    rc |= expect_u8_at("udch2-split-bad-keeps-crc", 0U, state.NxdnElementsContent.VCallCrcIsGood, 0U);
     return rc;
 }
 
@@ -831,6 +940,7 @@ main(void) {
     rc |= test_sacch2_state_update();
     rc |= test_cac_crc_failure_reset();
     rc |= test_pich_tch_dcr_csm_alias_state();
+    rc |= test_facch1_crc_gates_element_decode();
     rc |= test_facch2_udch_crc_state_update();
     rc |= test_facch3_udch2_crc_state_update();
     rc |= test_facch3_udch2_split_block_storage_and_crc_gate();

--- a/tests/protocol/nxdn/test_nxdn_element_bounds.c
+++ b/tests/protocol/nxdn/test_nxdn_element_bounds.c
@@ -32,14 +32,12 @@
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
-void NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, uint8_t CrcCorrect, const uint8_t* ElementsContent,
+void NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, const uint8_t* ElementsContent,
                                   size_t elements_bits);
 void NXDN_SACCH_Full_decode(dsd_opts* opts, dsd_state* state);
 void NXDN_decode_scch(dsd_opts* opts, dsd_state* state, const uint8_t* Message, uint8_t direction);
 
 static int g_alias_prop_calls;
-static uint8_t g_alias_prop_crc_ok;
-static uint8_t g_message_type_crc_ok;
 static int g_channel_to_frequency_calls;
 static int g_channel_to_frequency_quiet_calls;
 static uint16_t g_channel_to_frequency_channel;
@@ -58,27 +56,25 @@ void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType) {
     (void)opts;
+    (void)state;
     (void)MessageType;
-    g_message_type_crc_ok = state->NxdnElementsContent.VCallCrcIsGood;
 }
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-nxdn_alias_decode_arib(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+nxdn_alias_decode_arib(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits) {
     (void)opts;
     (void)state;
     (void)message_bits;
-    (void)crc_ok;
 }
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-nxdn_alias_decode_prop(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+nxdn_alias_decode_prop(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits) {
     (void)opts;
     (void)state;
     (void)message_bits;
     g_alias_prop_calls++;
-    g_alias_prop_crc_ok = crc_ok;
 }
 
 void
@@ -500,21 +496,18 @@ test_decode_guards_and_unknown_dispatch(void) {
     DSD_MEMSET(bits, 0, sizeof(bits));
 
     state->NxdnElementsContent.MessageType = 0x55U;
-    state->NxdnElementsContent.VCallCrcIsGood = 1U;
-    NXDN_Elements_Content_decode(NULL, state, 0U, bits, sizeof(bits));
-    NXDN_Elements_Content_decode(opts, NULL, 0U, bits, sizeof(bits));
-    NXDN_Elements_Content_decode(opts, state, 0U, NULL, sizeof(bits));
-    NXDN_Elements_Content_decode(opts, state, 0U, bits, 7U);
+    NXDN_Elements_Content_decode(NULL, state, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, NULL, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, NULL, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, 7U);
 
     int rc = 0;
     rc |= expect_int("decode-guards-type-preserved", state->NxdnElementsContent.MessageType, 0x55);
-    rc |= expect_int("decode-guards-crc-preserved", state->NxdnElementsContent.VCallCrcIsGood, 1);
 
     set_message_type(bits, 0x2AU);
     state->data_header_valid[0] = 1U;
-    NXDN_Elements_Content_decode(opts, state, 0U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
     rc |= expect_int("unknown-type-recorded", state->NxdnElementsContent.MessageType, 0x2A);
-    rc |= expect_int("unknown-crc-recorded", state->NxdnElementsContent.VCallCrcIsGood, 0);
     rc |= expect_int("unknown-keeps-data-state", state->data_header_valid[0], 1);
 
     dsd_state_ext_free_all(state);
@@ -548,10 +541,16 @@ test_sacch_full_decode_crc_gate_and_reset(void) {
     state->nxdn_sacch_frame_segcrc[2] = 0U;
     state->nxdn_sacch_frame_segcrc[3] = 0U;
 
+    /* One failed segment CRC must keep the assembled superframe out of the element decoder
+     * entirely: the caller is the gate (issue #411). The sentinel is what the decoder would
+     * overwrite with the real message type had it run. */
+    state->NxdnElementsContent.MessageType = 0x22U;
+
     NXDN_SACCH_Full_decode(opts, state);
 
     int rc = 0;
     rc |= expect_string("sacch-bad-crc-no-event", g_datacall_event, "");
+    rc |= expect_int("sacch-bad-crc-skips-elements", state->NxdnElementsContent.MessageType, 0x22);
     rc |= expect_int("sacch-bad-crc-reset", all_sacch_segments_are(1U, state), 1);
 
     load_sacch_segments_from_bits(state, bits);
@@ -618,7 +617,7 @@ test_disc_trunk_return_clears_call_state(void) {
     g_tune_cc_freq = 0;
     g_tune_cc_ted_sps = -1;
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_int("disc-tune-cc-called", g_tune_cc_calls, 1);
@@ -672,7 +671,7 @@ test_idle_keeps_active_call(void) {
     dsd_call_snapshot before;
     assert(dsd_call_state_get(state, 0U, &before) == 1);
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     dsd_call_snapshot after;
     int rc = 0;
@@ -681,53 +680,6 @@ test_idle_keeps_active_call(void) {
     rc |= expect_u64("idle-call-epoch", after.epoch, before.epoch);
     rc |= expect_u64("idle-call-target", after.ota_target_id, before.ota_target_id);
     rc |= expect_u64("idle-call-source", after.ota_source_id, before.ota_source_id);
-
-    dsd_state_ext_free_all(state);
-    free(state);
-    free(opts);
-    return rc;
-}
-
-static int
-test_bad_crc_release_keeps_active_call(void) {
-    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
-    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
-    uint8_t bits[96];
-    if (!opts || !state) {
-        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
-        free(state);
-        free(opts);
-        return 1;
-    }
-
-    const dsd_call_observation observation = {
-        .protocol = DSD_SYNC_NXDN_POS,
-        .slot = 0U,
-        .kind = DSD_CALL_KIND_GROUP_VOICE,
-        .ota_target_id = 0x4567U,
-        .policy_target_id = 0x4567U,
-        .ota_source_id = 0x1234U,
-    };
-    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
-    dsd_call_snapshot before;
-    assert(dsd_call_state_get(state, 0U, &before) == 1);
-
-    int rc = 0;
-    const uint8_t release_types[] = {0x08U, 0x11U};
-    for (size_t i = 0U; i < sizeof(release_types) / sizeof(release_types[0]); i++) {
-        DSD_MEMSET(bits, 0, sizeof(bits));
-        set_message_type(bits, release_types[i]);
-        g_message_type_crc_ok = 1U;
-        NXDN_Elements_Content_decode(opts, state, 0U, bits, sizeof(bits));
-
-        dsd_call_snapshot after;
-        rc |= expect_int("bad-crc-release-message-type-sees-crc", g_message_type_crc_ok, 0);
-        rc |= expect_int("bad-crc-release-call-present", dsd_call_state_get(state, 0U, &after), 1);
-        rc |= expect_int("bad-crc-release-call-active", after.phase, DSD_CALL_PHASE_ACTIVE);
-        rc |= expect_u64("bad-crc-release-call-epoch", after.epoch, before.epoch);
-        rc |= expect_u64("bad-crc-release-call-target", after.ota_target_id, before.ota_target_id);
-        rc |= expect_u64("bad-crc-release-call-source", after.ota_source_id, before.ota_source_id);
-    }
 
     dsd_state_ext_free_all(state);
     free(state);
@@ -768,8 +720,7 @@ test_release_ends_call_with_terminator_reason(void) {
 
         DSD_MEMSET(bits, 0, sizeof(bits));
         set_message_type(bits, release_types[i]);
-        state->NxdnElementsContent.VCallCrcIsGood = 1U;
-        NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+        NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
         dsd_call_snapshot after;
         rc |= expect_int("release-terminator-call-present", dsd_call_state_get(state, 0U, &after), 1);
@@ -801,7 +752,7 @@ test_sdcall_header_short_is_ignored(void) {
     state->data_header_valid[0] = 0U;
     state->payload_algid = 77;
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_int("sdcall-header-short-valid", state->data_header_valid[0], 0);
@@ -827,7 +778,7 @@ test_sdcall_iv_short_type_c_is_ignored(void) {
     set_message_type(bits, 0x3AU);
     state->payload_mi = 0x1122334455667788ULL;
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = expect_u64("sdcall-iv-short-type-c", (uint64_t)state->payload_mi, 0x1122334455667788ULL);
     free(state);
@@ -853,7 +804,7 @@ test_sdcall_iv_type_d_min_length_is_accepted(void) {
     DSD_SNPRINTF(state->nxdn_location_category, sizeof(state->nxdn_location_category), "%s", "Type-D");
     write_bits_u64(bits, 8U, iv22, 22U);
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = expect_u64("sdcall-iv-type-d-min-len", (uint64_t)state->payload_mi, iv22);
     free(state);
@@ -877,18 +828,15 @@ test_prop_form_alias_requires_marker(void) {
     DSD_MEMSET(bits, 0, sizeof(bits));
     set_message_type(bits, 0x3FU);
     g_alias_prop_calls = 0;
-    g_alias_prop_crc_ok = 0U;
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
     rc |= expect_int("prop-form-no-marker", g_alias_prop_calls, 0);
 
     DSD_MEMSET(bits, 0, sizeof(bits));
     set_message_type(bits, 0x3FU);
     write_standard_alias_marker(bits);
     g_alias_prop_calls = 0;
-    g_alias_prop_crc_ok = 0U;
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
     rc |= expect_int("prop-form-marker", g_alias_prop_calls, 1);
-    rc |= expect_int("prop-form-marker-crc", g_alias_prop_crc_ok, 1);
 
     free(state);
     free(opts);
@@ -915,7 +863,7 @@ test_short_dcall_data_is_rejected(uint8_t message_type, const char* tag_prefix) 
     state->data_header_format[0] = 3U; //8-byte block (still requires 80 bits total)
     DSD_MEMSET(state->dmr_pdu_sf[0], 0xA5, sizeof(state->dmr_pdu_sf[0]));
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     char tag_valid[64];
@@ -949,7 +897,7 @@ test_dst_id_info_complete_event(void) {
     write_bits_u64(bits, 10U, 4U, 6U);
     write_ascii_bits(bits, 16U, "RADIO");
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_string("dst-id-event", g_datacall_event, "NXDN Digital Station ID: RADIO");
@@ -986,7 +934,7 @@ test_srv_info_anchors_control_channel_from_rigctl(void) {
     state->nxdn_grant_chan = 77U;
     g_current_rigctl_freq = 855262500L;
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_int("srv-info-message-type", state->NxdnElementsContent.MessageType, 0x19);
@@ -1036,7 +984,7 @@ test_cch_dfa_maps_secondary_channels_and_seeds_control_frequency(void) {
     write_bits_u64(bits, 80U, ofn2, 16U);
     write_bits_u64(bits, 96U, ifn2, 16U);
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_int("cch-dfa-message-type", state->NxdnElementsContent.MessageType, 0x1A);
@@ -1127,7 +1075,7 @@ run_cch_dfa_adoption_case(const char* tag, int trunk_scan_enabled, int trunk_ena
     write_bits_u64(bits, 40U, ofn1, 16U);
     write_bits_u64(bits, 56U, ifn1, 16U);
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     char label[96];
     int rc = 0;
@@ -1219,7 +1167,7 @@ reset_scan_activity_capture(void) {
  * what the coordinator can run through talkgroup policy.
  */
 static int
-run_data_header_scan_activity_case(const char* tag, uint8_t message_type, uint8_t crc_ok, uint8_t call_type,
+run_data_header_scan_activity_case(const char* tag, uint8_t message_type, uint8_t confirmed, uint8_t call_type,
                                    uint8_t cipher, uint16_t source, uint16_t target, int expect_calls,
                                    int expect_private, int expect_encrypted) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
@@ -1242,12 +1190,12 @@ run_data_header_scan_activity_case(const char* tag, uint8_t message_type, uint8_
     write_bits_u64(bits, 56U, cipher, 2U);
     write_bits_u64(bits, 68U, 2U, 4U); /* block count */
 
-    /* In the decoder this element content is only reached through a CRC that has already
-     * confirmed the transmission, which is what admits a data header to the scan hold
-     * (issue #398). This case is about the header fields, so start from there. */
-    state->nxdn_confirmed = 1;
+    /* The element decoder is only ever handed CRC-verified content, so what admits a data header
+     * to the scan hold is whether that CRC evidence has confirmed the transmission yet
+     * (issue #398). */
+    state->nxdn_confirmed = confirmed;
 
-    NXDN_Elements_Content_decode(opts, state, crc_ok, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     char label[96];
     int rc = 0;
@@ -1282,9 +1230,9 @@ test_data_call_headers_report_conventional_scan_activity(void) {
     rc |= run_data_header_scan_activity_case("dcall-private-enc", 0x09U, 1U, 4U, 1U, 4321U, 8765U, 1, 1, 1);
     /* Short data calls carry the same identity and must hold the target too. */
     rc |= run_data_header_scan_activity_case("sdcall-group", 0x38U, 1U, 1U, 0U, 11U, 22U, 1, 0, 0);
-    /* A header the link layer could not verify must never park the coordinator. */
-    rc |= run_data_header_scan_activity_case("dcall-bad-crc", 0x09U, 0U, 1U, 0U, 1234U, 5678U, 0, 0, 0);
-    rc |= run_data_header_scan_activity_case("sdcall-bad-crc", 0x38U, 0U, 1U, 0U, 11U, 22U, 0, 0, 0);
+    /* A header whose transmission has not confirmed itself must never park the coordinator. */
+    rc |= run_data_header_scan_activity_case("dcall-unconfirmed", 0x09U, 0U, 1U, 0U, 1234U, 5678U, 0, 0, 0);
+    rc |= run_data_header_scan_activity_case("sdcall-unconfirmed", 0x38U, 0U, 1U, 0U, 11U, 22U, 0, 0, 0);
     /* Elements without a call identity are not activity reports. */
     rc |= run_data_header_scan_activity_case("sdcall-iv", 0x3AU, 1U, 1U, 0U, 11U, 22U, 0, 0, 0);
     rc |= run_data_header_scan_activity_case("dcall-data-block", 0x0BU, 1U, 1U, 0U, 11U, 22U, 0, 0, 0);
@@ -1322,7 +1270,7 @@ test_adj_site_skips_disabled_entries_for_channel_and_dfa_versions(void) {
     write_bits_u64(ch_bits, 112U, 0x03U, 6U);
     write_bits_u64(ch_bits, 118U, 0x333U, 10U);
 
-    NXDN_Elements_Content_decode(opts, state, 1U, ch_bits, sizeof(ch_bits));
+    NXDN_Elements_Content_decode(opts, state, ch_bits, sizeof(ch_bits));
 
     int rc = 0;
     rc |= expect_int("adj-site-ch-calls", g_channel_to_frequency_calls, 2);
@@ -1344,7 +1292,7 @@ test_adj_site_skips_disabled_entries_for_channel_and_dfa_versions(void) {
     write_bits_u64(dfa_bits, 86U, 1U, 2U);
     write_bits_u64(dfa_bits, 88U, 0x2882U, 16U);
 
-    NXDN_Elements_Content_decode(opts, state, 1U, dfa_bits, sizeof(dfa_bits));
+    NXDN_Elements_Content_decode(opts, state, dfa_bits, sizeof(dfa_bits));
 
     rc |= expect_int("adj-site-dfa-calls", g_channel_to_frequency_calls, 1);
     rc |= expect_int("adj-site-dfa-channel", g_channel_to_frequency_channel, 0x2882);
@@ -1393,14 +1341,14 @@ test_sdcall_des_data_decrypts_and_resets(void) {
     state->rkey_array[key_id] = des_key;
 
     write_data_call_header_fields(header_bits, 0x38U, 2U, key_id, 0x1234U, 0x4567U, 1U, 0U);
-    NXDN_Elements_Content_decode(opts, state, 1U, header_bits, sizeof(header_bits));
+    NXDN_Elements_Content_decode(opts, state, header_bits, sizeof(header_bits));
     state->data_header_format[0] = 3U;
 
     xor_payload(encrypted, plain, sizeof(encrypted), des_stub_byte);
     write_data_payload_frame(first_bits, 0x39U, 1U, 1U, encrypted, 8U);
     write_data_payload_frame(final_bits, 0x39U, 0U, 0U, encrypted + 8U, 8U);
-    NXDN_Elements_Content_decode(opts, state, 1U, first_bits, sizeof(first_bits));
-    NXDN_Elements_Content_decode(opts, state, 1U, final_bits, sizeof(final_bits));
+    NXDN_Elements_Content_decode(opts, state, first_bits, sizeof(first_bits));
+    NXDN_Elements_Content_decode(opts, state, final_bits, sizeof(final_bits));
 
     int rc = 0;
     rc |= expect_int("sdcall-des-calls", g_des_calls, 1);
@@ -1479,14 +1427,14 @@ test_dcall_aes_data_decrypts_with_manual_key_and_iv(void) {
         free(opts);
         return 1;
     }
-    NXDN_Elements_Content_decode(opts, state, 1U, header_bits, sizeof(header_bits));
+    NXDN_Elements_Content_decode(opts, state, header_bits, sizeof(header_bits));
     state->data_header_format[0] = 3U;
 
     xor_payload(encrypted, plain, sizeof(encrypted), aes_stub_byte);
     write_data_payload_frame(first_bits, 0x0BU, 1U, 1U, encrypted, 8U);
     write_data_payload_frame(final_bits, 0x0BU, 0U, 0U, encrypted + 8U, 8U);
-    NXDN_Elements_Content_decode(opts, state, 1U, first_bits, sizeof(first_bits));
-    NXDN_Elements_Content_decode(opts, state, 1U, final_bits, sizeof(final_bits));
+    NXDN_Elements_Content_decode(opts, state, first_bits, sizeof(first_bits));
+    NXDN_Elements_Content_decode(opts, state, final_bits, sizeof(final_bits));
     if (dsd_test_capture_stderr_end(&cap) != 0 || read_capture_file(cap.path, output, sizeof output) != 0) {
         DSD_FPRINTF(stderr, "capture stderr read failed\n");
         (void)remove(cap.path);
@@ -1590,7 +1538,7 @@ test_arib_vcall_uses_shifted_fields(void) {
 
     write_arib_vcall_fields(bits, 0xE1U, 0xABU, 0xA0U, 1U, 2U, 0x1234U, 0x4567U, 1U, 0x2AU);
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_int("arib-vcall-cc-option", state->NxdnElementsContent.CCOption, 0xA0);
@@ -1608,41 +1556,6 @@ test_arib_vcall_uses_shifted_fields(void) {
     rc |= expect_int("arib-vcall-key-state", state->nxdn_key, 0x2A);
     rc |= expect_int("arib-vcall-encrypted", state->dmr_encL, 1);
     dsd_state_ext_free_all(state);
-    free(state);
-    free(opts);
-    return rc;
-}
-
-static int
-test_bad_crc_encrypted_vcall_records_metadata(void) {
-    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
-    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
-    uint8_t bits[96];
-    if (!opts || !state) {
-        DSD_FPRINTF(stderr, "alloc-failed: %s%s\n", !opts ? "dsd_opts" : "", !state ? " dsd_state" : "");
-        free(state);
-        free(opts);
-        return 1;
-    }
-    DSD_MEMSET(bits, 0, sizeof(bits));
-
-    write_vcall_fields(bits, 0x01U, 0x20U, 1U, 2U, 0x1357U, 0x2468U, 3U, 0x09U);
-    NXDN_Elements_Content_decode(opts, state, 0U, bits, sizeof(bits));
-
-    int rc = 0;
-    rc |= expect_int("bad-crc-vcall-type", state->NxdnElementsContent.MessageType, 0x01);
-    rc |= expect_int("bad-crc-vcall-crc", state->NxdnElementsContent.VCallCrcIsGood, 0);
-    rc |= expect_int("bad-crc-vcall-src", state->NxdnElementsContent.SourceUnitID, 0x1357);
-    rc |= expect_int("bad-crc-vcall-dst", state->NxdnElementsContent.DestinationID, 0x2468);
-    rc |= expect_int("bad-crc-vcall-cipher", state->NxdnElementsContent.CipherType, 3);
-    rc |= expect_int("bad-crc-vcall-key", state->NxdnElementsContent.KeyID, 0x09);
-    dsd_call_snapshot call;
-    rc |= expect_int("bad-crc-vcall-no-canonical-call", dsd_call_state_get(state, 0U, &call), 0);
-    // The parse-level metadata above is recorded for display, but a CRC-failed VCALL may not
-    // mutate the live cipher the audio gate and the enc lockout act on: a trellis
-    // miscorrection here was one element away from muting a clear call.
-    rc |= expect_int("bad-crc-vcall-cipher-state", state->nxdn_cipher_type, 0);
-    rc |= expect_int("bad-crc-vcall-lockout", state->dmr_encL, 0);
     free(state);
     free(opts);
     return rc;
@@ -1669,7 +1582,7 @@ test_vcall_des_keyloader_and_iv_signal(void) {
     state->keyloader = 1;
     state->rkey_array[key_id] = des_key;
     write_vcall_fields(bits, 0x01U, 0x20U, 1U, 2U, 0x1234U, 0x4567U, 2U, key_id);
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_int("vcall-des-cipher", state->nxdn_cipher_type, 2);
@@ -1680,7 +1593,7 @@ test_vcall_des_keyloader_and_iv_signal(void) {
     rc |= expect_int("vcall-des-unmutes-loaded-key", state->dmr_encL, 0);
 
     write_vcall_iv_fields(iv_bits, iv);
-    NXDN_Elements_Content_decode(opts, state, 1U, iv_bits, sizeof(iv_bits));
+    NXDN_Elements_Content_decode(opts, state, iv_bits, sizeof(iv_bits));
     rc |= expect_u64("vcall-des-iv", (uint64_t)state->payload_miN, iv);
     rc |= expect_int("vcall-des-new-iv", state->nxdn_new_iv, 1);
 
@@ -1711,7 +1624,7 @@ test_vcall_scrambler_keyloader_uses_active_nxdn48_profile(void) {
     state->keyloader = 1;
     state->rkey_array[key_id] = scrambler_key;
     write_vcall_fields(bits, 0x01U, 0x20U, 1U, 2U, 0x1234U, 0x4567U, 1U, key_id);
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_int("vcall-scrambler-active-variant", dsd_frame_sync_active_nxdn_variant(opts, state),
@@ -1756,7 +1669,7 @@ test_vcall_aes_keyloader_and_iv_signal(void) {
     state->rkey_array[key_id + 0x201U] = a3;
     state->rkey_array[key_id + 0x301U] = a4;
     write_vcall_fields(bits, 0x01U, 0x20U, 1U, 2U, 0x1234U, 0x4567U, 3U, key_id);
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_int("vcall-aes-cipher", state->nxdn_cipher_type, 3);
@@ -1772,7 +1685,7 @@ test_vcall_aes_keyloader_and_iv_signal(void) {
     rc |= expect_int("vcall-aes-key-byte-31", state->aes_key[31], 0x38);
 
     write_vcall_iv_fields(iv_bits, iv);
-    NXDN_Elements_Content_decode(opts, state, 1U, iv_bits, sizeof(iv_bits));
+    NXDN_Elements_Content_decode(opts, state, iv_bits, sizeof(iv_bits));
     rc |= expect_u64("vcall-aes-iv", (uint64_t)state->payload_miN, iv);
     rc |= expect_int("vcall-aes-new-iv", state->nxdn_new_iv, 1);
     dsd_call_snapshot call;
@@ -1807,7 +1720,7 @@ test_vcall_aes_key_flag_drives_crypto_state(void) {
     state->A1[0] = 0U;
     state->A2[0] = 0x1112131415161718ULL;
     state->R = 0U;
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     dsd_call_snapshot call;
@@ -1821,7 +1734,7 @@ test_vcall_aes_key_flag_drives_crypto_state(void) {
     state->nxdn_confirmed = 1;
     state->R = 0xDEADBEEFU;
     state->aes_key_loaded[0] = 0;
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
     rc |= expect_int("stale-R AES canonical", dsd_call_state_get(state, 0U, &call), 1);
     rc |= expect_int("stale-R AES remains pending", call.crypto, DSD_CALL_CRYPTO_ENCRYPTED_PENDING);
     rc |= expect_int("stale-R AES blocks audio", call.audio_permitted, 0);
@@ -1921,7 +1834,7 @@ test_arib_tx_release_uses_shifted_fields_and_clears_call(void) {
     (void)dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN);
     DSD_SNPRINTF(state->generic_talker_alias[0], sizeof(state->generic_talker_alias[0]), "%s", "stale");
 
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_int("arib-release-cc-option", state->NxdnElementsContent.CCOption, 0x40);
@@ -1970,7 +1883,7 @@ test_assignment_group_grant_anchors_tunes_and_loads_scrambler(void) {
     g_mapped_channel_freq = grant_freq;
 
     write_assignment_fields(bits, 0x04U, 0x80U, 1U, 0U, source, target, channel, 0U);
-    NXDN_Elements_Content_decode(opts, state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(opts, state, bits, sizeof(bits));
 
     int rc = 0;
     rc |= expect_int("assignment-group-quiet-channel", g_channel_to_frequency_quiet_channel, channel);
@@ -2030,7 +1943,7 @@ test_assignment_data_gate_and_duplicate_release(void) {
     g_mapped_channel_freq = data_freq;
 
     write_assignment_fields(data_bits, 0x0DU, 0x00U, 1U, 3U, 0x0201U, 0x0302U, data_channel, 0U);
-    NXDN_Elements_Content_decode(opts, state, 1U, data_bits, sizeof(data_bits));
+    NXDN_Elements_Content_decode(opts, state, data_bits, sizeof(data_bits));
 
     int rc = 0;
     rc |= expect_int("assignment-data-grant-channel", state->nxdn_grant_chan, data_channel);
@@ -2047,7 +1960,7 @@ test_assignment_data_gate_and_duplicate_release(void) {
     g_mapped_channel_freq = voice_freq;
 
     write_assignment_fields(dup_bits, 0x05U, 0x00U, 1U, 2U, 0x0401U, 0x0502U, voice_channel, 0U);
-    NXDN_Elements_Content_decode(opts, state, 1U, dup_bits, sizeof(dup_bits));
+    NXDN_Elements_Content_decode(opts, state, dup_bits, sizeof(dup_bits));
 
     rc |= expect_int("assignment-dup-channel", state->nxdn_grant_chan, voice_channel);
     rc |= expect_int("assignment-dup-tune-calls", g_tune_freq_calls, 1);
@@ -2073,7 +1986,6 @@ main(void) {
     rc |= test_sacch_full_decode_crc_gate_and_reset();
     rc |= test_disc_trunk_return_clears_call_state();
     rc |= test_idle_keeps_active_call();
-    rc |= test_bad_crc_release_keeps_active_call();
     rc |= test_release_ends_call_with_terminator_reason();
     rc |= test_sdcall_header_short_is_ignored();
     rc |= test_sdcall_iv_short_type_c_is_ignored();
@@ -2090,7 +2002,6 @@ main(void) {
     rc |= test_sdcall_des_data_decrypts_and_resets();
     rc |= test_dcall_aes_data_decrypts_with_manual_key_and_iv();
     rc |= test_arib_vcall_uses_shifted_fields();
-    rc |= test_bad_crc_encrypted_vcall_records_metadata();
     rc |= test_vcall_des_keyloader_and_iv_signal();
     rc |= test_vcall_scrambler_keyloader_uses_active_nxdn48_profile();
     rc |= test_vcall_aes_keyloader_and_iv_signal();

--- a/tests/protocol/nxdn/test_nxdn_enc_class.c
+++ b/tests/protocol/nxdn/test_nxdn_enc_class.c
@@ -31,7 +31,7 @@
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
-void NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, uint8_t CrcCorrect, const uint8_t* ElementsContent,
+void NXDN_Elements_Content_decode(dsd_opts* opts, dsd_state* state, const uint8_t* ElementsContent,
                                   size_t elements_bits);
 
 /*
@@ -48,20 +48,18 @@ nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType) {
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-nxdn_alias_decode_arib(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+nxdn_alias_decode_arib(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits) {
     (void)opts;
     (void)state;
     (void)message_bits;
-    (void)crc_ok;
 }
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-nxdn_alias_decode_prop(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+nxdn_alias_decode_prop(const dsd_opts* opts, dsd_state* state, const uint8_t* message_bits) {
     (void)opts;
     (void)state;
     (void)message_bits;
-    (void)crc_ok;
 }
 
 void
@@ -227,7 +225,7 @@ test_vcall_enc_lockout_requires_corroboration(void) {
     // First CRC-good non-clear VCALL: classifies (and mutes) tentatively, but
     // no blocking entry and no forced disconnect.
     build_vcall(bits, 2U, 5U, 100U, 1234U);
-    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(&opts, &state, bits, sizeof(bits));
     assert(state.nxdn_cipher_type == 2U);
     assert(state.dmr_encL == 1);
     assert(!dsd_enc_lockout_lookup(&state, 1234U, 1, NULL));
@@ -235,32 +233,11 @@ test_vcall_enc_lockout_requires_corroboration(void) {
     // The matching repeat corroborates and the lockout acts -- in the session
     // ledger, never as a talkgroup-policy row.
     build_vcall(bits, 2U, 5U, 100U, 1234U);
-    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(&opts, &state, bits, sizeof(bits));
     assert(dsd_enc_lockout_entry_active(&state, 1234U, 1));
     dsd_enc_lockout_entry ledger_entry;
     assert(dsd_enc_lockout_lookup(&state, 1234U, 1, &ledger_entry) == 1);
     assert(ledger_entry.algid == 2);
-    assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
-    assert(lookup.match == DSD_TG_POLICY_MATCH_NONE);
-    dsd_state_ext_free_all(&state);
-}
-
-static void
-test_crc_failed_vcall_mutates_nothing(void) {
-    static dsd_opts opts;
-    static dsd_state state;
-    static Event_History_I history[2];
-    uint8_t bits[96];
-    dsd_tg_policy_lookup lookup;
-
-    reset_fixture(&opts, &state, history);
-
-    build_vcall(bits, 2U, 5U, 100U, 1234U);
-    NXDN_Elements_Content_decode(&opts, &state, 0U, bits, sizeof(bits));
-    assert(state.nxdn_cipher_type == 0U);
-    assert(state.dmr_encL == 0);
-    assert(nxdn_cipher_established_enc(&state) == 0);
-    assert(!dsd_enc_lockout_lookup(&state, 1234U, 1, NULL));
     assert(dsd_tg_policy_lookup_id(&state, 1234U, &lookup) == 0);
     assert(lookup.match == DSD_TG_POLICY_MATCH_NONE);
     dsd_state_ext_free_all(&state);
@@ -278,14 +255,14 @@ test_lone_contradicting_vcall_does_not_flap_established_clear(void) {
 
     // Two clear VCALLs establish the call clear.
     build_vcall(bits, 0U, 0U, 100U, 1234U);
-    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
-    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(&opts, &state, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(&opts, &state, bits, sizeof(bits));
     assert(state.nxdn_cipher_type == 0U);
 
     // A lone corrupt VCALL claiming DES: quarantined -- audio stays open, the
     // published crypto stays clear, no blocking entry, no forced disconnect.
     build_vcall(bits, 2U, 5U, 100U, 1234U);
-    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(&opts, &state, bits, sizeof(bits));
     assert(state.nxdn_cipher_type == 0U);
     assert(state.dmr_encL == 0);
     assert(!dsd_enc_lockout_lookup(&state, 1234U, 1, NULL));
@@ -296,7 +273,7 @@ test_lone_contradicting_vcall_does_not_flap_established_clear(void) {
     // The repeat corroborates a real change: the classification flips and the
     // lockout acts.
     build_vcall(bits, 2U, 5U, 100U, 1234U);
-    NXDN_Elements_Content_decode(&opts, &state, 1U, bits, sizeof(bits));
+    NXDN_Elements_Content_decode(&opts, &state, bits, sizeof(bits));
     assert(state.nxdn_cipher_type == 2U);
     assert(dsd_enc_lockout_entry_active(&state, 1234U, 1));
     dsd_state_ext_free_all(&state);
@@ -309,7 +286,6 @@ main(void) {
     test_contradiction_of_tentative_replaces();
     test_force_and_reset();
     test_vcall_enc_lockout_requires_corroboration();
-    test_crc_failed_vcall_mutates_nothing();
     test_lone_contradicting_vcall_does_not_flap_established_clear();
     printf("NXDN enc class: OK\n");
     return 0;

--- a/tests/protocol/nxdn/test_nxdn_grant_policy.c
+++ b/tests/protocol/nxdn/test_nxdn_grant_policy.c
@@ -64,20 +64,18 @@ nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType) {
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-nxdn_alias_decode_arib(dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+nxdn_alias_decode_arib(dsd_opts* opts, dsd_state* state, const uint8_t* message_bits) {
     (void)opts;
     (void)state;
     (void)message_bits;
-    (void)crc_ok;
 }
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-nxdn_alias_decode_prop(dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+nxdn_alias_decode_prop(dsd_opts* opts, dsd_state* state, const uint8_t* message_bits) {
     (void)opts;
     (void)state;
     (void)message_bits;
-    (void)crc_ok;
 }
 
 void

--- a/tests/protocol/nxdn/test_nxdn_grant_tune_matrix.c
+++ b/tests/protocol/nxdn/test_nxdn_grant_tune_matrix.c
@@ -90,20 +90,18 @@ nxdn_message_type(const dsd_opts* opts, dsd_state* state, uint8_t MessageType) {
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-nxdn_alias_decode_arib(dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+nxdn_alias_decode_arib(dsd_opts* opts, dsd_state* state, const uint8_t* message_bits) {
     (void)opts;
     (void)state;
     (void)message_bits;
-    (void)crc_ok;
 }
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-nxdn_alias_decode_prop(dsd_opts* opts, dsd_state* state, const uint8_t* message_bits, uint8_t crc_ok) {
+nxdn_alias_decode_prop(dsd_opts* opts, dsd_state* state, const uint8_t* message_bits) {
     (void)opts;
     (void)state;
     (void)message_bits;
-    (void)crc_ok;
 }
 
 void


### PR DESCRIPTION
Fixes #411.

## What

`state->NxdnElementsContent.VCallCrcIsGood` had one production write — `NXDN_Elements_Content_decode()` storing its `CrcCorrect` parameter — and all six callers passed a literal `1` (or a variable the enclosing branch had already proven to be 1). Nothing reset it, so it was 0 only until the first element of a run decoded and 1 permanently after.

Eight sites read it; four named it as their only CRC check — the live cipher mutation, the enc lockout's take and release, and the call end. All were constant-true.

## Why option 2 (drop it) and not option 1 (make it real)

The issue leaned toward (1) as safer. It isn't available:

- The write at `nxdn_element.c:507` ran **before every reader inside the same decode call**, so adding a per-transmission reset would still leave the flag at 1 at every read site. That half of (1) is a no-op.
- The only way `CrcCorrect = 0` could ever arrive is to call the decoder on content that failed its CRC — exactly dsd-fme's `aggressive_framesync` fallbacks, which #410 declined to reinstate. NXDN's CRCs are 6–16 bits; relaxing them is the #398 failure mode.

So (1) is either inert or a reversal of #410. This states the contract the code already keeps:

> Channel decoders hand `NXDN_Elements_Content_decode()` CRC-verified content only, having reported that CRC to `nxdn_confirm_note_evidence()`. The gate lives in the callers; `nxdn_confirm_is_confirmed()` is the frame-level check where a call is published or a scan hold refreshed.

Each channel checks its own CRC 1–8 lines above the call: SACCH CRC-6 (`nxdn_deperm.c:262`), FACCH1 CRC-12 (`:1160`), FACCH2/UDCH CRC-15 (`:530`), CAC CRC-16 (`:639`), FACCH3/UDCH2 (`:942`), and `NXDN_SACCH_Full_decode()` for an assembled superframe.

**No behaviour change:** every removed condition was constant-true.

## Changes

- `include/dsd-neo/core/state.h` — drop `VCallCrcIsGood`, plus `VCallIvCrcIsGood` and `CipherParameterValidity`, both declared and never touched anywhere in the tree.
- `include/dsd-neo/protocol/nxdn/nxdn_deperm.h` — `NXDN_Elements_Content_decode()` loses `CrcCorrect` and gains a doc comment stating the precondition, including the one deliberate exception (see below).
- `src/protocol/nxdn/nxdn_element.c` — remove the write and the seven reads; the comments now say where the gate is instead of claiming to be it. The local `CrcCorrect` in `NXDN_SACCH_Full_decode()` is a real four-segment verdict and stays.
- `src/protocol/nxdn/nxdn_deperm.c` — five call sites; `nxdn_message_type()`'s release teardown now gates on the message type alone.
- `nxdn_alias_crc_ok()` returned `1` on both branches, so the alias decoders' `crc_ok` parameter was only ever fed that constant: helper deleted, parameter dropped from `nxdn_alias_decode_prop()`/`_arib()` and their log helpers, along with the unreachable `(CRC ERR)` prints.
- `docs/code_map.md` — the caller-side contract, next to the existing `nxdn_confirm` note.

### The synthesized disconnect

`nxdn_vcall_run_enc_lockout()` fabricates a DISC element in a local buffer and feeds it through the decoder. With no flag left to stamp, that re-entry is behaviour-preserving; it is now documented as the deliberate exception — it exists to drive the same teardown a received DISC would.

### Deliberately not done

No `nxdn_confirm_is_confirmed()` added at cipher mutation / lockout / call end. Every channel that can carry a VCALL is strong evidence and confirms the transmission in the caller before the decode, so that check would be constant-true too — the same defect in a new coat. The lockout already requires `nxdn_cipher_established_enc()`, i.e. a superframe of corroboration.

## Coverage

The regression protection moves to where the gate actually is. Each channel gets a caller-side case that a failed CRC never reaches the element decoder, witnessed by the message type the decoder would otherwise overwrite.

- `NXDN_DEPERM_PRIMITIVES` — new `facch1-*`, `sacch-nsf-*` and `cac-*` cases. FACCH1 carries call setup, so it is tested on a real burst: no encoder is exported anywhere in the tree (`trellis_encode()` is static in `dsd_misc.c`, `nxdn_convolution.h` is decode-only), so the test runs the decoder's chain backwards — CRC-12, rate-1/2 K=5 encode, 16/9 puncture, permute — and the soft Viterbi decodes it exactly.
- `NXDN_ELEMENT_BOUNDS` — asserts the assembled-superframe gate the same way; the data-header hold case now varies `nxdn_confirmed` rather than the dead flag, so it exercises the half of that condition that does work.
- The cases that drove the decoder with a CRC-failed argument (`test_bad_crc_release_keeps_active_call`, `test_bad_crc_encrypted_vcall_records_metadata`, `test_crc_failed_vcall_mutates_nothing`, the `prop-crc-gate` alias case) are removed with the parameter: they tested a call no production caller can make.

## Verification

```
ctest --preset dev-debug --output-on-failure          # 571/571 pass
ctest --preset asan-ubsan-debug --output-on-failure   # 571/571 pass
tools/preflight_ci.sh                                 # clean
grep -rn 'VCallCrcIsGood\|VCallIvCrcIsGood\|CipherParameterValidity\|nxdn_alias_crc_ok' src include tests docs apps
#   → empty; only the real four-segment local `CrcCorrect` remains, in NXDN_SACCH_Full_decode()
```

Negative controls, each applied then reverted — removing a caller gate makes the matching new assertion fail:

| control | failing assertion |
|---|---|
| FACCH1 `if (crc == check && !duplicate)` → `if (!duplicate)` | `facch1-bad-crc-skips-elements: got 0x10 want 0x22` |
| FACCH2/UDCH `if (crc == check)` → `if (1)` | `facch2-bad-skips-elements: got 0x10 want 0x22` |
| CAC `if (crc == 0)` → `if (1)` | `cac-bad-crc-skips-elements: got 0x00 want 0x22` |
| SACCH NSF `if (sacch_crc_ok)` → `if (sacch_crc_ok \|\| 1)` | `sacch-nsf-bad-crc-skips-elements: got 0x2A want 0x22` |
| full SACCH `if (CrcCorrect == 1)` → `if (CrcCorrect == 1 \|\| 1)` | `sacch-bad-crc-skips-elements: got 0x17 want 0x22` |
