### PR TITLE
test: guard the radio-only test calls behind USE_RADIO

### DIFF
--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -2290,12 +2290,6 @@ main(void) {
     test_carrier_does_not_reset_the_hunt_budget();
     test_binary_profiles_override_unlocked_qpsk();
     test_four_level_profiles_reset_inherited_modulation();
-    test_sps_hunt_restores_learned_p25p1_cqpsk();
-    test_p25p1_auto_hunt_alternates_cqpsk_probe();
-    test_p25p1_probe_survives_its_dwell();
-    test_validated_p25p1_modulation_outranks_the_heuristics();
-    test_validated_cqpsk_survives_rotation_but_not_disproof();
-    test_p25p1_sync_reasserts_cqpsk_demod_profile();
     test_nxdn_variant_follows_active_profile();
     test_bounded_symbol_history_readiness_and_wrap();
     test_provoice_candidate_does_not_shadow_dstar_or_nxdn();
@@ -2312,6 +2306,12 @@ main(void) {
     test_p25_slot_activity_honors_ring_and_hangtime();
     test_hamming_helpers_find_best_patterns();
 #ifdef USE_RADIO
+    test_sps_hunt_restores_learned_p25p1_cqpsk();
+    test_p25p1_auto_hunt_alternates_cqpsk_probe();
+    test_p25p1_probe_survives_its_dwell();
+    test_validated_p25p1_modulation_outranks_the_heuristics();
+    test_validated_cqpsk_survives_rotation_but_not_disproof();
+    test_p25p1_sync_reasserts_cqpsk_demod_profile();
     test_rtl_symbol_profile_selection();
     test_decode_mode_profiles_agree_with_the_sps_hunt_table();
     test_rtl_p25p2_timing_reconciliation_preserves_cqpsk();

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1094,7 +1094,11 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
  * Tap-to-tune is gated on the live options at drain time, not on the frontend
  * hiding the affordance, and an accepted tap tears down call state so the
  * decoder re-acquires on the new frequency instead of aging out.
+ *
+ * Every check here observes ui_cmd_handle_manual_tune(), which is compiled only
+ * with the radio pipeline -- including the refusals, which are its early returns.
  */
+#ifdef USE_RADIO
 static int
 test_manual_tune_trunking_gate_and_reacquisition(void) {
     int rc = 0;
@@ -1175,6 +1179,7 @@ test_manual_tune_trunking_gate_and_reacquisition(void) {
     reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
     return rc;
 }
+#endif
 
 /*
  * Releasing the tuner is how a frontend says "stop moving this on your own"
@@ -1207,12 +1212,15 @@ test_tuner_release(void) {
     rc |= expect_contains("release explains itself", state.ui_msg, "Automatic tuning stopped");
     rc |= expect_int("release never touches the tuner itself", g_io_control_tune_calls, 0);
 
-    /* And it is the whole point that a tap now works where it was refused. */
+    /* And it is the whole point that a tap now works where it was refused --
+       which only means anything where the tap has a handler at all. */
+#ifdef USE_RADIO
     rc |= expect_int("tune after release queued", dsd_app_command_set_u32(DSD_APP_CMD_MANUAL_TUNE, 853125000U),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("tune after release drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_int("tune after release reaches the tuner", g_io_control_tune_calls, 1);
     rc |= expect_contains("tune after release reports applied", state.ui_msg, "Applied: tuned -> 853125000 Hz");
+#endif
     freeState(&state);
 
     /* Conventional scanner mode is the other owner, and a frontend cannot tell
@@ -1658,7 +1666,9 @@ main(void) {
     rc |= test_trunk_set();
 #ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
     rc |= test_manual_tune_commands_commit_only_after_acceptance();
+#ifdef USE_RADIO
     rc |= test_manual_tune_trunking_gate_and_reacquisition();
+#endif
     rc |= test_tuner_release();
 #endif
     if (rc == 0) {


### PR DESCRIPTION
Fixes the `linux-ci / backend-matrix (neither)` failure on `main` at 3ee7cbb8, plus a pre-existing failure in the same configuration found while verifying it.

## Problem

### 1. The build break (CI red on `main`)

`backend-matrix (neither)` builds with both SDR backends off, leaving `USE_RADIO` undefined:

```
tests/dsp/test_frame_sync_internal_helpers.c:2293:5: error: implicit declaration of
function 'test_sps_hunt_restores_learned_p25p1_cqpsk' [-Werror=implicit-function-declaration]
```

Six P25p1 CQPSK tests added in #425 are *defined* inside that file's `USE_RADIO` block — they drive `AUDIO_IN_RTL`, an `RtlSdrContext`, and the rtl stream metrics hooks — but their *calls* landed in the unguarded part of `main()`. Radio-off, the definitions disappear while the calls remain, and `-Werror` turns them into a build failure.

This could not have been caught by the PR: `backend-matrix` carries `if: github.event_name != 'pull_request'`. PRs get `backend-pr (both)`, which builds only the both-backends-on configuration, so the radio-off variants are first built *after* a merge lands.

### 2. `APP_COMMAND_QUEUE`, pre-existing in the same configuration

Once the build was fixed, running the suite radio-off surfaced a second failure — pre-existing, unrelated to #425, and invisible to CI because `backend-matrix` only *builds* and never runs ctest. All 14 failing checks were `DSD_APP_CMD_MANUAL_TUNE` expectations:

```
manual tune under trunking explains itself: "" does not contain "Trunking active"
manual tune reaches the tuner once: got 0 want 1
```

These commands have a deliberately split contract in `src/app_control/app_command_queue.c`:

- **Unguarded, every build:** `dsd_app_command_set_u32()`, `k_ui_cmd_coalescible_setter_ids`, `k_ui_cmd_payload_min_size_rules`. The command submits and drains normally.
- **Inside `#ifdef USE_RADIO`** (block opening at `app_command_queue.c:930`): the handler and its `apply_cmd_io_and_import_rtl_b` dispatch entry.

So radio-off the command is accepted, queued, drained, and consumed with no handler to run — `state.ui_msg` stays empty and the tuner stub is never called. The expectations observing those effects sat outside any guard. Note the refusal paths (`"Trunking active"`, `"Scanner active"`) are early returns *inside* the guarded handler, so they vanish too, even though the policy they encode has nothing to do with radio.

## Change

Both commits apply the same rule, which the codebase already sets: a test that observes a `USE_RADIO`-only symbol is itself `USE_RADIO`-only.

- `tests/dsp/test_frame_sync_internal_helpers.c` — moved the six calls into the existing `USE_RADIO` block in `main()`, beside the other radio-only tests.
- `tests/ui/test_ui_cmd_queue.c` — guarded `test_manual_tune_trunking_gate_and_reacquisition()` (every one of its checks observes the handler) and the four tap-after-release checks in `test_tuner_release()`. The release itself needs no radio and stays unguarded. This follows the pattern the same file already uses at line 882, where the `RTL_SET_FREQ` expectations in `test_manual_tune_commands_commit_only_after_acceptance()` are guarded exactly this way — the `MANUAL_TUNE` ones were simply missed.

Tests only; no production code and no behavioral change. No coverage is lost — every configuration that compiled these bodies still runs all of them.

**Deliberately not changed:** the silent accept-then-drop above. It is uniform across `MANUAL_TUNE`, `RTL_SET_FREQ`, `RTL_SET_GAIN`, `RTL_SET_PPM` and `RTL_SET_BW` — the command ABI keeps the same shape in every build and only the servicing disappears. Making these report "Unsupported" radio-off is a UX decision on app-control's public contract, in a configuration with no UI path to trigger it, so it belongs in its own change rather than a CI fix.

## Verification

| Configuration | Before | After |
| --- | --- | --- |
| `-DDSD_ENABLE_RTLSDR=OFF -DDSD_ENABLE_SOAPYSDR=OFF` | build failed; 535/536 once patched | builds clean, **536/536** |
| Both backends on | 575/575 | **575/575** |

- Reproduced the exact CI error locally under the `neither` flags before changing anything, then confirmed a clean 100% build.
- Both variants fully rebuilt and re-run against the final committed state. `rtl_only` and `soapy_only` both define `USE_RADIO` and take the same path as backends-on; the guard is binary and both of its states are covered.
- Confirmed the guards preserve coverage rather than delete it: injected a sentinel mismatch into the guarded `MANUAL_TUNE` test, verified the radio-on build still caught it and withheld its `OK`, then reverted.
- `tools/preflight_ci.sh` exit 0 on each commit — clang-format, clang-tidy, IWYU, `gcc -fanalyzer`, cppcheck, semgrep, arch rules.
