### PR TITLE
fix(core): stop dsd_state::symbolcnt overflowing after five days of uptime

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -502,7 +502,11 @@ struct dsd_state {
     char err_bufR[64];
     char fsubtype[16];
     char ftype[16];
-    int symbolcnt;
+    /* Free-running count of symbols getSymbol() has produced. Unsigned because it is only
+     * ever incremented and differenced modulo 2^32: a signed counter overflowed after about
+     * 5.2 days at 4800 symbols/s, which is undefined behaviour and aborts a UBSan build
+     * (#395). Readers must treat it as wrapping -- compare differences, never magnitudes. */
+    uint32_t symbolcnt;
     int symbolc;
     uint8_t symbol_replay_format;         /* DSD_SYMBOL_REPLAY_FORMAT_* */
     uint8_t symbol_replay_header_checked; /* header probe already done for current symbol file */
@@ -542,13 +546,14 @@ struct dsd_state {
      *   debited back, floored at zero, so a profile carrying traffic sits at zero and a
      *   profile matching nothing reaches its dwell. Zeroing this alone is a complete reset.
      * sps_hunt_symbolcnt_mark: dsd_state::symbolcnt as getFrameSync() last returned, so
-     *   the next call can measure what the handler consumed in between. Credit is per sync
-     *   and only counts once it reaches a frame's worth, which is what keeps the dwell
-     *   independent of how often an unproductive matcher fires.
+     *   the next call can measure what the handler consumed in between. It shares that
+     *   field's unsigned wrapping type, so the difference stays exact across the counter's
+     *   2^32 rollover. Credit is per sync and only counts once it reaches a frame's worth,
+     *   which is what keeps the dwell independent of how often an unproductive matcher fires.
      * sps_hunt_idx: current rate/profile index
      * (0=4800/4-level, 1=2400/4-level, 2=9600/binary, 3=6000/4-level, 4=4800/binary) */
     int sps_hunt_counter;
-    int sps_hunt_symbolcnt_mark;
+    uint32_t sps_hunt_symbolcnt_mark;
     int sps_hunt_idx;
     int lastsynctype;
     int lastp25type;

--- a/src/core/frames/dsd_dibit.c
+++ b/src/core/frames/dsd_dibit.c
@@ -170,7 +170,8 @@ print_datascope(const dsd_opts* opts, dsd_state* state, const float* sbuf2, int 
     }
     const float scale = 32.0f / span;
     build_datascope_spectrum(sbuf2, count, scale, spectrum);
-    if (state->symbolcnt > (4800 / opts->scoperate)) {
+    /* dsd_state::symbolcnt is unsigned; the refresh period is a small positive int. */
+    if (state->symbolcnt > (uint32_t)(4800 / opts->scoperate)) {
         dsd_call_snapshot call;
         DSD_MEMSET(&call, 0, sizeof(call));
         (void)dsd_call_state_get(state, 0U, &call);

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -2967,23 +2967,43 @@ frame_sync_sps_hunt_dwell_symbols(const dsd_opts* opts, const dsd_state* state) 
  */
 static void
 frame_sync_sps_hunt_note_handler_consumption(dsd_state* state) {
-    unsigned int consumed = (unsigned int)state->symbolcnt - (unsigned int)state->sps_hunt_symbolcnt_mark;
-    if (consumed > (unsigned int)INT_MAX) {
+    /* Both operands wrap at 2^32, so this modular difference stays exact when the free-running
+     * symbol counter rolls over mid-measurement. */
+    uint32_t consumed = state->symbolcnt - state->sps_hunt_symbolcnt_mark;
+    if (consumed > (uint32_t)INT_MAX) {
         /* symbolcnt went backwards, so an unrelated subsystem zeroed it rather than a
-         * handler having consumed 4 billion symbols (nxdn_reset_after_cac_fail(),
-         * initState() on an in-process restart). Credit nothing; the mark below re-anchors
-         * the measurement on the next call. */
+         * handler having consumed 4 billion symbols: nxdn_reset_after_cac_fail(),
+         * initState() on an in-process restart, and print_datascope() on each refresh.
+         * Credit nothing; the mark below re-anchors the measurement on the next call.
+         *
+         * The datascope is the only one of the three that can zero it faster than handlers
+         * consume -- once every opts->ssize symbols after the count passes
+         * 4800/opts->scoperate, so a few hundred symbols apart -- which means an interval
+         * that really did decode a frame can straddle a reset and be credited nothing.
+         * That is accepted here rather than worked around: nothing in the tree ever sets
+         * opts->datascope to 1, so the display is unreachable and the overlap is latent,
+         * and a missed credit costs only the debit, leaving the hunt on the undebited
+         * dwell it had before #390 rather than mis-crediting anything. Wiring the
+         * datascope back to a switch means giving its reset a form this can tell apart
+         * from a rollover. */
         consumed = 0;
     }
-    if (consumed >= (unsigned int)DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS) {
+    if (consumed >= (uint32_t)DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS) {
         /* dsd_state::sps_hunt_counter only ever counts up from zero, so this is exact.
          * Sites outside the hunt park a profile by zeroing it; the floor at zero means
          * consumption measured across such a reset cannot drive it negative. */
-        const unsigned int counter = (unsigned int)state->sps_hunt_counter;
+        const uint32_t counter = (uint32_t)state->sps_hunt_counter;
         state->sps_hunt_counter = (int)(consumed >= counter ? 0U : counter - consumed);
     }
     state->sps_hunt_symbolcnt_mark = state->symbolcnt;
 }
+
+#ifdef DSD_NEO_TEST_HOOKS
+void
+dsd_frame_sync_test_sps_hunt_note_handler_consumption(dsd_state* state) {
+    frame_sync_sps_hunt_note_handler_consumption(state);
+}
+#endif
 
 /** @brief Remember where the handler starts consuming, so the next call can measure it. */
 static void

--- a/src/dsp/frame_sync_test_support.h
+++ b/src/dsp/frame_sync_test_support.h
@@ -23,6 +23,7 @@ void dsd_frame_sync_test_set_recent_hamming(int ham_c4fm, int ham_qpsk, int ham_
 void dsd_frame_sync_test_get_mod_votes(int* out_c4fm, int* out_qpsk, int* out_gfsk);
 void dsd_frame_sync_test_reset_p25_trunk_tick_state(void);
 int dsd_frame_sync_test_handle_no_sync_timeout(dsd_opts* opts, dsd_state* state, int synctest_pos);
+void dsd_frame_sync_test_sps_hunt_note_handler_consumption(dsd_state* state);
 #ifdef USE_RADIO
 int dsd_frame_sync_test_rtl_profile_for_sps_index(const dsd_opts* opts, const dsd_state* state, int profile_index);
 #endif

--- a/tests/dsp/test_dsp_symbol_replay.c
+++ b/tests/dsp/test_dsp_symbol_replay.c
@@ -234,6 +234,50 @@ test_short_file_falls_back_to_legacy_replay(void) {
     opts.symbolfile = NULL;
 }
 
+/*
+ * dsd_state::symbolcnt free-runs for the life of the process, so it reaches its type's limit
+ * after about 5.2 days at 4800 symbols/s. As a signed int that increment was undefined
+ * behaviour and aborted the asan-ubsan build (issue #395); unsigned, it wraps to zero and
+ * decoding continues. Every reader differences it modulo 2^32, so the wrap costs nothing.
+ *
+ * This case is a UBSan tripwire, and which preset runs it decides what a revert looks like.
+ * Only `ctest --preset asan-ubsan-debug` sets UBSAN_OPTIONS=halt_on_error=1 (in
+ * CMakePresets.json), so only there does the signed increment abort and fail the test; under
+ * UBSan's default options the "signed integer overflow" diagnostic prints and the binary
+ * still exits 0, which ctest reports as Passed. What catches a revert under dev-debug is the
+ * build instead: the assertions below compare the field against uint32_t values, which is a
+ * -Werror=sign-compare break once it is signed again. Do not read a dev-debug pass as having
+ * exercised the overflow.
+ */
+static void
+test_symbol_count_wraps_instead_of_overflowing(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    init_symbol_replay_fixture(&opts, &state);
+    g_cleanup_calls = 0;
+
+    opts.symbolfile = tmpfile();
+    assert(opts.symbolfile != NULL);
+    assert(fputc(2, opts.symbolfile) != EOF);
+    assert(fputc(1, opts.symbolfile) != EOF);
+    rewind(opts.symbolfile);
+
+    /* The value that used to trap: one past INT32_MAX is where the signed increment was
+     * undefined. Unsigned, it is just another symbol. */
+    state.symbolcnt = (uint32_t)INT32_MAX;
+    assert(symbol_level_matches(getSymbol(&opts, &state, 0), 2U));
+    assert(state.symbolcnt == (uint32_t)INT32_MAX + 1U);
+
+    /* And the type's own limit rolls over to zero rather than trapping in turn. */
+    state.symbolcnt = UINT32_MAX;
+    assert(symbol_level_matches(getSymbol(&opts, &state, 0), 1U));
+    assert(state.symbolcnt == 0U);
+    assert(g_cleanup_calls == 0);
+
+    fclose(opts.symbolfile);
+    opts.symbolfile = NULL;
+}
+
 static void
 test_debug_replay_reopens_and_reprobes(void) {
     char path[DSD_TEST_PATH_MAX];
@@ -551,6 +595,7 @@ main(void) {
     exitflag = 0;
     test_soft_symbol_replay_record();
     test_short_file_falls_back_to_legacy_replay();
+    test_symbol_count_wraps_instead_of_overflowing();
     test_debug_replay_reopens_and_reprobes();
     test_missing_symbol_file_returns_error_symbol();
     test_unsupported_soft_headers_are_rejected();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -481,6 +481,64 @@ test_sps_hunt_budget_is_spent_in_symbols(void) {
     assert(state.sps_hunt_counter == 0);
 }
 
+/*
+ * dsd_state::symbolcnt free-runs and wraps at 2^32 (issue #395). The hunt measures what a
+ * handler consumed as a modular difference against its mark, so a rollover between the mark
+ * and the next getFrameSync() entry must still yield the true symbol count -- and a reset to
+ * zero must still be recognised as "an unrelated subsystem zeroed it" and credit nothing.
+ *
+ * This is a contract test, not a regression test: it passes against the pre-#395 signed
+ * fields too, because the helper already laundered the subtraction through explicit
+ * (unsigned int) casts, which made the arithmetic modular whatever the field types were.
+ * It pins the wrap-exactness the uint32_t fields now carry on their own -- so a later widen
+ * or re-signing of either field has to keep it -- but it is not what would have caught the
+ * overflow. DSP_SYMBOL_REPLAY's test_symbol_count_wraps_instead_of_overflowing() is.
+ */
+static void
+test_sps_hunt_consumption_is_exact_across_the_symbolcnt_wrap(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* 20 symbols consumed straddling the wrap: mark at UINT32_MAX - 25, counter at
+     * UINT32_MAX - 5. That is a frame's worth, so the budget is debited by exactly 20. */
+    reset(&opts, &state);
+    state.sps_hunt_counter = 1000;
+    state.sps_hunt_symbolcnt_mark = UINT32_MAX - 25U;
+    state.symbolcnt = UINT32_MAX - 5U;
+    dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
+    assert(state.sps_hunt_counter == 980);
+    assert(state.sps_hunt_symbolcnt_mark == UINT32_MAX - 5U);
+
+    /* Same 20 symbols, now with the wrap falling inside the interval. */
+    reset(&opts, &state);
+    state.sps_hunt_counter = 1000;
+    state.sps_hunt_symbolcnt_mark = UINT32_MAX - 15U;
+    state.symbolcnt = 4U;
+    dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
+    assert(state.sps_hunt_counter == 980);
+    assert(state.sps_hunt_symbolcnt_mark == 4U);
+
+    /* A reset to zero (nxdn_reset_after_cac_fail(), initState(), print_datascope()) looks
+     * like a backwards jump and buys the profile nothing; the mark re-anchors for the next
+     * call. */
+    reset(&opts, &state);
+    state.sps_hunt_counter = 1000;
+    state.sps_hunt_symbolcnt_mark = 5000U;
+    state.symbolcnt = 0U;
+    dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
+    assert(state.sps_hunt_counter == 1000);
+    assert(state.sps_hunt_symbolcnt_mark == 0U);
+
+    /* The floor still applies across the wrap: 6 symbols reach the rollover and the rest land
+     * past it, one short of a frame in all, so nothing is credited. */
+    reset(&opts, &state);
+    state.sps_hunt_counter = 1000;
+    state.sps_hunt_symbolcnt_mark = UINT32_MAX - 5U;
+    state.symbolcnt = (uint32_t)DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS - 1U - 6U;
+    dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
+    assert(state.sps_hunt_counter == 1000);
+}
+
 /* Carrier no longer wipes the hunt's progress from the modulation-switch path. */
 static void
 test_carrier_does_not_reset_the_hunt_budget(void) {
@@ -1731,6 +1789,7 @@ main(void) {
     test_sps_hunt_profile_updates_timing();
     test_sps_hunt_reconciles_external_timing();
     test_sps_hunt_budget_is_spent_in_symbols();
+    test_sps_hunt_consumption_is_exact_across_the_symbolcnt_wrap();
     test_carrier_does_not_reset_the_hunt_budget();
     test_binary_profiles_override_unlocked_qpsk();
     test_four_level_profiles_reset_inherited_modulation();

--- a/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
+++ b/tests/protocol/nxdn/test_nxdn_deperm_primitives.c
@@ -657,7 +657,7 @@ test_cac_crc_failure_reset(void) {
     rc |= expect_int("cac-reset-last-sync", state.lastsynctype, DSD_SYNC_NONE);
     rc |= expect_int("cac-reset-carrier", state.carrier, 0);
     rc |= expect_int("cac-reset-jitter", state.jitter, -1);
-    rc |= expect_int("cac-reset-symbolcnt", state.symbolcnt, 0);
+    rc |= expect_int("cac-reset-symbolcnt", (int)state.symbolcnt, 0);
     rc |= expect_int("cac-reset-offset", state.offset, 0);
     rc |= expect_int("cac-reset-dibit-pointer", (int)(state.dibit_buf_p - state.dibit_buf), 200);
     rc |= expect_int("cac-reset-data-blocks", state.data_header_blocks[0], 1);


### PR DESCRIPTION
## Summary

- `dsd_state::symbolcnt` was a signed `int` that nothing bounded, so at 4800 symbols/s it reached `INT_MAX` after ~5.2 days and overflowed — undefined behaviour, and under `asan-ubsan-debug` it aborts the decoder: `src/dsp/dsd_symbol.c:1856:21: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'`.
- Made `symbolcnt` a `uint32_t` so the increment wraps. Nothing reads it as a magnitude — the datascope compares it against a small refresh period and zeroes it, and the SPS hunt only ever differences it against its own mark. `sps_hunt_symbolcnt_mark` becomes `uint32_t` alongside it, which is what keeps that difference exact across the rollover.
- **Why `uint32_t` and not a wider type:** `frame_sync_sps_hunt_note_handler_consumption()` was already written for a wrapping counter — it did the subtraction through explicit unsigned casts and used the top half of the range to spot "an unrelated subsystem zeroed symbolcnt". `uint32_t` makes those casts redundant while leaving the heuristic exactly correct; `uint64_t` would truncate at that line and invalidate it.
- The one mandatory collateral edit is the datascope comparison in `print_datascope()`, which gains a cast on the `int` refresh period. Without it the now-`unsigned > int` compare trips `clang-diagnostic-sign-compare`, which `.clang-tidy` lists in `WarningsAsErrors` — so it would hard-fail the very preset this issue is about.
- No `%d`→`%u` changes exist anywhere in the tree; no UI, app, Android, serialization or ABI exposure.

**Test honesty.** `DSP_SYMBOL_REPLAY` seeds the counter at `INT32_MAX`/`UINT32_MAX` and drives the real `getSymbol()`, reproducing the UBSan abort against the old type — but that abort only *fails the run* under `ctest --preset asan-ubsan-debug`, the sole preset setting `UBSAN_OPTIONS=halt_on_error=1`. The case says so. The `FRAME_SYNC_INTERNAL_HELPERS` addition is a **contract test, not a regression test** — the helper's pre-existing unsigned casts already made that arithmetic modular, so it passes against the old field types too. Its comment now says that outright rather than letting it read as proof of the type change.

Closes #395.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / **none**.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: none. `symbolcnt` is never displayed or formatted anywhere in the tree.
- Compatibility or packaging impact: `include/dsd-neo/core/state.h` is a public header, but `dsd_state` is not serialized, memcpy'd across a boundary, version-stamped, or shipped by any `install()` rule — the layout is not an external contract. `core/state.h` is now registered for the public-header smoke test; it was the only unregistered `core/` header.
- Also ran `ctest --preset asan-ubsan-debug` (571/571) — this is the preset the reported abort fires under.
