### PR TITLE
test(dsp): share the frame-sync link stubs and state-buffer helpers

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6425,12 +6425,15 @@ add_test(NAME RTL_SYMBOL_PIPELINE COMMAND dsd-neo_test_rtl_symbol_pipeline)
 add_executable(
     dsd-neo_test_frame_sync_dmr_wav_rate
     dsp/test_frame_sync_dmr_wav_rate.c
+    test_support/frame_sync_dsp_stubs.c
+    test_support/frame_sync_dibit_stubs.c
 )
 target_include_directories(
     dsd-neo_test_frame_sync_dmr_wav_rate
     PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
 dsd_neo_link_dsp_test(dsd-neo_test_frame_sync_dmr_wav_rate
+  dsd-neo_test_support
   ${DSD_NEO_TEST_MATH_LIB}
   ${LIBSNDFILE_LIBRARIES}
 )
@@ -6460,6 +6463,7 @@ if(DSD_HAS_RADIO)
     add_executable(
         dsd-neo_test_frame_sync_p25p2_rtl
         dsp/test_frame_sync_p25p2_rtl.c
+        test_support/frame_sync_dsp_stubs.c
         ${PROJECT_SOURCE_DIR}/src/core/frames/dsd_dibit.c
     )
     target_include_directories(
@@ -6468,6 +6472,7 @@ if(DSD_HAS_RADIO)
     )
     dsd_neo_link_dsp_test(dsd-neo_test_frame_sync_p25p2_rtl
       dsd-neo_test_call_state_support
+      dsd-neo_test_support
       ${DSD_NEO_TEST_MATH_LIB}
       ${LIBSNDFILE_LIBRARIES}
     )
@@ -6476,12 +6481,18 @@ if(DSD_HAS_RADIO)
         COMMAND dsd-neo_test_frame_sync_p25p2_rtl
     )
 
-    add_executable(dsd-neo_test_frame_sync_m17 dsp/test_frame_sync_m17.c)
+    add_executable(
+        dsd-neo_test_frame_sync_m17
+        dsp/test_frame_sync_m17.c
+        test_support/frame_sync_dsp_stubs.c
+        test_support/frame_sync_dibit_stubs.c
+    )
     target_include_directories(
         dsd-neo_test_frame_sync_m17
         PRIVATE ${PROJECT_SOURCE_DIR}/include
     )
     dsd_neo_link_dsp_test(dsd-neo_test_frame_sync_m17
+      dsd-neo_test_support
       ${DSD_NEO_TEST_MATH_LIB}
       ${LIBSNDFILE_LIBRARIES}
     )
