### PR TITLE
fix(dsp): let AUTO reach and hold CQPSK on a P25p1 FDMA control channel (#423)

### DIFF
--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -583,6 +583,13 @@ struct dsd_state {
     uint32_t sps_hunt_symbolcnt_mark;
     int sps_hunt_last_frame_verdict;
     int sps_hunt_idx;
+    /* Parity toggle for the P25p1 modulation probe: which modulation the next hunt re-entry
+     * into the 4800/4-level profile watches. Zero-init keeps the first re-entry on C4FM.
+     * p25_p1_mod_probe_active marks the one dwell a probe is on trial for, so the modulation
+     * votes cannot take the demodulator back before the trial has had a chance to decode
+     * anything -- entering GFSK needs a single vote, which is a few dozen symbols. */
+    int p25_p1_mod_probe_next_qpsk;
+    int p25_p1_mod_probe_active;
     int lastsynctype;
     int lastp25type;
     int offset;
@@ -930,6 +937,18 @@ struct dsd_state {
      */
     int p25_vc_cqpsk_pref;
     int p25_vc_cqpsk_override;
+
+    /* Which demodulator last carried a P25p1 frame whose 63-bit NID BCH decoded, and when:
+     * -1 never validated, 0 the C4FM path, 1 the CQPSK path. A validated frame is the only
+     * direct evidence of what the signal actually is -- the SNR and sync-hamming heuristics
+     * that drive the modulation votes are indirect -- so this outranks them while it is fresh.
+     * System knowledge like p25_cc_is_tdma rather than acquisition state, so
+     * dsd_frame_sync_reset_mod_state(), retunes and no-carrier resets leave it alone; only
+     * initState(), the trunk-scan per-target snapshot and a CQPSK dwell that decodes nothing
+     * reset it. Freshness is measured in symbols because the hold it feeds only applies on the
+     * fixed-rate 4800/4-level profile. Ignored whenever opts->mod_cli_lock is set. */
+    int p25_p1_validated_rf_mod;
+    uint32_t p25_p1_validated_symbolcnt;
 
     // Candidate evaluation tracking (current freq and start time in monotonic seconds)
     long p25_cc_eval_freq;

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -894,6 +894,8 @@ init_state_p25_and_trunk_defaults(dsd_state* state) {
     state->p25_sys_is_tdma = 0;
     state->p25_vc_cqpsk_pref = -1;
     state->p25_vc_cqpsk_override = -1;
+    state->p25_p1_validated_rf_mod = -1;
+    state->p25_p1_validated_symbolcnt = 0;
 
     state->use_throttle = 0;
     state->symbol_replay_next_deadline_ns = 0;

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -587,6 +587,14 @@ frame_sync_accept_p25p1(frame_sync_match_ctx* ctx, int synctype, const char* lab
                         frame_sync_p25_center_mode_t center_mode) {
     const dsd_opts* opts = ctx->opts;
     dsd_state* state = ctx->state;
+#ifdef USE_RADIO
+    /* Hold the CQPSK chain the way P25p2 does, without claiming it: a P25p1 sync word is the
+     * same on both modulations, so it can only re-assert a decision already made, never make
+     * one. Re-pushing on every sync corrects front-end drift left by an engine retune. */
+    if (!opts->mod_cli_lock && state->rf_mod == 1) {
+        rtl_maybe_apply_active_demod_profile(opts, state);
+    }
+#endif
     frame_sync_set_basic_lock(ctx);
     state->dmrburstR = 17;
     state->payload_algidR = 0;
@@ -1943,6 +1951,41 @@ frame_sync_override_want_mod_with_hamming(const dsd_opts* opts, const dsd_state*
     return want_mod;
 }
 
+/**
+ * @brief Keep the CQPSK chain while it is the one decoding P25p1 frames.
+ *
+ * Both inputs to the modulation vote are indirect: the SNR bias compares an estimate the
+ * inactive chain cannot make honestly, and the sync-hamming candidates score patterns a strong
+ * signal matches on more than one modulation. A P25p1 frame whose 63-bit NID BCH decoded is
+ * direct evidence instead -- it says this demodulator is working right now -- so while such
+ * frames keep arriving the guesses do not get to move off it.
+ *
+ * This matters because CQPSK is the side that cannot defend itself. C4FM is the profile
+ * default and what every rotation falls back to, whereas entering GFSK costs a single vote, so
+ * without a hold the chain is taken back within a few dozen symbols and an LSM control channel
+ * never gets to keep the demodulator that decodes it. The hold lapses as soon as the frames
+ * stop, so it can never strand a profile on a modulation that has gone quiet.
+ */
+static int
+frame_sync_hold_validated_p25p1_modulation(const dsd_opts* opts, const dsd_state* state, int want_mod) {
+    if (opts->frame_p25p1 != 1 || state->sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4) {
+        return want_mod;
+    }
+    /* A trial the votes can revoke before it has decoded a single frame is not a trial, so the
+     * probe's own dwell is protected whichever chain it selected. */
+    if (state->p25_p1_mod_probe_active && (state->rf_mod == 0 || state->rf_mod == 1)) {
+        return state->rf_mod;
+    }
+    if (state->rf_mod != 1 || state->p25_p1_validated_rf_mod != 1) {
+        return want_mod;
+    }
+    if ((uint32_t)(state->symbolcnt - state->p25_p1_validated_symbolcnt)
+        >= DSD_FRAME_SYNC_P25P1_VALIDATED_HOLD_SYMBOLS) {
+        return want_mod;
+    }
+    return 1;
+}
+
 static void
 frame_sync_update_mod_votes(int want_mod) {
     if (want_mod == 1) {
@@ -2019,6 +2062,7 @@ frame_sync_maybe_auto_switch_modulation(const dsd_opts* opts, dsd_state* state, 
     int want_mod = frame_sync_active_profile_modulation(opts, state);
     want_mod = frame_sync_bias_want_mod_with_snr(opts, state, want_mod);
     want_mod = frame_sync_override_want_mod_with_hamming(opts, state, want_mod);
+    want_mod = frame_sync_hold_validated_p25p1_modulation(opts, state, want_mod);
     frame_sync_update_mod_votes(want_mod);
     frame_sync_apply_mod_switch(opts, state, frame_sync_decide_mod_switch(state, want_mod));
 }
@@ -2029,6 +2073,11 @@ dsd_frame_sync_test_set_recent_hamming(int ham_c4fm, int ham_qpsk, int ham_gfsk)
     atomic_store(&g_ham_c4fm_recent, ham_c4fm);
     atomic_store(&g_ham_qpsk_recent, ham_qpsk);
     atomic_store(&g_ham_gfsk_recent, ham_gfsk);
+}
+
+int
+dsd_frame_sync_test_qpsk_dwell_armed(void) {
+    return atomic_load(&g_qpsk_dwell_enter_ms) != 0;
 }
 
 void
@@ -2913,6 +2962,45 @@ frame_sync_apply_sps_profile_timing(const dsd_opts* opts, dsd_state* state, cons
     }
 }
 
+/**
+ * @brief Modulation a profile comes up on when the hunt normalises it.
+ *
+ * Four-level profiles default to C4FM, which is the right guess for a profile the hunt has
+ * learned nothing about. Once a P25p1 NID has decoded through the CQPSK chain, though, the
+ * 4800/4-level profile has been told which modulation the signal actually uses, and rotating
+ * away and back must not throw that away -- otherwise an LSM control channel loses the chain
+ * it just decoded on every time the hunt visits another protocol's profile.
+ */
+static int
+frame_sync_sps_profile_normalized_modulation(const dsd_opts* opts, const dsd_state* state,
+                                             const frame_sync_sps_profile* profile, int profile_index) {
+    const int requested = (profile_index == DSD_FRAME_SYNC_SPS_PROFILE_4800_4 && opts->frame_p25p1 == 1
+                           && state->p25_p1_validated_rf_mod == 1)
+                              ? 1
+                              : 0;
+    return dsd_frame_sync_profile_modulation(profile->levels, requested);
+}
+
+/**
+ * @brief Adopt a profile's modulation and start the vote state over for it.
+ *
+ * The votes and hamming counters belong to the acquisition that just ended, so they are always
+ * cleared. The QPSK dwell is different: it is the grace period a modulation gets before the
+ * votes may argue with it, and clearing it under a restored CQPSK would let the SNR bias and
+ * the three-vote C4FM re-entry evict that modulation before the first sync of the new dwell
+ * could even arrive.
+ */
+static void
+frame_sync_normalize_profile_modulation(dsd_state* state, int normalize, int modulation) {
+    if (normalize) {
+        state->rf_mod = modulation;
+    }
+    dsd_frame_sync_reset_mod_state();
+    if (normalize && modulation == 1) {
+        atomic_store(&g_qpsk_dwell_enter_ms, (int)(uint32_t)dsd_time_monotonic_ms());
+    }
+}
+
 void
 frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int next_idx, int preserve_modulation) {
     if (!opts || !state || next_idx < 0 || next_idx >= DSD_FRAME_SYNC_SPS_PROFILE_COUNT) {
@@ -2921,7 +3009,7 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
 
     const frame_sync_sps_profile* profile = frame_sync_sps_profile_for_index(next_idx);
     const int profile_changed = next_idx != state->sps_hunt_idx;
-    const int profile_default_modulation = dsd_frame_sync_profile_modulation(profile->levels, 0);
+    const int profile_default_modulation = frame_sync_sps_profile_normalized_modulation(opts, state, profile, next_idx);
     const int normalize_profile_modulation = !preserve_modulation && !opts->mod_cli_lock
                                              && state->rf_mod != profile_default_modulation
                                              && (profile_changed || profile->levels == 2);
@@ -2956,10 +3044,7 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
         state->sps_hunt_counter = 0;
         state->sps_hunt_symbolcnt_mark = state->symbolcnt;
     }
-    if (normalize_profile_modulation) {
-        state->rf_mod = profile_default_modulation;
-    }
-    dsd_frame_sync_reset_mod_state();
+    frame_sync_normalize_profile_modulation(state, normalize_profile_modulation, profile_default_modulation);
 
     if (profile_changed) {
         frame_sync_apply_sps_profile_timing(opts, state, profile);
@@ -3115,12 +3200,74 @@ frame_sync_sps_hunt_mark_return(dsd_state* state) {
     state->sps_hunt_symbolcnt_mark = state->symbolcnt;
 }
 
+/**
+ * @brief Spend alternate 4800/4-level dwells watching for P25p1 on the CQPSK chain.
+ *
+ * A P25p1 FDMA signal cannot argue its way onto CQPSK passively. Both passive routes are
+ * structurally closed: while the CQPSK chain is off the front end runs the FM discriminator, so
+ * the QPSK SNR estimate comes from a constellation ring fed raw un-derotated, un-timed IQ and
+ * never clears the entry margin; and the sync-hamming candidate scores a superset of the C4FM
+ * hypotheses, so an LSM signal -- which decodes its sync words unrotated through the
+ * discriminator -- ties rather than wins, and the override only moves on a strict improvement.
+ *
+ * So the decision is made by trying it. This runs only where a dwell has already expired with
+ * nothing productive decoded, which is exactly where the hunt was going to leave this profile
+ * anyway: a control channel that is decoding never gets here, because its handlers keep the
+ * dwell counter spent. Whichever chain then starts decoding P25p1 frames keeps the profile,
+ * because frame_sync_hold_validated_p25p1_modulation() stops the votes from arguing with it.
+ */
+static void
+frame_sync_maybe_probe_p25p1_cqpsk(const dsd_opts* opts, dsd_state* state, int preserve_modulation,
+                                   int expired_dwell_idx, int expired_dwell_rf_mod) {
+    if (preserve_modulation || opts->mod_cli_lock || opts->frame_p25p1 != 1) {
+        return;
+    }
+    if (opts->audio_in_type != AUDIO_IN_RTL || !state->rtl_ctx) {
+        return;
+    }
+    /* The dwell that just expired decoded nothing. If that dwell was this profile running on
+     * the CQPSK chain then whatever evidence put it there has been disproved, so withdraw it
+     * rather than let the restore keep handing the profile back to a chain producing nothing.
+     * This judges the dwell that ended, not the one about to start. */
+    if (expired_dwell_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4 && expired_dwell_rf_mod == 1
+        && state->p25_p1_validated_rf_mod == 1) {
+        state->p25_p1_validated_rf_mod = -1;
+    }
+    if (state->sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4) {
+        return;
+    }
+    if (state->p25_p1_validated_rf_mod == 1) {
+        return;
+    }
+
+    /* Own both directions. A profile the hunt re-enters at its own index is not normalised --
+     * frame_sync_apply_sps_hunt_profile() returns early when neither the index nor a binary
+     * profile forces its hand -- so without handing the chain back here a probe that decoded
+     * nothing would keep it for good. */
+    const int probe_qpsk = state->p25_p1_mod_probe_next_qpsk ? 1 : 0;
+    state->p25_p1_mod_probe_next_qpsk = !probe_qpsk;
+    if (state->rf_mod == probe_qpsk) {
+        return;
+    }
+
+    state->rf_mod = probe_qpsk;
+    state->p25_p1_mod_probe_active = 1;
+    if (probe_qpsk) {
+        atomic_store(&g_qpsk_dwell_enter_ms, (int)(uint32_t)dsd_time_monotonic_ms());
+    }
+#ifdef USE_RADIO
+    rtl_maybe_apply_active_demod_profile(opts, state);
+#endif
+}
+
 int
 frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
     if (state->sps_hunt_counter < frame_sync_sps_hunt_dwell_symbols(opts, state)) {
         return 0;
     }
     state->sps_hunt_counter = 0;
+    /* Reaching here is the trial's verdict: its dwell expired with nothing decoded. */
+    state->p25_p1_mod_probe_active = 0;
     const int preserve_modulation = opts->mod_cli_lock ? 1 : 0;
 
     /* Generic modulation locks retain their demodulator while rotating equal-timing protocol gates. A P25p2-specific
@@ -3138,6 +3285,7 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
     const int previous_idx = state->sps_hunt_idx;
     const int previous_mod = state->rf_mod;
     frame_sync_apply_sps_hunt_profile(opts, state, next_idx, preserve_modulation);
+    frame_sync_maybe_probe_p25p1_cqpsk(opts, state, preserve_modulation, previous_idx, previous_mod);
     /* A repeated binary profile is a step too: frame_sync_apply_sps_hunt_profile() normalises
      * dsd_state::rf_mod and resets the modulation vote state without the index moving, and the
      * caller's sync window -- its level ring, its min/max, its history -- was captured under the

--- a/src/dsp/frame_sync_internal.h
+++ b/src/dsp/frame_sync_internal.h
@@ -17,7 +17,13 @@ extern "C" {
  * The no-sync timeout fires after this many consecutive matchless symbols, and the SPS
  * hunt's dwell is a whole number of these (see dsd_frame_sync_sps_hunt_dwell_passes()).
  */
-#define DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS 1800
+#define DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS         1800
+
+/* How long a P25p1 frame that decoded its NID keeps the modulation heuristics off the
+ * demodulator that carried it, in symbols at 4800 sym/s (two seconds). Long enough to span the
+ * gaps between frames on a control channel, short enough that a modulation which has gone
+ * quiet is argued about again. */
+#define DSD_FRAME_SYNC_P25P1_VALIDATED_HOLD_SYMBOLS 9600U
 
 /**
  * @brief Symbols a frame handler must consume on one sync for that sync to count as a frame.
@@ -29,7 +35,7 @@ extern "C" {
  * that returns without reading a frame -- and below the 28 dibits of P25p1's TDU
  * (processTDU(), the shortest frame any protocol here decodes).
  */
-#define DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS    16
+#define DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS            16
 
 /** @brief One entry of the SPS hunt's rate/level table, indexed by dsd_state::sps_hunt_idx. */
 typedef struct {

--- a/src/dsp/frame_sync_test_support.h
+++ b/src/dsp/frame_sync_test_support.h
@@ -21,6 +21,8 @@ int dsd_frame_sync_test_eval_window(dsd_opts* opts, dsd_state* state, const char
                                     int symbol_count);
 void dsd_frame_sync_test_set_recent_hamming(int ham_c4fm, int ham_qpsk, int ham_gfsk);
 void dsd_frame_sync_test_get_mod_votes(int* out_c4fm, int* out_qpsk, int* out_gfsk);
+/** @brief Whether the 2 s QPSK dwell is currently armed. */
+int dsd_frame_sync_test_qpsk_dwell_armed(void);
 void dsd_frame_sync_test_reset_p25_trunk_tick_state(void);
 int dsd_frame_sync_test_handle_no_sync_timeout(dsd_opts* opts, dsd_state* state, int synctest_pos);
 void dsd_frame_sync_test_sps_hunt_note_handler_consumption(dsd_state* state);

--- a/src/engine/dispatch/dispatch_p25p1.c
+++ b/src/engine/dispatch/dispatch_p25p1.c
@@ -423,6 +423,15 @@ dsd_frame_verdict
 dsd_dispatch_handle_p25p1(dsd_opts* opts, dsd_state* state) {
     p25_status_accum_reset(state);
     uint8_t duid = p25p1_decode_nid_and_duid(opts, state);
+    /* A decoded NID is the one place that knows which demodulator actually carried a P25p1
+     * frame: the sync pattern is the same on C4FM and CQPSK, so nothing earlier can tell them
+     * apart. Recording it here is what lets the trunking retunes and the SPS hunt restore a
+     * modulation the signal itself has confirmed, and what lets the frame sync stop the
+     * modulation heuristics from second-guessing a demodulator that is visibly working. */
+    if (duid != P25P1_DUID_INVALID && !opts->mod_cli_lock && (state->rf_mod == 0 || state->rf_mod == 1)) {
+        state->p25_p1_validated_rf_mod = state->rf_mod;
+        state->p25_p1_validated_symbolcnt = state->symbolcnt;
+    }
     p25p1_dispatch_by_duid(opts, state, duid);
     /* The 63-bit BCH over the NID is the one verdict this path has that covers every DUID.
      * When it fails the DUID is invalid, p25p1_handle_unknown_duid() decodes nothing, and

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -109,6 +109,7 @@ typedef struct {
     int p25_sys_is_tdma;
     int p25_vc_cqpsk_pref;
     int p25_vc_cqpsk_override;
+    int p25_p1_validated_rf_mod;
     int p25_sm_mode;
     int nac;
     int samplesPerSymbol;
@@ -1014,6 +1015,7 @@ trunk_scan_snapshot_clear(dsd_trunk_scan_snapshot* snapshot) {
     snapshot->p25_cc_is_tdma = 2;
     snapshot->p25_vc_cqpsk_pref = -1;
     snapshot->p25_vc_cqpsk_override = -1;
+    snapshot->p25_p1_validated_rf_mod = -1;
     /* NXDN "not decoded yet" sentinels, matching initState() (src/core/util/dsd_init.c) and
      * noCarrier(): RAN 0 is a legal value, so a zeroed snapshot would publish a fabricated
      * RAN 0 for a target that has never decoded one. */
@@ -1146,6 +1148,7 @@ trunk_scan_save_p25_identity_snapshot(const dsd_state* state, dsd_trunk_scan_sna
     snapshot->p25_sys_is_tdma = state->p25_sys_is_tdma;
     snapshot->p25_vc_cqpsk_pref = state->p25_vc_cqpsk_pref;
     snapshot->p25_vc_cqpsk_override = state->p25_vc_cqpsk_override;
+    snapshot->p25_p1_validated_rf_mod = state->p25_p1_validated_rf_mod;
     snapshot->p25_sm_mode = state->p25_sm_mode;
     snapshot->nac = state->nac;
     snapshot->samplesPerSymbol = state->samplesPerSymbol;
@@ -1176,6 +1179,7 @@ trunk_scan_restore_p25_identity_snapshot(dsd_state* state, const dsd_trunk_scan_
     state->p25_sys_is_tdma = snapshot->p25_sys_is_tdma;
     state->p25_vc_cqpsk_pref = snapshot->p25_vc_cqpsk_pref;
     state->p25_vc_cqpsk_override = snapshot->p25_vc_cqpsk_override;
+    state->p25_p1_validated_rf_mod = snapshot->p25_p1_validated_rf_mod;
     state->p25_sm_mode = snapshot->p25_sm_mode;
     state->nac = snapshot->nac;
     state->samplesPerSymbol = snapshot->samplesPerSymbol;
@@ -1647,7 +1651,7 @@ trunk_scan_apply_p25_target_demod(const dsd_opts* opts, dsd_state* state, const 
     } else if (target->modulation == DSD_TRUNK_SCAN_MODULATION_C4FM) {
         state->rf_mod = 0;
     } else if (target->modulation == DSD_TRUNK_SCAN_MODULATION_AUTO || !opts->mod_cli_lock) {
-        state->rf_mod = (state->p25_cc_is_tdma == 1) ? 1 : 0;
+        state->rf_mod = (state->p25_cc_is_tdma == 1 || state->p25_p1_validated_rf_mod == 1) ? 1 : 0;
     }
 }
 
@@ -2594,7 +2598,7 @@ dsd_engine_trunk_scan_active_p25_cqpsk_request(const dsd_state* state, int* out_
         return 1;
     }
     if (target->modulation == DSD_TRUNK_SCAN_MODULATION_AUTO) {
-        *out_enable = (state->p25_cc_is_tdma == 1) ? 1 : 0;
+        *out_enable = (state->p25_cc_is_tdma == 1 || state->p25_p1_validated_rf_mod == 1) ? 1 : 0;
         return 1;
     }
     return 0;

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -110,6 +110,25 @@ dsd_engine_is_p25_profile_retune(const dsd_opts* opts, const dsd_state* state, i
     return dsd_engine_cc_is_p25(state);
 }
 
+/**
+ * @brief Whether an FDMA P25 control channel should come up on CQPSK.
+ *
+ * A P25p1 FDMA control channel carries no modulation hint of its own, so without this the
+ * front end is pinned to C4FM on every tune and an LSM site can never hold the CQPSK chain
+ * it just decoded on. dsd_state::p25_p1_cqpsk_learned only says 1 once a 63-bit NID BCH
+ * decoded through the CQPSK path, and an explicit -mq/-mc lock still wins.
+ */
+static int
+dsd_engine_p25_fdma_cc_wants_cqpsk(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return 0;
+    }
+    if (opts->mod_qpsk == 1) {
+        return 1;
+    }
+    return (!opts->mod_cli_lock && state->p25_p1_validated_rf_mod == 1) ? 1 : 0;
+}
+
 static void DSD_ATTR_USED
 dsd_engine_apply_cc_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     // Skipping is safe for the other protocols rather than merely harmless: DMR and NXDN96 are
@@ -123,7 +142,7 @@ dsd_engine_apply_cc_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     const int sym_rate = (state->p25_cc_is_tdma == 1) ? 6000 : 4800;
     state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, sym_rate, dsd_engine_current_demod_rate(opts, state));
     state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
-    state->rf_mod = (state->p25_cc_is_tdma == 1) ? 1 : ((opts->mod_qpsk == 1) ? 1 : 0);
+    state->rf_mod = (state->p25_cc_is_tdma == 1) ? 1 : dsd_engine_p25_fdma_cc_wants_cqpsk(opts, state);
     dsd_engine_select_p25_sps_profile(state, state->p25_cc_is_tdma == 1);
 }
 
@@ -287,7 +306,7 @@ dsd_engine_prepare_p25_cc_rtl_chain(const dsd_opts* opts, dsd_state* state, long
         cfg = dsd_neo_get_config();
     }
 
-    const int default_cqpsk = (state->p25_cc_is_tdma == 1 || opts->mod_qpsk == 1) ? 1 : 0;
+    const int default_cqpsk = (state->p25_cc_is_tdma == 1 || dsd_engine_p25_fdma_cc_wants_cqpsk(opts, state)) ? 1 : 0;
     int trunk_scan_cqpsk_request = 0;
     const int has_trunk_scan_cqpsk_request =
         dsd_engine_trunk_scan_active_p25_cqpsk_request(state, &trunk_scan_cqpsk_request);

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -1392,6 +1392,420 @@ test_rtl_p25p2_timing_reconciliation_preserves_cqpsk(void) {
     dsd_rtl_stream_metrics_hooks_set(NULL);
 }
 
+/*
+ * Issue #423: a P25p1 FDMA signal that has decoded through the CQPSK chain must keep it across
+ * a hunt rotation. Without the learned modulation the hunt normalises the 4800/4-level profile
+ * back to C4FM every time it comes back round, so an LSM control channel loses the chain it
+ * just decoded on.
+ */
+static void
+test_sps_hunt_restores_learned_p25p1_cqpsk(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+
+    /* Rotating back into the P25p1 profile restores the learned CQPSK instead of C4FM. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dstar = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.p25_p1_validated_rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.rf_mod = 2;
+    dsd_rtl_stream_metrics_hooks hooks = {
+        .output_rate_hz = fake_output_rate_hz,
+        .apply_demod_profile = fake_apply_demod_profile,
+    };
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    reset_fake_profile_capture();
+    frame_sync_apply_sps_hunt_profile(&opts, &state, DSD_FRAME_SYNC_SPS_PROFILE_4800_4, 0);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state.rf_mod == 1);
+    assert(g_profile_cqpsk == 1);
+    assert(g_profile_rate == 4800);
+    assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    /* The restored modulation gets its dwell back, or the votes evict it before the first
+     * sync of the new dwell can arrive. */
+    assert(dsd_frame_sync_test_qpsk_dwell_armed());
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+
+    /* Never validated, and validated through C4FM, both keep the C4FM default. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dstar = 1;
+    state.p25_p1_validated_rf_mod = -1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.rf_mod = 2;
+    frame_sync_apply_sps_hunt_profile(&opts, &state, DSD_FRAME_SYNC_SPS_PROFILE_4800_4, 0);
+    assert(state.rf_mod == 0);
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dstar = 1;
+    state.p25_p1_validated_rf_mod = 0;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.rf_mod = 2;
+    frame_sync_apply_sps_hunt_profile(&opts, &state, DSD_FRAME_SYNC_SPS_PROFILE_4800_4, 0);
+    assert(state.rf_mod == 0);
+
+    /* A learned CQPSK never overrides a binary profile: those force GFSK. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dstar = 1;
+    state.p25_p1_validated_rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 1;
+    frame_sync_apply_sps_hunt_profile(&opts, &state, DSD_FRAME_SYNC_SPS_PROFILE_4800_2, 0);
+    assert(state.rf_mod == 2);
+
+    /* The learned value is not consulted for a profile P25p1 does not own. */
+    reset(&opts, &state);
+    opts.frame_p25p2 = 1;
+    opts.frame_provoice = 1;
+    state.p25_p1_validated_rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_9600_2;
+    state.rf_mod = 2;
+    frame_sync_apply_sps_hunt_profile(&opts, &state, DSD_FRAME_SYNC_SPS_PROFILE_6000_4, 0);
+    assert(state.rf_mod == 0);
+
+    /* An explicit CLI modulation lock keeps its demodulator regardless. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dstar = 1;
+    opts.mod_cli_lock = 1;
+    state.p25_p1_validated_rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.rf_mod = 2;
+    frame_sync_apply_sps_hunt_profile(&opts, &state, DSD_FRAME_SYNC_SPS_PROFILE_4800_4, 0);
+    assert(state.rf_mod == 2);
+}
+
+/*
+ * Issue #423: P25p1 cannot reach CQPSK by measurement -- while the chain is off the QPSK SNR
+ * estimate comes from raw un-derotated IQ and the sync-hamming candidate can only tie -- so the
+ * hunt tries it on alternate visits to the profile instead.
+ */
+static void
+test_p25p1_auto_hunt_alternates_cqpsk_probe(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+
+    dsd_rtl_stream_metrics_hooks hooks = {
+        .output_rate_hz = fake_output_rate_hz,
+        .apply_demod_profile = fake_apply_demod_profile,
+    };
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.p25_p1_validated_rf_mod = -1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    const int dwell = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+
+    /* P25p1 alone is the only candidate, so every expired dwell wraps to the same profile.
+     * The first stays on C4FM, the next watches CQPSK, and it alternates from there. */
+    state.sps_hunt_counter = dwell;
+    frame_sync_no_sync_sps_hunt(&opts, &state);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state.rf_mod == 0);
+
+    reset_fake_profile_capture();
+    state.sps_hunt_counter = dwell;
+    assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 1);
+    assert(state.rf_mod == 1);
+    assert(g_profile_cqpsk == 1);
+    assert(g_profile_rate == 4800);
+    assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    assert(dsd_frame_sync_test_qpsk_dwell_armed());
+
+    /* A probe that decoded nothing hands the profile back to C4FM. */
+    state.sps_hunt_counter = dwell;
+    frame_sync_no_sync_sps_hunt(&opts, &state);
+    assert(state.rf_mod == 0);
+
+    state.sps_hunt_counter = dwell;
+    frame_sync_no_sync_sps_hunt(&opts, &state);
+    assert(state.rf_mod == 1);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+
+    /* An explicit modulation lock is never probed against. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.mod_cli_lock = 1;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    for (int i = 0; i < 4; i++) {
+        state.sps_hunt_counter = dwell;
+        frame_sync_no_sync_sps_hunt(&opts, &state);
+        assert(state.rf_mod == 0);
+    }
+
+    /* Only the RTL front end can be retuned into the CQPSK chain. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.audio_in_type = AUDIO_IN_WAV;
+    opts.wav_sample_rate = 48000;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    for (int i = 0; i < 4; i++) {
+        state.sps_hunt_counter = dwell;
+        frame_sync_no_sync_sps_hunt(&opts, &state);
+        assert(state.rf_mod == 0);
+    }
+
+    /* Without P25p1 enabled there is nothing on this profile that wants CQPSK. */
+    reset(&opts, &state);
+    opts.frame_dmr = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    for (int i = 0; i < 4; i++) {
+        state.sps_hunt_counter = dwell;
+        frame_sync_no_sync_sps_hunt(&opts, &state);
+        assert(state.rf_mod != 1);
+    }
+
+    /* A dwell that expired decoded nothing, so a GFSK profile-mate has no claim on the
+     * demodulator either: the probe takes its turn from there too. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dmr = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 2;
+    state.p25_p1_mod_probe_next_qpsk = 1;
+    state.sps_hunt_counter = dwell;
+    frame_sync_no_sync_sps_hunt(&opts, &state);
+    assert(state.rf_mod == 1);
+    assert(state.p25_p1_mod_probe_active == 1);
+}
+
+/*
+ * A trial the votes can revoke before it decodes anything is not a trial: entering GFSK takes
+ * a single vote. While a probe is on trial the modulation heuristics do not get to answer.
+ */
+static void
+test_p25p1_probe_survives_its_dwell(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+    int lastt = 24;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dmr = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 1;
+    state.p25_p1_mod_probe_active = 1;
+
+    /* A GFSK answer would normally take the demodulator on its first vote. */
+    set_fake_snr(-100.0, 20.0, -100.0, -100.0);
+    install_fake_snr_hooks();
+    dsd_frame_sync_test_set_recent_hamming(24, 24, 0);
+    frame_sync_maybe_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 1);
+    lastt = 24;
+    frame_sync_maybe_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 1);
+
+    /* Once the trial is over the heuristics are free again. */
+    state.p25_p1_mod_probe_active = 0;
+    dsd_frame_sync_test_set_recent_hamming(24, 24, 0);
+    lastt = 24;
+    frame_sync_maybe_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 2);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+/*
+ * A validated P25p1 frame is direct evidence of what the signal is; the SNR and hamming
+ * candidates are guesses. While such frames keep arriving the guesses do not get to move the
+ * demodulator -- and once they stop, they do.
+ */
+static void
+test_validated_p25p1_modulation_outranks_the_heuristics(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+    int lastt = 24;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dmr = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 1;
+    state.symbolcnt = 100000;
+    state.p25_p1_validated_rf_mod = 1;
+    state.p25_p1_validated_symbolcnt = state.symbolcnt;
+
+    set_fake_snr(-100.0, 20.0, -100.0, -100.0);
+    install_fake_snr_hooks();
+    dsd_frame_sync_test_set_recent_hamming(24, 24, 0);
+    frame_sync_maybe_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 1);
+
+    /* Frames stopped long enough ago that the hold has lapsed. */
+    state.symbolcnt = state.p25_p1_validated_symbolcnt + DSD_FRAME_SYNC_P25P1_VALIDATED_HOLD_SYMBOLS;
+    dsd_frame_sync_test_set_recent_hamming(24, 24, 0);
+    lastt = 24;
+    frame_sync_maybe_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 2);
+
+    /* The hold speaks only for a chain that actually validated a frame: a C4FM claim says
+     * nothing about the CQPSK chain the demodulator happens to be on. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dmr = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 1;
+    state.symbolcnt = 100000;
+    state.p25_p1_validated_rf_mod = 0;
+    state.p25_p1_validated_symbolcnt = state.symbolcnt;
+    dsd_frame_sync_test_set_recent_hamming(24, 24, 0);
+    lastt = 24;
+    frame_sync_maybe_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 2);
+
+    /* And a zeroed state claims nothing at all. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dmr = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 1;
+    dsd_frame_sync_test_set_recent_hamming(24, 24, 0);
+    lastt = 24;
+    frame_sync_maybe_auto_switch_modulation(&opts, &state, 24, &lastt);
+    assert(state.rf_mod == 2);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
+/*
+ * A claim that CQPSK works survives the hunt's tour of the other protocols' profiles, so a
+ * control channel does not have to re-earn its demodulator every time the hunt looks
+ * elsewhere. But it is a claim about a signal, not a permanent setting: a dwell that expires
+ * on the CQPSK chain having decoded nothing withdraws it.
+ */
+static void
+test_validated_cqpsk_survives_rotation_but_not_disproof(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dstar = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.p25_p1_validated_rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 1;
+    const int dwell = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
+
+    /* The first expired dwell ran on the CQPSK chain and decoded nothing, so the claim goes. */
+    state.sps_hunt_counter = dwell;
+    frame_sync_no_sync_sps_hunt(&opts, &state);
+    assert(state.p25_p1_validated_rf_mod != 1);
+
+    /* A claim made while the hunt is elsewhere is not disproved by that profile's dwell, and
+     * the profile comes back up on CQPSK when the rotation returns to it. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_dstar = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.p25_p1_validated_rf_mod = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.rf_mod = 2;
+    for (int i = 0; i < 6; i++) {
+        state.sps_hunt_counter = dwell;
+        frame_sync_no_sync_sps_hunt(&opts, &state);
+        if (state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4) {
+            assert(state.rf_mod == 1);
+            assert(state.p25_p1_validated_rf_mod == 1);
+            break;
+        }
+        assert(state.p25_p1_validated_rf_mod == 1);
+    }
+}
+
+/*
+ * Issue #423: a P25p1 sync cannot claim CQPSK -- the sync word is identical on both
+ * modulations -- but while the chain is already on it must re-assert the front-end profile the
+ * way P25p2 does, so an engine retune cannot leave the two out of step.
+ */
+static void
+test_p25p1_sync_reasserts_cqpsk_demod_profile(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+
+    dsd_rtl_stream_metrics_hooks hooks = {
+        .output_rate_hz = fake_output_rate_hz,
+        .apply_demod_profile = fake_apply_demod_profile,
+    };
+
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_p25p1 = 1;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 1;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    reset_fake_profile_capture();
+
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P1_SYNC, 24) == DSD_SYNC_P25P1_POS);
+    assert(state.rf_mod == 1);
+    assert(g_profile_set_calls == 1);
+    assert(g_profile_cqpsk == 1);
+    assert(g_profile_rate == 4800);
+    assert(g_profile_levels == 4);
+    assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+
+    /* On C4FM the same sync claims nothing and pushes nothing. */
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_p25p1 = 1;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 0;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    reset_fake_profile_capture();
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P1_SYNC, 24) == DSD_SYNC_P25P1_POS);
+    assert(state.rf_mod == 0);
+    assert(g_profile_set_calls == 0);
+
+    /* A CLI modulation lock owns the front end; the accept leaves it alone. */
+    reset(&opts, &state);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_p25p1 = 1;
+    opts.mod_cli_lock = 1;
+    opts.mod_qpsk = 1;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.rf_mod = 1;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    reset_fake_profile_capture();
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P1_SYNC, 24) == DSD_SYNC_P25P1_POS);
+    assert(g_profile_set_calls == 0);
+
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+}
+
 static void
 test_unlocked_rtl_p25p2_sync_switches_demod_family(void) {
     static dsd_opts opts;
@@ -1876,6 +2290,12 @@ main(void) {
     test_carrier_does_not_reset_the_hunt_budget();
     test_binary_profiles_override_unlocked_qpsk();
     test_four_level_profiles_reset_inherited_modulation();
+    test_sps_hunt_restores_learned_p25p1_cqpsk();
+    test_p25p1_auto_hunt_alternates_cqpsk_probe();
+    test_p25p1_probe_survives_its_dwell();
+    test_validated_p25p1_modulation_outranks_the_heuristics();
+    test_validated_cqpsk_survives_rotation_but_not_disproof();
+    test_p25p1_sync_reasserts_cqpsk_demod_profile();
     test_nxdn_variant_follows_active_profile();
     test_bounded_symbol_history_readiness_and_wrap();
     test_provoice_candidate_does_not_shadow_dstar_or_nxdn();

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -942,10 +942,15 @@ main(void) {
     state->rf_mod = 1;
     state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
     state->sps_hunt_counter = 23;
+    state->p25_p1_validated_rf_mod = 1;
 
     noCarrier(opts, state);
 
     rc |= expect_true("p25-rtl-nocarrier-cc-retune", g_rtl_tune_calls == 1 && g_rtl_tune_freq == 769868750U);
+    /* Issue #423: which modulation carried the last validated P25p1 frame is system knowledge,
+     * not acquisition state, so losing the carrier must not erase it -- otherwise every fade
+     * costs an LSM control channel the chain it had already earned. */
+    rc |= expect_true("p25-rtl-nocarrier-keeps-learned-modulation", state->p25_p1_validated_rf_mod == 1);
     rc |= expect_true("p25-rtl-nocarrier-syncs-selected-cc",
                       state->p25_cc_freq == 769868750 && state->trunk_cc_freq == 769868750);
     rc |= expect_true("p25-rtl-nocarrier-cc-profile-rate", g_rtl_symbol_rate_hz == 4800);
@@ -1585,6 +1590,7 @@ main(void) {
     rc |= expect_true("rtl-fsk-long-nosync-gap-reacquires-once", g_rtl_fsk_reacquire_requests == 1);
     rc |= expect_true("rtl-fsk-long-nosync-gap-records-request", state->rtl_fsk_reacquire_last_request_m > 0.0);
 #endif
+
     dsd_rtl_stream_metrics_hooks_set(NULL);
 #endif
 

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -1313,6 +1313,131 @@ main(void) {
     assert(g_rtl_ted_sps == 10);
     assert(g_rtl_ted_sps_override == 0);
     assert(g_frame_sync_reset_calls == 1);
+
+    /* Issue #423: under AUTO an FDMA control channel was pinned to C4FM on every tune, so a
+     * P25p1 LSM site could never keep the CQPSK chain it had just decoded on. Once a NID has
+     * validated through that chain the return-to-CC restores it without -mq. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 0;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 851000000;
+    state->trunk_cc_freq = 851000000;
+    state->p25_cc_is_tdma = 0;
+    state->p25_p2_active_slot = 0;
+    state->p25_p1_validated_rf_mod = 1;
+    state->rf_mod = 1;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 1;
+    g_rtl_symbol_rate_hz = 6000;
+    g_rtl_symbol_levels = 4;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    g_rtl_ted_sps = 8;
+    g_rtl_ted_sps_override = 8;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_return_to_cc_request(opts, state, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(state->rf_mod == 1);
+    assert(state->samplesPerSymbol == 10);
+    assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(g_rtl_cqpsk_enable == 1);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+
+    /* The counter-case that rules out simply preserving rf_mod: a C4FM control channel with
+     * P25p2 TDMA voice channels leaves rf_mod at 1 when the grant ends, and the control channel
+     * must still come back on C4FM. Nothing validated a P25p1 NID through CQPSK here. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 0;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 851000000;
+    state->trunk_cc_freq = 851000000;
+    state->p25_cc_is_tdma = 0;
+    state->p25_p2_active_slot = 0;
+    state->p25_p1_validated_rf_mod = -1;
+    state->rf_mod = 1;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 1;
+    g_rtl_symbol_rate_hz = 6000;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_return_to_cc_request(opts, state, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(state->rf_mod == 0);
+    assert(g_rtl_cqpsk_enable == 0);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
+
+    /* An explicit CLI modulation lock still owns the decision. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    opts->mod_qpsk = 0;
+    opts->mod_cli_lock = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_freq = 851000000;
+    state->trunk_cc_freq = 851000000;
+    state->p25_cc_is_tdma = 0;
+    state->p25_p1_validated_rf_mod = 1;
+    state->rf_mod = 1;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_cqpsk_enable = 1;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_return_to_cc_request(opts, state, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(state->rf_mod == 0);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_C4FM);
+
+    /* The CC-tune path stages the same decision, so a CC hunt lands on the learned chain. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_is_tdma = 0;
+    state->p25_p1_validated_rf_mod = 1;
+    state->lastsynctype = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_pending_active = 0;
+    g_rtl_pending_cqpsk = -1;
+    g_rtl_pending_channel_profile = -1;
+    assert(dsd_engine_trunk_tune_to_cc_request(opts, state, 852000000, 10, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(state->rf_mod == 1);
+    assert(g_rtl_cqpsk_enable == 1);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    rtl_stream_clear_pending_retune_profile();
+
+    /* A P25p1 FDMA voice grant carries no modulation of its own -- it inherits the control
+     * channel's -- so on an LSM site the voice channel reaches CQPSK too. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_enable = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->p25_cc_is_tdma = 0;
+    state->p25_p1_validated_rf_mod = 1;
+    state->p25_p2_active_slot = -1;
+    state->rf_mod = 1;
+    state->lastsynctype = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_pending_active = 0;
+    g_rtl_pending_cqpsk = -1;
+    g_rtl_pending_channel_profile = -1;
+    assert(dsd_engine_trunk_tune_to_freq_request(opts, state, 853000000, 10, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_cqpsk_enable == 1);
+    assert(g_rtl_symbol_rate_hz == 4800);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    rtl_stream_clear_pending_retune_profile();
 #endif
 
     printf("ENGINE_TRUNK_RETUNE_REGRESSION: OK\n");

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -4340,6 +4340,16 @@ test_active_p25_cqpsk_request_tracks_target_modulation(void) {
         DSD_FPRINTF(stderr, "active auto P25 target did not request TDMA default enable=%d\n", cqpsk_enable);
         test_rc = 1;
     }
+    /* Issue #423: an FDMA target that has decoded a P25p1 NID through the CQPSK chain keeps it
+     * across the scan rotation instead of falling back to the C4FM default. */
+    state.p25_cc_is_tdma = 0;
+    state.p25_p1_validated_rf_mod = 1;
+    cqpsk_enable = -1;
+    if (!dsd_engine_trunk_scan_active_p25_cqpsk_request(&state, &cqpsk_enable) || cqpsk_enable != 1) {
+        DSD_FPRINTF(stderr, "active auto P25 target dropped a learned CQPSK enable=%d\n", cqpsk_enable);
+        test_rc = 1;
+    }
+    state.p25_p1_validated_rf_mod = -1;
 
     trunk_scan_test_set_now(0.78);
     dsd_engine_trunk_scan_tick(&opts, &state);

--- a/tests/protocol/p25/test_p25_p1_sync_dispatch.c
+++ b/tests/protocol/p25/test_p25_p1_sync_dispatch.c
@@ -433,6 +433,64 @@ test_p25p1_mbe_output_and_resume_side_effects(void) {
     assert(state.lastp25type == 0);
 }
 
+/*
+ * Issue #423: a decoded NID is the only place that knows which modulation actually carried a
+ * P25p1 frame -- the sync word is identical on C4FM and CQPSK -- so it is where the trunking
+ * retunes and the SPS hunt learn what to restore.
+ */
+static void
+test_p25p1_valid_nid_learns_modulation(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* A frame that decoded through the CQPSK chain stamps CQPSK. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+    state.rf_mod = 1;
+    state.p25_p1_validated_rf_mod = -1;
+    dsd_dispatch_handle_p25p1(&opts, &state);
+    assert(state.p25_p1_validated_rf_mod == 1);
+
+    /* And one that decoded through C4FM stamps C4FM, so a wrong guess self-corrects. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+    state.rf_mod = 0;
+    state.p25_p1_validated_rf_mod = 1;
+    dsd_dispatch_handle_p25p1(&opts, &state);
+    assert(state.p25_p1_validated_rf_mod == 0);
+
+    /* A failed NID validated nothing, so it teaches nothing. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+    g_check_result = NID_DECODE_FAIL;
+    state.rf_mod = 0;
+    state.p25_p1_validated_rf_mod = 1;
+    dsd_dispatch_handle_p25p1(&opts, &state);
+    assert(state.p25_p1_validated_rf_mod == 1);
+
+    /* An explicit CLI modulation lock owns the decision outright. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+    opts.mod_cli_lock = 1;
+    state.rf_mod = 1;
+    state.p25_p1_validated_rf_mod = -1;
+    dsd_dispatch_handle_p25p1(&opts, &state);
+    assert(state.p25_p1_validated_rf_mod == -1);
+
+    /* GFSK is not a P25p1 modulation; nothing to learn from it. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_stub_state();
+    state.rf_mod = 2;
+    state.p25_p1_validated_rf_mod = -1;
+    dsd_dispatch_handle_p25p1(&opts, &state);
+    assert(state.p25_p1_validated_rf_mod == -1);
+}
+
 int
 main(void) {
     test_sync_pattern_lengths();
@@ -443,6 +501,7 @@ main(void) {
     test_p25p1_nid_correction_and_failure_state();
     test_p25p1_nac_update_guards();
     test_p25p1_mbe_output_and_resume_side_effects();
+    test_p25p1_valid_nid_learns_modulation();
     printf("P25_P1_SYNC_DISPATCH: OK\n");
     return 0;
 }

--- a/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
+++ b/tests/protocol/p25/test_p25_sm_return_to_cc_matrix.c
@@ -301,6 +301,7 @@ matrix_setup_fixture(matrix_fixture* fixture, const matrix_mode_case* mode) {
     fixture->state->p25_sys_is_tdma = mode->sys_is_tdma;
     fixture->state->p25_chan_tdma_explicit[mode->iden] = mode->tdma_hint;
     fixture->state->p25_vc_cqpsk_pref = -1;
+    fixture->state->p25_p1_validated_rf_mod = -1;
     fixture->state->p25_vc_cqpsk_override = -1;
     fixture->state->rf_mod = mode->initial_rf_mod;
     fixture->state->p25_p2_active_slot = -1;


### PR DESCRIPTION
Fixes #423.

Under `-fa` a P25 Phase 1 FDMA control channel could never end up on the CQPSK demod path, and nothing kept it there if something put it there. On the reporter's live LSM control channel that costs almost everything: locking the same run to CQPSK (`-fa -mq`) decodes **2085 TSBK/min** where AUTO managed **13–36**.

## Why both passive routes were dead ends

The pipeline was never the obstacle — `rf_mod == 1` is the entire enable, and `dsd_rtl_channel_profile_for()` already returns `P25_CQPSK` at any symbol rate. But neither way of *arguing* into it can fire:

- While the CQPSK chain is off, `demod_snr_update_qpsk_direct()` never runs, so `g_snr_qpsk_db` comes only from the constellation-ring fallback fed raw un-derotated, un-timed IQ. It cannot clear a +8 dB margin against a valid discriminator estimate.
- `dsd_qpsk_sync_hamming_with_remaps()` includes the identity remap, so `ham_qpsk <= ham_c4fm` always. An LSM signal decodes its sync words *unrotated* through the discriminator, so the QPSK candidate ties rather than wins, and the override only moves on a strict improvement.

So the decision is made by trying it, and then defended.

## What this does

- **Evidence.** A P25p1 frame whose 63-bit NID BCH decoded records which chain carried it (`p25_p1_validated_rf_mod`). The sync word is identical on both modulations, so a decoded NID is the only direct evidence of what the signal actually is.
- **Reach.** The SPS hunt spends alternate visits to the 4800/4-level profile watching the CQPSK chain. This runs only where a dwell already expired with nothing decoded — where the hunt was going to leave the profile anyway — so a control channel that is decoding never probes.
- **Hold against the votes.** While validated frames keep arriving (9600 symbols ≈ 2 s), the modulation votes don't get to argue with the chain producing them, and a probe is protected for its own dwell. This turned out to be the load-bearing piece: instrumenting the live site showed the vote machinery electing **GFSK 183 times a minute** on a P25 control channel (DMR/NXDN96 ham candidates share this profile, and GFSK entry costs a single vote), so a trial was revoked a few dozen symbols in, long before it could decode anything.
- **Hold across retunes.** The trunking CC appliers, the trunk-scan AUTO targets and the hunt's profile normalisation consult the validated modulation instead of pinning FDMA to C4FM. A CQPSK dwell that decodes nothing withdraws the claim.

Blind preservation of `rf_mod` would have been wrong: a C4FM control channel with P25p2 TDMA voice channels leaves `rf_mod` at 1 when a grant ends and must still come back on C4FM. That case is pinned by a test.

P25p1 FDMA **voice channels** need no separate work — grants inherit the control channel's modulation (`p25_grant_configure_channel_profile_for_tdma()` never touches `rf_mod` on the FDMA branch) — so an LSM site now reaches CQPSK on its voice channels too. There's a test for that as well.

## Measured

Reporter's site (`rtl:0 769.76875M`), three runs per cell:

| build | P25p1 syncs/min | TSBK/min | hunt rotations |
|---|---:|---:|---:|
| `main` `-fa` | 105–143 | 13–36 | 34–42 |
| **this PR** `-fa` | **1289–1359** | **1538–1602** | **10** |
| `-fa -mq` (locked-CQPSK ceiling) | 1715 | 2085 | — |

AUTO reaches ~76% of the locked-CQPSK ceiling, up from ~1.5%.

**Not a risk on C4FM sites:** the committed `p25p1_c4fm_cc` fixture decodes identically through either chain (27 syncs both ways) and is unchanged under `-fa` (12 syncs on both builds). Every locked or single-protocol preset is inert — `mod_cli_lock` skips all of it.

## Scope

Modulation selection and persistence only. #400 owns the dwell/rotation accounting and #374 the profile rotation under AUTO; `no_carrier_apply_p25_cc_symbolrate()` is deliberately unchanged since it never writes `rf_mod`.

## Tests

New cases in `test_frame_sync_internal_helpers` (probe alternation and its guards, trial protection, the validated-modulation hold and its lapse, hunt restore vs. disproof, accept-side re-push), `test_engine_trunk_retune_regression` (the #423 return-to-CC and CC-tune regressions, the mixed C4FM-CC/P2-VC counter-case, lock inertness, trunk-scan override precedence, and the FDMA voice-channel inheritance), `test_p25_p1_sync_dispatch` (what does and does not get recorded), plus `test_engine_trunk_scan` and `test_engine_no_carrier_reset`.

Full `ctest` (575) green on `dev-debug`, `asan-ubsan-debug` and `tsan-debug`; `tools/preflight_ci.sh` clean; no-radio backend build verified.