### PR TITLE
test(dsp): match the analog_gain_f stub to its real prototype

### DIFF
--- a/tests/dsp/test_rtl_symbol_cache_generation.c
+++ b/tests/dsp/test_rtl_symbol_cache_generation.c
@@ -4,26 +4,26 @@
  */
 
 #include <assert.h>
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/audio_filters.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/symbol.h>
+#include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/sockets.h>
 #include <dsd-neo/runtime/rtl_stream_io_hooks.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <dsd-neo/runtime/shutdown.h>
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include "dsd-neo/core/safe_api.h"
-
-#if defined(__GNUC__) && !defined(__cplusplus)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#endif
 
 static uint32_t g_stream_generation = 1;
 static int g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
@@ -115,7 +115,7 @@ pbf_f(dsd_state* state, float* input, int len) {
 
 void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
-analog_gain_f(dsd_opts* opts, dsd_state* state, float* input, int len) {
+analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) {
     (void)opts;
     (void)state;
     (void)input;
@@ -569,7 +569,3 @@ main(void) {
     dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
     return 0;
 }
-
-#if defined(__GNUC__) && !defined(__cplusplus)
-#pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION
Fixes #420.

## Problem

`tests/dsp/test_rtl_symbol_cache_generation.c` defined its `analog_gain_f` link stub as

```c
void analog_gain_f(dsd_opts* opts, dsd_state* state, float* input, int len)
```

while the real symbol in `include/dsd-neo/core/audio.h` is

```c
void analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len);
```

Two conflicting declarations of the same external symbol. It compiled only because the test never included `audio.h`, so no translation unit ever saw both forms. The sibling stub blocks in `test_dsp_symbol_replay.c`, `test_dsp_wav_input_eof.c`, and the shared `tests/test_support/frame_sync_dsp_stubs.c` all use the correct `const dsd_opts*`, so this was a single-file divergence.

## Change

- Corrected the `analog_gain_f` stub to `const dsd_opts*`.
- Included the headers that declare all eleven link stubs in this file — `core/audio.h`, `core/audio_filters.h`, `core/power.h`, `io/rigctl_client.h`, `runtime/shutdown.h` — so the compiler enforces every stub's type instead of the file declaring them implicitly through its own definitions. This is the pattern the sibling files and `frame_sync_dsp_stubs.c` already follow.
- Dropped the file-wide `-Wmissing-prototypes` suppression, which is dead now that every extern definition has a visible prototype.

No behavioral change; the stubs stay no-ops and the `dsd_request_shutdown` stub keeps the `g_cleanup_calls` side effect the tests assert on.

## Verification

- Put the old `dsd_opts*` signature back on top of this change and confirmed the guard now bites: `error: conflicting types for 'analog_gain_f'; have 'void(dsd_opts *, dsd_state *, float *, int)'`.
- `ctest --preset dev-debug --output-on-failure` — 575/575 pass, including `RTL_SYMBOL_CACHE_GENERATION`.
- `tools/preflight_ci.sh` clean on the changed path: clang-format, clang-tidy, IWYU strict, `gcc -fanalyzer` strict, semgrep strict, arch rules.