@@ -7701,6 +7712,8 @@ add_test(NAME FRAME_SYNC_POLICY COMMAND dsd-neo_test_frame_sync_policy)
 add_executable(
     dsd-neo_test_frame_sync_internal_helpers
     dsp/test_frame_sync_internal_helpers.c
+    test_support/frame_sync_dsp_stubs.c
+    test_support/frame_sync_dibit_stubs.c
 )
 if(DSD_HAS_RADIO)
     target_compile_definitions(
@@ -7729,6 +7742,8 @@ add_test(
 add_executable(
     dsd-neo_test_frame_sync_sps_hunt_false_sync
     dsp/test_frame_sync_sps_hunt_false_sync.c
+    test_support/frame_sync_dsp_stubs.c
+    test_support/frame_sync_dibit_stubs.c
 )
 if(DSD_HAS_RADIO)
     target_compile_definitions(
@@ -7744,6 +7759,7 @@ target_link_libraries(
     dsd-neo_test_frame_sync_sps_hunt_false_sync
     PRIVATE
         dsd-neo_dsp_private_test_support
+        dsd-neo_test_support
         ${DSD_NEO_TEST_MATH_LIB}
         ${LIBSNDFILE_LIBRARIES}
 )

--- a/tests/dsp/test_frame_sync_dmr_wav_rate.c
+++ b/tests/dsp/test_frame_sync_dmr_wav_rate.c
@@ -7,19 +7,14 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
-#include <dsd-neo/core/time_format.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/sync_calibration.h>
-#include <dsd-neo/platform/sockets.h>
-#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <time.h>
-#include "dsd-neo/core/dibit.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "frame_sync_state_buffers.h"
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -28,124 +23,6 @@
 
 static size_t g_symbol_index;
 static const char* g_sync_pattern = DMR_BS_DATA_SYNC;
-
-dsd_socket_t
-Connect(char* hostname, int portno) { // NOLINT(misc-use-internal-linkage)
-    (void)hostname;
-    (void)portno;
-    return (dsd_socket_t)0;
-}
-
-int
-openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    return -1;
-}
-
-int
-dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    return 0;
-}
-
-void
-dsd_request_shutdown(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-}
-
-void
-// NOLINTNEXTLINE(misc-use-internal-linkage)
-dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
-    (void)state;
-    (void)old_rate_hz;
-    (void)new_rate_hz;
-}
-
-int
-dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out,
-                          size_t out_size) { // NOLINT(misc-use-internal-linkage)
-    (void)timestamp;
-    (void)format;
-    return out ? DSD_SNPRINTF(out, out_size, "%s", "00:00:00") >= 0 : 0;
-}
-
-void
-printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-}
-
-void
-dsd_mark_cc_sync(dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-}
-
-void
-dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)slot;
-}
-
-void
-write_symbol_capture_record(dsd_opts* opts, dsd_state* state, int dibit, float symbol, const dsd_dibit_soft_t* soft) {
-    (void)opts;
-    (void)state;
-    (void)dibit;
-    (void)symbol;
-    (void)soft;
-}
-
-uint8_t
-dmr_compute_reliability(const dsd_state* st, float sym) {
-    (void)st;
-    (void)sym;
-    return 255;
-}
-
-double
-pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
-    (void)mean_power;
-    return 0.0;
-}
-
-void
-lpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-hpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-pbf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)input;
-    (void)len;
-}
 
 static float
 symbol_level_for_dibit(char dibit) {
@@ -164,34 +41,6 @@ getSymbol(dsd_opts* opts, dsd_state* state, int have_sync) { // NOLINT(misc-use-
     float symbol = symbol_level_for_dibit(dibit);
     dsd_symbol_history_push(state, symbol);
     return symbol;
-}
-
-static void
-free_state_buffers(dsd_state* state) {
-    free(state->dibit_buf);
-    free(state->dmr_payload_buf);
-    free(state->dmr_soft_buf);
-    free(state->symbol_history);
-    state->symbol_history = NULL;
-}
-
-static int
-init_state_buffers(dsd_state* state) {
-    state->dibit_buf = (int*)calloc(1000000U, sizeof(int));
-    state->dmr_payload_buf = (int*)calloc(1000000U, sizeof(int));
-    state->dmr_soft_buf = (dsd_dibit_soft_t*)calloc(1000000U, sizeof(dsd_dibit_soft_t));
-    state->symbol_history = (float*)calloc(DSD_SYMBOL_HISTORY_SIZE, sizeof(float));
-    if (!state->dibit_buf || !state->dmr_payload_buf || !state->dmr_soft_buf || !state->symbol_history) {
-        free_state_buffers(state);
-        return 0;
-    }
-    state->dibit_buf_p = state->dibit_buf + 200;
-    state->dmr_payload_p = state->dmr_payload_buf + 200;
-    state->dmr_soft_p = state->dmr_soft_buf + 200;
-    state->symbol_history_size = DSD_SYMBOL_HISTORY_SIZE;
-    state->symbol_history_head = 0;
-    state->symbol_history_count = 0;
-    return 1;
 }
 
 typedef struct {

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Coverage fixtures intentionally use private-source inclusion, synthetic sentinels,
 // invalid-value negative vectors, or wrapper symbols to exercise guarded behavior.
-// NOLINTBEGIN(misc-use-internal-linkage)
 /*
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
@@ -12,10 +11,8 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
-#include <dsd-neo/core/time_format.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/platform/posix_compat.h>
-#include <dsd-neo/platform/sockets.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
@@ -27,133 +24,10 @@
 #include <string.h>
 #include <time.h>
 
-#include "dsd-neo/core/dibit.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "frame_sync_internal.h"
 #include "frame_sync_test_support.h"
-
-#if defined(__GNUC__) && !defined(__cplusplus)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#endif
-
-dsd_socket_t
-Connect(char* hostname, int portno) { // NOLINT(misc-use-internal-linkage)
-    (void)hostname;
-    (void)portno;
-    return (dsd_socket_t)0;
-}
-
-int
-openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    return -1;
-}
-
-int
-dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    return 0;
-}
-
-void
-dsd_request_shutdown(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-}
-
-void
-dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
-    (void)state;
-    (void)old_rate_hz;
-    (void)new_rate_hz;
-}
-
-int
-dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out,
-                          size_t out_size) { // NOLINT(misc-use-internal-linkage)
-    (void)timestamp;
-    (void)format;
-    return out ? DSD_SNPRINTF(out, out_size, "%s", "00:00:00") >= 0 : 0;
-}
-
-void
-printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-}
-
-void
-dsd_mark_cc_sync(dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-}
-
-void
-dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)slot;
-}
-
-void
-write_symbol_capture_record(dsd_opts* opts, dsd_state* state, int dibit, float symbol, const dsd_dibit_soft_t* soft) {
-    (void)opts;
-    (void)state;
-    (void)dibit;
-    (void)symbol;
-    (void)soft;
-}
-
-uint8_t
-dmr_compute_reliability(const dsd_state* st, float sym) {
-    (void)st;
-    (void)sym;
-    return 255;
-}
-
-double
-pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
-    (void)mean_power;
-    return 0.0;
-}
-
-void
-lpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-hpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-pbf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)input;
-    (void)len;
-}
 
 static void
 reset(dsd_opts* opts, dsd_state* state) {
@@ -1957,8 +1831,3 @@ main(void) {
 #endif
     return 0;
 }
-
-#if defined(__GNUC__) && !defined(__cplusplus)
-#pragma GCC diagnostic pop
-#endif
-// NOLINTEND(misc-use-internal-linkage)

--- a/tests/dsp/test_frame_sync_m17.c
+++ b/tests/dsp/test_frame_sync_m17.c
@@ -7,148 +7,21 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
-#include <dsd-neo/core/time_format.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/io/rtl_stream_c.h>
-#include <dsd-neo/platform/sockets.h>
 #include <dsd-neo/runtime/rtl_stream_io_hooks.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <time.h>
-#include "dsd-neo/core/dibit.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
-
-#if defined(__GNUC__) && !defined(__cplusplus)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#endif
+#include "frame_sync_state_buffers.h"
 
 static size_t g_sample_index;
 static const char* g_sync_pattern = M17_PRE;
 static char g_fill_symbol = '1';
-
-dsd_socket_t
-Connect(char* hostname, int portno) { // NOLINT(misc-use-internal-linkage)
-    (void)hostname;
-    (void)portno;
-    return (dsd_socket_t)0;
-}
-
-int
-openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    return -1;
-}
-
-int
-dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    return 0;
-}
-
-void
-dsd_request_shutdown(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-}
-
-void
-// NOLINTNEXTLINE(misc-use-internal-linkage)
-dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
-    (void)state;
-    (void)old_rate_hz;
-    (void)new_rate_hz;
-}
-
-int
-dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out,
-                          size_t out_size) { // NOLINT(misc-use-internal-linkage)
-    (void)timestamp;
-    (void)format;
-    return out ? DSD_SNPRINTF(out, out_size, "%s", "00:00:00") >= 0 : 0;
-}
-
-void
-printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-}
-
-void
-dsd_mark_cc_sync(dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-}
-
-void
-dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)slot;
-}
-
-void
-write_symbol_capture_record(dsd_opts* opts, dsd_state* state, int dibit, float symbol, const dsd_dibit_soft_t* soft) {
-    (void)opts;
-    (void)state;
-    (void)dibit;
-    (void)symbol;
-    (void)soft;
-}
-
-uint8_t
-dmr_compute_reliability(const dsd_state* st, float sym) {
-    (void)st;
-    (void)sym;
-    return 255;
-}
-
-double
-pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
-    (void)mean_power;
-    return 0.0;
-}
-
-void
-lpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-hpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-pbf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)input;
-    (void)len;
-}
 
 static float
 symbol_level_for_m17(char dibit) {
@@ -218,28 +91,6 @@ fake_cqpsk_status(int* out_cqpsk_enable, int* out_cqpsk_timing_active) {
         *out_cqpsk_timing_active = 0;
     }
     return 0;
-}
-
-static void
-free_state_buffers(dsd_state* state) {
-    free(state->dibit_buf);
-    free(state->dmr_payload_buf);
-    free(state->dmr_soft_buf);
-}
-
-static int
-init_state_buffers(dsd_state* state) {
-    state->dibit_buf = (int*)calloc(1000000U, sizeof(int));
-    state->dmr_payload_buf = (int*)calloc(1000000U, sizeof(int));
-    state->dmr_soft_buf = (dsd_dibit_soft_t*)calloc(1000000U, sizeof(dsd_dibit_soft_t));
-    if (!state->dibit_buf || !state->dmr_payload_buf || !state->dmr_soft_buf) {
-        free_state_buffers(state);
-        return 0;
-    }
-    state->dibit_buf_p = state->dibit_buf + 200;
-    state->dmr_payload_p = state->dmr_payload_buf + 200;
-    state->dmr_soft_p = state->dmr_soft_buf + 200;
-    return 1;
 }
 
 static void
@@ -386,7 +237,3 @@ main(void) {
         run_m17_two_step_case(M17_PRE M17_PRE, DSD_SYNC_M17_PRE_POS, M17_PKT, -1, "M17 rejects packet after preamble");
     return rc;
 }
-
-#if defined(__GNUC__) && !defined(__cplusplus)
-#pragma GCC diagnostic pop
-#endif

--- a/tests/dsp/test_frame_sync_p25p2_rtl.c
+++ b/tests/dsp/test_frame_sync_p25p2_rtl.c
@@ -8,11 +8,8 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
-#include <dsd-neo/core/time_format.h>
 #include <dsd-neo/dsp/frame_sync.h>
-#include <dsd-neo/dsp/sync_calibration.h>
 #include <dsd-neo/io/rtl_stream_c.h>
-#include <dsd-neo/platform/sockets.h>
 #include <dsd-neo/runtime/rtl_stream_io_hooks.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <math.h>
@@ -20,122 +17,15 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 #include "dsd-neo/core/dibit.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
-
-#if defined(__GNUC__) && !defined(__cplusplus)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#endif
+#include "frame_sync_state_buffers.h"
 
 static size_t g_symbol_index;
 static const char* g_sync_pattern = P25P2_SYNC;
 static int g_symbol_rate_hz = 6000;
-
-dsd_socket_t
-Connect(char* hostname, int portno) { // NOLINT(misc-use-internal-linkage)
-    (void)hostname;
-    (void)portno;
-    return (dsd_socket_t)0;
-}
-
-int
-openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    return -1;
-}
-
-int
-dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    return 0;
-}
-
-void
-dsd_request_shutdown(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-}
-
-void
-// NOLINTNEXTLINE(misc-use-internal-linkage)
-dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
-    (void)state;
-    (void)old_rate_hz;
-    (void)new_rate_hz;
-}
-
-int
-dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out,
-                          size_t out_size) { // NOLINT(misc-use-internal-linkage)
-    (void)timestamp;
-    (void)format;
-    return out ? DSD_SNPRINTF(out, out_size, "%s", "00:00:00") >= 0 : 0;
-}
-
-void
-printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-}
-
-void
-dsd_mark_cc_sync(dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-}
-
-void
-dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)slot;
-}
-
-double
-pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
-    (void)mean_power;
-    return 0.0;
-}
-
-void
-lpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-hpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-pbf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)input;
-    (void)len;
-}
 
 static float
 symbol_level_for_dibit(char dibit) {
@@ -232,34 +122,6 @@ fake_cqpsk_status(int* out_cqpsk_enable, int* out_cqpsk_timing_active) {
         *out_cqpsk_timing_active = 1;
     }
     return 0;
-}
-
-static void
-free_state_buffers(dsd_state* state) {
-    free(state->dibit_buf);
-    free(state->dmr_payload_buf);
-    free(state->dmr_soft_buf);
-    free(state->symbol_history);
-    state->symbol_history = NULL;
-}
-
-static int
-init_state_buffers(dsd_state* state) {
-    state->dibit_buf = (int*)calloc(1000000U, sizeof(int));
-    state->dmr_payload_buf = (int*)calloc(1000000U, sizeof(int));
-    state->dmr_soft_buf = (dsd_dibit_soft_t*)calloc(1000000U, sizeof(dsd_dibit_soft_t));
-    state->symbol_history = (float*)calloc(DSD_SYMBOL_HISTORY_SIZE, sizeof(float));
-    if (!state->dibit_buf || !state->dmr_payload_buf || !state->dmr_soft_buf || !state->symbol_history) {
-        free_state_buffers(state);
-        return 0;
-    }
-    state->dibit_buf_p = state->dibit_buf + 200;
-    state->dmr_payload_p = state->dmr_payload_buf + 200;
-    state->dmr_soft_p = state->dmr_soft_buf + 200;
-    state->symbol_history_size = DSD_SYMBOL_HISTORY_SIZE;
-    state->symbol_history_head = 0;
-    state->symbol_history_count = 0;
-    return 1;
 }
 
 static int
@@ -507,7 +369,3 @@ main(void) {
     rc |= test_cqpsk_map_is_p25_scoped();
     return rc;
 }
-
-#if defined(__GNUC__) && !defined(__cplusplus)
-#pragma GCC diagnostic pop
-#endif

--- a/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
+++ b/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
@@ -24,21 +24,16 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
-#include <dsd-neo/core/time_format.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/sync_calibration.h>
-#include <dsd-neo/platform/sockets.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
-#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <time.h>
-#include "dsd-neo/core/dibit.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "frame_sync_internal.h"
+#include "frame_sync_state_buffers.h"
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic push
@@ -80,124 +75,6 @@ stream_next_dibit(void) {
     return dibit;
 }
 
-dsd_socket_t
-Connect(char* hostname, int portno) { // NOLINT(misc-use-internal-linkage)
-    (void)hostname;
-    (void)portno;
-    return (dsd_socket_t)0;
-}
-
-int
-openAudioInput(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    return -1;
-}
-
-int
-dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    return 0;
-}
-
-void
-dsd_request_shutdown(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-}
-
-void
-// NOLINTNEXTLINE(misc-use-internal-linkage)
-dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
-    (void)state;
-    (void)old_rate_hz;
-    (void)new_rate_hz;
-}
-
-int
-dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out,
-                          size_t out_size) { // NOLINT(misc-use-internal-linkage)
-    (void)timestamp;
-    (void)format;
-    return out ? DSD_SNPRINTF(out, out_size, "%s", "00:00:00") >= 0 : 0;
-}
-
-void
-printFrameInfo(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-}
-
-void
-dsd_mark_cc_sync(dsd_state* state) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-}
-
-void
-dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)slot;
-}
-
-void
-write_symbol_capture_record(dsd_opts* opts, dsd_state* state, int dibit, float symbol, const dsd_dibit_soft_t* soft) {
-    (void)opts;
-    (void)state;
-    (void)dibit;
-    (void)symbol;
-    (void)soft;
-}
-
-uint8_t
-dmr_compute_reliability(const dsd_state* st, float sym) {
-    (void)st;
-    (void)sym;
-    return 255;
-}
-
-double
-pwr_to_dB(double mean_power) { // NOLINT(misc-use-internal-linkage)
-    (void)mean_power;
-    return 0.0;
-}
-
-void
-lpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-hpf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-pbf_f(dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
-void
-agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) { // NOLINT(misc-use-internal-linkage)
-    (void)opts;
-    (void)state;
-    (void)input;
-    (void)len;
-}
-
 /* Mirrors the production slicer's bookkeeping: history push plus the symbol counter
  * that src/dsp/dsd_symbol.c bumps on every getSymbol() path. */
 float
@@ -210,37 +87,6 @@ getSymbol(dsd_opts* opts, dsd_state* state, int have_sync) { // NOLINT(misc-use-
     dsd_symbol_history_push(state, symbol);
     state->symbolcnt++;
     return symbol;
-}
-
-static void
-free_state_buffers(dsd_state* state) {
-    free(state->dibit_buf);
-    free(state->dmr_payload_buf);
-    free(state->dmr_soft_buf);
-    free(state->symbol_history);
-    state->dibit_buf = NULL;
-    state->dmr_payload_buf = NULL;
-    state->dmr_soft_buf = NULL;
-    state->symbol_history = NULL;
-}
-
-static int
-init_state_buffers(dsd_state* state) {
-    state->dibit_buf = (int*)calloc(1000000U, sizeof(int));
-    state->dmr_payload_buf = (int*)calloc(1000000U, sizeof(int));
-    state->dmr_soft_buf = (dsd_dibit_soft_t*)calloc(1000000U, sizeof(dsd_dibit_soft_t));
-    state->symbol_history = (float*)calloc(DSD_SYMBOL_HISTORY_SIZE, sizeof(float));
-    if (!state->dibit_buf || !state->dmr_payload_buf || !state->dmr_soft_buf || !state->symbol_history) {
-        free_state_buffers(state);
-        return 0;
-    }
-    state->dibit_buf_p = state->dibit_buf + 200;
-    state->dmr_payload_p = state->dmr_payload_buf + 200;
-    state->dmr_soft_p = state->dmr_soft_buf + 200;
-    state->symbol_history_size = DSD_SYMBOL_HISTORY_SIZE;
-    state->symbol_history_head = 0;
-    state->symbol_history_count = 0;
-    return 1;
 }
 
 /* Every digital candidate enabled, C4FM selected, timing on the 4800/4 profile: the

--- a/tests/test_support/frame_sync_dibit_stubs.c
+++ b/tests/test_support/frame_sync_dibit_stubs.c
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/* Dibit-capture stubs for frame-sync tests that do not source-list src/core/frames/dsd_dibit.c. */
+
+#include <dsd-neo/core/dibit.h>
+#include <stdint.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+void
+write_symbol_capture_record(dsd_opts* opts, dsd_state* state, int dibit, float symbol, const dsd_dibit_soft_t* soft) {
+    (void)opts;
+    (void)state;
+    (void)dibit;
+    (void)symbol;
+    (void)soft;
+}
+
+uint8_t
+dmr_compute_reliability(const dsd_state* st, float sym) {
+    (void)st;
+    (void)sym;
+    return 255;
+}

--- a/tests/test_support/frame_sync_dsp_stubs.c
+++ b/tests/test_support/frame_sync_dsp_stubs.c
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/* No-op decoder-side link stubs shared by the frame-sync DSP tests. */
+
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/audio_filters.h>
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/frame.h>
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/time_format.h>
+#include <dsd-neo/io/rigctl_client.h>
+#include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/runtime/shutdown.h>
+#include <stdint.h>
+#include <time.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+
+dsd_socket_t
+Connect(char* hostname, int portno) {
+    (void)hostname;
+    (void)portno;
+    return (dsd_socket_t)0;
+}
+
+int
+openAudioInput(dsd_opts* opts) {
+    (void)opts;
+    return -1;
+}
+
+int
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) {
+    (void)opts;
+    return 0;
+}
+
+void
+dsd_request_shutdown(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
+    (void)state;
+    (void)old_rate_hz;
+    (void)new_rate_hz;
+}
+
+int
+dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out, size_t out_size) {
+    (void)timestamp;
+    (void)format;
+    return out ? DSD_SNPRINTF(out, out_size, "%s", "00:00:00") >= 0 : 0;
+}
+
+void
+printFrameInfo(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+dsd_mark_cc_sync(dsd_state* state) {
+    (void)state;
+}
+
+void
+dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) {
+    (void)opts;
+    (void)state;
+    (void)slot;
+}
+
+double
+pwr_to_dB(double mean_power) {
+    (void)mean_power;
+    return 0.0;
+}
+
+void
+lpf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+hpf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+pbf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}

