### PR TITLE
ci: build and test the radio-off backend variant on pull requests

### DIFF
--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -18,10 +18,15 @@ permissions:
   contents: read
 
 jobs:
+  # Runs on every event, pull requests included. The `neither` variant is the
+  # only configuration in CI that leaves USE_RADIO undefined, so it is the only
+  # job that can catch a symbol referenced from outside its `#ifdef USE_RADIO`
+  # guard — and it has to do that on the pull request, not on the push that
+  # follows it. Every variant runs ctest as well as building, because a
+  # radio-off *test* failure is invisible to a build-only job.
   backend-matrix:
     name: backend-matrix (${{ matrix.variant }})
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -99,60 +104,7 @@ jobs:
         run: |
           cmake --build --preset dev-debug -j
 
-  backend-pr:
-    name: backend-pr (both)
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential cmake ninja-build pkg-config git \
-            libsndfile1-dev libpulse-dev libncurses-dev \
-            libusb-1.0-0-dev libfftw3-dev libblas-dev liblapack-dev gfortran \
-            libcodec2-dev librtlsdr-dev libsoapysdr-dev libcurl4-openssl-dev libexpat1-dev
-
-      - name: Build and install mbelib-neo
-        run: |
-          set -euxo pipefail
-          source tools/ci-dependency-pins.env
-          tools/fetch-pinned-git.sh https://github.com/arancormonk/mbelib-neo "$MBELIB_NEO_SHA" /tmp/mbelib-neo
-          cmake -S /tmp/mbelib-neo -B /tmp/mbelib-neo/build -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON \
-            -DCMAKE_INSTALL_PREFIX="$HOME/.local"
-          cmake --build /tmp/mbelib-neo/build -j
-          cmake --install /tmp/mbelib-neo/build
-
-      - name: Prepare local dependency environment
-        run: |
-          {
-            echo "PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:$HOME/.local/lib64/pkgconfig:${PKG_CONFIG_PATH:-}"
-            echo "CMAKE_PREFIX_PATH=$HOME/.local:${CMAKE_PREFIX_PATH:-}"
-            echo "LD_LIBRARY_PATH=$HOME/.local/lib:$HOME/.local/lib64:${LD_LIBRARY_PATH:-}"
-          } >> "$GITHUB_ENV"
-
-      - name: Configure
-        run: |
-          set -euxo pipefail
-          log="$RUNNER_TEMP/configure-both.log"
-          cmake --preset dev-debug \
-            -DDSD_ENABLE_RTLSDR=ON \
-            -DDSD_REQUIRE_RTLSDR=ON \
-            -DDSD_ENABLE_SOAPYSDR=ON \
-            -DDSD_REQUIRE_SOAPYSDR=ON \
-            2>&1 | tee "$log"
-          grep -F "RTL-SDR backend enabled: ON (available: ON)" "$log"
-          grep -F "SoapySDR backend enabled: ON (available: ON)" "$log"
-          grep -F "Radio pipeline available: ON" "$log"
-
-      - name: Build
-        run: cmake --build --preset dev-debug -j
-
-      - name: Test
+      - name: Test (${{ matrix.variant }})
         run: ctest --preset dev-debug --output-on-failure
 
   android-shape-host:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -169,6 +169,41 @@ cmake --build --preset dev-debug -j --target dsd-neo_test_ui_qt_radio_reference_
 ctest --preset dev-debug -R '^UI_QT_RADIO_REFERENCE$' --output-on-failure
 ```
 
+#### Guards that gate which code compiles
+
+`USE_RADIO` is defined only when the radio pipeline is available — an SDR
+backend was found, or `DSD_FORCE_RADIO_PIPELINE=ON` — and it guards
+declarations, not only call sites. A test that calls a `USE_RADIO`-only helper
+from outside the guard therefore compiles wherever a backend is present and
+fails only where the symbol is absent:
+
+```
+error: implicit declaration of function 'test_...' [-Werror=implicit-function-declaration]
+```
+
+The run-time form of the same mistake is quieter. A case that asserts on a
+handler existing only under `USE_RADIO` — a queued `DSD_APP_CMD_MANUAL_TUNE`,
+say — watches the command drain with no handler in a radio-off build, so the
+expectation stops holding without anything failing to compile.
+`tests/ui/test_ui_cmd_queue.c` shows the split: validation cases that hold in
+any build stay outside the guard, cases observing a radio handler sit inside it.
+
+`backend-matrix (neither)` builds and runs ctest with both SDR backends off, on
+pull requests as well as pushes, so either mistake fails the pull request rather
+than the default branch. Reproduce that configuration locally when a change
+touches a `USE_RADIO` guard:
+
+```sh
+cmake --preset dev-debug -DDSD_ENABLE_RTLSDR=OFF -DDSD_REQUIRE_RTLSDR=OFF \
+  -DDSD_ENABLE_SOAPYSDR=OFF -DDSD_REQUIRE_SOAPYSDR=OFF
+cmake --build --preset dev-debug -j
+ctest --preset dev-debug --output-on-failure
+```
+
+Clear the `DSD_REQUIRE_*` flags alongside the `DSD_ENABLE_*` ones. Against a
+cached build tree, configure otherwise stops with
+`DSD_REQUIRE_RTLSDR=ON requires DSD_ENABLE_RTLSDR=ON.`
+
 ## Continuous Integration
 
 GitHub Actions runs tests and quality checks on pull requests, primary-branch
@@ -178,7 +213,10 @@ secret scanning, OSV scanning, repository guardrails for secret redaction and
 workflow source/download pinning, fuzz smoke tests, and install/package
 validation run where their workflows declare those events. Dependency review is
 PR-only, release tag validation is tag-only, and extended fuzzing is scheduled
-or manually dispatched.
+or manually dispatched. The backend matrix builds and tests all four
+SDR-backend combinations — `both`, `rtl_only`, `soapy_only` and `neither` — on
+pull requests as well as pushes, so the radio-off build is proven before a merge
+rather than after one.
 
 ## Regression Test Requirement
 


### PR DESCRIPTION
Closes #427. `backend-matrix` now runs on pull requests and runs ctest, so the radio-off configuration is proven before a merge instead of after one.

> [!IMPORTANT]
> **This PR cannot merge until `main`'s required status checks are updated.** `backend-pr (both)` is a required context and is deleted here, so it will never report again — including on this PR, which will sit on "Expected — waiting for status". Replace it with `backend-matrix (both)`, `backend-matrix (rtl_only)`, `backend-matrix (soapy_only)` and `backend-matrix (neither)`.

## Problem

Builds where `USE_RADIO` is undefined were covered by exactly one CI job, and that job neither ran on pull requests nor ran any tests.

`backend-matrix` builds all four backend variants including `neither` (`-DDSD_ENABLE_RTLSDR=OFF -DDSD_ENABLE_SOAPYSDR=OFF`), the only configuration in CI that leaves `USE_RADIO` undefined — `DSD_HAS_RADIO` is `DSD_HAS_RTLSDR OR DSD_HAS_SOAPYSDR OR DSD_FORCE_RADIO_PIPELINE` (`CMakeLists.txt:759-762`), and `USE_RADIO` follows it (`CMakeLists.txt:1113`). Two properties combined badly:

1. **Gated to non-PR events** (`if: github.event_name != 'pull_request'`). Pull requests got `backend-pr (both)` instead, which configures only both-backends-on. So `neither`, `rtl_only` and `soapy_only` were first built *after* a merge landed on `main`.
2. **It never ran ctest.** Its steps ended at Build, unlike `backend-pr`. A radio-off *test* failure was therefore invisible in every event type, on every branch.

`android-shape-host` looks like it might cover this, but it does not: it sets both SDR libraries `OFF` *and* passes `-DDSD_FORCE_RADIO_PIPELINE=ON`, asserting `Radio pipeline available: ON`. `USE_RADIO` is defined there — it exercises the opposite side of the guard.

Both failure modes have already occurred for real:

| Gap | Incident |
| --- | --- |
| Never built on PRs | #425 was green as a pull request and broke `main` on push — six `-Werror=implicit-function-declaration` errors in `tests/dsp/test_frame_sync_internal_helpers.c`, in `backend-matrix (neither)` ([run 33347694887](https://github.com/arancormonk/dsd-neo/actions/runs/33347694887)) |
| Never tested anywhere | `APP_COMMAND_QUEUE` had been failing radio-off for an unknown length of time — 14 `DSD_APP_CMD_MANUAL_TUNE` expectations observing a handler that exists only under `USE_RADIO`. Found by hand while fixing the first; nothing in CI could ever have reported it |

Both were fixed in #426. This PR closes the gap that let them land.

## Change

**`.github/workflows/linux-ci.yaml`**

- Dropped `backend-matrix`'s job-level `if:`, so all four variants run on pull requests as well as pushes, tags and dispatches.
- Added `Test (${{ matrix.variant }})` — `ctest --preset dev-debug --output-on-failure` — to every variant. This is what makes a radio-off test failure visible at all, and it is the half that would have caught gap 2.
- Deleted `backend-pr`. Its cmake flags were character-for-character the `both` variant's, so it is pure duplication once the matrix covers pull requests.
- Added a comment on the job recording why the `neither` variant has to gate pull requests, so the `if:` does not come back.

**`docs/testing.md`** — a "Guards that gate which code compiles" subsection beside the existing "Build-time constants that gate a branch" material, since `USE_RADIO` is the same failure class. It covers both shapes of the mistake (compile-time `-Werror=implicit-function-declaration`, and the quieter run-time one where a command drains with no handler), points at the `tests/ui/test_ui_cmd_queue.c` split as the worked example, and gives the local reproduction — including that `DSD_REQUIRE_*` must be cleared alongside `DSD_ENABLE_*`, or a cached tree stops with `DSD_REQUIRE_RTLSDR=ON requires DSD_ENABLE_RTLSDR=ON.` (`CMakeLists.txt:714`).

No production code and no test code. Per the regression policy in `docs/testing.md`, this is the "a better guardrail exists, such as a static-analysis rule or workflow check" case — the check *is* the deliverable, and it verifies itself: `backend-matrix (neither)` appearing in this PR's check list, with test results, is the proof.

## Cost

Measured from [run 33349049577](https://github.com/arancormonk/dsd-neo/actions/runs/33349049577) (push to `main`) and the most recent pull-request run:

| Job | Duration |
| --- | --- |
| `backend-matrix (both)` | 94s |
| `backend-matrix (rtl_only)` | 75s |
| `backend-matrix (soapy_only)` | 87s |
| `backend-matrix (neither)` | 92s (build step 49s) |
| `backend-pr (both)`, ctest included | 140s |

Pull requests go from one backend job to four and lose one, so the net cost is roughly three extra job-slots of about two minutes each.

## Verification

| Check | Result |
| --- | --- |
| Radio-off suite locally (`neither` flags) | **536/536 pass**, `Radio pipeline available: OFF (forced: OFF)` |
| `tools/workflow_lint.sh` (actionlint) | 0 findings |
| `tools/zizmor.sh` | No findings to report |
| `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh` | clean |
| `tools/preflight_ci.sh` | exit 0 |
| Parsed YAML structure | `backend-pr` absent, no job-level `if:`, four variants, Test step present on each |

The radio-off run was done on this branch's base, `9a55cd59`; the branch changes only workflow and documentation, so the build it exercised is identical. That run is what confirms the new Test step is green at HEAD rather than a landmine — #426 had only just fixed the one failure it would otherwise have caught.

Claims in the documentation were checked against source rather than against the issue text: the `DSD_HAS_RADIO` derivation, the exact `FATAL_ERROR` string, and the real compiler error from the failed run.
