### PR TITLE
fix(dsp): make D-STAR voice and ProVoice prove a transmission before buying dwell

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -314,11 +314,19 @@ Notes
   the permissive 4800/4 matchers produce these on signals belonging to another profile -- buys nothing however often it
   fires, and the dwell does not depend on that cadence. Frame sync also sees a verdict where the protocol produces one:
   a YSF frame before the transmission's first FICH CRC has held, a failed EDACS BCH, a failed D-STAR header CRC, a
-  failed P25 Phase 1 NID, and an NXDN frame whose transmission has not yet passed a CRC all buy no dwell however many
-  symbols they consumed. Handlers that report no verdict are credited as before, and they are the majority: every DMR,
-  M17, P25 Phase 2, dPMR and X2-TDMA frame is unconditionally productive, as is every D-STAR voice and ProVoice frame,
-  which have no check at any point. A false match on any of them still delays the hunt in proportion to what it
-  swallows -- 1992 symbols for D-STAR voice and 736 for ProVoice, the two worst cases.
+  failed P25 Phase 1 NID, an NXDN or M17 frame whose transmission has not yet passed a CRC, and a D-STAR voice or
+  ProVoice frame whose transmission has not yet proved itself all buy no dwell however many symbols they consumed.
+  Handlers that report no verdict are credited as before: every DMR, P25 Phase 2, dPMR and X2-TDMA frame is
+  unconditionally productive, and a false match on one of those still delays the hunt in proportion to what it
+  swallows.
+- D-STAR voice and ProVoice prove a transmission rather than a frame, because neither has a per-frame check worth the
+  name. A D-STAR superframe spends 1992 symbols and a ProVoice frame 736, and the vocoder error counts both leave
+  behind are soft corrections rather than a verdict. So a CRC-16/X.25 -- the D-STAR RF header, or the header
+  rebroadcast that slow data carries through a transmission -- confirms outright, and failing that, a second frame
+  arriving before the carrier drops does: each sits behind its own exact sync word, 24 symbols for D-STAR and 32 for
+  ProVoice, which noise does not supply twice in a row. A real call therefore pays at most one frame of withheld
+  credit at the very start, and none at all when it opens with a decodable header, while an isolated false match on
+  either profile buys nothing.
 - NXDN announces nothing until a frame's content checks out. Its 10-symbol sync word and one-parity-bit LICH are weak
   enough that receiver noise clears both, so a frame that reaches the protocol layer does not by itself refresh the
   scan hold, synthesize voice, publish a RAN, or open a call record. One CRC of 12 bits or more (FACCH, CAC, UDCH,

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -321,6 +321,17 @@ Private per-protocol modules worth knowing about:
   `NXDN_Elements_Content_decode()` carries no CRC verdict of its own: the channel decoders in `nxdn_deperm.c` and
   `NXDN_SACCH_Full_decode()` hand it CRC-verified content only, so the gate lives in those callers, with
   `nxdn_confirm_is_confirmed()` as the frame-level check at the sites that publish a call or refresh a scan hold.
+- `src/protocol/m17/m17_confirm.{c,h}` — the same module for M17, whose sync chain opens on a preamble that is only an
+  alternating symbol run. Frame handlers report `(own check || confirmed)`, `dispatch_m17.c` reports it on an EOT, and
+  `dsd_frame_sync.c` reads the raw state to decide whether to keep extending a candidate chain.
+- `src/protocol/dstar/dstar_confirm.{c,h}` and `src/protocol/provoice/provoice_confirm.{c,h}` — the same shape again,
+  answering only the SPS hunt rather than gating audio (issue #421). Neither protocol has a per-frame check: a D-STAR
+  superframe costs 1992 symbols and a ProVoice frame 736, and the AMBE/IMBE error counts they leave in
+  `dsd_state::errs`/`errs2` are soft corrections, not verdicts. D-STAR confirms on a CRC-16/X.25 — the RF header via
+  `processDSTAR_HD()`, or the header rebroadcast in `dstar_slow_data.c` — and both confirm on a second frame arriving
+  behind its own exact sync word before the carrier drops. `processDSTAR()` and `processProVoice()` return the answer,
+  the dispatch handlers map it to `dsd_frame_verdict`, and the engine clears it with the carrier through the exported
+  `dstar_confirm_reset()`/`provoice_confirm_reset()`.
 
 Build files: `src/protocol/CMakeLists.txt` and per‑protocol `src/protocol/<name>/CMakeLists.txt`
 

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -1169,6 +1169,18 @@ struct dsd_state {
     //edacs
     int ea_mode;
 
+    /* ProVoice frame-content confirmation (src/protocol/provoice/provoice_confirm.c). Nothing
+     * in a ProVoice frame can fail a check -- no CRC, no BCH, no parity -- so the evidence is
+     * that the stream keeps arriving: each frame sits behind its own exact 32-symbol sync
+     * word, and two in a row confirm the transmission (issues #391, #421).
+     *
+     * provoice_confirmed: this transmission has produced verified content.
+     * provoice_confirm_weak_streak: consecutive frames decoded behind their own sync word.
+     * provoice_confirm_frame_evidence: strongest provoice_evidence seen since begin_frame(). */
+    uint8_t provoice_confirmed;
+    uint8_t provoice_confirm_weak_streak;
+    uint8_t provoice_confirm_frame_evidence;
+
     unsigned short esk_mask;
     uint32_t edacs_sys_id;
     uint32_t edacs_area_code;
@@ -1250,6 +1262,19 @@ struct dsd_state {
     //DSTAR Call Strings and Info
     char dstar_txt[60];
     char dstar_gps[60];
+
+    /* D-STAR frame-content confirmation (src/protocol/dstar/dstar_confirm.c). A voice sync
+     * commits 1992 symbols, and nothing inside them is checkable on its own: the AMBE error
+     * counts are soft corrections, not a verdict. A CRC-16/X.25 -- the RF header, or the
+     * header rebroadcast in slow data -- proves the transmission; a superframe that carries
+     * only filler has to repeat instead (issues #391, #421).
+     *
+     * dstar_confirmed: this transmission has produced verified content.
+     * dstar_confirm_weak_streak: consecutive superframes carrying no check of their own.
+     * dstar_confirm_frame_evidence: strongest dstar_evidence seen since begin_frame(). */
+    uint8_t dstar_confirmed;
+    uint8_t dstar_confirm_weak_streak;
+    uint8_t dstar_confirm_frame_evidence;
 
     //M17 Storage
     uint8_t m17_lsf[360];

--- a/include/dsd-neo/protocol/dstar/dstar.h
+++ b/include/dsd-neo/protocol/dstar/dstar.h
@@ -20,18 +20,36 @@
 extern "C" {
 #endif
 
-void processDSTAR(dsd_opts* opts, dsd_state* state);
+/**
+ * @brief Decode one D-STAR voice superframe.
+ *
+ * @return 1 once this transmission has proved itself -- a CRC-16/X.25 on the RF header or
+ *         on the header rebroadcast in slow data, or a second superframe arriving behind
+ *         its own exact sync word -- and 0 until then. The 1992 symbols a superframe
+ *         consumes are the largest block any handler takes, and on the 4800/2 hunt profile
+ *         D-STAR is the only candidate, so an unproved one must not buy dwell (#391, #421).
+ *         The evidence lives in dsd_state::dstar_confirmed and clears with the carrier.
+ */
+int processDSTAR(dsd_opts* opts, dsd_state* state);
 
 /**
  * @brief Decode a D-STAR header frame and the voice frame that follows it.
  *
- * @return 1 when the header's CRC-16/X.25 matched, 0 otherwise. Nothing further down this
- *         path is checkable -- processDSTAR() runs either way -- so this is the whole of
- *         what the D-STAR data path can tell the SPS hunt about the 2652 symbols it took
- *         (#391).
+ * @return 1 when the header's CRC-16/X.25 matched, 0 otherwise. A header opens a
+ *         transmission, so this stays the header's own verdict rather than riding evidence
+ *         an earlier frame supplied; the voice superframe behind it reports separately
+ *         through processDSTAR() (#391, #421).
  */
 int processDSTAR_HD(dsd_opts* opts, dsd_state* state);
 void processDSTAR_SD(const dsd_opts* opts, dsd_state* state, uint8_t* sd);
+
+/**
+ * @brief Forget the evidence gathered for the current D-STAR transmission.
+ *
+ * Defined in src/protocol/dstar/dstar_confirm.c and declared here so the engine can clear
+ * it with the carrier; the rest of that module's interface is private to the protocol.
+ */
+void dstar_confirm_reset(dsd_state* state);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/protocol/provoice/provoice.h
+++ b/include/dsd-neo/protocol/provoice/provoice.h
@@ -18,7 +18,26 @@
 extern "C" {
 #endif
 
-void processProVoice(dsd_opts* opts, dsd_state* state);
+/**
+ * @brief Decode one ProVoice frame.
+ *
+ * @return 1 once this transmission has proved itself and 0 until then. Nothing inside the
+ *         736 dibits a frame consumes can fail a check -- there is no CRC, no BCH and no
+ *         parity, and the IMBE error counts are soft corrections -- so the evidence is that
+ *         a second frame arrived behind its own exact 32-symbol sync word. A lone false
+ *         match buys no dwell on the 9600/2 profile ProVoice shares with EDACS, which
+ *         already reports its own BCH verdict (#391, #421). The evidence lives in
+ *         dsd_state::provoice_confirmed and clears with the carrier.
+ */
+int processProVoice(dsd_opts* opts, dsd_state* state);
+
+/**
+ * @brief Forget the evidence gathered for the current ProVoice transmission.
+ *
+ * Defined in src/protocol/provoice/provoice_confirm.c and declared here so the engine can
+ * clear it with the carrier; the rest of that module's interface is private to the protocol.
+ */
+void provoice_confirm_reset(dsd_state* state);
 
 #ifdef __cplusplus
 }

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -791,6 +791,12 @@ init_state_protocol_defaults_b(dsd_state* state) {
     //NXDN, when a new IV has arrived
     state->nxdn_new_iv = 0;
 
+    /* Cleared directly rather than through provoice_confirm_reset(): core must not call into
+     * protocol modules. */
+    state->provoice_confirmed = 0;
+    state->provoice_confirm_weak_streak = 0;
+    state->provoice_confirm_frame_evidence = 0;
+
     state->p25vc = 0;
     state->payload_miP = 0;
     state->payload_miN = 0;
@@ -1052,6 +1058,11 @@ init_state_string_and_m17_defaults(dsd_state* state) {
     //DSTAR Call Strings
     set_spaces(state->dstar_txt, 8); //8 spaces
     set_spaces(state->dstar_gps, 8); //8 spaces
+    /* Cleared directly rather than through dstar_confirm_reset(): core must not call into
+     * protocol modules. */
+    state->dstar_confirmed = 0;
+    state->dstar_confirm_weak_streak = 0;
+    state->dstar_confirm_frame_evidence = 0;
 
     //M17 Storage
     DSD_MEMSET(state->m17_lsf, 0, sizeof(state->m17_lsf));

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -3141,11 +3141,13 @@ frame_sync_sps_hunt_dwell_symbols(const dsd_opts* opts, const dsd_state* state) 
  * Size alone cannot separate a decoded frame from a block skipped on a sync no CRC would
  * accept, so a handler that ran a check and failed it says so: processFrame() leaves its
  * dsd_frame_verdict in dsd_state::sps_hunt_last_frame_verdict, and an unproductive one is
- * refused the debit however much it took (#391). The verdict is default-productive, so
- * every handler that reports nothing -- DMR, M17, P25 Phase 2, dPMR, X2-TDMA, D-STAR voice
- * and ProVoice, which is the whole of the set that does not, whether because the check it
- * would report is per transmission rather than per frame or because it has none at any point
- * -- still buys dwell in proportion to what it swallowed, as before.
+ * refused the debit however much it took (#391). Where the check is per transmission rather
+ * than per frame the protocol reports a sticky verdict instead, so a frame that fails its own
+ * check inside a confirmed transmission still counts -- D-STAR voice and ProVoice were the
+ * last two with no verdict at any point and now confirm this way (#421). The verdict is
+ * default-productive, so every handler that still reports nothing -- DMR, P25 Phase 2, dPMR
+ * and X2-TDMA, which is the whole of the set that does not -- buys dwell in proportion to
+ * what it swallowed, as before.
  */
 static void
 frame_sync_sps_hunt_note_handler_consumption(dsd_state* state) {

--- a/src/engine/dispatch/dispatch_dstar.c
+++ b/src/engine/dispatch/dispatch_dstar.c
@@ -28,14 +28,12 @@ dsd_dispatch_handle_dstar(dsd_opts* opts, dsd_state* state) {
 
     if (state->synctype == DSD_SYNC_DSTAR_VOICE_POS || state->synctype == DSD_SYNC_DSTAR_VOICE_NEG) {
         DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " VOICE        ");
-        processDSTAR(opts, state);
-        /* Productive by default, and this is the hole #391 measures. processDSTAR() spends
-         * 1992 symbols with no return value, no error accumulator and no frame-count check;
-         * it overwrites state->errs/errs2 21 times and reads them never, and its only CRC
-         * (dstar_slow_data.c) is consulted on the sd_bytes[0] == 0x55 branch alone, about 1
-         * match in 256 against noise. Nothing here can honestly say "unproductive", and a
-         * threshold invented on state->errs would be the guess this contract forbids. */
-        return DSD_FRAME_VERDICT_PRODUCTIVE;
+        /* 1992 symbols, the largest block any handler consumes, on the profile where D-STAR
+         * is the only candidate. processDSTAR() reports whether this transmission has proved
+         * itself: a CRC-16/X.25 on the RF header or the slow-data header rebroadcast, or a
+         * second superframe behind its own exact sync word. Until one of those lands the
+         * symbols bought nothing, and the SPS hunt is told so (#421). */
+        return processDSTAR(opts, state) != 0 ? DSD_FRAME_VERDICT_PRODUCTIVE : DSD_FRAME_VERDICT_UNPRODUCTIVE;
     }
 
     DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " DATA         ");

--- a/src/engine/dispatch/dispatch_provoice.c
+++ b/src/engine/dispatch/dispatch_provoice.c
@@ -21,12 +21,11 @@ dsd_dispatch_matches_provoice(int synctype) {
 }
 
 /*
- * Always productive, and this one is a known hole. processProVoice() spends 736 dibits per
- * call on the same 9600/2 profile EDACS uses, with no CRC, no FEC verdict and no error
- * return -- its only failure path fires when the dibit callback fails, never on bad data.
- * A false ProVoice match therefore still buys the profile 736 symbols of dwell. Closing it
- * needs a confidence module shaped like src/protocol/nxdn/nxdn_confirm.c, not a threshold
- * on a counter nothing computes (#391).
+ * 736 dibits per call on the same 9600/2 profile EDACS uses, and nothing inside them can
+ * fail a check: no CRC, no BCH, no parity, and IMBE correction counts that never report a
+ * bad frame. So processProVoice() reports the one thing that is checkable -- that a second
+ * frame arrived behind its own exact 32-symbol sync word -- and a lone false match buys the
+ * profile nothing, the way EDACS's BCH verdict beside it already does (#421).
  */
 dsd_frame_verdict
 dsd_dispatch_handle_provoice(dsd_opts* opts, dsd_state* state) {
@@ -34,6 +33,5 @@ dsd_dispatch_handle_provoice(dsd_opts* opts, dsd_state* state) {
         openMbeOutFile(opts, state);
     }
     DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " VOICE        ");
-    processProVoice(opts, state);
-    return DSD_FRAME_VERDICT_PRODUCTIVE;
+    return processProVoice(opts, state) != 0 ? DSD_FRAME_VERDICT_PRODUCTIVE : DSD_FRAME_VERDICT_UNPRODUCTIVE;
 }

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -36,6 +36,7 @@
 #include <dsd-neo/platform/timing.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/protocol/dstar/dstar.h>
 #include <dsd-neo/protocol/m17/m17.h>
 #include <dsd-neo/protocol/nxdn/nxdn.h>
 #include <dsd-neo/protocol/nxdn/nxdn_convolution.h>
@@ -43,6 +44,7 @@
 #include <dsd-neo/protocol/p25/p25_crypto.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/protocol/provoice/provoice.h>
 #include <dsd-neo/runtime/cli.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/control_pump.h>
@@ -1858,6 +1860,9 @@ no_carrier_reset_decode_state(dsd_state* state, int preserve_dmr_confidence) {
     state->m17_pre_candidate = 0;
     state->m17_pre_candidate_ttl = 0;
     m17_confirm_reset(state);
+    /* Same rule for ProVoice: a frame proves nothing on its own, so the streak that does
+     * cannot span the dead channel that brought us here (issue #421). */
+    provoice_confirm_reset(state);
     state->err_str[0] = '\0';
     state->err_strR[0] = '\0';
     set_spaces(state->fsubtype, 14);
@@ -2164,6 +2169,8 @@ no_carrier_reset_ysf_and_dstar_strings(dsd_state* state) {
 
     set_spaces(state->dstar_txt, 8);
     set_spaces(state->dstar_gps, 8);
+    /* Evidence is per-transmission: the next carrier proves itself again (issue #421). */
+    dstar_confirm_reset(state);
 }
 
 // `retuned` says whether this noCarrier() pass moved the receiver before reaching here. A call still

--- a/src/protocol/dstar/CMakeLists.txt
+++ b/src/protocol/dstar/CMakeLists.txt
@@ -2,7 +2,12 @@ add_library(dsd-neo_proto_dstar)
 
 target_sources(
     dsd-neo_proto_dstar
-    PRIVATE dstar.c dstar_header.c dstar_header_utils.c dstar_slow_data.c
+    PRIVATE
+        dstar.c
+        dstar_confirm.c
+        dstar_header.c
+        dstar_header_utils.c
+        dstar_slow_data.c
 )
 
 target_include_directories(

--- a/src/protocol/dstar/dstar.c
+++ b/src/protocol/dstar/dstar.c
@@ -16,15 +16,22 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dstar_confirm.h"
 
 //simplified DSTAR
-void
+int
 processDSTAR(dsd_opts* opts, dsd_state* state) {
     uint8_t sd[480];
     DSD_MEMSET(sd, 0, sizeof(sd));
     int i, j;
     char ambe_fr[4][24];
     DSD_MEMSET(ambe_fr, 0, sizeof(ambe_fr));
+
+    /* The superframe sits behind an exact 24-symbol sync word, which is the only thing about
+     * it that can be checked from here; a CRC-16 in the slow data below may yet prove it
+     * outright. Weak on its own, so it has to repeat -- see dstar_confirm.h. */
+    dstar_confirm_begin_frame(state);
+    dstar_confirm_note_evidence(state, DSTAR_EVIDENCE_WEAK);
 
     //20 voice and 19 slow data frames (20th is frame sync)
     for (j = 0; j < 21; j++) {
@@ -64,6 +71,9 @@ processDSTAR(dsd_opts* opts, dsd_state* state) {
     }
 
     DSD_FPRINTF(stderr, "\n");
+
+    dstar_confirm_end_frame(state);
+    return dstar_confirm_is_confirmed(state);
 }
 
 int
@@ -78,6 +88,11 @@ processDSTAR_HD(dsd_opts* opts, dsd_state* state) {
     }
 
     const int header_ok = dstar_header_decode_soft(state, soft_symbols);
-    processDSTAR(opts, state);
+    if (header_ok) {
+        /* A CRC-16/X.25 over 39 octets: proof on its own, and it opens the transmission the
+         * voice superframe below belongs to. */
+        dstar_confirm_note_evidence(state, DSTAR_EVIDENCE_STRONG);
+    }
+    (void)processDSTAR(opts, state);
     return header_ok;
 }

--- a/src/protocol/dstar/dstar_confirm.c
+++ b/src/protocol/dstar/dstar_confirm.c
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "dstar_confirm.h"
+
+#include <dsd-neo/core/state.h>
+#include <stdint.h>
+
+#include "dsd-neo/core/state_fwd.h"
+
+void
+dstar_confirm_reset(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    state->dstar_confirmed = 0;
+    state->dstar_confirm_weak_streak = 0;
+    state->dstar_confirm_frame_evidence = 0;
+}
+
+void
+dstar_confirm_begin_frame(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    state->dstar_confirm_frame_evidence = 0;
+}
+
+void
+dstar_confirm_note_evidence(dsd_state* state, dstar_evidence evidence) {
+    if (!state) {
+        return;
+    }
+    if (evidence == DSTAR_EVIDENCE_STRONG) {
+        state->dstar_confirm_frame_evidence = (uint8_t)DSTAR_EVIDENCE_STRONG;
+        state->dstar_confirm_weak_streak = 0;
+        state->dstar_confirmed = 1;
+        return;
+    }
+    if (evidence != DSTAR_EVIDENCE_WEAK || state->dstar_confirm_frame_evidence != 0) {
+        /* One superframe is one frame's worth of evidence however often it is reported. */
+        return;
+    }
+    state->dstar_confirm_frame_evidence = (uint8_t)DSTAR_EVIDENCE_WEAK;
+    if (state->dstar_confirm_weak_streak < 0xFFU) {
+        state->dstar_confirm_weak_streak++;
+    }
+    if (state->dstar_confirm_weak_streak >= DSTAR_CONFIRM_WEAK_OBSERVES) {
+        state->dstar_confirmed = 1;
+    }
+}
+
+void
+dstar_confirm_end_frame(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    if (state->dstar_confirm_frame_evidence == 0) {
+        state->dstar_confirm_weak_streak = 0;
+    }
+}
+
+int
+dstar_confirm_is_confirmed(const dsd_state* state) {
+    return state && state->dstar_confirmed != 0;
+}

--- a/src/protocol/dstar/dstar_confirm.h
+++ b/src/protocol/dstar/dstar_confirm.h
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Whether a D-STAR transmission has proved itself well enough to hold a hunt profile.
+ *
+ * processDSTAR() spends 1992 symbols on any voice sync and, before this module, could say
+ * nothing about them: no return value, no error accumulator, no frame-count check. It
+ * overwrites state->errs/errs2 twenty-one times and reads them never, and those are soft
+ * AMBE correction counts in any case -- mbelib's Golay(23,12) maps every input to some
+ * codeword, so there is no hard validity verdict hiding in them. On the 4800/2 hunt profile
+ * D-STAR is the only candidate, so a false match held the profile for the largest block any
+ * handler consumes (issues #391, #421).
+ *
+ * Two kinds of evidence answer that. A CRC-16/X.25 is proof on its own, and D-STAR offers
+ * two of them: the RF header, and the header rebroadcast that ICOM radios fold into slow
+ * data through a transmission. So is the "$$CRC" fixed-form literal, which needs the 0x35
+ * type byte and forty more exact bits behind it.
+ *
+ * A superframe that carries only filler proves none of that, so it counts as weak evidence
+ * and has to repeat. That is a real check rather than a guess about quality: two counted
+ * frames in a row mean a second exact 24-symbol sync word was matched -- strcmp, no error
+ * budget -- within the matchless pass that would otherwise have torn the carrier down, since
+ * getFrameSync() runs the no-carrier hook after DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS symbols
+ * and that hook resets this module. Against noise that is roughly 4 patterns x 1800 symbols
+ * x 2^-24, about four in ten thousand per false match, and a false confirmation still dies at
+ * the next matchless pass. A real call pays at most one superframe of withheld credit, and
+ * none at all when it opens with a decodable RF header.
+ *
+ * Sibling of src/protocol/provoice/provoice_confirm.{c,h}, src/protocol/nxdn/nxdn_confirm.{c,h},
+ * src/protocol/m17/m17_confirm.{c,h} and src/protocol/dmr/dmr_confidence.{c,h}, which do the
+ * same job for those protocols.
+ */
+
+#ifndef DSD_NEO_PROTOCOL_DSTAR_DSTAR_CONFIRM_H
+#define DSD_NEO_PROTOCOL_DSTAR_DSTAR_CONFIRM_H
+
+#include <dsd-neo/core/state_fwd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief How much a passing check is worth. */
+typedef enum {
+    DSTAR_EVIDENCE_WEAK = 1,  /**< A superframe that decoded but checked nothing. */
+    DSTAR_EVIDENCE_STRONG = 2 /**< A CRC-16/X.25: RF header or slow-data header. Also "$$CRC". */
+} dstar_evidence;
+
+/** @brief Frames of weak evidence in a row that together confirm a transmission. */
+#define DSTAR_CONFIRM_WEAK_OBSERVES 2U
+
+/** @brief Forget everything learned about the current transmission. */
+void dstar_confirm_reset(dsd_state* state);
+
+/** @brief Start a frame's evidence accounting; call once before decoding its contents. */
+void dstar_confirm_begin_frame(dsd_state* state);
+
+/**
+ * @brief Report a check this frame passed.
+ *
+ * Strong evidence confirms immediately. Weak evidence counts once per frame however many
+ * times it is reported, and confirms on the DSTAR_CONFIRM_WEAK_OBSERVES'th frame in a row.
+ */
+void dstar_confirm_note_evidence(dsd_state* state, dstar_evidence evidence);
+
+/** @brief Close a frame's accounting; a frame that proved nothing breaks the weak streak. */
+void dstar_confirm_end_frame(dsd_state* state);
+
+/** @brief Whether the current transmission has proved itself. */
+int dstar_confirm_is_confirmed(const dsd_state* state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_PROTOCOL_DSTAR_DSTAR_CONFIRM_H */

--- a/src/protocol/dstar/dstar_slow_data.c
+++ b/src/protocol/dstar/dstar_slow_data.c
@@ -18,6 +18,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "dstar_confirm.h"
 
 static inline void dsd_append(char* dst, size_t dstsz, const char* src);
 
@@ -181,6 +182,9 @@ dstar_sd_print_header_flags(uint8_t flags) {
 static void
 dstar_sd_handle_header_format(dsd_state* state, const dstar_sd_ctx* ctx) {
     if (ctx->crc_cmp == ctx->crc_ext) {
+        /* A CRC-16/X.25 over 39 octets of rebroadcast header: proof the transmission is
+         * real, on its own (#421). */
+        dstar_confirm_note_evidence(state, DSTAR_EVIDENCE_STRONG);
         DSD_FPRINTF(stderr, " RPT 2: %s", ctx->str1);
         DSD_FPRINTF(stderr, " RPT 1: %s", ctx->str2);
         DSD_FPRINTF(stderr, " DST: %s", ctx->str3);
@@ -363,6 +367,9 @@ dstar_sd_handle_text_message(dsd_state* state, dstar_sd_ctx* ctx) {
 static void
 dstar_sd_handle_fixed_form(dsd_state* state, dstar_sd_ctx* ctx) {
     if (strcmp(ctx->type, "$$CRC") == 0) {
+        /* Forty exact bits behind the 0x35 type byte that selected this branch: not a
+         * checksum, but a literal noise does not produce (#421). */
+        dstar_confirm_note_evidence(state, DSTAR_EVIDENCE_STRONG);
         DSD_MEMSET(ctx->strt, 0x20, sizeof(ctx->strt));
         DSD_FPRINTF(stderr, " DATA: ");
         dstar_sd_emit_truncated_ascii(ctx->sd_bytes, ctx->strt, 0);

--- a/src/protocol/provoice/CMakeLists.txt
+++ b/src/protocol/provoice/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_library(dsd-neo_proto_provoice)
 
-target_sources(dsd-neo_proto_provoice PRIVATE provoice.c provoice_frame.c)
+target_sources(
+    dsd-neo_proto_provoice
+    PRIVATE provoice.c provoice_confirm.c provoice_frame.c
+)
 
 target_include_directories(
     dsd-neo_proto_provoice

--- a/src/protocol/provoice/provoice.c
+++ b/src/protocol/provoice/provoice.c
@@ -14,6 +14,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "provoice_confirm.h"
 #include "provoice_frame.h"
 
 typedef struct {
@@ -91,7 +92,7 @@ provoice_decode_imbe_pair(dsd_opts* opts, dsd_state* state, char frame1[7][24], 
     provoice_play_voice(opts, state);
 }
 
-void
+int
 processProVoice(dsd_opts* opts, dsd_state* state) {
     uint8_t raw_bits[800];
     char imbe7100_fr1[DSD_PROVOICE_IMBE_ROWS][DSD_PROVOICE_IMBE_COLS];
@@ -103,6 +104,12 @@ processProVoice(dsd_opts* opts, dsd_state* state) {
     provoice_reader reader;
 
     DSD_MEMSET(raw_bits, 0, sizeof(raw_bits));
+
+    /* Nothing in the frame below can fail a check, so the evidence is that this one arrived
+     * behind its own exact 32-symbol sync word. Weak on its own; two in a row confirm the
+     * transmission -- see provoice_confirm.h. */
+    provoice_confirm_begin_frame(state);
+    provoice_confirm_note_evidence(state, PROVOICE_EVIDENCE_WEAK);
 
     reader.opts = opts;
     reader.state = state;
@@ -124,7 +131,8 @@ processProVoice(dsd_opts* opts, dsd_state* state) {
 
     if (dsd_provoice_load_imbe_frame_pair(provoice_next_dibit_callback, &reader, imbe7100_fr1, imbe7100_fr2) < 0) {
         DSD_FPRINTF(stderr, "\n");
-        return;
+        provoice_confirm_end_frame(state);
+        return provoice_confirm_is_confirmed(state);
     }
     provoice_decode_imbe_pair(opts, state, imbe7100_fr1, imbe7100_fr2);
 
@@ -137,10 +145,14 @@ processProVoice(dsd_opts* opts, dsd_state* state) {
 
     if (dsd_provoice_load_imbe_frame_pair(provoice_next_dibit_callback, &reader, imbe7100_fr1, imbe7100_fr2) < 0) {
         DSD_FPRINTF(stderr, "\n");
-        return;
+        provoice_confirm_end_frame(state);
+        return provoice_confirm_is_confirmed(state);
     }
     provoice_decode_imbe_pair(opts, state, imbe7100_fr1, imbe7100_fr2);
 
     provoice_read_raw_bits(&reader, 2);
     DSD_FPRINTF(stderr, "\n");
+
+    provoice_confirm_end_frame(state);
+    return provoice_confirm_is_confirmed(state);
 }

--- a/src/protocol/provoice/provoice_confirm.c
+++ b/src/protocol/provoice/provoice_confirm.c
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "provoice_confirm.h"
+
+#include <dsd-neo/core/state.h>
+#include <stdint.h>
+
+#include "dsd-neo/core/state_fwd.h"
+
+void
+provoice_confirm_reset(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    state->provoice_confirmed = 0;
+    state->provoice_confirm_weak_streak = 0;
+    state->provoice_confirm_frame_evidence = 0;
+}
+
+void
+provoice_confirm_begin_frame(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    state->provoice_confirm_frame_evidence = 0;
+}
+
+void
+provoice_confirm_note_evidence(dsd_state* state, provoice_evidence evidence) {
+    if (!state) {
+        return;
+    }
+    if (evidence == PROVOICE_EVIDENCE_STRONG) {
+        state->provoice_confirm_frame_evidence = (uint8_t)PROVOICE_EVIDENCE_STRONG;
+        state->provoice_confirm_weak_streak = 0;
+        state->provoice_confirmed = 1;
+        return;
+    }
+    if (evidence != PROVOICE_EVIDENCE_WEAK || state->provoice_confirm_frame_evidence != 0) {
+        /* One frame is one frame's worth of evidence however often it is reported. */
+        return;
+    }
+    state->provoice_confirm_frame_evidence = (uint8_t)PROVOICE_EVIDENCE_WEAK;
+    if (state->provoice_confirm_weak_streak < 0xFFU) {
+        state->provoice_confirm_weak_streak++;
+    }
+    if (state->provoice_confirm_weak_streak >= PROVOICE_CONFIRM_WEAK_OBSERVES) {
+        state->provoice_confirmed = 1;
+    }
+}
+
+void
+provoice_confirm_end_frame(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    if (state->provoice_confirm_frame_evidence == 0) {
+        state->provoice_confirm_weak_streak = 0;
+    }
+}
+
+int
+provoice_confirm_is_confirmed(const dsd_state* state) {
+    return state && state->provoice_confirmed != 0;
+}

--- a/src/protocol/provoice/provoice_confirm.h
+++ b/src/protocol/provoice/provoice_confirm.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Whether a ProVoice transmission has proved itself well enough to hold a hunt profile.
+ *
+ * ProVoice has nothing checkable in it. processProVoice() spends 736 dibits per call and the
+ * frame carries no CRC, no BCH and no parity anywhere: the 64-bit opening field, the 16-bit
+ * LID and the 64-bit secondary are read into locals and printed under -p, and the two IMBE
+ * pairs behind them yield only mbelib correction counts, which map every input to some
+ * codeword and so never fail. Its one early return fires when the dibit callback fails, never
+ * on bad data. On the 9600/2 hunt profile it shares with EDACS -- which does report its BCH
+ * verdict -- a false ProVoice match therefore bought 736 symbols of dwell that EDACS's own
+ * gate would have refused (issues #391, #421).
+ *
+ * What is checkable is that the stream keeps coming. A real voice channel emits frames
+ * back to back, each behind a fresh 32-symbol sync word matched exactly, with no error
+ * budget; noise does not supply a second one. So a frame counts as weak evidence and has to
+ * repeat: two in a row confirm, and getFrameSync() runs the no-carrier hook -- which resets
+ * this module -- after DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS matchless symbols, so "in a row"
+ * cannot span a dead channel. Against noise that is roughly 4 patterns x 1800 symbols x
+ * 2^-32, under two in a million per false match. A real call confirms on its second frame,
+ * about 77 ms in, and a single dropped sync mid-call does not break the streak because one
+ * missed frame is far short of a whole matchless pass.
+ *
+ * The LID would be the obvious content to key on -- it should repeat within a transmission --
+ * but there is no committed ProVoice fixture to measure against and EDACS ESK masking of
+ * these fields is unverified. Keying a verdict on it risks the failure #391 names explicitly:
+ * live traffic that decodes but never reports it, rotating the hunt away.
+ *
+ * Sibling of src/protocol/dstar/dstar_confirm.{c,h}, src/protocol/nxdn/nxdn_confirm.{c,h},
+ * src/protocol/m17/m17_confirm.{c,h} and src/protocol/dmr/dmr_confidence.{c,h}, which do the
+ * same job for those protocols.
+ */
+
+#ifndef DSD_NEO_PROTOCOL_PROVOICE_PROVOICE_CONFIRM_H
+#define DSD_NEO_PROTOCOL_PROVOICE_PROVOICE_CONFIRM_H
+
+#include <dsd-neo/core/state_fwd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief How much a passing check is worth. */
+typedef enum {
+    PROVOICE_EVIDENCE_WEAK = 1, /**< A frame that decoded behind its own exact sync word. */
+    /** Reserved: no ProVoice field carries a check that can fail. Kept so this module reads
+     *  the same as its siblings and so a future checkable field has somewhere to report. */
+    PROVOICE_EVIDENCE_STRONG = 2
+} provoice_evidence;
+
+/** @brief Frames of weak evidence in a row that together confirm a transmission. */
+#define PROVOICE_CONFIRM_WEAK_OBSERVES 2U
+
+/** @brief Forget everything learned about the current transmission. */
+void provoice_confirm_reset(dsd_state* state);
+
+/** @brief Start a frame's evidence accounting; call once before decoding its contents. */
+void provoice_confirm_begin_frame(dsd_state* state);
+
+/**
+ * @brief Report a check this frame passed.
+ *
+ * Strong evidence confirms immediately. Weak evidence counts once per frame however many
+ * times it is reported, and confirms on the PROVOICE_CONFIRM_WEAK_OBSERVES'th frame in a row.
+ */
+void provoice_confirm_note_evidence(dsd_state* state, provoice_evidence evidence);
+
+/** @brief Close a frame's accounting; a frame that proved nothing breaks the weak streak. */
+void provoice_confirm_end_frame(dsd_state* state);
+
+/** @brief Whether the current transmission has proved itself. */
+int provoice_confirm_is_confirmed(const dsd_state* state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_PROTOCOL_PROVOICE_PROVOICE_CONFIRM_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -890,12 +890,28 @@ add_executable(
     protocol/dstar/test_dstar_process.c
     ${PROJECT_SOURCE_DIR}/src/core/audio/dispatch.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dstar/dstar.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dstar/dstar_confirm.c
 )
 target_include_directories(
     dsd-neo_test_dstar_process
-    PRIVATE ${PROJECT_SOURCE_DIR}/include
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/protocol/dstar
 )
 add_test(NAME DSTAR_PROCESS COMMAND dsd-neo_test_dstar_process)
+
+add_executable(
+    dsd-neo_test_dstar_confirm
+    protocol/dstar/test_dstar_confirm.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dstar/dstar_confirm.c
+)
+target_include_directories(
+    dsd-neo_test_dstar_confirm
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/protocol/dstar
+)
+add_test(NAME DSTAR_CONFIRM COMMAND dsd-neo_test_dstar_confirm)
 
 add_executable(
     dsd-neo_test_dstar_sync_dispatch
@@ -929,6 +945,7 @@ add_executable(
     protocol/provoice/test_provoice_process.c
     test_support/call_state_stubs.c
     ${PROJECT_SOURCE_DIR}/src/protocol/provoice/provoice.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/provoice/provoice_confirm.c
     ${PROJECT_SOURCE_DIR}/src/protocol/provoice/provoice_frame.c
 )
 target_include_directories(
@@ -938,6 +955,19 @@ target_include_directories(
         ${PROJECT_SOURCE_DIR}/src/protocol/provoice
 )
 add_test(NAME PROVOICE_PROCESS COMMAND dsd-neo_test_provoice_process)
+
+add_executable(
+    dsd-neo_test_provoice_confirm
+    protocol/provoice/test_provoice_confirm.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/provoice/provoice_confirm.c
+)
+target_include_directories(
+    dsd-neo_test_provoice_confirm
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+        ${PROJECT_SOURCE_DIR}/src/protocol/provoice
+)
+add_test(NAME PROVOICE_CONFIRM COMMAND dsd-neo_test_provoice_confirm)
 
 add_executable(
     dsd-neo_test_provoice_sync_dispatch

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -352,12 +352,27 @@ main(void) {
     // productive to the SPS hunt for as long as this flag stands, so carrying it across a carrier
     // loss would let the next channel's first FICH failure buy dwell it validated nothing for.
     state->ysf_fich_confirmed = 1U;
+    // D-STAR and ProVoice carry the same kind of evidence (issue #421). Both lean on a weak
+    // streak that only means anything while the frames stay adjacent, so carrying a streak --
+    // or a confirmation -- across a carrier loss would let the next channel's first false
+    // match buy the 1992 or 736 symbols it consumed.
+    state->dstar_confirmed = 1;
+    state->dstar_confirm_weak_streak = 1;
+    state->dstar_confirm_frame_evidence = 2;
+    state->provoice_confirmed = 1;
+    state->provoice_confirm_weak_streak = 1;
+    state->provoice_confirm_frame_evidence = 2;
 
     noCarrier(opts, state);
 
     rc |= expect_true("nxdn-confirmation-reset", state->nxdn_confirmed == 0 && state->nxdn_confirm_weak_streak == 0
                                                      && state->nxdn_confirm_frame_evidence == 0);
     rc |= expect_true("ysf-fich-confirmation-reset", state->ysf_fich_confirmed == 0U);
+    rc |= expect_true("dstar-confirmation-reset", state->dstar_confirmed == 0 && state->dstar_confirm_weak_streak == 0
+                                                      && state->dstar_confirm_frame_evidence == 0);
+    rc |= expect_true("provoice-confirmation-reset", state->provoice_confirmed == 0
+                                                         && state->provoice_confirm_weak_streak == 0
+                                                         && state->provoice_confirm_frame_evidence == 0);
 
     dsd_call_snapshot ended_call;
     rc |= expect_true("no-carrier retains canonical snapshot", dsd_call_state_get(state, 0U, &ended_call) == 1);

--- a/tests/protocol/dstar/test_dstar_confirm.c
+++ b/tests/protocol/dstar/test_dstar_confirm.c
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Unit coverage for the D-STAR transmission confirmation gate (issue #421).
+ *
+ * The gate decides whether the 1992 symbols a voice superframe consumes bought the hunt
+ * profile anything. A CRC-16/X.25 -- the RF header, or the header rebroadcast in slow data --
+ * is proof by itself; a superframe that carries only filler has to repeat, because one
+ * arriving at all means a second exact 24-symbol sync word was matched.
+ *
+ * Sibling of tests/protocol/provoice/test_provoice_confirm.c and
+ * tests/protocol/nxdn/test_nxdn_confirm.c.
+ */
+
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "dsd-neo/core/state_fwd.h"
+#include "dstar_confirm.h"
+
+static int g_failures;
+
+static void
+expect(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", label, got, want);
+        g_failures++;
+    }
+}
+
+/** @brief One superframe that reported @p evidence, or nothing when @p evidence is 0. */
+static void
+run_frame(dsd_state* state, int evidence) {
+    dstar_confirm_begin_frame(state);
+    if (evidence != 0) {
+        dstar_confirm_note_evidence(state, (dstar_evidence)evidence);
+    }
+    dstar_confirm_end_frame(state);
+}
+
+int
+main(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!state) {
+        DSD_FPRINTF(stderr, "alloc-failed: dsd_state\n");
+        return 1;
+    }
+
+    /* Nothing is believed until something checks out. */
+    expect("fresh state is unconfirmed", dstar_confirm_is_confirmed(state), 0);
+
+    /* One CRC-16 is enough. */
+    run_frame(state, DSTAR_EVIDENCE_STRONG);
+    expect("one strong frame confirms", dstar_confirm_is_confirmed(state), 1);
+
+    /* Confirmation survives later superframes that prove nothing: a real call whose slow data
+     * carries only filler is still decoding, and withdrawing the verdict mid-transmission
+     * would rotate the hunt off live traffic -- the risk #391 names. */
+    run_frame(state, 0);
+    run_frame(state, 0);
+    expect("confirmation survives empty frames", dstar_confirm_is_confirmed(state), 1);
+
+    dstar_confirm_reset(state);
+    expect("reset clears confirmation", dstar_confirm_is_confirmed(state), 0);
+
+    /* One unchecked superframe is not enough; the second running is. */
+    run_frame(state, DSTAR_EVIDENCE_WEAK);
+    expect("one weak frame is pending", dstar_confirm_is_confirmed(state), 0);
+    run_frame(state, DSTAR_EVIDENCE_WEAK);
+    expect("two weak frames confirm", dstar_confirm_is_confirmed(state), 1);
+
+    /* The two have to be consecutive. */
+    dstar_confirm_reset(state);
+    run_frame(state, DSTAR_EVIDENCE_WEAK);
+    run_frame(state, 0);
+    run_frame(state, DSTAR_EVIDENCE_WEAK);
+    expect("a gap breaks the weak streak", dstar_confirm_is_confirmed(state), 0);
+    run_frame(state, DSTAR_EVIDENCE_WEAK);
+    expect("the streak resumes from the gap", dstar_confirm_is_confirmed(state), 1);
+
+    /* Reporting the same superframe twice is one frame's worth of evidence, not two --
+     * otherwise a single false match would confirm itself. */
+    dstar_confirm_reset(state);
+    dstar_confirm_begin_frame(state);
+    dstar_confirm_note_evidence(state, DSTAR_EVIDENCE_WEAK);
+    dstar_confirm_note_evidence(state, DSTAR_EVIDENCE_WEAK);
+    dstar_confirm_note_evidence(state, DSTAR_EVIDENCE_WEAK);
+    dstar_confirm_end_frame(state);
+    expect("weak evidence counts once per frame", dstar_confirm_is_confirmed(state), 0);
+
+    /* A CRC arriving after the superframe was counted still confirms immediately: that is the
+     * order the decoder produces them in, since the slow data is read last. */
+    dstar_confirm_reset(state);
+    run_frame(state, DSTAR_EVIDENCE_WEAK);
+    dstar_confirm_begin_frame(state);
+    dstar_confirm_note_evidence(state, DSTAR_EVIDENCE_WEAK);
+    dstar_confirm_note_evidence(state, DSTAR_EVIDENCE_STRONG);
+    dstar_confirm_end_frame(state);
+    expect("strong evidence overrides a pending streak", dstar_confirm_is_confirmed(state), 1);
+
+    /* NULL is tolerated: the gate is called from paths that run before state exists. */
+    dstar_confirm_reset(NULL);
+    dstar_confirm_begin_frame(NULL);
+    dstar_confirm_note_evidence(NULL, DSTAR_EVIDENCE_STRONG);
+    dstar_confirm_end_frame(NULL);
+    expect("null state is not confirmed", dstar_confirm_is_confirmed(NULL), 0);
+
+    free(state);
+    if (g_failures == 0) {
+        DSD_FPRINTF(stdout, "DSTAR_CONFIRM: OK\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/protocol/dstar/test_dstar_process.c
+++ b/tests/protocol/dstar/test_dstar_process.c
@@ -201,7 +201,9 @@ test_voice_process_without_telemetry(void) {
     opts.pulse_digi_out_channels = 1;
     reset_counters();
 
-    processDSTAR(&opts, &state);
+    /* Unconfirmed on its own: one superframe whose slow data checked nothing is weak
+     * evidence, and weak evidence has to repeat (#421). */
+    assert(processDSTAR(&opts, &state) == 0);
 
     assert_voice_loop_counts(0);
     assert(soft_symbol_calls == 0);
@@ -270,12 +272,83 @@ test_header_process_reports_the_header_crc_verdict(void) {
     header_decode_soft_result = 1;
 }
 
+/* #421: the 1992 symbols a superframe takes are the largest block any handler consumes, on
+ * the profile where D-STAR is the only candidate. One is weak evidence -- an exact 24-symbol
+ * sync word was matched, nothing more -- so the verdict only turns productive when a second
+ * arrives before the carrier drops. */
+static void
+test_voice_process_confirms_on_the_second_superframe(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.floating_point = 1;
+    opts.pulse_digi_out_channels = 1;
+
+    reset_counters();
+    assert(processDSTAR(&opts, &state) == 0);
+    assert(state.dstar_confirm_weak_streak == 1);
+
+    reset_counters();
+    assert(processDSTAR(&opts, &state) == 1);
+    assert(state.dstar_confirmed == 1);
+
+    /* Sticky: a third superframe that proves nothing of its own stays productive, because a
+     * confirmed transmission that fades is still decoding (#391). */
+    reset_counters();
+    assert(processDSTAR(&opts, &state) == 1);
+
+    /* And it clears with the carrier. */
+    dstar_confirm_reset(&state);
+    assert(state.dstar_confirmed == 0);
+    assert(state.dstar_confirm_weak_streak == 0);
+}
+
+/* A passing header CRC-16/X.25 is proof on its own, so the voice superframe behind it is
+ * productive on the first call rather than the second (#421). */
+static void
+test_passing_header_confirms_the_voice_frame_behind_it(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.floating_point = 1;
+    opts.pulse_digi_out_channels = 1;
+    reset_counters();
+
+    header_decode_soft_result = 1;
+    assert(processDSTAR_HD(&opts, &state) == 1);
+    assert(state.dstar_confirmed == 1);
+}
+
+/* A failed header leaves the transmission unproved: the superframe it consumed anyway is
+ * weak evidence only, so it reports unconfirmed and the header's own verdict stands. */
+static void
+test_failed_header_leaves_the_transmission_pending(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.floating_point = 1;
+    opts.pulse_digi_out_channels = 1;
+    reset_counters();
+
+    header_decode_soft_result = 0;
+    assert(processDSTAR_HD(&opts, &state) == 0);
+    assert(state.dstar_confirmed == 0);
+    assert(state.dstar_confirm_weak_streak == 1);
+    header_decode_soft_result = 1;
+}
+
 int
 main(void) {
     test_voice_process_without_telemetry();
     test_voice_process_with_telemetry_attached();
     test_header_process_captures_header_then_voice();
     test_header_process_reports_the_header_crc_verdict();
+    test_voice_process_confirms_on_the_second_superframe();
+    test_passing_header_confirms_the_voice_frame_behind_it();
+    test_failed_header_leaves_the_transmission_pending();
     printf("DSTAR_PROCESS: OK\n");
     return 0;
 }

--- a/tests/protocol/dstar/test_dstar_sync_dispatch.c
+++ b/tests/protocol/dstar/test_dstar_sync_dispatch.c
@@ -39,11 +39,15 @@ openMbeOutFile(dsd_opts* opts, dsd_state* state) {
     open_calls++;
 }
 
-void
+/* The stubbed confirmation verdict dsd_dispatch_handle_dstar() must pass through. */
+static int voice_confirm_result = 1;
+
+int
 processDSTAR(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
     voice_calls++;
+    return voice_confirm_result;
 }
 
 /* The stubbed header CRC verdict dsd_dispatch_handle_dstar() must pass through. */
@@ -96,7 +100,9 @@ test_voice_dispatch(void) {
         DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "%s", "out");
         state.synctype = voice_synctypes[i];
 
-        /* Voice stays productive: processDSTAR() has no verdict at any point (#391). */
+        /* A confirmed transmission is productive: the superframe decoded content that
+         * proved itself, so the 1992 symbols it took are earned (#421). */
+        voice_confirm_result = 1;
         assert(dsd_dispatch_handle_dstar(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
 
         assert(strcmp(state.fsubtype, " VOICE        ") == 0);
@@ -131,8 +137,35 @@ test_header_dispatch(void) {
     }
 }
 
+/* #421: until a D-STAR transmission proves itself -- a CRC-16/X.25 on the RF header or the
+ * slow-data header rebroadcast, or a second superframe behind its own exact sync word -- the
+ * 1992 symbols a voice superframe consumes validated nothing, and the SPS hunt must not pay
+ * for them. This is the hole #419 left open. */
+static void
+test_unconfirmed_voice_reports_unproductive(void) {
+    static const int voice_synctypes[] = {DSD_SYNC_DSTAR_VOICE_POS, DSD_SYNC_DSTAR_VOICE_NEG};
+
+    for (size_t i = 0; i < sizeof voice_synctypes / sizeof voice_synctypes[0]; i++) {
+        static dsd_opts opts;
+        static dsd_state state;
+        DSD_MEMSET(&opts, 0, sizeof(opts));
+        DSD_MEMSET(&state, 0, sizeof(state));
+        reset_calls();
+
+        state.synctype = voice_synctypes[i];
+        voice_confirm_result = 0;
+
+        assert(dsd_dispatch_handle_dstar(&opts, &state) == DSD_FRAME_VERDICT_UNPRODUCTIVE);
+        assert(voice_calls == 1);
+        assert(header_calls == 0);
+    }
+    voice_confirm_result = 1;
+}
+
 /* #391: a header whose CRC-16/X.25 failed consumed 2652 symbols and validated none of them,
- * so the handler must say so rather than letting the SPS hunt pay for them. */
+ * so the handler must say so rather than letting the SPS hunt pay for them. A header opens a
+ * transmission, so it reports its own verdict even where the voice frame behind it confirms
+ * (#421). */
 static void
 test_failed_header_reports_unproductive(void) {
     static dsd_opts opts;
@@ -143,6 +176,7 @@ test_failed_header_reports_unproductive(void) {
 
     state.synctype = DSD_SYNC_DSTAR_HD_POS;
     header_decode_result = 0;
+    voice_confirm_result = 1;
 
     assert(dsd_dispatch_handle_dstar(&opts, &state) == DSD_FRAME_VERDICT_UNPRODUCTIVE);
     assert(header_calls == 1);
@@ -154,6 +188,7 @@ main(void) {
     test_sync_pattern_lengths();
     test_synctype_helpers();
     test_voice_dispatch();
+    test_unconfirmed_voice_reports_unproductive();
     test_header_dispatch();
     test_failed_header_reports_unproductive();
     printf("DSTAR_SYNC_DISPATCH: OK\n");

--- a/tests/protocol/provoice/test_provoice_confirm.c
+++ b/tests/protocol/provoice/test_provoice_confirm.c
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Unit coverage for the ProVoice transmission confirmation gate (issue #421).
+ *
+ * The gate decides whether the 736 dibits a frame consumes bought the hunt profile anything.
+ * Nothing inside a ProVoice frame can fail a check, so the only evidence is that a frame
+ * arrived at all -- behind its own exact 32-symbol sync word -- and it has to repeat. The
+ * strong tier has no producer in the decoder today and is exercised here so the module keeps
+ * reading the same as its siblings.
+ *
+ * Sibling of tests/protocol/dstar/test_dstar_confirm.c and
+ * tests/protocol/nxdn/test_nxdn_confirm.c.
+ */
+
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "dsd-neo/core/state_fwd.h"
+#include "provoice_confirm.h"
+
+static int g_failures;
+
+static void
+expect(const char* label, int got, int want) {
+    if (got != want) {
+        DSD_FPRINTF(stderr, "%s: got %d want %d\n", label, got, want);
+        g_failures++;
+    }
+}
+
+/** @brief One frame that reported @p evidence, or nothing when @p evidence is 0. */
+static void
+run_frame(dsd_state* state, int evidence) {
+    provoice_confirm_begin_frame(state);
+    if (evidence != 0) {
+        provoice_confirm_note_evidence(state, (provoice_evidence)evidence);
+    }
+    provoice_confirm_end_frame(state);
+}
+
+int
+main(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!state) {
+        DSD_FPRINTF(stderr, "alloc-failed: dsd_state\n");
+        return 1;
+    }
+
+    /* Nothing is believed until something checks out. */
+    expect("fresh state is unconfirmed", provoice_confirm_is_confirmed(state), 0);
+
+    /* One CRC-16 is enough. */
+    run_frame(state, PROVOICE_EVIDENCE_STRONG);
+    expect("one strong frame confirms", provoice_confirm_is_confirmed(state), 1);
+
+    /* Confirmation survives later frames that prove nothing: a real call is still decoding,
+     * and withdrawing the verdict mid-transmission would rotate the hunt off live traffic --
+     * the risk #391 names. */
+    run_frame(state, 0);
+    run_frame(state, 0);
+    expect("confirmation survives empty frames", provoice_confirm_is_confirmed(state), 1);
+
+    provoice_confirm_reset(state);
+    expect("reset clears confirmation", provoice_confirm_is_confirmed(state), 0);
+
+    /* One frame is not enough; the second running is. */
+    run_frame(state, PROVOICE_EVIDENCE_WEAK);
+    expect("one weak frame is pending", provoice_confirm_is_confirmed(state), 0);
+    run_frame(state, PROVOICE_EVIDENCE_WEAK);
+    expect("two weak frames confirm", provoice_confirm_is_confirmed(state), 1);
+
+    /* The two have to be consecutive. */
+    provoice_confirm_reset(state);
+    run_frame(state, PROVOICE_EVIDENCE_WEAK);
+    run_frame(state, 0);
+    run_frame(state, PROVOICE_EVIDENCE_WEAK);
+    expect("a gap breaks the weak streak", provoice_confirm_is_confirmed(state), 0);
+    run_frame(state, PROVOICE_EVIDENCE_WEAK);
+    expect("the streak resumes from the gap", provoice_confirm_is_confirmed(state), 1);
+
+    /* Reporting the same frame twice is one frame's worth of evidence, not two -- otherwise
+     * a single false match would confirm itself. */
+    provoice_confirm_reset(state);
+    provoice_confirm_begin_frame(state);
+    provoice_confirm_note_evidence(state, PROVOICE_EVIDENCE_WEAK);
+    provoice_confirm_note_evidence(state, PROVOICE_EVIDENCE_WEAK);
+    provoice_confirm_note_evidence(state, PROVOICE_EVIDENCE_WEAK);
+    provoice_confirm_end_frame(state);
+    expect("weak evidence counts once per frame", provoice_confirm_is_confirmed(state), 0);
+
+    /* Strong evidence still confirms immediately where a frame has already been counted. */
+    provoice_confirm_reset(state);
+    run_frame(state, PROVOICE_EVIDENCE_WEAK);
+    provoice_confirm_begin_frame(state);
+    provoice_confirm_note_evidence(state, PROVOICE_EVIDENCE_WEAK);
+    provoice_confirm_note_evidence(state, PROVOICE_EVIDENCE_STRONG);
+    provoice_confirm_end_frame(state);
+    expect("strong evidence overrides a pending streak", provoice_confirm_is_confirmed(state), 1);
+
+    /* NULL is tolerated: the gate is called from paths that run before state exists. */
+    provoice_confirm_reset(NULL);
+    provoice_confirm_begin_frame(NULL);
+    provoice_confirm_note_evidence(NULL, PROVOICE_EVIDENCE_STRONG);
+    provoice_confirm_end_frame(NULL);
+    expect("null state is not confirmed", provoice_confirm_is_confirmed(NULL), 0);
+
+    free(state);
+    if (g_failures == 0) {
+        DSD_FPRINTF(stdout, "PROVOICE_CONFIRM: OK\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+}

--- a/tests/protocol/provoice/test_provoice_process.c
+++ b/tests/protocol/provoice/test_provoice_process.c
@@ -121,7 +121,8 @@ test_process_voice_integer_playback(void) {
     state.edacs_tuned_lcn = 4;
     reset_counters();
 
-    processProVoice(&opts, &state);
+    /* Unconfirmed on its own: one frame proves only that its own sync word matched (#421). */
+    assert(processProVoice(&opts, &state) == 0);
 
     assert(dibit_calls == PROVOICE_EXPECTED_TOTAL_DIBITS);
     assert(mbe_calls == 4);
@@ -144,7 +145,7 @@ test_process_voice_float_playback(void) {
     state.edacs_tuned_lcn = 6;
     reset_counters();
 
-    processProVoice(&opts, &state);
+    assert(processProVoice(&opts, &state) == 0);
 
     assert(dibit_calls == PROVOICE_EXPECTED_TOTAL_DIBITS);
     assert(mbe_calls == 4);
@@ -152,10 +153,40 @@ test_process_voice_float_playback(void) {
     assert(play_fm_calls == 4);
 }
 
+/* #421: nothing inside the 736 dibits can fail a check, so a lone frame buys the 9600/2
+ * profile nothing. Two in a row -- each behind its own exact 32-symbol sync word, which noise
+ * does not supply twice before the carrier drops -- confirm the transmission. */
+static void
+test_voice_process_confirms_on_the_second_frame(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.floating_point = 1;
+
+    reset_counters();
+    assert(processProVoice(&opts, &state) == 0);
+    assert(state.provoice_confirm_weak_streak == 1);
+
+    reset_counters();
+    assert(processProVoice(&opts, &state) == 1);
+    assert(state.provoice_confirmed == 1);
+
+    /* Sticky: a confirmed transmission stays productive. */
+    reset_counters();
+    assert(processProVoice(&opts, &state) == 1);
+
+    /* And it clears with the carrier. */
+    provoice_confirm_reset(&state);
+    assert(state.provoice_confirmed == 0);
+    assert(state.provoice_confirm_weak_streak == 0);
+}
+
 int
 main(void) {
     test_process_voice_integer_playback();
     test_process_voice_float_playback();
+    test_voice_process_confirms_on_the_second_frame();
     printf("PROVOICE_PROCESS: OK\n");
     return 0;
 }

--- a/tests/protocol/provoice/test_provoice_sync_dispatch.c
+++ b/tests/protocol/provoice/test_provoice_sync_dispatch.c
@@ -37,11 +37,15 @@ openMbeOutFile(dsd_opts* opts, dsd_state* state) {
     open_calls++;
 }
 
-void
+/* The stubbed confirmation verdict dsd_dispatch_handle_provoice() must pass through. */
+static int voice_confirm_result = 1;
+
+int
 processProVoice(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
     voice_calls++;
+    return voice_confirm_result;
 }
 
 static void
@@ -89,12 +93,38 @@ test_voice_dispatch(void) {
         DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "%s", "out");
         state.synctype = voice_synctypes[i];
 
-        dsd_dispatch_handle_provoice(&opts, &state);
+        /* A confirmed transmission is productive: a second frame arrived behind its own
+         * exact 32-symbol sync word, so the 736 dibits are earned (#421). */
+        voice_confirm_result = 1;
+        assert(dsd_dispatch_handle_provoice(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
 
         assert(strcmp(state.fsubtype, " VOICE        ") == 0);
         assert(open_calls == 1);
         assert(voice_calls == 1);
     }
+}
+
+/* #421: nothing inside a ProVoice frame can fail a check, so a lone frame proves nothing.
+ * Until a second one arrives behind its own sync word the 736 dibits validated nothing, and
+ * the SPS hunt must not pay for them on the 9600/2 profile EDACS shares. */
+static void
+test_unconfirmed_voice_reports_unproductive(void) {
+    static const int voice_synctypes[] = {DSD_SYNC_PROVOICE_POS, DSD_SYNC_PROVOICE_NEG};
+
+    for (size_t i = 0; i < sizeof voice_synctypes / sizeof voice_synctypes[0]; i++) {
+        static dsd_opts opts;
+        static dsd_state state;
+        DSD_MEMSET(&opts, 0, sizeof(opts));
+        DSD_MEMSET(&state, 0, sizeof(state));
+        reset_calls();
+
+        state.synctype = voice_synctypes[i];
+        voice_confirm_result = 0;
+
+        assert(dsd_dispatch_handle_provoice(&opts, &state) == DSD_FRAME_VERDICT_UNPRODUCTIVE);
+        assert(voice_calls == 1);
+    }
+    voice_confirm_result = 1;
 }
 
 static void
@@ -108,8 +138,9 @@ test_voice_dispatch_keeps_open_file(void) {
     DSD_SNPRINTF(opts.mbe_out_dir, sizeof(opts.mbe_out_dir), "%s", "out");
     opts.mbe_out_f = stdout;
     state.synctype = DSD_SYNC_PROVOICE_POS;
+    voice_confirm_result = 1;
 
-    dsd_dispatch_handle_provoice(&opts, &state);
+    assert(dsd_dispatch_handle_provoice(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
 
     assert(strcmp(state.fsubtype, " VOICE        ") == 0);
     assert(open_calls == 0);
@@ -121,6 +152,7 @@ main(void) {
     test_sync_pattern_lengths();
     test_synctype_helpers();
     test_voice_dispatch();
+    test_unconfirmed_voice_reports_unproductive();
     test_voice_dispatch_keeps_open_file();
     printf("PROVOICE_SYNC_DISPATCH: OK\n");
     return 0;


### PR DESCRIPTION
## Summary

Closes the residual #419 deliberately left open. `dsd_protocol_handler::handle_frame` has reported a `dsd_frame_verdict` since #419, but **D-STAR voice and ProVoice had no verdict to report at any point**, so under the default-productive contract a false sync match still bought the SPS hunt dwell it had not earned — 1992 symbols for a D-STAR voice superframe, the largest block any handler consumes, and 736 for a ProVoice frame. Both sit on profiles where they are effectively the only candidate (`4800_2` → D-STAR, `9600_2` → ProVoice/EDACS), so a false match held a profile nothing else wanted.

**No threshold was invented on `state->errs`.** Those are soft AMBE/IMBE correction counts, and mbelib's `Golay(23,12)`/`Hamming(15,11)` map every input to *some* codeword with no uncorrectable-syndrome return — there is no hard validity verdict hiding in them. Thresholding one would be the guess `protocol_dispatch.h` forbids and the risk direction #391 names.

Instead each protocol gets a per-transmission confidence module in the shape of `nxdn_confirm.c`/`m17_confirm.c`: sticky evidence that clears with the carrier, so a frame whose own check fails inside a confirmed transmission still counts.

## The evidence, and why it is a check rather than a guess

**D-STAR confirms outright on a CRC-16/X.25.** Two of them exist: the RF header (`dstar_header_decode_soft()`, already computed and already driving the HD-branch verdict), and the header rebroadcast ICOM radios fold into slow data through a transmission — computed every superframe at `dstar_slow_data.c` and, until now, consulted for printing only. The `$$CRC` fixed-form literal counts too: the `0x35` type byte plus forty more exact bits.

**Failing that — and for ProVoice, which has no CRC, no BCH and no parity anywhere in its 736 dibits — a second frame arriving before the carrier drops confirms.** That is a real structural check, not a quality metric: each frame sits behind its own exact sync word (24 symbols for D-STAR, 32 for ProVoice) matched by `strcmp` with no error budget, and `getFrameSync()` runs the no-carrier hook after `DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS` (1800) matchless symbols — which resets these modules — so "in a row" cannot span a dead channel. Against noise that is roughly `4 × 1800 × 2^-24 ≈ 4e-4` per false D-STAR match and `4 × 1800 × 2^-32 ≈ 2e-6` per false ProVoice one, and a false confirmation still dies at the next matchless pass.

## Worst case, stated

**At most one frame of withheld credit at the very start of a transmission**, and none at all when a D-STAR call opens with a decodable RF header or its first superframe carries the rebroadcast. Between adjacent frames the hunt counter grows only by the few symbols spent searching, so an unconfirmed first frame leaves almost nothing unrefunded. Being unproductive can only *withhold* credit from a counter floored at zero — it never adds to it.

Two things I deliberately did **not** do, both in the #391 risk direction:

- **No LID keying for ProVoice.** The 16-bit LID should repeat within a transmission and is the obvious content to key on, but there is no committed ProVoice fixture (a documented coverage gap) and EDACS ESK masking of that field is unverified. Keying a verdict on it risks live traffic that decodes and never says so.
- **The D-STAR header branch keeps reporting strictly its own CRC**, not `header_ok || confirmed`. A header opens a transmission, so it does not ride evidence an earlier frame supplied. #419's pinned failed-header tests are unchanged.

## Also corrected

`docs/cli.md` and the `frame_sync_sps_hunt_note_handler_consumption()` doc block both listed M17 among the handlers that report no verdict. That went stale with #422 — M17's only unconditional branch is an unreachable preamble path already below the min-frame floor. The remaining no-verdict set is DMR, P25 Phase 2, dPMR and X2-TDMA. `docs/code_map.md` gains entries for the two new modules and for `m17_confirm`, which it had never picked up.

## Test

Suite goes 575 → 577. New `DSTAR_CONFIRM`/`PROVOICE_CONFIRM` twins of `NXDN_CONFIRM` (full assertion list including NULL tolerance); both `*_SYNC_DISPATCH` tests gain an unproductive case (`PROVOICE_SYNC_DISPATCH` asserted nothing about the verdict before); both `*_PROCESS` tests drive the streak through the real decoder — first call unconfirmed, second confirmed, third sticky, then cleared; `ENGINE_NO_CARRIER_RESET` covers both new field trios.

**Every new assertion was mutation-checked** and fails against the code it names: dispatch forced back to unconditional `PRODUCTIVE` (both protocols), `WEAK_OBSERVES` dropped to 1, and the two `noCarrier` resets removed.

**Replay A/B against `main` on the committed fixtures** (same base commit, separate worktree build): the `dstar` fixture under `-fd` and `-fa` and the `edacs` fixture under `-fh` produce output **identical to main** — 3/3 `SRC: KB7WUK` lines, 4/4 voice superframes, 52/52 audio errors, 42/42 EDACS Site IDs. The real capture confirms on its slow-data header CRC repeatedly, which is the expected path for live traffic.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / **none**.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. *(none added)*
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes *(no workflow changes)*
- [ ] `tools/osv_scan.sh` for dependency input changes *(no dependency changes)*
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` *(via preflight)*

Also ran `ctest --preset asan-ubsan-debug` (577/577) and `ctest -L iq-decode`, since preflight does not cover the sanitizer job.

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: an unproductive verdict can only withhold credit from a counter floored at zero, never add to it. Worst case is a profile carrying real traffic reaching its dwell one frame later than before, never being penalised. Decoder output, audio, call records and display are untouched — this reports to the SPS hunt only, and does not gate voice synthesis the way `nxdn_confirm` does.
- Compatibility or packaging impact: `processDSTAR()` and `processProVoice()` change from `void` to `int` in their public headers; all callers (the two dispatch handlers) and all test stubs were updated. Two new private modules, two new public `*_confirm_reset()` declarations.

Closes #421. Refs #391.