--- a/tests/test_support/frame_sync_state_buffers.h
+++ b/tests/test_support/frame_sync_state_buffers.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Shared dibit/payload/soft/symbol-history buffer setup for the frame-sync DSP tests.
+ *
+ * free_state_buffers() nulls every pointer it releases. Every current caller
+ * zeroes its reused static dsd_state before the next init_state_buffers(), so
+ * no double free is reachable today; the nulling is hygiene for a helper that is
+ * shared across test files and also runs from inside init_state_buffers() on a
+ * partial allocation failure, where the caller sees a half-built state.
+ */
+
+#pragma once
+
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/sync_calibration.h>
+#include <stdlib.h>
+
+static inline void
+free_state_buffers(dsd_state* state) {
+    free(state->dibit_buf);
+    free(state->dmr_payload_buf);
+    free(state->dmr_soft_buf);
+    free(state->symbol_history);
+    state->dibit_buf = NULL;
+    state->dmr_payload_buf = NULL;
+    state->dmr_soft_buf = NULL;
+    state->symbol_history = NULL;
+}
+
+static inline int
+init_state_buffers(dsd_state* state) {
+    state->dibit_buf = (int*)calloc(1000000U, sizeof(int));
+    state->dmr_payload_buf = (int*)calloc(1000000U, sizeof(int));
+    state->dmr_soft_buf = (dsd_dibit_soft_t*)calloc(1000000U, sizeof(dsd_dibit_soft_t));
+    state->symbol_history = (float*)calloc(DSD_SYMBOL_HISTORY_SIZE, sizeof(float));
+    if (!state->dibit_buf || !state->dmr_payload_buf || !state->dmr_soft_buf || !state->symbol_history) {
+        free_state_buffers(state);
+        return 0;
+    }
+    state->dibit_buf_p = state->dibit_buf + 200;
+    state->dmr_payload_p = state->dmr_payload_buf + 200;
+    state->dmr_soft_p = state->dmr_soft_buf + 200;
+    state->symbol_history_size = DSD_SYMBOL_HISTORY_SIZE;
+    state->symbol_history_head = 0;
+    state->symbol_history_count = 0;
+    return 1;
+}


