### PR TITLE
fix(dsp): let a frame handler tell the SPS hunt it validated nothing

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -312,8 +312,13 @@ Notes
   zero, because a decoded frame costs hundreds of symbols and the next sync follows within a few. Credit is counted per
   sync, and only once a handler reaches a frame's worth of symbols, so a matcher that recognises a marker and bails --
   the permissive 4800/4 matchers produce these on signals belonging to another profile -- buys nothing however often it
-  fires, and the dwell does not depend on that cadence. A handler that does swallow a frame's worth on a sync no CRC
-  would accept still delays the hunt, in proportion to the symbols it took; frame sync cannot see a CRC verdict.
+  fires, and the dwell does not depend on that cadence. Frame sync also sees a verdict where the protocol produces one:
+  a YSF frame before the transmission's first FICH CRC has held, a failed EDACS BCH, a failed D-STAR header CRC, a
+  failed P25 Phase 1 NID, and an NXDN frame whose transmission has not yet passed a CRC all buy no dwell however many
+  symbols they consumed. Handlers that report no verdict are credited as before, and they are the majority: every DMR,
+  M17, P25 Phase 2, dPMR and X2-TDMA frame is unconditionally productive, as is every D-STAR voice and ProVoice frame,
+  which have no check at any point. A false match on any of them still delays the hunt in proportion to what it
+  swallows -- 1992 symbols for D-STAR voice and 736 for ProVoice, the two worst cases.
 - NXDN announces nothing until a frame's content checks out. Its 10-symbol sync word and one-parity-bit LICH are weak
   enough that receiver noise clears both, so a frame that reaches the protocol layer does not by itself refresh the
   scan hold, synthesize voice, publish a RAN, or open a call record. One CRC of 12 bits or more (FACCH, CAC, UDCH,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -70,10 +70,18 @@ is invertible), so those fixtures exercise the same code path but carry none of
 the original RF impairments. Where a genuine off-air I/Q recording exists (P25
 C4FM/CQPSK, NXDN48/96, dPMR) it is used directly.
 
