### PR TITLE
fix(io): keep the active symbol profile across RTL retunes (#405)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -302,6 +302,9 @@ Notes
 - On RTL-family FSK input the decoder's symbol timing follows the hunt profile from the moment the hunt selects it. The
   matching front-end channel profile is requested asynchronously and is applied by the demod thread on its next block,
   so the two are briefly out of step after every hunt step; decoding does not wait for the front end to catch up.
+- A retune -- a scanner hop, a trunking tune, or a replay RESET -- keeps the symbol profile the front end is on and
+  recomputes only the timing samples-per-symbol, and then only if the output rate changed. The profile is derived from
+  the enabled decoders at stream open only.
 - The hunt dwells on each candidate profile for a bounded budget of symbols searched for sync, so a full rotation over
   the five profiles takes roughly six seconds at 48 kHz. A transmission that starts mid-rotation and lasts less than one
   rotation can therefore be missed entirely even though the same capture decodes under its native preset -- Auto

--- a/docs/rtl-demod-pipeline-audit.md
+++ b/docs/rtl-demod-pipeline-audit.md
@@ -64,7 +64,9 @@ SoapySDR, and IQ replay; all four sources feed the same direct-output contracts.
 
 - `IO_RTL_DEMOD_CONFIG` validates the full mode matrix at 48 kHz and key 24 kHz
   cases, including output kind, symbol rate, level count, LPF profile, and CQPSK
-  TED SPS.
+  TED SPS. It also covers the retune finalize path, which preserves the active
+  symbol profile; deriving the profile from the enabled decoders is stream-open
+  behavior only.
 - `RTL_SYMBOL_PIPELINE` synthesizes FSK discriminator samples and CQPSK symbols
   through `full_demod()` and checks the direct-output contracts.
 - `DSP_FSK_MODEM` covers discriminator count, sign, centering, scale, and reset

--- a/include/dsd-neo/io/rtl_demod_config.h
+++ b/include/dsd-neo/io/rtl_demod_config.h
@@ -85,12 +85,17 @@ void rtl_demod_maybe_update_resampler_after_rate_change(struct demod_state* demo
  * Refresh TED SPS after rate changes unless explicitly overridden by
  * runtime configuration.
  *
- * @param demod  Demodulator state.
- * @param opts   Decoder options (mode flags).
- * @param output Output state (current sink rate).
+ * @param demod                  Demodulator state.
+ * @param opts                   Decoder options (mode flags); may be NULL.
+ * @param output                 Output state (current sink rate).
+ * @param preserve_active_profile Non-zero keeps the symbol rate and level count the front end is
+ *                               already on (set by the SPS hunt, the trunking engine, or the
+ *                               operator) and recomputes only the timing SPS for the current
+ *                               output rate; zero seeds the profile from @p opts, which is the
+ *                               stream-open default.
  */
 void rtl_demod_maybe_refresh_ted_sps_after_rate_change(struct demod_state* demod, const dsd_opts* opts,
-                                                       const struct output_state* output);
+                                                       const struct output_state* output, int preserve_active_profile);
 
 /**
  * Release resources owned by the demodulator state.

--- a/src/io/radio/rtl_demod_config.cpp
+++ b/src/io/radio/rtl_demod_config.cpp
@@ -827,55 +827,64 @@ rtl_demod_maybe_update_resampler_after_rate_change(struct demod_state* demod, st
 }
 
 /**
- * @brief Refresh CQPSK timing SPS after capture/output rate changes.
+ * @brief Refresh timing SPS after capture/output rate changes.
  *
- * Recompute the nominal samples-per-symbol from the current output rate and
- * mode unless an explicit CQPSK timing SPS override is active.
+ * Recompute the nominal samples-per-symbol for the current output rate unless an explicit timing
+ * SPS override is active. The symbol rate and level count come either from the profile the front
+ * end is already on or from the decoder options, per @p preserve_active_profile.
  *
- * @param demod  Demodulator state.
- * @param opts   Decoder options (mode flags).
- * @param output Output ring (for sink rate).
+ * @param demod                   Demodulator state.
+ * @param opts                    Decoder options (mode flags); may be NULL.
+ * @param output                  Output ring (for sink rate).
+ * @param preserve_active_profile Non-zero keeps the active symbol rate and level count (retunes);
+ *                                zero derives them from @p opts (stream open).
  */
 void
 rtl_demod_maybe_refresh_ted_sps_after_rate_change(struct demod_state* demod, const dsd_opts* opts,
-                                                  const struct output_state* output) {
+                                                  const struct output_state* output, int preserve_active_profile) {
     if (!demod || !output) {
         return;
     }
 
     int Fs_cx = rtl_demod_resolve_complex_rate(demod, output);
-    int sps = 0;
-    int sym_rate = demod->symbol_rate_hz > 0 ? demod->symbol_rate_hz : 4800;
-    if (opts) {
+    int sym_rate;
+    int sym_levels;
+    if (preserve_active_profile) {
+        /* Retunes keep whatever the SPS hunt, the trunking engine, or the operator last published
+         * through rtl_stream_set_symbol_profile(); only the timing SPS follows the new rate. The
+         * option flags cannot answer this: with more than one rate class enabled they always say
+         * 4800/4, which would drag a run parked on 2400/4 (NXDN48, dPMR) or 9600/2 (ProVoice) off
+         * its profile on every hop. Fall back to the option-derived default only when no profile
+         * has been established yet. */
+        sym_rate = demod->symbol_rate_hz > 0 ? demod->symbol_rate_hz : opts_symbol_rate_hz(opts);
+        sym_levels = (demod->symbol_levels == 2 || demod->symbol_levels == 4)
+                         ? demod->symbol_levels
+                         : opts_symbol_levels_for_rate(opts, sym_rate);
+    } else {
         /* When only P25P2/X2-TDMA is enabled (without P25P1), use 6000 sym/s.
          * When mod_qpsk is set for P25P1 CQPSK/LSM, use 4800 sym/s.
          * When both P25P1 and P25P2 are enabled (trunking mode), default to
          * P25P1 rate (4800) since CC is typically encountered first; the trunk
          * state machine will override via ted_sps_override when tuning to P25P2 VC. */
         sym_rate = opts_symbol_rate_hz(opts);
-        if (opts->mod_qpsk == 1 && sym_rate != 6000) {
+        if (opts && opts->mod_qpsk == 1 && sym_rate != 6000) {
             sym_rate = 4800;
         }
-        if (Fs_cx < (sym_rate * 2)) {
-            LOG_WARN("WARNING: CQPSK timing SPS: demod rate %d Hz is low for ~%d sym/s; clamping to minimum SPS.\n",
-                     Fs_cx, sym_rate);
-        }
-        sps = (Fs_cx + (sym_rate / 2)) / sym_rate;
-        if ((Fs_cx % sym_rate) == 0) {
-            demod->sps_is_integer = 1;
-        } else {
-            demod->sps_is_integer = 0;
-            rtl_demod_log_non_integer_after_rate_change(demod, Fs_cx, sym_rate);
-        }
+        sym_levels = opts_symbol_levels_for_rate(opts, sym_rate);
+    }
+    if (Fs_cx < (sym_rate * 2)) {
+        LOG_WARN("WARNING: CQPSK timing SPS: demod rate %d Hz is low for ~%d sym/s; clamping to minimum SPS.\n", Fs_cx,
+                 sym_rate);
+    }
+    int sps = (Fs_cx + (sym_rate / 2)) / sym_rate;
+    if ((Fs_cx % sym_rate) == 0) {
+        demod->sps_is_integer = 1;
     } else {
-        sps = (Fs_cx + 2400) / 4800;
-        demod->sps_is_integer = ((Fs_cx % 4800) == 0) ? 1 : 0;
-        if (!demod->sps_is_integer) {
-            rtl_demod_log_non_integer_after_rate_change(demod, Fs_cx, 4800);
-        }
+        demod->sps_is_integer = 0;
+        rtl_demod_log_non_integer_after_rate_change(demod, Fs_cx, sym_rate);
     }
     demod->symbol_rate_hz = sym_rate;
-    demod->symbol_levels = opts_symbol_levels_for_rate(opts, sym_rate);
+    demod->symbol_levels = sym_levels;
     sps = rtl_demod_clamp_sps(sps);
     if (demod->ted_sps_override > 0) {
         demod->ted_sps = demod->ted_sps_override;

--- a/src/io/radio/rtl_sdr_fm.cpp
+++ b/src/io/radio/rtl_sdr_fm.cpp
@@ -3933,7 +3933,10 @@ controller_finalize_rate_chain(struct controller_state* s, const dsd_opts* opts,
         return;
     }
     s->last_applied_freq_hz.store(center_freq_hz, std::memory_order_release);
-    rtl_demod_maybe_refresh_ted_sps_after_rate_change(&demod, opts, &output);
+    /* Retunes keep the symbol profile the front end is on; only the timing SPS follows the new
+     * output rate. Re-deriving it from the option flags here would snap a multi-protocol run back
+     * to 4800/4 on every hop, discarding whatever the SPS hunt is parked on. */
+    rtl_demod_maybe_refresh_ted_sps_after_rate_change(&demod, opts, &output, /*preserve_active_profile=*/1);
     rtl_stream_apply_retune_profile(retune_profile, center_freq_hz);
     rtl_demod_maybe_update_resampler_after_rate_change(&demod, &output, rtl_dsp_bw_hz);
     DemodRetuneResetPlan reset_plan = demod_retune_reset_plan(reset_reason, previous_center_freq_hz, center_freq_hz,
@@ -6618,7 +6621,9 @@ stream_open_configure_pipeline_state(dsd_opts* opts, RadioSourceKind source_kind
         return -1;
     }
     stream_open_configure_resampler_chain();
-    rtl_demod_maybe_refresh_ted_sps_after_rate_change(&demod, opts, &output);
+    /* Stream open is the one place the profile legitimately comes from the option flags: nothing
+     * has hunted yet, and demod_apply_output_kind() just seeded the same defaults. */
+    rtl_demod_maybe_refresh_ted_sps_after_rate_change(&demod, opts, &output, /*preserve_active_profile=*/0);
     stream_open_update_output_rates();
     stream_open_log_rate_chain_summary();
     return 0;
@@ -7416,8 +7421,8 @@ rtl_stream_set_ted_sps_no_override(int sps) {
         }
     }
     rtl_stream_publish_demod_profile_snapshot();
-    /* Does NOT set ted_sps_override, allowing rate-change refresh to
-       recalculate SPS later. Use when returning to CC or switching protocols. */
+    /* Does NOT set ted_sps_override, allowing rate-change refresh to recalculate SPS later from
+       the symbol profile published above. Use when returning to CC or switching protocols. */
 }
 
 extern "C" void
@@ -9808,6 +9813,80 @@ extern "C" int
 rtl_stream_test_steady_state_watermark_enabled(const char* audio_in_dev) {
     UNUSED(audio_in_dev);
     return stream_steady_state_watermark_enabled(NULL);
+}
+
+extern "C" int
+rtl_stream_test_finalize_rate_chain_profile(const dsd_opts* opts, int rate_out_hz, int seed_symbol_rate_hz,
+                                            int seed_symbol_levels, int seed_channel_profile,
+                                            rtl_stream_test_finalize_profile_result* out_result) {
+    if (!out_result || rate_out_hz <= 0 || seed_symbol_rate_hz <= 0) {
+        return -1;
+    }
+    if (seed_symbol_levels != 2 && seed_symbol_levels != 4) {
+        return -1;
+    }
+
+    int prev_output_kind = demod.output_kind;
+    int prev_cqpsk_enable = demod.cqpsk_enable;
+    int prev_rate_in = demod.rate_in;
+    int prev_rate_out = demod.rate_out;
+    int prev_symbol_rate_hz = demod.symbol_rate_hz;
+    int prev_symbol_levels = demod.symbol_levels;
+    int prev_channel_lpf_profile = demod.channel_lpf_profile;
+    int prev_ted_sps = demod.ted_sps;
+    int prev_ted_sps_override = demod.ted_sps_override;
+    int prev_sps_is_integer = demod.sps_is_integer;
+    int prev_resamp_target_hz = demod.resamp_target_hz;
+    int prev_resamp_enabled = demod.resamp_enabled;
+    int prev_costas_reset_pending = demod.costas_reset_pending;
+    dsd_fsk_modem_state prev_fsk_modem_state = demod.fsk_modem_state;
+    unsigned int prev_output_rate = output.rate;
+    uint32_t prev_last_applied_freq_hz = controller.last_applied_freq_hz.load(std::memory_order_acquire);
+    int prev_fsk_cfg_pending = g_fsk_modem_config_pending.load(std::memory_order_acquire);
+
+    demod.output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
+    demod.cqpsk_enable = 0;
+    demod.rate_in = rate_out_hz;
+    demod.rate_out = rate_out_hz;
+    demod.resamp_target_hz = 0;
+    demod.resamp_enabled = 0;
+    demod.ted_sps_override = 0;
+    output.rate = (unsigned int)rate_out_hz;
+    /* Seed through the path the SPS hunt uses, so the front end is on a real published profile. */
+    (void)rtl_stream_set_symbol_profile(seed_symbol_rate_hz, seed_symbol_levels, seed_channel_profile);
+
+    /* Same previous/next frequency and rate keeps the reset plan on the retain-FLL path. */
+    const uint32_t center_freq_hz = 851012500U;
+    controller_finalize_rate_chain(&controller, opts, center_freq_hz, /*mark_reconfigure=*/1,
+                                   DemodRetuneResetReason::FrequencyRetune, center_freq_hz, rate_out_hz,
+                                   /*retune_profile=*/NULL);
+
+    out_result->symbol_rate_hz = demod.symbol_rate_hz;
+    out_result->symbol_levels = demod.symbol_levels;
+    out_result->ted_sps = demod.ted_sps;
+    out_result->ted_sps_override = demod.ted_sps_override;
+    out_result->sps_is_integer = demod.sps_is_integer;
+    out_result->channel_lpf_profile = demod.channel_lpf_profile;
+
+    demod.output_kind = prev_output_kind;
+    demod.cqpsk_enable = prev_cqpsk_enable;
+    demod.rate_in = prev_rate_in;
+    demod.rate_out = prev_rate_out;
+    demod.symbol_rate_hz = prev_symbol_rate_hz;
+    demod.symbol_levels = prev_symbol_levels;
+    demod.channel_lpf_profile = prev_channel_lpf_profile;
+    demod.ted_sps = prev_ted_sps;
+    demod.ted_sps_override = prev_ted_sps_override;
+    demod.sps_is_integer = prev_sps_is_integer;
+    demod.resamp_target_hz = prev_resamp_target_hz;
+    demod.resamp_enabled = prev_resamp_enabled;
+    demod.costas_reset_pending = prev_costas_reset_pending;
+    demod.fsk_modem_state = prev_fsk_modem_state;
+    output.rate = prev_output_rate;
+    controller.last_applied_freq_hz.store(prev_last_applied_freq_hz, std::memory_order_release);
+    g_fsk_modem_config_pending.store(prev_fsk_cfg_pending, std::memory_order_release);
+    rtl_stream_publish_demod_profile_snapshot();
+    return 0;
 }
 #endif
 

--- a/src/io/radio/rtl_stream_test_support.h
+++ b/src/io/radio/rtl_stream_test_support.h
@@ -3,6 +3,7 @@
 #ifndef DSD_NEO_SRC_IO_RADIO_RTL_STREAM_TEST_SUPPORT_H_
 #define DSD_NEO_SRC_IO_RADIO_RTL_STREAM_TEST_SUPPORT_H_
 
+#include <dsd-neo/core/opts_fwd.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -145,6 +146,21 @@ int rtl_stream_test_tagged_retune_ownership(uint64_t owner_token, uint64_t conte
 int dsd_rtl_stream_test_retune_without_controller_rejected(void);
 int rtl_stream_test_retune_profile_gain_binding(int* out_gain_is_set, int* out_gain_tenth_db, int* out_gain_is_auto,
                                                 int* out_autogain_is_set, int* out_autogain_on);
+
+typedef struct rtl_stream_test_finalize_profile_result {
+    int symbol_rate_hz;
+    int symbol_levels;
+    int ted_sps;
+    int ted_sps_override;
+    int sps_is_integer;
+    int channel_lpf_profile;
+} rtl_stream_test_finalize_profile_result;
+
+/* Seed the published symbol profile, then run the retune finalize path with the given decoder
+ * options (NULL models a replay RESET) and report the profile the front end ended up on. */
+int rtl_stream_test_finalize_rate_chain_profile(const dsd_opts* opts, int rate_out_hz, int seed_symbol_rate_hz,
+                                                int seed_symbol_levels, int seed_channel_profile,
+                                                rtl_stream_test_finalize_profile_result* out_result);
 
 typedef struct rtl_stream_test_replay_state {
     int replay_input_eof;

--- a/tests/io/test_io_rtl_demod_config.cpp
+++ b/tests/io/test_io_rtl_demod_config.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/dsp/demod_state.h>
+#include <dsd-neo/dsp/fsk_modem.h>
 #include <dsd-neo/io/rtl_demod_config.h>
 #include <dsd-neo/io/rtl_metrics.h>
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -85,7 +86,7 @@ expect_sps(const char* label, const dsd_opts& opts, int rate_hz, int override_sp
     demod.ted_sps_override = override_sps;
     output.rate = static_cast<unsigned int>(rate_hz);
 
-    rtl_demod_maybe_refresh_ted_sps_after_rate_change(&demod, &opts, &output);
+    rtl_demod_maybe_refresh_ted_sps_after_rate_change(&demod, &opts, &output, /*preserve_active_profile=*/0);
     if (demod.ted_sps != want_sps) {
         DSD_FPRINTF(stderr, "%s: got ted_sps=%d want=%d\n", label, demod.ted_sps, want_sps);
         return 1;
@@ -95,6 +96,161 @@ expect_sps(const char* label, const dsd_opts& opts, int rate_hz, int override_sp
         return 1;
     }
     return 0;
+}
+
+/*
+ * Retunes must keep the symbol profile the front end is already on (whatever the SPS hunt, the
+ * trunking engine, or the operator last published) and recompute only the timing SPS for the
+ * current output rate. Re-deriving the profile from the option flags here snapped multi-protocol
+ * runs back to 4800/4 on every hop.
+ */
+static int
+expect_preserved_profile(const char* label, const dsd_opts* opts, int rate_hz, int seed_rate, int seed_levels,
+                         int override_sps, int want_rate, int want_levels, int want_sps) {
+    static demod_state demod;
+    output_state output;
+    DSD_MEMSET(&demod, 0, sizeof(demod));
+    DSD_MEMSET(&output, 0, sizeof(output));
+    demod.output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
+    demod.rate_out = rate_hz;
+    demod.symbol_rate_hz = seed_rate;
+    demod.symbol_levels = seed_levels;
+    demod.ted_sps_override = override_sps;
+    output.rate = static_cast<unsigned int>(rate_hz);
+
+    rtl_demod_maybe_refresh_ted_sps_after_rate_change(&demod, opts, &output, /*preserve_active_profile=*/1);
+
+    int rc = 0;
+    rc |= expect_int_eq(label, demod.symbol_rate_hz, want_rate);
+    rc |= expect_int_eq(label, demod.symbol_levels, want_levels);
+    rc |= expect_int_eq(label, demod.ted_sps, want_sps);
+    return rc;
+}
+
+static int
+expect_retune_preserves_active_profile(void) {
+    int rc = 0;
+
+    /* Multi-protocol opts: opts_symbol_rate_hz() answers 4800 because the enabled decoders span
+     * more than one rate class, which is what -fa always looks like. */
+    static dsd_opts fa_opts;
+    DSD_MEMSET(&fa_opts, 0, sizeof(fa_opts));
+    fa_opts.frame_dmr = 1;
+    fa_opts.frame_nxdn48 = 1;
+
+    rc |= expect_preserved_profile("retune keeps hunt profile 2400/4", &fa_opts, 48000, 2400, 4, 0, 2400, 4, 20);
+    rc |= expect_preserved_profile("retune keeps hunt profile at 24 kHz", &fa_opts, 24000, 2400, 4, 0, 2400, 4, 10);
+    rc |= expect_preserved_profile("retune keeps two-level profile", &fa_opts, 48000, 4800, 2, 0, 4800, 2, 10);
+
+    static dsd_opts fa_provoice;
+    DSD_MEMSET(&fa_provoice, 0, sizeof(fa_provoice));
+    fa_provoice.frame_dmr = 1;
+    fa_provoice.frame_provoice = 1;
+    rc |= expect_preserved_profile("retune keeps ProVoice 9600/2", &fa_provoice, 48000, 9600, 2, 0, 9600, 2, 5);
+
+    /* The mod_qpsk snap to 4800 belongs to stream open only. */
+    static dsd_opts p25p1_qpsk_opts;
+    DSD_MEMSET(&p25p1_qpsk_opts, 0, sizeof(p25p1_qpsk_opts));
+    p25p1_qpsk_opts.frame_p25p1 = 1;
+    p25p1_qpsk_opts.mod_qpsk = 1;
+    rc |=
+        expect_preserved_profile("retune does not snap QPSK to 4800", &p25p1_qpsk_opts, 48000, 2400, 4, 0, 2400, 4, 20);
+
+    /* Replay RESET events reach the refresh with no opts at all. */
+    rc |= expect_preserved_profile("replay reset keeps 9600/2 without opts", NULL, 48000, 9600, 2, 0, 9600, 2, 5);
+    rc |= expect_preserved_profile("replay reset keeps 2400/4 without opts", NULL, 48000, 2400, 4, 0, 2400, 4, 20);
+
+    /* An unset profile still falls back to the opts-derived default. */
+    rc |= expect_preserved_profile("unset profile falls back to opts", &fa_opts, 48000, 0, 0, 0, 4800, 4, 10);
+    rc |=
+        expect_preserved_profile("unset profile without opts falls back to 4800/4", NULL, 48000, 0, 0, 0, 4800, 4, 10);
+
+    /* A manual TED SPS override still wins over the recomputed value. */
+    rc |= expect_preserved_profile("ted_sps override still wins", &fa_opts, 48000, 2400, 4, 8, 2400, 4, 8);
+
+    return rc;
+}
+
+/*
+ * The FSK modem only resets its DC-centering and peak-AGC estimators when its configuration
+ * actually changes, so preserving the profile across a retune also stops the needless reset.
+ */
+static int
+expect_preserved_profile_keeps_fsk_modem_config(void) {
+    static demod_state demod;
+    output_state output;
+    static dsd_opts fa_opts;
+    int rc = 0;
+
+    DSD_MEMSET(&fa_opts, 0, sizeof(fa_opts));
+    fa_opts.frame_dmr = 1;
+    fa_opts.frame_nxdn48 = 1;
+
+    for (int preserve = 0; preserve <= 1; preserve++) {
+        DSD_MEMSET(&demod, 0, sizeof(demod));
+        DSD_MEMSET(&output, 0, sizeof(output));
+        demod.output_kind = DSD_DEMOD_OUTPUT_FSK_DISCRIMINATOR;
+        demod.rate_out = 48000;
+        demod.symbol_rate_hz = 2400;
+        demod.symbol_levels = 4;
+        demod.channel_lpf_profile = DSD_CH_LPF_PROFILE_6K25;
+        output.rate = 48000U;
+
+        dsd_fsk_modem_config cfg;
+        cfg.sample_rate_hz = 48000;
+        cfg.symbol_rate_hz = 2400;
+        cfg.levels = 4;
+        cfg.channel_profile = DSD_CH_LPF_PROFILE_6K25;
+        dsd_fsk_modem_configure(&demod.fsk_modem_state, &cfg);
+        demod.fsk_modem_state.dc_est = 0.5f;
+
+        rtl_demod_maybe_refresh_ted_sps_after_rate_change(&demod, &fa_opts, &output, preserve);
+
+        if (preserve) {
+            rc |= expect_double_near("preserved profile keeps FSK modem estimators",
+                                     static_cast<double>(demod.fsk_modem_state.dc_est), 0.5, 1e-6);
+        } else {
+            rc |= expect_double_near("opts-derived profile resets FSK modem estimators",
+                                     static_cast<double>(demod.fsk_modem_state.dc_est), 0.0, 1e-6);
+        }
+    }
+    return rc;
+}
+
+/*
+ * Cover the wiring, not just the helper: run the real retune finalize path and confirm the
+ * published profile survives it.
+ */
+static int
+expect_finalize_rate_chain_preserves_profile(void) {
+    int rc = 0;
+    rtl_stream_test_finalize_profile_result result;
+
+    static dsd_opts fa_opts;
+    DSD_MEMSET(&fa_opts, 0, sizeof(fa_opts));
+    fa_opts.frame_dmr = 1;
+    fa_opts.frame_nxdn48 = 1;
+
+    DSD_MEMSET(&result, 0, sizeof(result));
+    rc |= expect_int_eq(
+        "finalize seam accepts NXDN48 profile",
+        rtl_stream_test_finalize_rate_chain_profile(&fa_opts, 48000, 2400, 4, DSD_CH_LPF_PROFILE_6K25, &result), 0);
+    rc |= expect_int_eq("retune finalize keeps 2400 sym/s", result.symbol_rate_hz, 2400);
+    rc |= expect_int_eq("retune finalize keeps four levels", result.symbol_levels, 4);
+    rc |= expect_int_eq("retune finalize keeps ted_sps 20", result.ted_sps, 20);
+    rc |= expect_int_eq("retune finalize leaves override clear", result.ted_sps_override, 0);
+    rc |= expect_int_eq("retune finalize keeps integer sps flag", result.sps_is_integer, 1);
+    rc |= expect_int_eq("retune finalize keeps channel profile", result.channel_lpf_profile, DSD_CH_LPF_PROFILE_6K25);
+
+    DSD_MEMSET(&result, 0, sizeof(result));
+    rc |= expect_int_eq(
+        "finalize seam accepts ProVoice profile without opts",
+        rtl_stream_test_finalize_rate_chain_profile(NULL, 48000, 9600, 2, DSD_CH_LPF_PROFILE_PROVOICE, &result), 0);
+    rc |= expect_int_eq("replay reset finalize keeps 9600 sym/s", result.symbol_rate_hz, 9600);
+    rc |= expect_int_eq("replay reset finalize keeps two levels", result.symbol_levels, 2);
+    rc |= expect_int_eq("replay reset finalize keeps ted_sps 5", result.ted_sps, 5);
+
+    return rc;
 }
 
 static int
@@ -1118,6 +1274,9 @@ main(void) {
     rc |= expect_rtl_metrics_exports_and_toggles();
     rc |= expect_public_control_wrapper_contracts();
     rc |= expect_fsk_snr_sps_uses_active_profile();
+    rc |= expect_retune_preserves_active_profile();
+    rc |= expect_preserved_profile_keeps_fsk_modem_config();
+    rc |= expect_finalize_rate_chain_preserves_profile();
     rc |= expect_direct_output_open_rate_uses_demod_rate();
     rc |= expect_passes_for_device_rate();
     rc |= expect_digital_resample_policy();


### PR DESCRIPTION
Fixes #405.

## Problem

`controller_finalize_rate_chain()` (`src/io/radio/rtl_sdr_fm.cpp`) called `rtl_demod_maybe_refresh_ted_sps_after_rate_change()` on every retune, and that helper re-derived the whole FSK profile from the decoder option flags. `opts_symbol_rate_hz()` answers 4800 whenever the enabled decoders span more than one rate class, so under `-fa` every scanner hop and every replay RESET snapped the front end to 4800/4 no matter which profile the SPS hunt was parked on — 2400/4 (NXDN48, dPMR), 9600/2 (ProVoice), 6000/4 (P25p2). The config flip also made `dsd_fsk_modem_configure()` reset the modem's DC-centering and peak-AGC estimators each time.

Only P25 trunking escaped it, because the engine queues a profile snapshot that `rtl_stream_apply_retune_profile()` re-applies immediately afterwards. The hunt publishes with `ted_sps_is_override = 0`, so the `ted_sps_override` guard never covered it, and `symbol_rate_hz`/`symbol_levels` have no override concept at all.

A second defect on the same lines: `rtl_replay_on_reset_event()` reaches the helper with `opts == NULL`. That branch computed the SPS for a hardcoded 4800 and called `opts_symbol_levels_for_rate(NULL, …)`, which returns 4 — so replay RESETs clobbered two-level profiles too.

## Change

`rtl_demod_maybe_refresh_ted_sps_after_rate_change()` takes a `preserve_active_profile` flag.

- **Retunes pass 1.** The symbol rate and level count stay as published through `rtl_stream_set_symbol_profile()` (by the hunt, the trunking engine, or the operator); only the timing SPS is recomputed for the current output rate. An unset profile still falls back to the option-derived default, which also fixes the NULL-opts replay path.
- **Stream open passes 0.** Bit-for-bit today's behavior, and the only place the `mod_qpsk` snap to 4800 belongs — nothing has hunted yet and `demod_apply_output_kind()` just seeded the same defaults.
- The `ted_sps_override` guard, the CQPSK channel-profile line, and `fsk_modem_apply_config()` are unchanged. With the profile preserved, that last call now sees an unchanged config and skips the estimator reset.

One intended semantic change worth flagging: a replay **loop restart** now carries the active profile across the rewind instead of resetting to the opts default. A rewind is not a mode change, so this matches the rest of the fix.

## Tests

New cases in `IO_RTL_DEMOD_CONFIG`, red before the fix and green after:

- Helper-level: profile preserved at 2400/4, 4800/2 and 9600/2; no `mod_qpsk` snap on the preserve path; the NULL-opts replay-RESET case; fallbacks when no profile is set yet; the TED SPS override still winning; recompute on an output-rate change; and the FSK modem keeping its estimators when the config does not change.
- Wiring-level: a new `rtl_stream_test_finalize_rate_chain_profile()` seam drives the real `controller_finalize_rate_chain()` and asserts the published profile survives it, covering the `preserve=1` call site itself.

No CMake changes — the cases land in the existing target, which already links the internal-test-hooks mirror and sits inside `if(DSD_HAS_RADIO)`.

## Verification

- `ctest --preset dev-debug` — 577/577 pass.
- `tools/preflight_ci.sh` — exit 0 (arch rules OK, clang-tidy clean, cppcheck passed, IWYU 0 findings, GCC `-fanalyzer` 0 diagnostics, semgrep 0 findings).
- End to end: the NXDN48 I/Q fixture replayed under `-fa` with synthetic RESET events. On `main` all ten resets report `retune reset sps=10`; with this change they follow whichever profile the hunt holds (`sps=20` while parked on 2400/4).

## Docs

`docs/cli.md` AUTO notes now state that a retune preserves the profile; `docs/rtl-demod-pipeline-audit.md` records the widened `IO_RTL_DEMOD_CONFIG` scope.
