### PR TITLE
fix(dsp): give an adopted SPS profile its own dwell

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -544,12 +544,29 @@ struct dsd_state {
      * sps_hunt_counter: symbols the search burned that no frame handler claimed. Symbols
      *   spent looking for a sync count up; symbols a handler consumed on one sync are
      *   debited back, floored at zero, so a profile carrying traffic sits at zero and a
-     *   profile matching nothing reaches its dwell. Zeroing this alone is a complete reset.
+     *   profile matching nothing reaches its dwell. The budget belongs to the profile, so
+     *   zeroing this alone is not a complete reset: a profile change owes this and
+     *   sps_hunt_symbolcnt_mark together. frame_sync_apply_sps_hunt_profile() does both
+     *   whenever it moves the index, so its callers need not -- but it is not the only way
+     *   sps_hunt_idx moves, and the sites that assign the index directly still owe both
+     *   themselves (#394). None of them pays in full today: the app-control and engine
+     *   retune paths (svc_publish_symbol_profile(), set_cc_symbol_timing(),
+     *   dsd_engine_select_p25_sps_profile(), no_carrier_apply_p25_cc_symbolrate() and the
+     *   two trunk-scan target helpers) zero the counter and leave the anchor where it was,
+     *   which is harmless only because whatever that anchor then credits is debited from the
+     *   counter they just zeroed and floored there; the -m2/-m3/-m4 branches of the CLI 'm'
+     *   case do neither, and are benign only because they run before the first
+     *   getFrameSync().
      * sps_hunt_symbolcnt_mark: dsd_state::symbolcnt as getFrameSync() last returned, so
      *   the next call can measure what the handler consumed in between. It shares that
      *   field's unsigned wrapping type, so the difference stays exact across the counter's
      *   2^32 rollover. Credit is per sync and only counts once it reaches a frame's worth,
      *   which is what keeps the dwell independent of how often an unproductive matcher fires.
+     *   Re-anchored alongside the counter whenever frame_sync_apply_sps_hunt_profile() moves
+     *   the index, so a fresh budget is never paired with an anchor taken under the outgoing
+     *   profile. Inside getFrameSync() the mark is already current at every such call, so that
+     *   half is contract rather than repair; it is what a direct assigner would have to do for
+     *   itself.
      * sps_hunt_idx: current rate/profile index
      * (0=4800/4-level, 1=2400/4-level, 2=9600/binary, 3=6000/4-level, 4=4800/binary) */
     int sps_hunt_counter;

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -2863,6 +2863,32 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
     }
 
     state->sps_hunt_idx = next_idx;
+    if (profile_changed) {
+        /* The dwell belongs to the profile, so adopting one starts its budget over. That is
+         * the defect: left alone, the incoming profile inherits whatever the outgoing one had
+         * already spent, and one that arrives a symbol short of the dwell is stepped off again
+         * on the very next symbol, because frame_sync_advance_sync_window() bills one symbol
+         * per symbol (#394).
+         *
+         * The measurement anchor moves with the budget so the pair stays consistent, not
+         * because it is stale today: every path that reaches here already has a current mark.
+         * getFrameSync() runs frame_sync_sps_hunt_note_handler_consumption() -- which
+         * re-anchors -- immediately before frame_sync_ensure_enabled_sps_profile(), and the
+         * hunt's own call site leaves getFrameSync() through frame_sync_sps_hunt_mark_return()
+         * at the same symbolcnt. A fresh budget paired with an anchor taken under the outgoing
+         * profile is what would let frame_sync_sps_hunt_note_handler_consumption() credit the
+         * new profile for symbols a handler consumed before it was selected, so the two are
+         * written together rather than left to each caller to keep in step.
+         *
+         * This sits here rather than at the call sites so it covers every path through the
+         * helper: the hunt itself (which zeroes the counter just before calling), both adopt
+         * paths in frame_sync_ensure_enabled_sps_profile(), and any future caller. The guard is
+         * load-bearing -- a call that leaves the index alone can still get past the early-out
+         * above to normalise a two-level profile's modulation, and that is the same profile
+         * spending the same dwell, so its budget must survive. */
+        state->sps_hunt_counter = 0;
+        state->sps_hunt_symbolcnt_mark = state->symbolcnt;
+    }
     if (normalize_profile_modulation) {
         state->rf_mod = profile_default_modulation;
     }

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -699,6 +699,95 @@ test_sps_hunt_reconciles_external_timing(void) {
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P1_SYNC, 24) == DSD_SYNC_P25P1_POS);
 }
 