-`DECODE_IQ_*_AUTO_HUNT` cases assert on an `SPS hunt:` rotation line rather than a decoded payload. The `dstar` (4 s)
-and `p25p2_cc` (2 s) fixtures are shorter than one full hunt rotation (~6 s at 48 kHz), so under `-fa` they cannot be
-expected to decode; what they can prove is that the hunt is not pinned on its starting profile, which is the defect
-those cases cover.
+`DECODE_IQ_DSTAR_AUTO_HUNT` and `DECODE_IQ_P25P2_CC_AUTO_HUNT` assert on an `SPS hunt:` rotation line rather than a
+decoded payload. The `dstar` (4 s) and `p25p2_cc` (2 s) fixtures are shorter than one full hunt rotation (~6 s at
+48 kHz), so under `-fa` they cannot be expected to decode; what they can prove is that the hunt is not pinned on its
+starting profile, which is the defect those cases cover.
+
+`DECODE_IQ_YSF_AUTO_HUNT` covers the opposite direction, the one issue #391 names: a handler that reports its frames
+validated nothing while decoding them rotates the hunt off live traffic. Every other fixture that exercises a
+protocol which reports a verdict pins its frame type (`-fy`, `-fh`, `-fn`, `-fi`, `-fz`), so the hunt is inactive in
+it. The `ysf` capture is 6 s — one full rotation — and decodes on the hunt's starting profile, so it can assert both
+halves: the payload still decodes under `-fa`, and no `SPS hunt: trying` line appears at all. Reporting every YSF
+frame unproductive drops the payload from 23 hits to 13 and steps the hunt to 20 sps partway through the capture.
+`dsd_neo_add_iq_decode_test` takes the "must be absent" regex as an optional fifth argument.
 
 Reject cases assert the opposite: that a fixture produces *no* decode. `dsd_neo_add_iq_reject_test` takes a
 `NOT_EXPECTED` regex alongside the usual `EXPECTED` one, so a run that printed nothing at all cannot pass by

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -567,10 +567,21 @@ struct dsd_state {
      *   profile. Inside getFrameSync() the mark is already current at every such call, so that
      *   half is contract rather than repair; it is what a direct assigner would have to do for
      *   itself.
+     * sps_hunt_last_frame_verdict: what the last frame handler made of what it consumed,
+     *   as a dsd_frame_verdict (engine/protocol_dispatch.h). A field rather than a return
+     *   value because frame sync reads it at the next getFrameSync() entry, not at the
+     *   call site. Zero is DSD_FRAME_VERDICT_PRODUCTIVE, so a handler that reports nothing
+     *   -- and a zeroed dsd_state -- is credited as having decoded a frame; only a
+     *   protocol that ran a check and failed it debits nothing (#391). Strictly per frame,
+     *   so unlike the two fields above it owes a profile change nothing: processFrame()
+     *   re-stamps it on every dispatch and
+     *   frame_sync_sps_hunt_note_handler_consumption() clears it on every read, so it
+     *   cannot survive into the profile that follows.
      * sps_hunt_idx: current rate/profile index
      * (0=4800/4-level, 1=2400/4-level, 2=9600/binary, 3=6000/4-level, 4=4800/binary) */
     int sps_hunt_counter;
     uint32_t sps_hunt_symbolcnt_mark;
+    int sps_hunt_last_frame_verdict;
     int sps_hunt_idx;
     int lastsynctype;
     int lastp25type;
@@ -1206,6 +1217,11 @@ struct dsd_state {
     uint8_t ysf_dt; //data type -- VD1, VD2, Full Rate, etc.
     uint8_t ysf_fi; //frame information -- HC, CC, TC
     uint8_t ysf_cm; //group or private call
+    /* Sticky for the transmission: set once a FICH passes its Golay+CRC-16, cleared with the
+     * rest of the YSF strings on noCarrier(). A later FICH failure still lays the payload out
+     * from the previous frame's dt/fi and still synthesizes voice from it, so once one FICH
+     * has confirmed the transmission those frames are decoding, not validating nothing (#391). */
+    uint8_t ysf_fich_confirmed;
     char ysf_rm1[6];
     char ysf_rm2[6];
     char ysf_rm3[6];

--- a/include/dsd-neo/engine/protocol_dispatch.h
+++ b/include/dsd-neo/engine/protocol_dispatch.h
@@ -18,10 +18,30 @@
 extern "C" {
 #endif
 
+/**
+ * @brief What a frame handler made of the symbols it consumed.
+ *
+ * The SPS hunt pays a profile for the symbols its handlers consume, and cannot tell a
+ * decoded frame from a block skipped on a sync no CRC would accept by size alone. This
+ * is how a handler that knows says so.
+ *
+ * PRODUCTIVE is zero and therefore the default: a handler with no verdict to give, a
+ * synctype with no handler at all, and a zeroed dsd_state all read as "decoded a frame".
+ * That is deliberate. A site that decodes successfully but fails to report it would make
+ * the hunt rotate off live traffic, which is the one failure this must not have; a site
+ * that consumes nothing and claims productivity costs at most the symbols it took. Report
+ * UNPRODUCTIVE only from a check the protocol actually ran and actually failed -- never
+ * from a threshold that guesses.
+ */
+typedef enum {
+    DSD_FRAME_VERDICT_PRODUCTIVE = 0,   /**< default: assume the handler decoded a frame */
+    DSD_FRAME_VERDICT_UNPRODUCTIVE = 1, /**< consumed symbols, validated nothing */
+} dsd_frame_verdict;
+
 typedef struct dsd_protocol_handler {
     const char* name;
     int (*matches_synctype)(int synctype);
-    void (*handle_frame)(dsd_opts* opts, dsd_state* state);
+    dsd_frame_verdict (*handle_frame)(dsd_opts* opts, dsd_state* state);
     void (*on_reset)(dsd_opts* opts, dsd_state* state);
 } dsd_protocol_handler;
 

--- a/include/dsd-neo/protocol/dstar/dstar.h
+++ b/include/dsd-neo/protocol/dstar/dstar.h
@@ -21,7 +21,16 @@ extern "C" {
 #endif
 
 void processDSTAR(dsd_opts* opts, dsd_state* state);
-void processDSTAR_HD(dsd_opts* opts, dsd_state* state);
+
+/**
+ * @brief Decode a D-STAR header frame and the voice frame that follows it.
+ *
+ * @return 1 when the header's CRC-16/X.25 matched, 0 otherwise. Nothing further down this
+ *         path is checkable -- processDSTAR() runs either way -- so this is the whole of
+ *         what the D-STAR data path can tell the SPS hunt about the 2652 symbols it took
+ *         (#391).
+ */
+int processDSTAR_HD(dsd_opts* opts, dsd_state* state);
 void processDSTAR_SD(const dsd_opts* opts, dsd_state* state, uint8_t* sd);
 
 #ifdef __cplusplus

--- a/include/dsd-neo/protocol/dstar/dstar_header.h
+++ b/include/dsd-neo/protocol/dstar/dstar_header.h
@@ -15,7 +15,13 @@ struct dsd_state;
  * @brief D-STAR header decode interface.
  */
 
-/** @brief Decode a coded D-STAR header using soft-decision Viterbi decoding. */
-void dstar_header_decode_soft(struct dsd_state* state, const float soft_symbols[DSD_DSTAR_HEADER_CODED_BITS]);
+/**
+ * @brief Decode a coded D-STAR header using soft-decision Viterbi decoding.
+ *
+ * @return 1 when the header's CRC-16/X.25 over its 39 payload octets matched, 0 otherwise.
+ *         This is the only real check on the D-STAR data path, and it fires before
+ *         processDSTAR() consumes the 1992 symbols that follow (#391).
+ */
+int dstar_header_decode_soft(struct dsd_state* state, const float soft_symbols[DSD_DSTAR_HEADER_CODED_BITS]);
 
 #endif /* DSD_NEO_PROTOCOL_DSTAR_HEADER_H */

--- a/include/dsd-neo/protocol/edacs/edacs.h
+++ b/include/dsd-neo/protocol/edacs/edacs.h
@@ -18,7 +18,16 @@
 extern "C" {
 #endif
 
-void edacs(dsd_opts* opts, dsd_state* state);
+/**
+ * @brief Decode one EDACS control-channel frame.
+ *
+ * @return 1 when the triple-voted 40-bit frames both re-derived their 12-bit BCH, 0 when
+ *         the BCH failed. The check runs on the collected bits before the tuned-trunk
+ *         early-out, so a frame the call declines to act on still reports the verdict it
+ *         earned rather than a blanket failure -- the SPS hunt reads this to decide
+ *         whether the 240 dibits bought any dwell (#391).
+ */
+int edacs(dsd_opts* opts, dsd_state* state);
 void eot_cc(dsd_opts* opts, dsd_state* state);
 
 #ifdef __cplusplus

--- a/include/dsd-neo/protocol/nxdn/nxdn.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn.h
@@ -20,7 +20,17 @@
 extern "C" {
 #endif
 
-void nxdn_frame(dsd_opts* opts, dsd_state* state);
+/**
+ * @brief Decode one NXDN frame.
+ *
+ * @return 1 once the current transmission has produced CRC-verified content, 0 while it
+ *         has not. This is nxdn_confirm_is_confirmed(), the sticky per-transmission flag
+ *         rather than the per-frame one: a real call confirms on its first FACCH and every
+ *         frame after it answers 1, while a stream of noise clearing the weak sync word and
+ *         LICH never does. The SPS hunt refuses those frames the dwell their 182 symbols
+ *         would otherwise buy (#391).
+ */
+int nxdn_frame(dsd_opts* opts, dsd_state* state);
 
 /* Cipher-classification hysteresis for the NXDN cipher field (values 0..3).
  * Backed by dsd_state.nxdn_cipher_class*; see src/protocol/nxdn/nxdn_enc_class.c. */

--- a/include/dsd-neo/protocol/ysf/ysf.h
+++ b/include/dsd-neo/protocol/ysf/ysf.h
@@ -18,7 +18,18 @@
 extern "C" {
 #endif
 
-void processYSF(dsd_opts* opts, dsd_state* state);
+/**
+ * @brief Decode one YSF frame.
+ *
+ * @return 1 once any FICH in this transmission has decoded -- Golay corrected and the
+ *         CRC-16 over the corrected bits held -- and 0 until then. A FICH failure before
+ *         the first success means the ~460 dibits this call goes on to consume were laid
+ *         out by nothing read off the air, and the SPS hunt refuses them the dwell they
+ *         would otherwise buy; a failure after it falls back to dt/fi a confirmed frame
+ *         supplied and still produces audio, which is a decode (#391). The flag lives in
+ *         dsd_state::ysf_fich_confirmed and clears with the rest of the YSF state.
+ */
+int processYSF(dsd_opts* opts, dsd_state* state);
 
 #ifdef __cplusplus
 }

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -1045,6 +1045,7 @@ init_state_string_and_m17_defaults(dsd_state* state) {
     state->ysf_dt = 9;
     state->ysf_fi = 9;
     state->ysf_cm = 9;
+    state->ysf_fich_confirmed = 0;
 
     //DSTAR Call Strings
     set_spaces(state->dstar_txt, 8); //8 spaces

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -2986,13 +2986,24 @@ frame_sync_sps_hunt_dwell_symbols(const dsd_opts* opts, const dsd_state* state) 
  * presents, banked a refund faster than the search could spend the budget and pinned the
  * profile for good (#388).
  *
- * A handler that does consume a frame's worth on a sync no CRC would accept is still
- * credited, because frame sync cannot see a CRC verdict. What it buys is bounded by what it
- * actually took rather than the whole budget, so it delays the hunt in proportion to the
- * stream it swallowed instead of resetting it.
+ * Size alone cannot separate a decoded frame from a block skipped on a sync no CRC would
+ * accept, so a handler that ran a check and failed it says so: processFrame() leaves its
+ * dsd_frame_verdict in dsd_state::sps_hunt_last_frame_verdict, and an unproductive one is
+ * refused the debit however much it took (#391). The verdict is default-productive, so
+ * every handler that reports nothing -- DMR, M17, P25 Phase 2, dPMR, X2-TDMA, D-STAR voice
+ * and ProVoice, which is the whole of the set that does not, whether because the check it
+ * would report is per transmission rather than per frame or because it has none at any point
+ * -- still buys dwell in proportion to what it swallowed, as before.
  */
 static void
 frame_sync_sps_hunt_note_handler_consumption(dsd_state* state) {
+    const int unproductive = state->sps_hunt_last_frame_verdict != 0;
+    /* One verdict answers for one handler call. processFrame() already re-stamps the field
+     * on every dispatch, so this is belt and braces for the entries no handler precedes --
+     * a no-sync return, or a frame the retune generation made undispatchable -- where a
+     * stale verdict would be read against consumption that is not the handler's. */
+    state->sps_hunt_last_frame_verdict = 0;
+
     /* Both operands wrap at 2^32, so this modular difference stays exact when the free-running
      * symbol counter rolls over mid-measurement. */
     uint32_t consumed = state->symbolcnt - state->sps_hunt_symbolcnt_mark;
@@ -3014,7 +3025,7 @@ frame_sync_sps_hunt_note_handler_consumption(dsd_state* state) {
          * from a rollover. */
         consumed = 0;
     }
-    if (consumed >= (uint32_t)DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS) {
+    if (!unproductive && consumed >= (uint32_t)DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS) {
         /* dsd_state::sps_hunt_counter only ever counts up from zero, so this is exact.
          * Sites outside the hunt park a profile by zeroing it; the floor at zero means
          * consumption measured across such a reset cannot drive it negative. */

--- a/src/engine/dispatch/dispatch_dmr.c
+++ b/src/engine/dispatch/dispatch_dmr.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <stdio.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -130,17 +131,24 @@ dsd_dispatch_matches_dmr(int synctype) {
     return DSD_SYNC_IS_DMR(synctype);
 }
 
-void
+/*
+ * Always productive. DMR's per-burst verdicts live in the colour-code lock and voice-open
+ * counters of src/protocol/dmr/dmr_confidence.c, which answer "is this transmission real"
+ * across bursts rather than "did this burst validate"; a burst that fails the lock is not
+ * the same thing as a burst that decoded nothing, and mapping one onto the other would be
+ * guesswork. Left productive until DMR grows a per-burst answer (#391).
+ */
+dsd_frame_verdict
 dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state) {
     if (!DSD_SYNC_IS_DMR(state->synctype)) {
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
 
     /* A standalone RC burst is a one-shot 10 ms event: decode it without
      * touching slot lights, MBE output files, or per-slot call state. */
     if (state->synctype == DSD_SYNC_DMR_RC_DATA) {
         dmrRC(opts, state);
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
 
     dmr_update_branding(state);
@@ -148,11 +156,12 @@ dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state) {
 
     if (dmr_is_voice_synctype(state->synctype)) {
         dmr_handle_voice(opts, state);
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
     if (dmr_is_ms_data_synctype(state->synctype)) {
         dmr_handle_ms_data(opts, state);
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
     dmr_handle_other_data(opts, state);
+    return DSD_FRAME_VERDICT_PRODUCTIVE;
 }

--- a/src/engine/dispatch/dispatch_dpmr.c
+++ b/src/engine/dispatch/dispatch_dpmr.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <stdio.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -41,7 +42,11 @@ dsd_dispatch_matches_dpmr(int synctype) {
     return DSD_SYNC_IS_DPMR(synctype);
 }
 
-void
+/*
+ * Always productive. FS1/FS3/FS4 consume nothing beyond the sync itself, and the FS2 voice
+ * path (processdPMRvoice) has no CRC or FEC verdict to report (#391).
+ */
+dsd_frame_verdict
 dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state) {
 
     //dPMR
@@ -73,7 +78,7 @@ dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state) {
         DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " VOICE        ");
         processdPMRvoice(opts, state);
 
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
 
     } else if ((state->synctype == DSD_SYNC_DPMR_FS3_POS) || (state->synctype == DSD_SYNC_DPMR_FS3_NEG)) {
         /* dPMR Frame Sync 3 */
@@ -91,4 +96,5 @@ dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state) {
         }
     }
     //dPMR
+    return DSD_FRAME_VERDICT_PRODUCTIVE;
 }

--- a/src/engine/dispatch/dispatch_dstar.c
+++ b/src/engine/dispatch/dispatch_dstar.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/dstar/dstar.h>
 #include <stdio.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -19,7 +20,7 @@ dsd_dispatch_matches_dstar(int synctype) {
     return DSD_SYNC_IS_DSTAR(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_dstar(dsd_opts* opts, dsd_state* state) {
     if ((opts->mbe_out_dir[0] != 0) && (opts->mbe_out_f == NULL)) {
         openMbeOutFile(opts, state);
@@ -28,9 +29,17 @@ dsd_dispatch_handle_dstar(dsd_opts* opts, dsd_state* state) {
     if (state->synctype == DSD_SYNC_DSTAR_VOICE_POS || state->synctype == DSD_SYNC_DSTAR_VOICE_NEG) {
         DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " VOICE        ");
         processDSTAR(opts, state);
-        return;
+        /* Productive by default, and this is the hole #391 measures. processDSTAR() spends
+         * 1992 symbols with no return value, no error accumulator and no frame-count check;
+         * it overwrites state->errs/errs2 21 times and reads them never, and its only CRC
+         * (dstar_slow_data.c) is consulted on the sd_bytes[0] == 0x55 branch alone, about 1
+         * match in 256 against noise. Nothing here can honestly say "unproductive", and a
+         * threshold invented on state->errs would be the guess this contract forbids. */
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
 
     DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " DATA         ");
-    processDSTAR_HD(opts, state);
+    /* The header CRC-16/X.25 runs before processDSTAR() consumes the voice frame behind it,
+     * so a header that fails condemns the whole 2652-symbol call. */
+    return processDSTAR_HD(opts, state) != 0 ? DSD_FRAME_VERDICT_PRODUCTIVE : DSD_FRAME_VERDICT_UNPRODUCTIVE;
 }

--- a/src/engine/dispatch/dispatch_edacs.c
+++ b/src/engine/dispatch/dispatch_edacs.c
@@ -6,6 +6,7 @@
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/edacs/edacs.h>
 #include <stddef.h>
 
@@ -18,10 +19,14 @@ dsd_dispatch_matches_edacs(int synctype) {
     return synctype == DSD_SYNC_EDACS_POS || synctype == DSD_SYNC_EDACS_NEG;
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_edacs(dsd_opts* opts, dsd_state* state) {
     if (opts->mbe_out_f != NULL) {
         closeMbeOutFile(opts, state);
     }
-    edacs(opts, state);
+    /* Zero means the 12-bit BCH over the triple-voted frame failed, so the 240 dibits behind
+     * it were not an EDACS control frame. edacs() runs that check even when a tuned trunk
+     * makes it forgo acting on the message, so declining to decode does not read here as
+     * failing to (#391). */
+    return edacs(opts, state) != 0 ? DSD_FRAME_VERDICT_PRODUCTIVE : DSD_FRAME_VERDICT_UNPRODUCTIVE;
 }

--- a/src/engine/dispatch/dispatch_m17.c
+++ b/src/engine/dispatch/dispatch_m17.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/m17/m17.h>
 
 #include "dsd-neo/core/opts_fwd.h"
@@ -22,11 +23,14 @@ dsd_dispatch_matches_m17(int synctype) {
     return DSD_SYNC_IS_M17(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_m17(dsd_opts* opts, dsd_state* state) {
     if (state->synctype == DSD_SYNC_M17_PRE_POS || state->synctype == DSD_SYNC_M17_PRE_NEG) {
+        /* 8 dibits is below DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS, which was calibrated against
+         * exactly this path (#388): the floor already refuses it credit, so a verdict here
+         * would be decoration. */
         skipDibit(opts, state, 8);
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
 
     if (state->synctype == DSD_SYNC_M17_EOT_POS || state->synctype == DSD_SYNC_M17_EOT_NEG) {
@@ -49,23 +53,30 @@ dsd_dispatch_handle_m17(dsd_opts* opts, dsd_state* state) {
         state->m17_bert_errors = 0;
         state->m17_bert_resyncs = 0;
         state->lastsynctype = DSD_SYNC_NONE;
-        return;
+        /* The marker itself is the decode, so the SPS hunt is told the same thing the call
+         * state was told above (#391). frame_sync_try_m17_eot() only matches an EOT whose
+         * lastsynctype is an M17 LSF, STR, PKT or BRT sync, so it cannot fire on cold noise
+         * the way the permissive preamble matcher can, and clearing lastsynctype here means
+         * it fires at most once per transmission. The 184 dibits behind it are discarded,
+         * but they are the rest of a frame this profile really was carrying. */
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
 
     if (state->synctype == DSD_SYNC_M17_LSF_POS || state->synctype == DSD_SYNC_M17_LSF_NEG) {
         processM17LSF(opts, state);
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
 
     if (state->synctype == DSD_SYNC_M17_BRT_POS || state->synctype == DSD_SYNC_M17_BRT_NEG) {
         processM17BRT(opts, state);
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
 
     if (state->synctype == DSD_SYNC_M17_PKT_POS || state->synctype == DSD_SYNC_M17_PKT_NEG) {
         processM17PKT(opts, state);
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
 
     processM17STR(opts, state);
+    return DSD_FRAME_VERDICT_PRODUCTIVE;
 }

--- a/src/engine/dispatch/dispatch_nxdn.c
+++ b/src/engine/dispatch/dispatch_nxdn.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/nxdn/nxdn.h>
 
 #include "dsd-neo/core/opts_fwd.h"
@@ -15,7 +16,10 @@ dsd_dispatch_matches_nxdn(int synctype) {
     return DSD_SYNC_IS_NXDN(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_nxdn(dsd_opts* opts, dsd_state* state) {
-    nxdn_frame(opts, state);
+    /* NXDN's sync word and LICH are weak enough that receiver noise clears both (#398), so
+     * a frame reaching the body proves nothing on its own. nxdn_frame() answers with the
+     * transmission's CRC confirmation, which noise never reaches. */
+    return nxdn_frame(opts, state) != 0 ? DSD_FRAME_VERDICT_PRODUCTIVE : DSD_FRAME_VERDICT_UNPRODUCTIVE;
 }

--- a/src/engine/dispatch/dispatch_p25p1.c
+++ b/src/engine/dispatch/dispatch_p25p1.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/io/control.h>
 #include <dsd-neo/platform/platform.h>
 #include <dsd-neo/protocol/p25/p25.h>
@@ -418,9 +419,15 @@ dsd_dispatch_matches_p25p1(int synctype) {
     return DSD_SYNC_IS_P25P1(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_p25p1(dsd_opts* opts, dsd_state* state) {
     p25_status_accum_reset(state);
     uint8_t duid = p25p1_decode_nid_and_duid(opts, state);
     p25p1_dispatch_by_duid(opts, state, duid);
+    /* The 63-bit BCH over the NID is the one verdict this path has that covers every DUID.
+     * When it fails the DUID is invalid, p25p1_handle_unknown_duid() decodes nothing, and
+     * the 33 dibits already read validated nothing. Past that the picture is mixed --
+     * state->p25_p1_fec_ok counts TSBK and MPDU header successes only, and says nothing
+     * about HDU, LDU1/2, TDU or TDULC -- so a decoded NID is taken at its word. */
+    return duid != P25P1_DUID_INVALID ? DSD_FRAME_VERDICT_PRODUCTIVE : DSD_FRAME_VERDICT_UNPRODUCTIVE;
 }

--- a/src/engine/dispatch/dispatch_p25p2.c
+++ b/src/engine/dispatch/dispatch_p25p2.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/p25/p25.h>
 
 #include "dsd-neo/core/opts_fwd.h"
@@ -15,7 +16,12 @@ dsd_dispatch_matches_p25p2(int synctype) {
     return DSD_SYNC_IS_P25P2(synctype);
 }
 
-void
+/*
+ * Always productive. processP2() returns nothing, and its per-burst FEC results are spread
+ * across the MAC/ISCH paths with no single answer to "did this burst validate" (#391).
+ */
+dsd_frame_verdict
 dsd_dispatch_handle_p25p2(dsd_opts* opts, dsd_state* state) {
     processP2(opts, state);
+    return DSD_FRAME_VERDICT_PRODUCTIVE;
 }

--- a/src/engine/dispatch/dispatch_provoice.c
+++ b/src/engine/dispatch/dispatch_provoice.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/provoice/provoice.h>
 #include <stdio.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -19,11 +20,20 @@ dsd_dispatch_matches_provoice(int synctype) {
     return synctype == DSD_SYNC_PROVOICE_POS || synctype == DSD_SYNC_PROVOICE_NEG;
 }
 
-void
+/*
+ * Always productive, and this one is a known hole. processProVoice() spends 736 dibits per
+ * call on the same 9600/2 profile EDACS uses, with no CRC, no FEC verdict and no error
+ * return -- its only failure path fires when the dibit callback fails, never on bad data.
+ * A false ProVoice match therefore still buys the profile 736 symbols of dwell. Closing it
+ * needs a confidence module shaped like src/protocol/nxdn/nxdn_confirm.c, not a threshold
+ * on a counter nothing computes (#391).
+ */
+dsd_frame_verdict
 dsd_dispatch_handle_provoice(dsd_opts* opts, dsd_state* state) {
     if ((opts->mbe_out_dir[0] != 0) && (opts->mbe_out_f == NULL)) {
         openMbeOutFile(opts, state);
     }
     DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " VOICE        ");
     processProVoice(opts, state);
+    return DSD_FRAME_VERDICT_PRODUCTIVE;
 }

--- a/src/engine/dispatch/dispatch_x2tdma.c
+++ b/src/engine/dispatch/dispatch_x2tdma.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/x2tdma/x2tdma.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -23,7 +24,11 @@ dsd_dispatch_matches_x2tdma(int synctype) {
     return DSD_SYNC_IS_X2TDMA(synctype);
 }
 
-void
+/*
+ * Always productive. Neither processX2TDMAvoice() nor processX2TDMAdata() reports a
+ * decode verdict (#391).
+ */
+dsd_frame_verdict
 dsd_dispatch_handle_x2tdma(dsd_opts* opts, dsd_state* state) {
     state->nac = 0;
     if (opts->errorbars == 1) {
@@ -36,7 +41,7 @@ dsd_dispatch_handle_x2tdma(dsd_opts* opts, dsd_state* state) {
         }
         DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " VOICE        ");
         processX2TDMAvoice(opts, state);
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
 
     if (opts->mbe_out_f != NULL) {
@@ -50,4 +55,5 @@ dsd_dispatch_handle_x2tdma(dsd_opts* opts, dsd_state* state) {
         && DSD_SYNC_IS_X2TDMA(call.protocol) && dsd_call_state_end(state, slot, 0.0) > 0) {
         dsd_event_sync_slot(opts, state, slot);
     }
+    return DSD_FRAME_VERDICT_PRODUCTIVE;
 }

--- a/src/engine/dispatch/dispatch_ysf.c
+++ b/src/engine/dispatch/dispatch_ysf.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/ysf/ysf.h>
 
 #include "dsd-neo/core/opts_fwd.h"
@@ -15,7 +16,14 @@ dsd_dispatch_matches_ysf(int synctype) {
     return DSD_SYNC_IS_YSF(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_ysf(dsd_opts* opts, dsd_state* state) {
-    processYSF(opts, state);
+    /* processYSF() answers with dsd_state::ysf_fich_confirmed, which is sticky for the
+     * transmission rather than per frame: zero only until one FICH has decoded -- Golay
+     * corrected and the CRC-16 over the corrected bits held. Before that, a failure leaves the
+     * ~460 dibits behind it laid out on dt/fi nothing read off the air supplied, so they
+     * validated nothing. After it, the same failure falls back to dt/fi a confirmed frame
+     * supplied and ysf_handle_vd_type2() still synthesizes and plays voice from them, so the
+     * frame is productive whatever its own FICH did. */
+    return processYSF(opts, state) != 0 ? DSD_FRAME_VERDICT_PRODUCTIVE : DSD_FRAME_VERDICT_UNPRODUCTIVE;
 }

--- a/src/engine/dispatch/protocol_dispatch.c
+++ b/src/engine/dispatch/protocol_dispatch.c
@@ -37,9 +37,14 @@ processFrame(dsd_opts* opts, dsd_state* state) {
         state->minref = state->min;
     }
 
+    /* Default-productive, and set before the call so an early return inside a handler
+     * cannot leave the previous frame's verdict standing. A synctype no handler claims
+     * consumed nothing, so crediting it changes nothing either way. */
+    state->sps_hunt_last_frame_verdict = DSD_FRAME_VERDICT_PRODUCTIVE;
+
     const dsd_protocol_handler* handler = dsd_find_protocol_handler(state->synctype);
     if (handler != NULL && handler->handle_frame != NULL) {
-        handler->handle_frame(opts, state);
+        state->sps_hunt_last_frame_verdict = (int)handler->handle_frame(opts, state);
     }
 }
 

--- a/src/engine/dispatch/protocol_dispatch_impl.h
+++ b/src/engine/dispatch/protocol_dispatch_impl.h
@@ -6,40 +6,42 @@
 #ifndef DSD_NEO_SRC_ENGINE_DISPATCH_PROTOCOL_DISPATCH_IMPL_H_
 #define DSD_NEO_SRC_ENGINE_DISPATCH_PROTOCOL_DISPATCH_IMPL_H_
 
+#include <dsd-neo/engine/protocol_dispatch.h>
+
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 
 int dsd_dispatch_matches_nxdn(int synctype);
-void dsd_dispatch_handle_nxdn(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_nxdn(dsd_opts* opts, dsd_state* state);
 
 int dsd_dispatch_matches_dstar(int synctype);
-void dsd_dispatch_handle_dstar(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_dstar(dsd_opts* opts, dsd_state* state);
 
 int dsd_dispatch_matches_dmr(int synctype);
-void dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state);
 
 int dsd_dispatch_matches_x2tdma(int synctype);
-void dsd_dispatch_handle_x2tdma(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_x2tdma(dsd_opts* opts, dsd_state* state);
 
 int dsd_dispatch_matches_provoice(int synctype);
-void dsd_dispatch_handle_provoice(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_provoice(dsd_opts* opts, dsd_state* state);
 
 int dsd_dispatch_matches_edacs(int synctype);
-void dsd_dispatch_handle_edacs(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_edacs(dsd_opts* opts, dsd_state* state);
 
 int dsd_dispatch_matches_ysf(int synctype);
-void dsd_dispatch_handle_ysf(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_ysf(dsd_opts* opts, dsd_state* state);
 
 int dsd_dispatch_matches_m17(int synctype);
-void dsd_dispatch_handle_m17(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_m17(dsd_opts* opts, dsd_state* state);
 
 int dsd_dispatch_matches_p25p2(int synctype);
-void dsd_dispatch_handle_p25p2(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_p25p2(dsd_opts* opts, dsd_state* state);
 
 int dsd_dispatch_matches_dpmr(int synctype);
-void dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state);
 
 int dsd_dispatch_matches_p25p1(int synctype);
-void dsd_dispatch_handle_p25p1(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_p25p1(dsd_opts* opts, dsd_state* state);
 
 #endif /* DSD_NEO_SRC_ENGINE_DISPATCH_PROTOCOL_DISPATCH_IMPL_H_ */

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2154,6 +2154,7 @@ no_carrier_reset_ysf_and_dstar_strings(dsd_state* state) {
     state->ysf_dt = 9;
     state->ysf_fi = 9;
     state->ysf_cm = 9;
+    state->ysf_fich_confirmed = 0;
 
     set_spaces(state->dstar_txt, 8);
     set_spaces(state->dstar_gps, 8);

--- a/src/protocol/dstar/dstar.c
+++ b/src/protocol/dstar/dstar.c
@@ -66,7 +66,7 @@ processDSTAR(dsd_opts* opts, dsd_state* state) {
     DSD_FPRINTF(stderr, "\n");
 }
 
-void
+int
 processDSTAR_HD(dsd_opts* opts, dsd_state* state) {
 
     int i;
@@ -77,6 +77,7 @@ processDSTAR_HD(dsd_opts* opts, dsd_state* state) {
         getDibitAndSoftSymbol(opts, state, &soft_symbols[i]);
     }
 
-    dstar_header_decode_soft(state, soft_symbols);
+    const int header_ok = dstar_header_decode_soft(state, soft_symbols);
     processDSTAR(opts, state);
+    return header_ok;
 }

--- a/src/protocol/dstar/dstar_header.c
+++ b/src/protocol/dstar/dstar_header.c
@@ -14,7 +14,7 @@
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/protocol/dstar/dstar_header_utils.h"
 
-void
+int
 dstar_header_decode_soft(dsd_state* state, const float soft_symbols[DSD_DSTAR_HEADER_CODED_BITS]) {
     uint16_t soft_costs[DSD_DSTAR_HEADER_CODED_BITS];
     uint16_t soft_scrambled[DSD_DSTAR_HEADER_CODED_BITS];
@@ -95,17 +95,20 @@ dstar_header_decode_soft(dsd_state* state, const float soft_symbols[DSD_DSTAR_HE
         DSD_FPRINTF(stderr, " URGENT");
     }
 
-    if (crc_cmp == crc_ext) {
-        int protocol = DSD_SYNC_IS_DSTAR(state->synctype) ? state->synctype : DSD_SYNC_DSTAR_HD_POS;
-        dsd_call_observation observation = {
-            .protocol = protocol,
-            .slot = 0U,
-            .kind = ((uint8_t)radioheader[0] & 0x80U) != 0U ? DSD_CALL_KIND_DATA : DSD_CALL_KIND_VOICE,
-        };
-        DSD_SNPRINTF(observation.source_text, sizeof(observation.source_text), "%s", str4);
-        DSD_SNPRINTF(observation.target_text, sizeof(observation.target_text), "%s", str3);
-        DSD_SNPRINTF(observation.route_text[0], sizeof(observation.route_text[0]), "%s", str2);
-        DSD_SNPRINTF(observation.route_text[1], sizeof(observation.route_text[1]), "%s", str1);
-        (void)dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_CONTINUE);
+    if (crc_cmp != crc_ext) {
+        return 0;
     }
+
+    int protocol = DSD_SYNC_IS_DSTAR(state->synctype) ? state->synctype : DSD_SYNC_DSTAR_HD_POS;
+    dsd_call_observation observation = {
+        .protocol = protocol,
+        .slot = 0U,
+        .kind = ((uint8_t)radioheader[0] & 0x80U) != 0U ? DSD_CALL_KIND_DATA : DSD_CALL_KIND_VOICE,
+    };
+    DSD_SNPRINTF(observation.source_text, sizeof(observation.source_text), "%s", str4);
+    DSD_SNPRINTF(observation.target_text, sizeof(observation.target_text), "%s", str3);
+    DSD_SNPRINTF(observation.route_text[0], sizeof(observation.route_text[0]), "%s", str2);
+    DSD_SNPRINTF(observation.route_text[1], sizeof(observation.route_text[1]), "%s", str1);
+    (void)dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_CONTINUE);
+    return 1;
 }

--- a/src/protocol/edacs/edacs-fme.c
+++ b/src/protocol/edacs/edacs-fme.c
@@ -2012,24 +2012,19 @@ edacs_process_valid_frame(dsd_opts* opts, dsd_state* state, unsigned long long i
     edacs_print_mode_selection_hint(msg_1, msg_2);
 }
 
-void
-edacs(dsd_opts* opts, dsd_state* state) {
-    edacs_init_afs_layout(state);
-
-    char timestr[7];
-    char datestr[9];
-    (void)dsd_format_local_datetime(time(NULL), DSD_LOCAL_DATETIME_TIME_COMPACT, timestr, sizeof timestr);
-    (void)dsd_format_local_datetime(time(NULL), DSD_LOCAL_DATETIME_DATE_COMPACT, datestr, sizeof datestr);
-
-    int edacs_bit[241] = {0}; //zero out bit array and collect bits into it.
-    edacs_collect_bits(opts, state, edacs_bit);
-
-    // If we have executed a tune to a channel, then we will forego decoding any more edacs until we return from the voice channel
-    // Once tuned away from the control channel, do not decode stale control symbols as a new source identity.
-    if (opts->trunk_is_tuned == 1) {
-        goto EDACS_END;
-    }
-
+/**
+ * @brief Vote the six raw 40-bit copies and re-derive each message's 12-bit BCH.
+ *
+ * Pure: the caller's 240 collected bits in, the two error-corrected 40-bit codewords and a
+ * pass/fail out. Split out of edacs() so the trunk_is_tuned early-out, which forgoes acting
+ * on the message but has already paid for the symbols, can still report whether the frame
+ * checked out (#391).
+ *
+ * @return 1 when both voted codewords re-derived their own BCH, 0 otherwise.
+ */
+int
+edacs_frame_bch_verdict(const int* edacs_bit, unsigned long long int* msg_1_ec_out,
+                        unsigned long long int* msg_2_ec_out) {
     unsigned long long int fr_1 = 0;
     unsigned long long int fr_2 = 0;
     unsigned long long int fr_3 = 0;
@@ -2039,18 +2034,51 @@ edacs(dsd_opts* opts, dsd_state* state) {
     edacs_build_raw_frames(edacs_bit, &fr_1, &fr_2, &fr_3, &fr_4, &fr_5, &fr_6);
 
     //Take our 3 copies of the first and second message and vote them to extract the two "error-corrected" messages
-    unsigned long long int msg_1_ec = edacs_vote_frames(fr_1, fr_2, fr_3);
-    unsigned long long int msg_2_ec = edacs_vote_frames(fr_4, fr_5, fr_6);
+    const unsigned long long int msg_1_ec = edacs_vote_frames(fr_1, fr_2, fr_3);
+    const unsigned long long int msg_2_ec = edacs_vote_frames(fr_4, fr_5, fr_6);
 
-    //Get just the 28-bit message portion
-    unsigned long long int msg_1_ec_m = msg_1_ec >> 12;
-    unsigned long long int msg_2_ec_m = msg_2_ec >> 12;
+    if (msg_1_ec_out != NULL) {
+        *msg_1_ec_out = msg_1_ec;
+    }
+    if (msg_2_ec_out != NULL) {
+        *msg_2_ec_out = msg_2_ec;
+    }
 
     //Take the message and create a new crc for it. If the newly crc-ed message matches the old one, we have a good frame.
-    unsigned long long int msg_1_ec_new_bch = edacs_bch(msg_1_ec_m) & 0xFFFFFFFFFF;
-    unsigned long long int msg_2_ec_new_bch = edacs_bch(msg_2_ec_m) & 0xFFFFFFFFFF;
+    const unsigned long long int msg_1_ec_new_bch = edacs_bch(msg_1_ec >> 12) & 0xFFFFFFFFFF;
+    const unsigned long long int msg_2_ec_new_bch = edacs_bch(msg_2_ec >> 12) & 0xFFFFFFFFFF;
 
-    if (msg_1_ec != msg_1_ec_new_bch || msg_2_ec != msg_2_ec_new_bch) {
+    return (msg_1_ec == msg_1_ec_new_bch && msg_2_ec == msg_2_ec_new_bch) ? 1 : 0;
+}
+
+int
+edacs(dsd_opts* opts, dsd_state* state) {
+    edacs_init_afs_layout(state);
+    int decoded = 0;
+
+    char timestr[7];
+    char datestr[9];
+    (void)dsd_format_local_datetime(time(NULL), DSD_LOCAL_DATETIME_TIME_COMPACT, timestr, sizeof timestr);
+    (void)dsd_format_local_datetime(time(NULL), DSD_LOCAL_DATETIME_DATE_COMPACT, datestr, sizeof datestr);
+
+    int edacs_bit[241] = {0}; //zero out bit array and collect bits into it.
+    edacs_collect_bits(opts, state, edacs_bit);
+
+    /* Vote and check before the tuned early-out below. The 240 dibits are already read, so
+     * the vote and two BCH re-derivations cost nothing next to them, and their answer is
+     * this frame's verdict whether or not the call goes on to act on the message. Deciding
+     * not to decode must not read as the check having failed (#391). */
+    unsigned long long int msg_1_ec = 0;
+    unsigned long long int msg_2_ec = 0;
+    decoded = edacs_frame_bch_verdict(edacs_bit, &msg_1_ec, &msg_2_ec);
+
+    // If we have executed a tune to a channel, then we will forego decoding any more edacs until we return from the voice channel
+    // Once tuned away from the control channel, do not decode stale control symbols as a new source identity.
+    if (opts->trunk_is_tuned == 1) {
+        goto EDACS_END;
+    }
+
+    if (!decoded) {
         DSD_FPRINTF(stderr, " BCH FAIL ");
     } else {
         // Rename the message variables (sans BCH) at the point of use.
@@ -2068,6 +2096,11 @@ EDACS_END:
 
     //when on a CC, rotate the symbol out file every hour, if enabled
     rotate_symbol_out_file(opts, state);
+
+    /* The BCH verdict on the frame that was read, on both paths: a tuned trunk declines to
+     * act on the message, but the frame it declined to act on still either checked out or
+     * did not, and the SPS hunt is owed that answer rather than a blanket zero. */
+    return decoded;
 }
 
 void

--- a/src/protocol/edacs/edacs_internal.h
+++ b/src/protocol/edacs/edacs_internal.h
@@ -26,6 +26,7 @@ void edacs_update_lcn_count(dsd_state* state, int lcn);
 void edacs_build_raw_frames(const int* edacs_bit, unsigned long long* fr_1, unsigned long long* fr_2,
                             unsigned long long* fr_3, unsigned long long* fr_4, unsigned long long* fr_5,
                             unsigned long long* fr_6);
+int edacs_frame_bch_verdict(const int* edacs_bit, unsigned long long* msg_1_ec_out, unsigned long long* msg_2_ec_out);
 unsigned long long edacs_build_symbol_register(const dsd_opts* opts, dsd_state* state, const short* analog1);
 void edacs_reset_digitize_overflow(dsd_state* state);
 int edacs_collect_analog_triplet(dsd_opts* opts, dsd_state* state, short* analog1, short* analog2, short* analog3,

--- a/src/protocol/nxdn/nxdn_frame.c
+++ b/src/protocol/nxdn/nxdn_frame.c
@@ -602,7 +602,7 @@ nxdn_finalize_sync_reject(dsd_state* state) {
     }
 }
 
-void
+int
 nxdn_frame(dsd_opts* opts, dsd_state* state) {
     nxdn_frame_ctx ctx;
 
@@ -662,4 +662,8 @@ nxdn_frame(dsd_opts* opts, dsd_state* state) {
 
 END:
     nxdn_finalize_sync_reject(state);
+    /* The sticky flag, not this frame's evidence: a confirmed transmission whose current
+     * frame happens to carry no CRC still decoded, and reporting it unproductive would let
+     * the SPS hunt rotate off a live call. */
+    return nxdn_confirm_is_confirmed(state);
 }

--- a/src/protocol/ysf/ysf.c
+++ b/src/protocol/ysf/ysf.c
@@ -921,7 +921,7 @@ ysf_dispatch_payload(dsd_opts* opts, dsd_state* state, const ysf_fich_info* info
     }
 }
 
-void
+int
 processYSF(dsd_opts* opts, dsd_state* state) {
     static uint8_t last_dt;
     static uint8_t last_fi;
@@ -936,4 +936,15 @@ processYSF(dsd_opts* opts, dsd_state* state) {
 
     DSD_FPRINTF(stderr, "%s", KNRM);
     DSD_FPRINTF(stderr, "\n");
+
+    /* Sticky per transmission, the shape nxdn_confirm_is_confirmed() uses. A FICH failure on
+     * its own says nothing decoded only until one FICH has passed: after that the fallback
+     * dt/fi come from a frame that did check out, ysf_dispatch_payload() lays the rest of the
+     * frame out on them, and ysf_handle_vd_type2() synthesizes and plays voice from it. A
+     * frame that produced audio must not tell the SPS hunt it validated nothing (#391).
+     * noCarrier() clears the flag with the other per-transmission YSF state. */
+    if (info.err == 0) {
+        state->ysf_fich_confirmed = 1;
+    }
+    return state->ysf_fich_confirmed != 0 ? 1 : 0;
 } //end processYSF

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7641,6 +7641,36 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
     )
 endif()
 
+# The tuned-trunk early-out must report the frame's real BCH verdict rather than the zero a
+# failed check returns (issue #391), so this drives edacs() itself over a synthetic control
+# frame with the dibit source wrapped.
+if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
+    add_executable(
+        dsd-neo_test_edacs_frame_verdict
+        protocol/edacs/test_edacs_frame_verdict.c
+    )
+    target_include_directories(
+        dsd-neo_test_edacs_frame_verdict
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src/protocol/edacs
+    )
+    target_link_libraries(
+        dsd-neo_test_edacs_frame_verdict
+        PRIVATE
+            "-Wl,--start-group"
+            ${_DSD_RUNTIME_CLI_PARSE_LIBS}
+            "-Wl,--end-group"
+            ${LIBS}
+            dsd-neo_test_support
+    )
+    target_link_options(
+        dsd-neo_test_edacs_frame_verdict
+        PRIVATE "-Wl,--wrap=get_dibit_and_analog_signal"
+    )
+    add_test(NAME EDACS_FRAME_VERDICT COMMAND dsd-neo_test_edacs_frame_verdict)
+endif()
+
 # Symbol .bin dibit→symbol mapping unit test
 add_executable(dsd-neo_test_symbol_bin_mapping dsp/test_symbol_bin_mapping.c)
 target_include_directories(
@@ -8984,15 +9014,21 @@ if(DSD_HAS_RADIO)
 
     # iq_decode_check.cmake enforces exit code 0 AND the payload regex AND the
     # absence of sanitizer reports; PASS_REGULAR_EXPRESSION alone would ignore
-    # the exit code and let a crash after the first payload match pass.
+    # the exit code and let a crash after the first payload match pass. An
+    # optional fifth argument adds a regex that must be *absent* as well, for
+    # cases where decoding the payload is only half the property.
     function(dsd_neo_add_iq_decode_test test_name fixture mode expected)
+        set(_not_expected_arg)
+        if(ARGC GREATER 4)
+            set(_not_expected_arg "-DNOT_EXPECTED=${ARGV4}")
+        endif()
         add_test(
             NAME ${test_name}
             COMMAND
                 ${CMAKE_COMMAND} "-DDSD_BIN=$<TARGET_FILE:dsd-neo>"
                 "-DMODE=${mode}"
                 "-DFIXTURE=${_DSD_NEO_IQ_FIXTURE_DIR}/${fixture}.iq.json"
-                "-DEXPECTED=${expected}" -P
+                "-DEXPECTED=${expected}" ${_not_expected_arg} -P
                 "${CMAKE_CURRENT_SOURCE_DIR}/iq_decode_check.cmake"
         )
         set_tests_properties(
@@ -9116,6 +9152,21 @@ if(DSD_HAS_RADIO)
         p25p2_cc
         "-fa -v 3"
         "SPS hunt: trying 20 sps"
+    )
+
+    # The other direction, which is the one issue #391 warns about: a handler that reports
+    # its frames validated nothing while decoding them rotates the hunt off live traffic.
+    # Every other fixture that exercises a newly-reporting protocol pins its frame type, so
+    # the hunt is inactive in it. The ysf capture is 6 s -- one full rotation -- and decodes
+    # on the hunt's starting profile, so under -fa the payload must still decode and the
+    # hunt must never step. Reporting every YSF frame unproductive drops the payload from 23
+    # hits to 13 and steps the hunt to 20 sps partway through the capture.
+    dsd_neo_add_iq_decode_test(
+        DECODE_IQ_YSF_AUTO_HUNT
+        ysf
+        -fa
+        "V/D2 RID Mode Repeater CC"
+        "SPS hunt: trying"
     )
 
     # Open-squelch receiver noise, with no signal in it at all. NXDN's 10-symbol sync word

--- a/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
+++ b/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
@@ -17,6 +17,12 @@
  * every returned sync is "handled" by consuming symbols, exactly as a protocol dispatch
  * handler consumes dibits. What separates a false sync from a real one is how many symbols
  * the handler takes, so that is what the hunt is asked to measure.
+ *
+ * Since #391 a handler may also report a dsd_frame_verdict. processFrame() leaves it in
+ * dsd_state::sps_hunt_last_frame_verdict for the next getFrameSync() entry to read, so
+ * these cases write that field after "handling" a sync exactly as processFrame() does --
+ * and one case deliberately stops writing it, to pin that a verdict is read once and
+ * cleared rather than standing over the entries no processFrame() precedes.
  */
 
 #include <assert.h>
@@ -26,6 +32,7 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/sync_calibration.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
 #include <stdio.h>
 #include <string.h>
@@ -145,6 +152,9 @@ typedef struct {
     const char* marker;                                  /* sync marker injected into the stream ("" = never syncs) */
     int marker_gap;                                      /* filler symbols between markers */
     int handler_symbols;                                 /* symbols the "protocol handler" consumes per returned sync */
+    int handler_unproductive;                            /* verdict the handler reports on every sync (#391) */
+    int unproductive_lead_syncs;                         /* ... plus the first N syncs, always UNPRODUCTIVE */
+    int stamp_verdict_syncs;                             /* 0 = every sync stamps a verdict; N = only the first N */
     long symbol_budget;                                  /* stop after this many symbols leave the source */
     int expect_step;                                     /* 1 = the hunt must leave its starting profile */
     int mod_cli_lock;                                    /* 0 = AUTO (-fa), 1 = a generic modulation lock (-mc) */
@@ -192,6 +202,14 @@ drive_hunt(const HuntCase* tc) {
         result.syncs_seen++;
         for (int i = 0; i < tc->handler_symbols; i++) {
             (void)getSymbol(&opts, &state, 1);
+        }
+        /* What processFrame() does with the handler's dsd_frame_verdict. stamp_verdict_syncs
+         * stops the stamping partway, which is the engine's other shape: an entry no
+         * processFrame() precedes leaves the field exactly as the last one left it. */
+        if (tc->stamp_verdict_syncs == 0 || result.syncs_seen <= tc->stamp_verdict_syncs) {
+            const int unproductive = tc->handler_unproductive || result.syncs_seen <= tc->unproductive_lead_syncs;
+            state.sps_hunt_last_frame_verdict =
+                unproductive ? DSD_FRAME_VERDICT_UNPRODUCTIVE : DSD_FRAME_VERDICT_PRODUCTIVE;
         }
     }
 
@@ -281,7 +299,11 @@ test_dense_false_syncs_do_not_starve_the_hunt(void) {
 
 /* The floor is the whole of the density fix, so state where it sits. One symbol short of a
  * frame's worth, at the densest cadence the stream can produce, is the worst case an
- * unproductive matcher can present -- and it still gets exactly the idle dwell. */
+ * unproductive matcher can present -- and it still gets exactly the idle dwell.
+ *
+ * Deliberately left on the default PRODUCTIVE verdict after #391: the floor is what stops
+ * a marker-and-bail matcher buying dwell, and it must keep doing that on its own, for the
+ * protocols that have no verdict to report. */
 static void
 test_sub_frame_consumption_never_buys_dwell(void) {
     const HuntCase tc = {
@@ -289,6 +311,7 @@ test_sub_frame_consumption_never_buys_dwell(void) {
         .marker = FALSE_SYNC_MARKER,
         .marker_gap = 0,
         .handler_symbols = DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS - 1,
+        .handler_unproductive = 0,
         .symbol_budget = 400000,
         .expect_step = 1,
     };
@@ -307,12 +330,100 @@ static void
 test_consumed_frames_hold_the_profile(void) {
     /* Same marker, same cadence -- only the handler's appetite differs. A protocol
      * reading real frames consumes far more than it searches (NXDN96 spends 182
-     * symbols per frame, P25p1 408, M17 184). */
+     * symbols per frame, P25p1 408, M17 184).
+     *
+     * On the default PRODUCTIVE verdict, which is what #391 leaves every protocol with no
+     * check of its own -- D-STAR voice, ProVoice, dPMR, X2-TDMA, P25p2, DMR. A frame's
+     * worth consumed still holds the profile for them, exactly as before. */
     const HuntCase tc = {
         .label = "decoded frames at 4800/4",
         .marker = FALSE_SYNC_MARKER,
         .marker_gap = 84,
         .handler_symbols = 400,
+        .handler_unproductive = 0,
+        .symbol_budget = 60000,
+        .expect_step = 0,
+    };
+    const HuntResult r = drive_hunt(&tc);
+
+    assert(r.syncs_seen > 50);
+    assert(r.stepped == 0);
+    assert(r.final_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(r.final_sps == HUNT_SPS_4800);
+}
+
+/* #391: the new property. Same marker, same cadence and the same frame's worth of symbols
+ * as test_consumed_frames_hold_the_profile() -- the one difference is that the handler
+ * reports it validated nothing, which is what a failed FICH CRC, a failed EDACS BCH, a
+ * failed D-STAR header CRC, a failed P25p1 NID or an unconfirmed NXDN frame say. That
+ * profile must reach its dwell like an idle one instead of being held by symbols no CRC
+ * would have accepted. */
+static void
+test_unproductive_frames_never_buy_dwell(void) {
+    const HuntCase tc = {
+        .label = "unproductive frames at 4800/4",
+        .marker = FALSE_SYNC_MARKER,
+        .marker_gap = 84,
+        .handler_symbols = 400,
+        .handler_unproductive = 1,
+        .symbol_budget = 400000,
+        .expect_step = 1,
+    };
+    const HuntResult r = drive_hunt(&tc);
+
+    assert(r.syncs_seen > 10);
+    assert_auto_stepped_to_2400_4(&r);
+    /* The idle dwell, no more: an unproductive verdict buys nothing however large the
+     * block behind it was. The upper bound allows for the handler's own symbols, which
+     * leave the source without counting against the searched budget. */
+    const long dwell_symbols = (long)DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS * 3;
+    assert(r.symbols_at_step >= dwell_symbols);
+    assert(r.symbols_at_step < dwell_symbols * 6);
+}
+
+/* #391, the other half of the same rule: an unproductive lead does not condemn the
+ * transmission behind it. A transmission that starts with frames the protocol cannot yet
+ * confirm -- NXDN before its first FACCH, YSF before its first FICH CRC -- and then decodes
+ * must hold its profile from the frame it confirms on. This pins the hunt's arithmetic, not
+ * the clear: every sync here stamps a verdict of its own, as processFrame() does. */
+static void
+test_a_confirming_transmission_holds_its_profile(void) {
+    const HuntCase tc = {
+        .label = "unproductive lead, then decoded frames",
+        .marker = FALSE_SYNC_MARKER,
+        .marker_gap = 84,
+        .handler_symbols = 400,
+        .handler_unproductive = 0,
+        .unproductive_lead_syncs = 3,
+        .symbol_budget = 60000,
+        .expect_step = 0,
+    };
+    const HuntResult r = drive_hunt(&tc);
+
+    assert(r.syncs_seen > 50);
+    assert(r.stepped == 0);
+    assert(r.final_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(r.final_sps == HUNT_SPS_4800);
+}
+
+/* #391: one verdict answers for one handler call. frame_sync_sps_hunt_note_handler_consumption()
+ * clears dsd_state::sps_hunt_last_frame_verdict as it reads it, so a verdict cannot be charged
+ * against consumption that is not the handler's -- the entries no processFrame() precedes, such
+ * as a frame live_scanner_process_synced_frames() finds undispatchable after a retune.
+ *
+ * Only the first sync stamps anything here, and it stamps UNPRODUCTIVE; every sync after it
+ * consumes a frame's worth with the field left exactly as it was. Without the clear that one
+ * verdict stands for the rest of the run, every later frame is refused its credit, and the
+ * profile that is decoding is rotated away from. */
+static void
+test_a_verdict_is_read_once_and_cleared(void) {
+    const HuntCase tc = {
+        .label = "one unproductive verdict, then unstamped frames",
+        .marker = FALSE_SYNC_MARKER,
+        .marker_gap = 84,
+        .handler_symbols = 400,
+        .handler_unproductive = 1,
+        .stamp_verdict_syncs = 1,
         .symbol_budget = 60000,
         .expect_step = 0,
     };
@@ -454,6 +565,9 @@ main(void) {
     test_dense_false_syncs_do_not_starve_the_hunt();
     test_sub_frame_consumption_never_buys_dwell();
     test_consumed_frames_hold_the_profile();
+    test_unproductive_frames_never_buy_dwell();
+    test_a_confirming_transmission_holds_its_profile();
+    test_a_verdict_is_read_once_and_cleared();
     test_idle_rotation_period_is_unchanged();
     test_locked_modulation_rotates_within_equal_timing();
     test_budget_exit_runs_the_no_sync_hooks();

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -348,11 +348,16 @@ main(void) {
     state->nxdn_confirmed = 1;
     state->nxdn_confirm_weak_streak = 1;
     state->nxdn_confirm_frame_evidence = 2;
+    // YSF's FICH evidence is per-transmission the same way (issue #391): processYSF() reports
+    // productive to the SPS hunt for as long as this flag stands, so carrying it across a carrier
+    // loss would let the next channel's first FICH failure buy dwell it validated nothing for.
+    state->ysf_fich_confirmed = 1U;
 
     noCarrier(opts, state);
 
     rc |= expect_true("nxdn-confirmation-reset", state->nxdn_confirmed == 0 && state->nxdn_confirm_weak_streak == 0
                                                      && state->nxdn_confirm_frame_evidence == 0);
+    rc |= expect_true("ysf-fich-confirmation-reset", state->ysf_fich_confirmed == 0U);
 
     dsd_call_snapshot ended_call;
     rc |= expect_true("no-carrier retains canonical snapshot", dsd_call_state_get(state, 0U, &ended_call) == 1);

--- a/tests/engine/test_engine_protocol_dispatch.c
+++ b/tests/engine/test_engine_protocol_dispatch.c
@@ -32,11 +32,14 @@ enum {
 };
 
 static int g_called_handler = TEST_HANDLER_NONE;
+/* The verdict every stub reports, so one case can drive the whole table. */
+static dsd_frame_verdict g_handler_verdict = DSD_FRAME_VERDICT_PRODUCTIVE;
 
-static void
+static dsd_frame_verdict
 record_handler(int handler_id) {
     assert(g_called_handler == TEST_HANDLER_NONE);
     g_called_handler = handler_id;
+    return g_handler_verdict;
 }
 
 int
@@ -44,11 +47,11 @@ dsd_dispatch_matches_nxdn(int synctype) {
     return DSD_SYNC_IS_NXDN(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_nxdn(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_NXDN);
+    return record_handler(TEST_HANDLER_NXDN);
 }
 
 int
@@ -56,11 +59,11 @@ dsd_dispatch_matches_dstar(int synctype) {
     return DSD_SYNC_IS_DSTAR(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_dstar(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_DSTAR);
+    return record_handler(TEST_HANDLER_DSTAR);
 }
 
 int
@@ -68,11 +71,11 @@ dsd_dispatch_matches_dmr(int synctype) {
     return DSD_SYNC_IS_DMR(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_DMR);
+    return record_handler(TEST_HANDLER_DMR);
 }
 
 int
@@ -80,11 +83,11 @@ dsd_dispatch_matches_x2tdma(int synctype) {
     return DSD_SYNC_IS_X2TDMA(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_x2tdma(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_X2TDMA);
+    return record_handler(TEST_HANDLER_X2TDMA);
 }
 
 int
@@ -92,11 +95,11 @@ dsd_dispatch_matches_provoice(int synctype) {
     return DSD_SYNC_IS_PROVOICE(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_provoice(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_PROVOICE);
+    return record_handler(TEST_HANDLER_PROVOICE);
 }
 
 int
@@ -104,11 +107,11 @@ dsd_dispatch_matches_edacs(int synctype) {
     return DSD_SYNC_IS_EDACS(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_edacs(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_EDACS);
+    return record_handler(TEST_HANDLER_EDACS);
 }
 
 int
@@ -116,11 +119,11 @@ dsd_dispatch_matches_ysf(int synctype) {
     return DSD_SYNC_IS_YSF(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_ysf(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_YSF);
+    return record_handler(TEST_HANDLER_YSF);
 }
 
 int
@@ -128,11 +131,11 @@ dsd_dispatch_matches_m17(int synctype) {
     return DSD_SYNC_IS_M17(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_m17(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_M17);
+    return record_handler(TEST_HANDLER_M17);
 }
 
 int
@@ -140,11 +143,11 @@ dsd_dispatch_matches_p25p2(int synctype) {
     return DSD_SYNC_IS_P25P2(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_p25p2(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_P25P2);
+    return record_handler(TEST_HANDLER_P25P2);
 }
 
 int
@@ -152,11 +155,11 @@ dsd_dispatch_matches_dpmr(int synctype) {
     return DSD_SYNC_IS_DPMR(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_DPMR);
+    return record_handler(TEST_HANDLER_DPMR);
 }
 
 int
@@ -164,15 +167,15 @@ dsd_dispatch_matches_p25p1(int synctype) {
     return DSD_SYNC_IS_P25P1(synctype);
 }
 
-void
+dsd_frame_verdict
 dsd_dispatch_handle_p25p1(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
-    record_handler(TEST_HANDLER_P25P1);
+    return record_handler(TEST_HANDLER_P25P1);
 }
 
 static void
-run_dispatch_case(int synctype, int expected_handler) {
+run_dispatch_case_verdict(int synctype, int expected_handler, dsd_frame_verdict verdict, int stale_verdict_in_state) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
     assert(opts != NULL);
@@ -181,15 +184,28 @@ run_dispatch_case(int synctype, int expected_handler) {
     state->rf_mod = 1;
     state->max = 100.0F;
     state->min = -50.0F;
+    state->sps_hunt_last_frame_verdict = stale_verdict_in_state;
     g_called_handler = TEST_HANDLER_NONE;
+    g_handler_verdict = verdict;
 
     processFrame(opts, state);
 
     assert(g_called_handler == expected_handler);
     assert(state->maxref == 80.0F);
     assert(state->minref == -40.0F);
+    /* #391: the handler's verdict, recorded where getFrameSync() reads it on its next entry.
+     * A synctype no handler claims leaves it productive -- the pre-#391 behaviour -- and
+     * either way a verdict left over from the previous frame must not survive. */
+    assert(state->sps_hunt_last_frame_verdict
+           == (expected_handler == TEST_HANDLER_NONE ? DSD_FRAME_VERDICT_PRODUCTIVE : (int)verdict));
+    g_handler_verdict = DSD_FRAME_VERDICT_PRODUCTIVE;
     free(state);
     free(opts);
+}
+
+static void
+run_dispatch_case(int synctype, int expected_handler) {
+    run_dispatch_case_verdict(synctype, expected_handler, DSD_FRAME_VERDICT_PRODUCTIVE, 0);
 }
 
 static void
@@ -202,13 +218,27 @@ check_public_handler_table(void) {
     assert(dsd_protocol_handlers[11].name == NULL);
 }
 
+/* #391: the zero value is PRODUCTIVE, which is what makes the contract safe by omission --
+ * a handler with nothing to say, and a zeroed dsd_state, both read as "decoded a frame". */
+static void
+check_verdict_default_is_productive(void) {
+    _Static_assert(DSD_FRAME_VERDICT_PRODUCTIVE == 0, "PRODUCTIVE must be the zero value");
+    _Static_assert(DSD_FRAME_VERDICT_UNPRODUCTIVE != 0, "UNPRODUCTIVE must be non-zero");
+}
+
 int
 main(void) {
     check_public_handler_table();
+    check_verdict_default_is_productive();
     run_dispatch_case(DSD_SYNC_DMR_BS_VOICE_POS, TEST_HANDLER_DMR);
     run_dispatch_case(DSD_SYNC_DPMR_FS1_POS, TEST_HANDLER_DPMR);
     run_dispatch_case(DSD_SYNC_P25P1_POS, TEST_HANDLER_P25P1);
     run_dispatch_case(-1, TEST_HANDLER_NONE);
+    run_dispatch_case_verdict(DSD_SYNC_YSF_POS, TEST_HANDLER_YSF, DSD_FRAME_VERDICT_UNPRODUCTIVE, 0);
+    /* A stale UNPRODUCTIVE must not survive a productive frame, nor a frame no handler took. */
+    run_dispatch_case_verdict(DSD_SYNC_YSF_POS, TEST_HANDLER_YSF, DSD_FRAME_VERDICT_PRODUCTIVE,
+                              DSD_FRAME_VERDICT_UNPRODUCTIVE);
+    run_dispatch_case_verdict(-1, TEST_HANDLER_NONE, DSD_FRAME_VERDICT_PRODUCTIVE, DSD_FRAME_VERDICT_UNPRODUCTIVE);
 
     printf("ENGINE_PROTOCOL_DISPATCH: OK\n");
     return 0;

--- a/tests/protocol/dmr/test_dmr_sync_dispatch.c
+++ b/tests/protocol/dmr/test_dmr_sync_dispatch.c
@@ -13,12 +13,13 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <stdio.h>
 #include <string.h>
 
 int dsd_dispatch_matches_dmr(int synctype);
-void dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state);
 
 static int bs_bootstrap_calls;
 static int bs_bootstrap_stereo;

--- a/tests/protocol/dpmr/test_dpmr_sync_dispatch.c
+++ b/tests/protocol/dpmr/test_dpmr_sync_dispatch.c
@@ -15,12 +15,13 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
 int dsd_dispatch_matches_dpmr(int synctype);
-void dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state);
 
 static int g_close_calls;
 static int g_open_calls;

--- a/tests/protocol/dstar/test_dstar_header_utils.c
+++ b/tests/protocol/dstar/test_dstar_header_utils.c
@@ -101,7 +101,7 @@ test_soft_decode_pipeline(void) {
 }
 
 static void
-build_encoded_header_fixture(float soft_rx[DSD_DSTAR_HEADER_CODED_BITS], uint8_t flags) {
+build_encoded_header_fixture_ex(float soft_rx[DSD_DSTAR_HEADER_CODED_BITS], uint8_t flags, int corrupt_crc) {
     uint8_t header[41];
     int info_bits[DSD_DSTAR_HEADER_INFO_BITS];
     int coded[DSD_DSTAR_HEADER_CODED_BITS];
@@ -115,7 +115,7 @@ build_encoded_header_fixture(float soft_rx[DSD_DSTAR_HEADER_CODED_BITS], uint8_t
     DSD_MEMCPY(header + 11, "RPT1TST ", 8);
     DSD_MEMCPY(header + 19, "CQCQCQ  ", 8);
     DSD_MEMCPY(header + 27, "N0CALL  /TST", 12);
-    const uint16_t crc = dstar_crc16(header, 39U);
+    const uint16_t crc = (uint16_t)(dstar_crc16(header, 39U) ^ (corrupt_crc ? 0xFFFFU : 0x0000U));
     header[39] = (uint8_t)(crc >> 8U);
     header[40] = (uint8_t)crc;
 
@@ -139,6 +139,11 @@ build_encoded_header_fixture(float soft_rx[DSD_DSTAR_HEADER_CODED_BITS], uint8_t
 }
 
 static void
+build_encoded_header_fixture(float soft_rx[DSD_DSTAR_HEADER_CODED_BITS], uint8_t flags) {
+    build_encoded_header_fixture_ex(soft_rx, flags, 0);
+}
+
+static void
 test_soft_header_decode_extracts_callsigns(void) {
     static dsd_state state;
     float soft_rx[DSD_DSTAR_HEADER_CODED_BITS];
@@ -149,7 +154,7 @@ test_soft_header_decode_extracts_callsigns(void) {
     state.max = 1.0F;
     build_encoded_header_fixture(soft_rx, 0x78U);
 
-    dstar_header_decode_soft(&state, soft_rx);
+    assert(dstar_header_decode_soft(&state, soft_rx) == 1);
 
     const dsd_call_snapshot call = get_dstar_call(&state);
     assert(call.kind == DSD_CALL_KIND_VOICE);
@@ -170,7 +175,7 @@ test_soft_data_header_preserves_callsigns(void) {
     state.max = 1.0F;
     build_encoded_header_fixture(soft_rx, 0x80U);
 
-    dstar_header_decode_soft(&state, soft_rx);
+    assert(dstar_header_decode_soft(&state, soft_rx) == 1);
 
     const dsd_call_snapshot call = get_dstar_call(&state);
     assert(call.kind == DSD_CALL_KIND_DATA);
@@ -178,6 +183,28 @@ test_soft_data_header_preserves_callsigns(void) {
     assert(strcmp(call.route_text[0], "RPT1TST") == 0);
     assert(strcmp(call.target_text, "CQCQCQ") == 0);
     assert(strcmp(call.source_text, "N0CALL /TST") == 0);
+}
+
+/* #391: the header CRC-16/X.25 is the D-STAR data path's only real check, and the SPS hunt
+ * now spends it. Corrupt one soft bit's worth of the CRC field and the decode must say so
+ * rather than publishing the callsigns it recovered anyway. */
+static void
+test_soft_header_decode_reports_a_failed_crc(void) {
+    static dsd_state state;
+    float soft_rx[DSD_DSTAR_HEADER_CODED_BITS];
+
+    DSD_MEMSET(&state, 0, sizeof state);
+    state.min = -1.0F;
+    state.center = 0.0F;
+    state.max = 1.0F;
+    build_encoded_header_fixture_ex(soft_rx, 0x78U, 1);
+
+    assert(dstar_header_decode_soft(&state, soft_rx) == 0);
+
+    /* Nothing was published either: a header whose CRC failed is not a call observation. */
+    dsd_call_snapshot call;
+    DSD_MEMSET(&call, 0, sizeof(call));
+    assert(dsd_call_state_get(&state, 0U, &call) != 1);
 }
 
 static void
@@ -343,6 +370,7 @@ main(void) {
     test_soft_decode_pipeline();
     test_soft_header_decode_extracts_callsigns();
     test_soft_data_header_preserves_callsigns();
+    test_soft_header_decode_reports_a_failed_crc();
     test_crc16();
     test_slow_data_header_accepts_wire_crc_order();
     test_slow_data_text_keeps_byte_after_marker();

--- a/tests/protocol/dstar/test_dstar_process.c
+++ b/tests/protocol/dstar/test_dstar_process.c
@@ -41,6 +41,8 @@ static int telemetry_active;
 static int watchdog_history_calls;
 static int watchdog_current_calls;
 static int header_decode_soft_calls;
+/* What the stubbed header CRC reports; processDSTAR_HD() must hand it straight back. */
+static int header_decode_soft_result = 1;
 static uint8_t captured_slow_data[DSTAR_EXPECTED_SLOW_DIBITS];
 static char captured_ambe_frame[4][24];
 static float captured_soft_symbols[DSD_DSTAR_HEADER_CODED_BITS];
@@ -153,12 +155,13 @@ dsd_event_sync_slot(dsd_opts* opts, dsd_state* state, uint8_t slot) {
     watchdog_current_calls++;
 }
 
-void
+int
 dstar_header_decode_soft(struct dsd_state* state, const float soft_symbols[DSD_DSTAR_HEADER_CODED_BITS]) {
     (void)state;
     assert(soft_symbols != NULL);
     DSD_MEMCPY(captured_soft_symbols, soft_symbols, sizeof(captured_soft_symbols));
     header_decode_soft_calls++;
+    return header_decode_soft_result;
 }
 
 static void
@@ -235,7 +238,8 @@ test_header_process_captures_header_then_voice(void) {
     opts.pulse_digi_out_channels = 1;
     reset_counters();
 
-    processDSTAR_HD(&opts, &state);
+    header_decode_soft_result = 1;
+    assert(processDSTAR_HD(&opts, &state) == 1);
 
     assert(soft_symbol_calls == DSD_DSTAR_HEADER_CODED_BITS);
     assert(header_decode_soft_calls == 1);
@@ -244,11 +248,34 @@ test_header_process_captures_header_then_voice(void) {
     assert_voice_loop_counts(0);
 }
 
+/* #391: the header CRC is the only verdict the D-STAR data path has, and processDSTAR_HD()
+ * must report it unchanged -- it decodes the voice frame behind a failed header either way,
+ * so the caller's only way to know those 1992 symbols validated nothing is this return. */
+static void
+test_header_process_reports_the_header_crc_verdict(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.floating_point = 1;
+    opts.pulse_digi_out_channels = 1;
+    reset_counters();
+
+    header_decode_soft_result = 0;
+    assert(processDSTAR_HD(&opts, &state) == 0);
+
+    assert(header_decode_soft_calls == 1);
+    /* The voice frame is consumed regardless: that is the point of reporting the failure. */
+    assert_voice_loop_counts(0);
+    header_decode_soft_result = 1;
+}
+
 int
 main(void) {
     test_voice_process_without_telemetry();
     test_voice_process_with_telemetry_attached();
     test_header_process_captures_header_then_voice();
+    test_header_process_reports_the_header_crc_verdict();
     printf("DSTAR_PROCESS: OK\n");
     return 0;
 }

--- a/tests/protocol/dstar/test_dstar_sync_dispatch.c
+++ b/tests/protocol/dstar/test_dstar_sync_dispatch.c
@@ -13,12 +13,13 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/dstar/dstar.h>
 #include <stdio.h>
 #include <string.h>
 
 int dsd_dispatch_matches_dstar(int synctype);
-void dsd_dispatch_handle_dstar(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_dstar(dsd_opts* opts, dsd_state* state);
 
 static int header_calls;
 static int open_calls;
@@ -45,11 +46,15 @@ processDSTAR(dsd_opts* opts, dsd_state* state) {
     voice_calls++;
 }
 
-void
+/* The stubbed header CRC verdict dsd_dispatch_handle_dstar() must pass through. */
+static int header_decode_result = 1;
+
+int
 processDSTAR_HD(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
     header_calls++;
+    return header_decode_result;
 }
 
 static void
@@ -91,7 +96,8 @@ test_voice_dispatch(void) {
         DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "%s", "out");
         state.synctype = voice_synctypes[i];
 
-        dsd_dispatch_handle_dstar(&opts, &state);
+        /* Voice stays productive: processDSTAR() has no verdict at any point (#391). */
+        assert(dsd_dispatch_handle_dstar(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
 
         assert(strcmp(state.fsubtype, " VOICE        ") == 0);
         assert(open_calls == 1);
@@ -115,7 +121,8 @@ test_header_dispatch(void) {
         DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "%s", "out");
         state.synctype = header_synctypes[i];
 
-        dsd_dispatch_handle_dstar(&opts, &state);
+        header_decode_result = 1;
+        assert(dsd_dispatch_handle_dstar(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
 
         assert(strcmp(state.fsubtype, " DATA         ") == 0);
         assert(open_calls == 0);
@@ -124,12 +131,31 @@ test_header_dispatch(void) {
     }
 }
 
+/* #391: a header whose CRC-16/X.25 failed consumed 2652 symbols and validated none of them,
+ * so the handler must say so rather than letting the SPS hunt pay for them. */
+static void
+test_failed_header_reports_unproductive(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+
+    state.synctype = DSD_SYNC_DSTAR_HD_POS;
+    header_decode_result = 0;
+
+    assert(dsd_dispatch_handle_dstar(&opts, &state) == DSD_FRAME_VERDICT_UNPRODUCTIVE);
+    assert(header_calls == 1);
+    header_decode_result = 1;
+}
+
 int
 main(void) {
     test_sync_pattern_lengths();
     test_synctype_helpers();
     test_voice_dispatch();
     test_header_dispatch();
+    test_failed_header_reports_unproductive();
     printf("DSTAR_SYNC_DISPATCH: OK\n");
     return 0;
 }

--- a/tests/protocol/edacs/test_edacs_frame_verdict.c
+++ b/tests/protocol/edacs/test_edacs_frame_verdict.c
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * EDACS control-frame verdict (issue #391).
+ *
+ * edacs() consumes 240 dibits before it looks at anything, and the SPS hunt pays the profile
+ * for them unless the handler says the frame validated nothing. The tuned-trunk early-out
+ * deliberately forgoes acting on the message, and used to return the same zero a failed BCH
+ * returns -- so "we chose not to decode" was reported as "the check failed", which is the
+ * direction #391 warns about. These cases drive the real edacs() over a synthetic dibit
+ * stream, with get_dibit_and_analog_signal() wrapped at link time.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/protocol/edacs/edacs.h>
+#include <dsd-neo/protocol/edacs/edacs_bch.h>
+#include <stdio.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "edacs_internal.h"
+
+/* The 240-bit control frame edacs_collect_bits() reads, one bit per call. */
+static int g_frame_bits[240];
+static int g_bit_pos;
+static int g_dibit_calls;
+
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+int __wrap_get_dibit_and_analog_signal(dsd_opts* opts, dsd_state* state, int* out_analog_signal);
+
+int
+// NOLINTNEXTLINE(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+__wrap_get_dibit_and_analog_signal(dsd_opts* opts, dsd_state* state, int* out_analog_signal) {
+    (void)opts;
+    (void)state;
+    if (out_analog_signal != NULL) {
+        *out_analog_signal = 0;
+    }
+    g_dibit_calls++;
+    if (g_bit_pos >= (int)(sizeof(g_frame_bits) / sizeof(g_frame_bits[0]))) {
+        return 0;
+    }
+    return g_frame_bits[g_bit_pos++];
+}
+
+/* One 40-bit codeword, MSB first, into bits[offset .. offset + 39]. */
+static void
+write_codeword(int offset, unsigned long long int codeword) {
+    for (int i = 0; i < 40; i++) {
+        g_frame_bits[offset + i] = (int)((codeword >> (39 - i)) & 1ULL);
+    }
+}
+
+/* The on-air layout edacs_build_raw_frames()/edacs_vote_frames() expect: each message sent
+ * three times, with the middle copy inverted. */
+static void
+build_frame(unsigned long long int cw_1, unsigned long long int cw_2) {
+    write_codeword(0, cw_1);
+    write_codeword(40, (~cw_1) & 0xFFFFFFFFFFULL);
+    write_codeword(80, cw_1);
+    write_codeword(120, cw_2);
+    write_codeword(160, (~cw_2) & 0xFFFFFFFFFFULL);
+    write_codeword(200, cw_2);
+    g_bit_pos = 0;
+    g_dibit_calls = 0;
+}
+
+static unsigned long long int
+codeword_for(unsigned long long int message) {
+    return edacs_bch(message) & 0xFFFFFFFFFFULL;
+}
+
+/* The vote and the two BCH re-derivations, on their own. */
+static void
+test_frame_bch_verdict_reads_the_voted_frames(void) {
+    unsigned long long int msg_1_ec = 0;
+    unsigned long long int msg_2_ec = 0;
+    const unsigned long long int cw_1 = codeword_for(0x0123456ULL);
+    const unsigned long long int cw_2 = codeword_for(0x0ABCDEFULL);
+
+    build_frame(cw_1, cw_2);
+    assert(edacs_frame_bch_verdict(g_frame_bits, &msg_1_ec, &msg_2_ec) == 1);
+    assert(msg_1_ec == cw_1);
+    assert(msg_2_ec == cw_2);
+    assert((msg_1_ec >> 12) == 0x0123456ULL);
+    assert((msg_2_ec >> 12) == 0x0ABCDEFULL);
+
+    /* One flipped message bit in every copy outvotes the majority and breaks the BCH. */
+    build_frame(cw_1 ^ (1ULL << 39), cw_2);
+    assert(edacs_frame_bch_verdict(g_frame_bits, &msg_1_ec, &msg_2_ec) == 0);
+
+    /* The output pointers are optional. */
+    build_frame(cw_1, cw_2);
+    assert(edacs_frame_bch_verdict(g_frame_bits, NULL, NULL) == 1);
+}
+
+/* The fix: a tuned trunk forgoes acting on the message, but the frame it read still either
+ * checked out or did not, and edacs() reports which. Before #391's follow-up this returned 0
+ * for a frame whose BCH held, telling the SPS hunt that 240 dibits of real control channel
+ * validated nothing. */
+static void
+test_tuned_early_out_reports_the_real_verdict(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    const unsigned long long int cw_1 = codeword_for(0x0123456ULL);
+    const unsigned long long int cw_2 = codeword_for(0x0ABCDEFULL);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.trunk_is_tuned = 1;
+
+    build_frame(cw_1, cw_2);
+    assert(edacs(&opts, &state) == 1);
+    /* Exactly the frame and no more: the early-out still forgoes the message itself, so no
+     * source identity is taken from stale control symbols. */
+    assert(g_dibit_calls == 240);
+
+    /* A frame that really did fail its BCH still reports the failure while tuned. */
+    build_frame(cw_1 ^ (1ULL << 39), cw_2);
+    assert(edacs(&opts, &state) == 0);
+    assert(g_dibit_calls == 240);
+}
+
+/* Untuned, the BCH failure path is unchanged: 240 dibits gone, nothing decoded. */
+static void
+test_failed_bch_reports_zero_untuned(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    const unsigned long long int cw_1 = codeword_for(0x0123456ULL);
+    const unsigned long long int cw_2 = codeword_for(0x0ABCDEFULL);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.trunk_is_tuned = 0;
+
+    build_frame(cw_1, cw_2 ^ (1ULL << 39));
+    assert(edacs(&opts, &state) == 0);
+    assert(g_dibit_calls == 240);
+}
+
+int
+main(void) {
+    test_frame_bch_verdict_reads_the_voted_frames();
+    test_tuned_early_out_reports_the_real_verdict();
+    test_failed_bch_reports_zero_untuned();
+    printf("EDACS_FRAME_VERDICT: OK\n");
+    return 0;
+}

--- a/tests/protocol/edacs/test_edacs_sync_dispatch.c
+++ b/tests/protocol/edacs/test_edacs_sync_dispatch.c
@@ -13,11 +13,12 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/edacs/edacs.h>
 #include <stdio.h>
 
 int dsd_dispatch_matches_edacs(int synctype);
-void dsd_dispatch_handle_edacs(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_edacs(dsd_opts* opts, dsd_state* state);
 
 static int close_calls;
 static int edacs_calls;
@@ -35,11 +36,15 @@ closeMbeOutFile(dsd_opts* opts, dsd_state* state) {
     opts->mbe_out_f = NULL;
 }
 
-void
+/* The stubbed BCH verdict dsd_dispatch_handle_edacs() must pass through. */
+static int edacs_decoded = 1;
+
+int
 edacs(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
     edacs_calls++;
+    return edacs_decoded;
 }
 
 void
@@ -81,7 +86,7 @@ test_edacs_dispatch_closes_mbe_output(void) {
 
     opts.mbe_out_f = stdout;
 
-    dsd_dispatch_handle_edacs(&opts, &state);
+    assert(dsd_dispatch_handle_edacs(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
 
     assert(close_calls == 1);
     assert(edacs_calls == 1);
@@ -96,10 +101,27 @@ test_edacs_dispatch_without_mbe_output(void) {
     DSD_MEMSET(&state, 0, sizeof(state));
     reset_calls();
 
-    dsd_dispatch_handle_edacs(&opts, &state);
+    assert(dsd_dispatch_handle_edacs(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
 
     assert(close_calls == 0);
     assert(edacs_calls == 1);
+}
+
+/* #391: edacs() answers zero on the BCH failure and on the trunk_is_tuned early-out alike.
+ * Either way the 240 dibits are already gone, so the handler must refuse them the dwell. */
+static void
+test_failed_bch_reports_unproductive(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+
+    edacs_decoded = 0;
+
+    assert(dsd_dispatch_handle_edacs(&opts, &state) == DSD_FRAME_VERDICT_UNPRODUCTIVE);
+    assert(edacs_calls == 1);
+    edacs_decoded = 1;
 }
 
 int
@@ -108,6 +130,7 @@ main(void) {
     test_synctype_helpers();
     test_edacs_dispatch_closes_mbe_output();
     test_edacs_dispatch_without_mbe_output();
+    test_failed_bch_reports_unproductive();
     printf("EDACS_SYNC_DISPATCH: OK\n");
     return 0;
 }

--- a/tests/protocol/m17/test_m17_sync_dispatch.c
+++ b/tests/protocol/m17/test_m17_sync_dispatch.c
@@ -13,12 +13,13 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/m17/m17.h>
 #include <stdio.h>
 #include <string.h>
 
 int dsd_dispatch_matches_m17(int synctype);
-void dsd_dispatch_handle_m17(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_m17(dsd_opts* opts, dsd_state* state);
 
 static int lsf_calls;
 static int pkt_calls;
@@ -127,6 +128,10 @@ test_synctype_names(void) {
     assert(strcmp(dsd_synctype_to_string(DSD_SYNC_M17_EOT_NEG), "M17 EOT") == 0);
 }
 
+/* Verdict of the most recent dispatch_one(), so cases can check it without threading a
+ * second return value through every caller (#391). */
+static dsd_frame_verdict last_verdict = DSD_FRAME_VERDICT_PRODUCTIVE;
+
 static int
 dispatch_one(int synctype) {
     static dsd_opts opts;
@@ -136,13 +141,17 @@ dispatch_one(int synctype) {
     reset_calls();
 
     state.synctype = synctype;
-    dsd_dispatch_handle_m17(&opts, &state);
+    last_verdict = dsd_dispatch_handle_m17(&opts, &state);
     return state.lastsynctype;
 }
 
 static void
 test_preamble_dispatch(void) {
     dispatch_one(DSD_SYNC_M17_PRE_POS);
+    /* 8 dibits is below DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS, which #388 calibrated against
+     * exactly this path, so the floor already refuses it credit and the verdict stays at
+     * the default. */
+    assert(last_verdict == DSD_FRAME_VERDICT_PRODUCTIVE);
     assert(skip_calls == 1);
     assert(skipped_dibits == 8);
     assert(lsf_calls == 0);
@@ -184,6 +193,8 @@ test_payload_dispatch(void) {
     assert(str_calls == 0);
 
     dispatch_one(DSD_SYNC_M17_STR_POS);
+    /* A stream frame is a decode, whatever the payload turns out to hold. */
+    assert(last_verdict == DSD_FRAME_VERDICT_PRODUCTIVE);
     assert(skip_calls == 0);
     assert(lsf_calls == 0);
     assert(pkt_calls == 0);
@@ -199,6 +210,9 @@ test_payload_dispatch(void) {
 static void
 test_eot_dispatch(void) {
     int lastsynctype = dispatch_one(DSD_SYNC_M17_EOT_POS);
+    /* #391: the EOT marker is positive evidence, and this branch acts on it -- the same
+     * DSD_CALL_END_TERMINATOR the call state is given. The SPS hunt is told the same. */
+    assert(last_verdict == DSD_FRAME_VERDICT_PRODUCTIVE);
     assert(skip_calls == 1);
     assert(skipped_dibits == 184);
     assert(lsf_calls == 0);

--- a/tests/protocol/nxdn/test_nxdn_sync_dispatch.c
+++ b/tests/protocol/nxdn/test_nxdn_sync_dispatch.c
@@ -12,19 +12,24 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/nxdn/nxdn.h>
 #include <stdio.h>
 
 int dsd_dispatch_matches_nxdn(int synctype);
-void dsd_dispatch_handle_nxdn(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_nxdn(dsd_opts* opts, dsd_state* state);
 
 static int frame_calls;
 
-void
+/* The stubbed CRC confirmation dsd_dispatch_handle_nxdn() must pass through. */
+static int frame_confirmed = 1;
+
+int
 nxdn_frame(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
     frame_calls++;
+    return frame_confirmed;
 }
 
 static void
@@ -65,11 +70,28 @@ test_dispatch_calls_frame(void) {
     frame_calls = 0;
 
     state.synctype = DSD_SYNC_NXDN_POS;
-    dsd_dispatch_handle_nxdn(&opts, &state);
+    assert(dsd_dispatch_handle_nxdn(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
     state.synctype = DSD_SYNC_NXDN_NEG;
-    dsd_dispatch_handle_nxdn(&opts, &state);
+    assert(dsd_dispatch_handle_nxdn(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
 
     assert(frame_calls == 2);
+}
+
+/* #391: NXDN's sync word and LICH are weak enough that noise clears both (#398), so an
+ * unconfirmed frame's 182 symbols must not buy the SPS hunt's dwell. */
+static void
+test_unconfirmed_frame_reports_unproductive(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    frame_calls = 0;
+    frame_confirmed = 0;
+
+    state.synctype = DSD_SYNC_NXDN_POS;
+    assert(dsd_dispatch_handle_nxdn(&opts, &state) == DSD_FRAME_VERDICT_UNPRODUCTIVE);
+    assert(frame_calls == 1);
+    frame_confirmed = 1;
 }
 
 int
@@ -77,6 +99,7 @@ main(void) {
     test_sync_pattern_lengths();
     test_synctype_helpers();
     test_dispatch_calls_frame();
+    test_unconfirmed_frame_reports_unproductive();
     printf("NXDN_SYNC_DISPATCH: OK\n");
     return 0;
 }

--- a/tests/protocol/p25/test_p25_p1_sync_dispatch.c
+++ b/tests/protocol/p25/test_p25_p1_sync_dispatch.c
@@ -16,6 +16,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/io/control.h>
 #include <dsd-neo/protocol/p25/p25.h>
 #include <dsd-neo/protocol/p25/p25_status_symbol.h>
@@ -25,7 +26,7 @@
 #include <string.h>
 
 int dsd_dispatch_matches_p25p1(int synctype);
-void dsd_dispatch_handle_p25p1(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_p25p1(dsd_opts* opts, dsd_state* state);
 
 static uint8_t g_test_duid = 0x3U;
 static int g_check_result = NID_OK;
@@ -302,7 +303,8 @@ test_p25p1_nid_correction_and_failure_state(void) {
     g_new_nac = 0x321;
     g_test_duid = 0x3U;
 
-    dsd_dispatch_handle_p25p1(&opts, &state);
+    /* A decoded NID is taken at its word: the BCH held, so the burst behind it counts. */
+    assert(dsd_dispatch_handle_p25p1(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
 
     assert(state.nid_corrections_total == 3U);
     assert(state.nid_parity_overrides == 1U);
@@ -317,7 +319,9 @@ test_p25p1_nid_correction_and_failure_state(void) {
     g_check_result = NID_DECODE_FAIL;
     g_test_duid = 0x5U;
 
-    dsd_dispatch_handle_p25p1(&opts, &state);
+    /* #391: the 63-bit BCH failed, the DUID is invalid and nothing is decoded past it, so
+     * the 33 dibits already read validated nothing. */
+    assert(dsd_dispatch_handle_p25p1(&opts, &state) == DSD_FRAME_VERDICT_UNPRODUCTIVE);
 
     assert(state.nid_failures_total == 1U);
     assert(state.debug_header_critical_errors == 1U);

--- a/tests/protocol/p25/test_p25_p2_ysf_sync_dispatch.c
+++ b/tests/protocol/p25/test_p25_p2_ysf_sync_dispatch.c
@@ -11,15 +11,16 @@
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/p25/p25.h>
 #include <dsd-neo/protocol/ysf/ysf.h>
 #include <stdio.h>
 #include <string.h>
 
 int dsd_dispatch_matches_p25p2(int synctype);
-void dsd_dispatch_handle_p25p2(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_p25p2(dsd_opts* opts, dsd_state* state);
 int dsd_dispatch_matches_ysf(int synctype);
-void dsd_dispatch_handle_ysf(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_ysf(dsd_opts* opts, dsd_state* state);
 
 static int g_process_p2_calls;
 static int g_process_ysf_calls;
@@ -32,12 +33,16 @@ processP2(dsd_opts* opts, dsd_state* state) {
     state->lastp25type = 2;
 }
 
-void
+/* The stubbed FICH verdict dsd_dispatch_handle_ysf() must pass through. */
+static int g_process_ysf_result = 1;
+
+int
 processYSF(dsd_opts* opts, dsd_state* state) {
     assert(opts != NULL);
     assert(state != NULL);
     g_process_ysf_calls++;
     DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), "%s", " YSF          ");
+    return g_process_ysf_result;
 }
 
 static void
@@ -69,15 +74,33 @@ test_ysf_match_and_dispatch(void) {
     assert(!dsd_dispatch_matches_ysf(DSD_SYNC_P25P2_POS));
     assert(!dsd_dispatch_matches_ysf(DSD_SYNC_DMR_BS_DATA_POS));
 
-    dsd_dispatch_handle_ysf(&opts, &state);
+    assert(dsd_dispatch_handle_ysf(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
     assert(g_process_ysf_calls == 1);
     assert(strcmp(state.fsubtype, " YSF          ") == 0);
+}
+
+/* #391: a FICH whose CRC-16 failed leaves processYSF() reading the rest of the frame on the
+ * previous frame's dt/fi. Those ~460 symbols validated nothing and must buy no dwell. */
+static void
+test_ysf_failed_fich_reports_unproductive(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    g_process_ysf_calls = 0;
+    g_process_ysf_result = 0;
+
+    assert(dsd_dispatch_handle_ysf(&opts, &state) == DSD_FRAME_VERDICT_UNPRODUCTIVE);
+    assert(g_process_ysf_calls == 1);
+    g_process_ysf_result = 1;
 }
 
 int
 main(void) {
     test_p25p2_match_and_dispatch();
     test_ysf_match_and_dispatch();
+    test_ysf_failed_fich_reports_unproductive();
     printf("P25_P2_YSF_SYNC_DISPATCH: OK\n");
     return 0;
 }

--- a/tests/protocol/provoice/test_provoice_sync_dispatch.c
+++ b/tests/protocol/provoice/test_provoice_sync_dispatch.c
@@ -13,12 +13,13 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/provoice/provoice.h>
 #include <stdio.h>
 #include <string.h>
 
 int dsd_dispatch_matches_provoice(int synctype);
-void dsd_dispatch_handle_provoice(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_provoice(dsd_opts* opts, dsd_state* state);
 
 static int open_calls;
 static int voice_calls;

--- a/tests/protocol/x2tdma/test_x2tdma_sync_dispatch.c
+++ b/tests/protocol/x2tdma/test_x2tdma_sync_dispatch.c
@@ -14,12 +14,13 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/x2tdma/x2tdma.h>
 #include <stdio.h>
 #include <string.h>
 
 int dsd_dispatch_matches_x2tdma(int synctype);
-void dsd_dispatch_handle_x2tdma(dsd_opts* opts, dsd_state* state);
+dsd_frame_verdict dsd_dispatch_handle_x2tdma(dsd_opts* opts, dsd_state* state);
 
 static int close_calls;
 static int data_calls;

--- a/tests/protocol/ysf/test_ysf_dch_decode.c
+++ b/tests/protocol/ysf/test_ysf_dch_decode.c
@@ -795,6 +795,75 @@ test_process_ysf_bad_fich_fallback_reopens_ysf_epoch(void) {
     dsd_state_ext_free_all(&state);
 }
 
+/* #391: processYSF()'s verdict is sticky for the transmission, not per frame. A FICH failure
+ * before any FICH has held means the ~460 dibits behind it were laid out by nothing read off
+ * the air, so the SPS hunt must refuse them their dwell. After one has held, the same failure
+ * falls back to a confirmed frame's dt/fi and still synthesizes and plays voice -- a frame
+ * that produced audio must not report having validated nothing. */
+static void
+test_process_ysf_fich_verdict_is_sticky_per_transmission(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t fich_bits[48];
+    uint8_t fich_input[100];
+    uint8_t dch[180];
+
+    InitAllFecFunction();
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    DSD_MEMSET(g_dibit_stream, 0, sizeof(g_dibit_stream));
+    state.synctype = DSD_SYNC_YSF_NEG;
+
+    make_fich_bits_for_vd_type1(fich_bits);
+    encode_dch_payload_to_input("VD1DST0001VD1SRC0002", 20U, dch, 176U, 9U, 0);
+
+    /* Nothing has confirmed yet, so a failed FICH validated nothing. */
+    encode_fich_input(fich_bits, 1, 0, fich_input);
+    g_dibit_stream_len = 0U;
+    g_dibit_stream_pos = 0U;
+    g_process_mbe_call_count = 0;
+    append_dibits_to_stream(fich_input, 100U);
+    append_vd_type1_blocks(dch, 1U);
+    assert(processYSF(&opts, &state) == 0);
+    assert(state.ysf_fich_confirmed == 0U);
+
+    /* A FICH that holds confirms the transmission. */
+    encode_fich_input(fich_bits, 0, 0, fich_input);
+    g_dibit_stream_len = 0U;
+    g_dibit_stream_pos = 0U;
+    g_process_mbe_call_count = 0;
+    append_dibits_to_stream(fich_input, 100U);
+    append_vd_type1_blocks(dch, 1U);
+    assert(processYSF(&opts, &state) == 1);
+    assert(state.ysf_fich_confirmed == 1U);
+
+    /* The same failure as the first frame, but the fallback dt/fi now come from a frame that
+     * did check out, and the payload still reaches the vocoder. */
+    encode_fich_input(fich_bits, 1, 0, fich_input);
+    g_dibit_stream_len = 0U;
+    g_dibit_stream_pos = 0U;
+    g_process_mbe_call_count = 0;
+    append_dibits_to_stream(fich_input, 100U);
+    append_vd_type1_blocks(dch, 1U);
+    assert(processYSF(&opts, &state) == 1);
+    assert(g_process_mbe_call_count == 4);
+
+    /* The flag alone gates the verdict: cleared, the very frame that just reported productive
+     * reports unproductive again, so a new transmission cannot inherit the last one's
+     * confidence. This binary links only dsd-neo_proto_ysf, so noCarrier() -- which is what
+     * clears the flag in the running decoder -- is not reachable here; ENGINE_NO_CARRIER_RESET
+     * pins that reset against the real function. */
+    state.ysf_fich_confirmed = 0U;
+    g_dibit_stream_len = 0U;
+    g_dibit_stream_pos = 0U;
+    g_process_mbe_call_count = 0;
+    append_dibits_to_stream(fich_input, 100U);
+    append_vd_type1_blocks(dch, 1U);
+    assert(processYSF(&opts, &state) == 0);
+
+    dsd_state_ext_free_all(&state);
+}
+
 static void
 test_process_ysf_vd_type2_routes_dch2_voice_and_audio_errors(void) {
     static dsd_opts opts;
@@ -902,6 +971,7 @@ main(void) {
     test_process_ysf_full_rate_data_routes_fich_and_dch_state();
     test_process_ysf_vd_type1_routes_ehr_voice_and_dch_state();
     test_process_ysf_bad_fich_fallback_reopens_ysf_epoch();
+    test_process_ysf_fich_verdict_is_sticky_per_transmission();
     test_process_ysf_vd_type2_routes_dch2_voice_and_audio_errors();
     test_process_ysf_terminator_enriches_identity_before_call_end();
     return 0;


### PR DESCRIPTION
## Summary

Implements the full dispatch refactor issue #391 proposes. `dsd_protocol_handler::handle_frame` now returns a `dsd_frame_verdict`; `processFrame()` records it in `dsd_state`; and `frame_sync_sps_hunt_note_handler_consumption()` refuses the dwell debit when the last verdict was unproductive.

**`PRODUCTIVE` is the zero value and the default.** That is what makes this safe: the issue's stated risk — a site that decodes successfully but fails to report it, rotating the hunt off live traffic — becomes unreachable by omission rather than merely unlikely. A frame the retune generation makes undispatchable skips `processFrame()` entirely and leaves the field at the cleared zero, i.e. the safe default.

Five protocols now report a verdict they already computed and were discarding: the YSF FICH Golay+CRC-16, the D-STAR header CRC-16/X.25, the EDACS BCH check, NXDN's sticky confirmation, and a failed P25p1 63-bit NID BCH. The seven that stay unconditionally productive each carry an in-code reason.

## Two corrections to the issue

1. **The EDACS `eot_cc()` bullet is wrong.** `eot_cc` is not a dispatch path — it is a frame-sync hook, called from `frame_sync_handle_edacs_dotting()` inside `frame_sync_eval_window()`, whose matcher returns `DSD_SYNC_NONE`. The `getFrameSync()` loop therefore continues, `frame_sync_advance_sync_window()` charges that iteration exactly +1, and every exit re-anchors `sps_hunt_symbolcnt_mark` past the skip. Those 1920 symbols are **never measured as handler consumption in either direction** — budget-neutral, no verdict needed. Verified independently, twice.
2. **Two bulk consumers the issue does not name.** `processProVoice()` spends ~736 dibits per call on the same `9600_2` binary profile as EDACS, with no CRC, no FEC verdict and no error return. `processYSF()` spends ~460 with a verdict it already had and ignored — that one is fixed here.

## Honest residual — this does not close #391

**D-STAR voice (1992 symbols) and ProVoice (~736) have no usable verdict at any point**, so under a default-productive contract they keep buying dwell. D-STAR voice is the issue's own worst-case arithmetic, so this says `Refs #391`, not `Closes`. `processDSTAR()` has no return value, no error accumulator and no frame-count check — it overwrites `state->errs`/`errs2` 21 times and reads them never, and its only real CRC is consulted on one slow-data branch reached ~1/256 of the time against noise.

No threshold on `state->errs` was invented to paper over this; that is exactly the risk direction the issue warns about. Closing it needs a per-protocol confidence module shaped like `nxdn_confirm.c` — a feature, not this fix. `docs/cli.md` is narrowed to say frame sync sees a verdict where the protocol produces one, and names the full set that produces none.

## Review-driven corrections

An independent review pass caught three places where the first cut had the risk direction backwards, all fixed here:

- **EDACS** reported "failed the check" when it had merely *declined* to run it (the `trunk_is_tuned` early-out jumped the BCH vote). It now computes the real verdict before the early-out.
- **YSF** reported frames as validating nothing *while they were still producing audio* — `ysf_dispatch_payload()` runs on carried-over `dt`/`fi` regardless. Now uses a sticky per-transmission confirmation, the same shape as NXDN: a FICH failure is unproductive only until one FICH has decoded.
- **M17's** EOT branch told the call-state layer the marker validated and the SPS hunt it did not. Resolved to productive — a decoded EOT marker is positive evidence of a real transmission on that profile.

It also found a test that could not fail (it stayed green with the code it named deleted); rewritten, and the new `-fa` iq-decode case is mutation-checked.

## Test

Suite goes 571 → 573. Each newly reporting protocol's sync-dispatch test gains a failing-check case; `DSTAR_HEADER_UTILS` gains a corrupted-CRC fixture; the two `#388` cases keep their properties and gain siblings for the new rule. `test_unproductive_frames_never_buy_dwell()` was verified to fail without the debit skip.

Refs #391. The residual is tracked as #421.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / **none**.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: an unproductive verdict can only **withhold** credit from a counter floored at zero — it never adds to it. Worst case is a profile carrying real traffic reaching its dwell more slowly than before, never being penalised. Measured directly on six I/Q fixtures under `-fa` with and without the change: no payload regression (ysf 23/23, nxdn96 38/38).
- Compatibility or packaging impact: `dsd_protocol_handler::handle_frame` changes signature; all 11 handlers are declared in one impl header and all were updated, as was `tests/engine/test_engine_protocol_dispatch.c`, which restubs all 11.
- Also ran `ctest --preset asan-ubsan-debug` and `ctest -L iq-decode`.
