### PR TITLE
fix(dsp): drop the inverted-P25p1 carve-out from the no-sync timeout

### DIFF
--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -3097,9 +3097,18 @@ frame_sync_no_sync_run_hooks(dsd_opts* opts, dsd_state* state, time_t now) {
     dsd_frame_sync_hook_no_carrier(opts, state);
 }
 
+/**
+ * @brief Give up on this call once a whole matchless pass has gone by.
+ *
+ * The dwell is the only gate: no protocol gets a carve-out here. A
+ * `lastsynctype == DSD_SYNC_P25P1_NEG` term used to short-circuit the whole timeout,
+ * inherited unexplained from upstream DSD, which let an inverted P25p1 sync hold off
+ * this exit -- and only this one -- until the sync window's 10200-symbol wrap fired
+ * no_carrier and cleared lastsynctype (#389).
+ */
 static int
 frame_sync_handle_no_sync_timeout(dsd_opts* opts, dsd_state* state, const frame_sync_runtime_ctx* rt, time_t now) {
-    if (state->lastsynctype == DSD_SYNC_P25P1_NEG || rt->synctest_pos < DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS) {
+    if (rt->synctest_pos < DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS) {
         return 0;
     }
 

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -163,8 +163,10 @@ reset(dsd_opts* opts, dsd_state* state) {
 
 static int g_vc_sync_hook_calls;
 static int g_vc_no_sync_hook_calls;
+static int g_release_hook_calls;
 static int g_no_carrier_hook_calls;
 static int g_vc_no_sync_hook_order;
+static int g_release_hook_order;
 static int g_no_carrier_hook_order;
 static int g_hook_order;
 
@@ -181,6 +183,14 @@ fake_p25_sm_vc_no_sync(dsd_opts* opts, const dsd_state* state) {
     (void)state;
     g_vc_no_sync_hook_calls++;
     g_vc_no_sync_hook_order = ++g_hook_order;
+}
+
+static void
+fake_p25_sm_release(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    g_release_hook_calls++;
+    g_release_hook_order = ++g_hook_order;
 }
 
 static void
@@ -237,6 +247,38 @@ test_p25_vc_acquisition_hooks(void) {
     assert(g_vc_no_sync_hook_calls == 1);
     assert(g_no_carrier_hook_calls == 1);
     assert(g_vc_no_sync_hook_order < g_no_carrier_hook_order);
+
+    /* An inverted P25p1 sync used to short-circuit this timeout outright, so the dwell
+     * never expired while it was the last sync seen and only the hunt's budget exit ever
+     * returned no-sync (#389). The dwell is the only gate now, and the timeout owes the
+     * P25 SM the same accounting in the same order as the other no-sync exit. */
+    reset(&opts, &state);
+    opts.trunk_enable = 1;
+    opts.trunk_is_tuned = 1;
+    state.lastsynctype = DSD_SYNC_P25P1_NEG;
+    g_vc_no_sync_hook_calls = 0;
+    g_release_hook_calls = 0;
+    g_no_carrier_hook_calls = 0;
+    g_vc_no_sync_hook_order = 0;
+    g_release_hook_order = 0;
+    g_no_carrier_hook_order = 0;
+    g_hook_order = 0;
+    dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){
+        .p25_sm_release = fake_p25_sm_release,
+        .p25_sm_vc_no_sync = fake_p25_sm_vc_no_sync,
+        .no_carrier = fake_no_carrier,
+    });
+
+    assert(dsd_frame_sync_test_handle_no_sync_timeout(&opts, &state, DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS - 1) == 0);
+    assert(g_vc_no_sync_hook_calls == 0);
+    assert(g_release_hook_calls == 0);
+    assert(g_no_carrier_hook_calls == 0);
+    assert(dsd_frame_sync_test_handle_no_sync_timeout(&opts, &state, DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS) == 1);
+    assert(g_vc_no_sync_hook_calls == 1);
+    assert(g_release_hook_calls == 1);
+    assert(g_no_carrier_hook_calls == 1);
+    assert(g_vc_no_sync_hook_order < g_release_hook_order);
+    assert(g_release_hook_order < g_no_carrier_hook_order);
 
     dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){0});
 }


### PR DESCRIPTION
## Summary

- `frame_sync_handle_no_sync_timeout()` gated on `state->lastsynctype == DSD_SYNC_P25P1_NEG || rt->synctest_pos < <dwell>`. The second term is the intended dwell; the first suppressed the timeout outright whenever an inverted P25p1 sync was the last one seen. Removed, leaving the dwell as the only gate.
- **The term is vestigial, not designed.** It arrived with the scaffold commit `300644e9` as upstream DSD's bare `if (state->lastsynctype != 1)` and has never carried a comment. `git blame` points elsewhere only because `4d948f82` substituted the named dwell constant for the `1800` literal and `98a1eacb` hoisted the condition into this helper. Nothing else in the tree reads `DSD_SYNC_P25P1_NEG` off `lastsynctype` — every other consumer goes through `DSD_SYNC_IS_P25P1()`, which matches both polarities and is unaffected.
- **Impact is narrower than issue #389 states**, and the PR says so rather than repeating the issue. Since #390 there is a second no-sync exit at the bottom of the `getFrameSync()` loop that does not consult `lastsynctype`, so the hunt still stepped at the dwell; and the 10200-symbol window wrap fired the no-carrier hook, which clears `lastsynctype` and released the carve-out on its own.
- What was actually wrong: the two no-sync exits **disagreed**. With an inverted P25p1 `lastsynctype` the timeout exit stayed silent for up to ~10200 symbols — no `Sync: no sync` line and no in-order hook run — so the `p25_sm_vc_no_sync` note and hangtime release that #393 established were skipped. When the hunt had no second profile to step to, `frame_sync_no_sync_sps_hunt()` returns 0 and the loop-bottom exit did not fire either, skipping that accounting entirely.
- Regression test drives the seam with `lastsynctype = DSD_SYNC_P25P1_NEG`: no fire one symbol short of the dwell, fire at the dwell, hooks in contract order. Verified to abort against the pre-fix guard.

**Known follow-up, deliberately not in this diff:** the timeout now returns unconditionally at the dwell, so `rt->synctest_pos` can never reach 10200 and the wrap branch in `frame_sync_advance_sync_window()` is dead in production. Removing it forces a signature change plus a call-site edit, so it stays out of this focused diff. It is a cleanup, not a behavior gap — for every non-NEG synctype that branch was already unreachable before this commit.

Closes #389.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / **none**.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: an inverted-P25p1 acquisition now gets the same 1800-symbol no-sync dwell every other synctype has, instead of ~10200. That is >2 P25p1 frames within a single `getFrameSync()` call, so an actively decoding inverted signal cannot reach it. `-v 3` sessions may see a `Sync: no sync` line where the carve-out previously silenced one.
- Compatibility or packaging impact: none.
- Not measured end-to-end: no inverted-P25p1 I/Q fixture exists, and issue #389 states nothing reproduces the condition. The change rests on the provenance argument plus the unit seam, not on a capture.