+/* #394: a profile the reconciliation adopts starts its dwell over. Before the fix it
+ * inherited whatever the outgoing profile had already spent, so an adoption landing one
+ * symbol short of the dwell was stepped away from on the very next symbol. */
+static void
+test_adopted_profile_starts_its_dwell_over(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.frame_p25p2 = 1;
+    opts.frame_dstar = 1;
+    opts.mod_qpsk = 1;
+    state.rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 6000, 48000);
+    state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
+
+    const int dwell = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
+    assert(dwell > 1);
+
+    /* The outgoing profile is one symbol short of stepping, and its measurement anchor sits
+     * where the handler that ran under it started consuming. */
+    state.symbolcnt = 4096U;
+    state.sps_hunt_counter = dwell - 1;
+    state.sps_hunt_symbolcnt_mark = 1024U;
+
+    frame_sync_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(state.sps_hunt_counter == 0);
+    assert(state.sps_hunt_symbolcnt_mark == state.symbolcnt);
+
+    /* frame_sync_advance_sync_window() bills one symbol per symbol, so the adopted profile
+     * must be able to spend a whole dwell before the hunt may rotate off it. */
+    for (int spent = 1; spent < dwell; spent++) {
+        state.sps_hunt_counter++;
+        assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 0);
+        assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    }
+    state.sps_hunt_counter++;
+    assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 1);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
+
+    /* A reconciliation with nothing to do is still not allowed to refund the budget: it is
+     * the same profile spending the same dwell. This one turns back at the helper's own
+     * early-out, so it pins the early-out rather than the profile_changed guard. */
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.frame_p25p2 = 1;
+    opts.frame_dstar = 1;
+    state.rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 6000, 48000);
+    state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
+    state.symbolcnt = 4096U;
+    state.sps_hunt_counter = dwell - 1;
+    state.sps_hunt_symbolcnt_mark = 4096U;
+
+    frame_sync_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(state.sps_hunt_counter == dwell - 1);
+
+    /* The guard itself. A two-level profile whose modulation is not GFSK gets past the
+     * early-out to normalise dsd_state::rf_mod without the index moving -- the one shape that
+     * reaches the reset with profile_changed clear. Still the same profile spending the same
+     * dwell, so an unguarded reset would refund a live budget here, and re-anchoring the mark
+     * would hand that profile credit for symbols it had already been billed for. */
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    opts.frame_dstar = 1;
+    state.rf_mod = 0;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.samplesPerSymbol = dsd_opts_compute_sps_rate(&opts, 4800, 48000);
+    state.symbolCenter = dsd_opts_symbol_center(state.samplesPerSymbol);
+    state.symbolcnt = 4096U;
+    state.sps_hunt_counter = dwell - 1;
+    state.sps_hunt_symbolcnt_mark = 1024U;
+
+    frame_sync_ensure_enabled_sps_profile(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
+    /* Proof the call ran past the early-out rather than turning back at it. */
+    assert(state.rf_mod == 2);
+    assert(state.sps_hunt_counter == dwell - 1);
+    assert(state.sps_hunt_symbolcnt_mark == 1024U);
+}
+
 static void
 test_binary_profiles_override_unlocked_qpsk(void) {
     static dsd_opts opts;
@@ -1830,6 +1919,7 @@ main(void) {
     test_sps_hunt_skips_disabled_protocol_rates();
     test_sps_hunt_profile_updates_timing();
     test_sps_hunt_reconciles_external_timing();
+    test_adopted_profile_starts_its_dwell_over();
     test_sps_hunt_budget_is_spent_in_symbols();
     test_sps_hunt_consumption_is_exact_across_the_symbolcnt_wrap();
     test_carrier_does_not_reset_the_hunt_budget();


### PR DESCRIPTION
## Summary

- `frame_sync_ensure_enabled_sps_profile()` runs on every `getFrameSync()` entry and has **two** paths that move `sps_hunt_idx` (the issue names one): the timing reconciliation, and the fallback loop when the current index has no enabled candidate. Both went through `frame_sync_apply_sps_hunt_profile()`, which wrote only the index, `rf_mod` and timing — never `sps_hunt_counter`.
- The incoming profile therefore inherited the outgoing profile's spent budget. `frame_sync_advance_sync_window()` bills one symbol per symbol unconditionally and the loop-bottom step fires as soon as the dwell is met, so a profile adopted one symbol short of the dwell was rotated away from on the very next symbol — never getting a dwell at all.
- Fix resets the counter **inside** `frame_sync_apply_sps_hunt_profile()`, guarded on its existing `profile_changed` local. One placement covers both adopt paths, the hunt's own step, and any future caller. The guard is what keeps it from wiping a live budget: a call that leaves the index alone can still get past the early-out to normalise a two-level profile's modulation, and that is the same profile spending the same dwell.
- `sps_hunt_symbolcnt_mark` is re-anchored in the same place, **as contract rather than repair** — it is provably not stale on any path that reaches the helper in this tree. Written anyway so a fresh budget can never be paired with an anchor taken under the outgoing profile.
- **Three sites the issue missed:** the `-m2`, `-m3` and `-m4` branches in `src/runtime/cli/args.c` assign `sps_hunt_idx` without zeroing the counter. They run at CLI-parse time before any `getFrameSync()`, so they are benign — but they are counterexamples, so the fix deliberately does not rest on the "every site zeroes it" invariant.
- The `dsd_state` doc block now states the invariant for both sides rather than declaring the helper sufficient: nine sites assign the index directly and still owe it themselves (six retune paths that zero the counter but leave the anchor, plus those three CLI branches that do neither). Its old claim that "zeroing this alone is a complete reset" is what this change fixes.

Closes #394.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / **none**.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: under `-fa`, a profile adopted by timing reconciliation now serves its full dwell instead of possibly being rotated away after one symbol. Rotation period for the ordinary idle case is unchanged and pinned by `test_idle_rotation_period_is_unchanged()`.
- Compatibility or packaging impact: none. Also ran `ctest --preset asan-ubsan-debug` (571/571), since this changes hunt arithmetic.