### PR DESCRIPTION
## Summary

- Extracts the ~117-line DSP link-stub block duplicated across the five `tests/dsp/test_frame_sync_*.c` files into `tests/test_support/`, plus the `init_state_buffers()`/`free_state_buffers()` pair, following the existing `call_state_stubs.c` convention. Net **−738/+230**.
- **The split is not optional.** `test_frame_sync_p25p2_rtl.c` omits two of the stubs (`write_symbol_capture_record()`, `dmr_compute_reliability()`) because its target source-lists the real `src/core/frames/dsd_dibit.c`, which defines both — a single monolithic stub file would be a duplicate-symbol link error. The `dsd_dibit` stubs therefore live in their own file, source-listed only into the four targets that need them.
- Because every stubbed symbol has a real declaration in a public header, the shared files include those headers and drop the `-Wmissing-prototypes` pragma wrapper and all 15 per-stub NOLINTs.
- The buffer helpers had **three** behaviourally distinct variants, not one. Unified on the superset, keeping `sps_hunt_false_sync`'s defensive pointer nulling.
- Include paths go through the existing `dsd-neo_test_support` INTERFACE library rather than hand-rolled include-dir entries, matching the ~108 existing uses.

**One non-neutral delta, called out explicitly:** sharing the buffer helpers means `test_frame_sync_m17.c` now allocates `symbol_history`, which its local helper did not — so `M17_FRAME_SYNC` previously took the `DSD_WARM_START_NO_HISTORY` early-return path and now does not. The target passes either way, and it is verified rather than assumed.

**Follow-ups found while scoping, deliberately out of this diff:**
1. `tests/core/test_dibit_symbol_bin_soft.c` holds a fifth copy of the buffer helpers (different test area, outside the five files #397 names).
2. `tests/dsp/test_rtl_symbol_cache_generation.c` declares `analog_gain_f(dsd_opts*, ...)` where the real prototype is `const dsd_opts*` — a conflicting redeclaration that survives only because that file does not include `audio.h`. Filed as #420.

Test-only change; nothing under `src/`.

Closes #397.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / **none**.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: none — tests only, nothing under `src/`.
- Compatibility or packaging impact: none. The shared files compile both with and without `USE_RADIO`, which three of the five targets require.
