### PR TITLE
fix(dsp): stop the SPS hunt rotating off a channel the engine tuned (#392)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -322,6 +322,19 @@ Notes
   Handlers that report no verdict are credited as before: every DMR, P25 Phase 2, dPMR and X2-TDMA frame is
   unconditionally productive, and a false match on one of those still delays the hunt in proportion to what it
   swallows.
+- A sync the decoder deliberately declines to process costs the profile nothing either way. Trunking skips the DMR
+  direct-mode paths outright, and any frame arriving while a retune is still in flight is dropped rather than
+  dispatched; neither reads a symbol, so neither can earn credit, and the search that found the sync used to stand
+  charged with nothing to pay it back -- enough, on a trunked system, to rotate the profile off a voice channel the
+  control channel had just granted. Those searches are now refunded, so the cycle comes out neutral. It is only ever
+  a refund of that one cycle, so a stream of false matches on a declined path still cannot hold a profile that is
+  finding nothing.
+- While the tuner is parked on a trunked voice channel, the hunt holds whatever profile the grant tuned it to and
+  does not rotate. The channel and its symbol rate were chosen deliberately, so a call fading toward the noise floor
+  -- crediting less than the search between its syncs burns -- keeps its timing instead of having it changed mid-call.
+  Giving the channel up is still hangtime's decision, unchanged: when the call ends the tuner returns to the control
+  channel and the hunt resumes there. Control channels are not held this way, so Auto still searches and still
+  converges on them.
 - D-STAR voice and ProVoice prove a transmission rather than a frame, because neither has a per-frame check worth the
   name. A D-STAR superframe spends 1992 symbols and a ProVoice frame 736, and the vocoder error counts both leave
   behind are soft corrections rather than a verdict. So a CRC-16/X.25 -- the D-STAR RF header, or the header

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -549,14 +549,23 @@ struct dsd_state {
      *   sps_hunt_symbolcnt_mark together. frame_sync_apply_sps_hunt_profile() does both
      *   whenever it moves the index, so its callers need not -- but it is not the only way
      *   sps_hunt_idx moves, and the sites that assign the index directly still owe both
-     *   themselves (#394). None of them pays in full today: the app-control and engine
+     *   themselves (#394). Most of them still do not: the app-control and engine
      *   retune paths (svc_publish_symbol_profile(), set_cc_symbol_timing(),
      *   dsd_engine_select_p25_sps_profile(), no_carrier_apply_p25_cc_symbolrate() and the
      *   two trunk-scan target helpers) zero the counter and leave the anchor where it was,
      *   which is harmless only because whatever that anchor then credits is debited from the
      *   counter they just zeroed and floored there; the -m2/-m3/-m4 branches of the CLI 'm'
      *   case do neither, and are benign only because they run before the first
-     *   getFrameSync().
+     *   getFrameSync(). dsd_frame_sync_sps_hunt_restart_dwell() is the one that pays in
+     *   full, and is what a new direct assigner should call.
+     * sps_hunt_counter_at_entry: sps_hunt_counter as this search cycle began, so a frame
+     *   the engine declined to dispatch can hand back exactly what that cycle's search
+     *   charged and nothing else (DSD_FRAME_VERDICT_WITHHELD, #392). Restoring to a
+     *   snapshot rather than subtracting a count keeps it exact without a second counter:
+     *   charging happens only inside frame_sync_advance_sync_window(), between this being
+     *   stamped and the verdict being read. The restore is clamped so it can only lower the
+     *   counter, which is what makes it safe against the resets that fire in between -- a
+     *   profile change, a retune, a trunk-scan target switch -- none of which this can undo.
      * sps_hunt_symbolcnt_mark: dsd_state::symbolcnt as getFrameSync() last returned, so
      *   the next call can measure what the handler consumed in between. It shares that
      *   field's unsigned wrapping type, so the difference stays exact across the counter's
@@ -573,7 +582,9 @@ struct dsd_state {
      *   call site. Zero is DSD_FRAME_VERDICT_PRODUCTIVE, so a handler that reports nothing
      *   -- and a zeroed dsd_state -- is credited as having decoded a frame; only a
      *   protocol that ran a check and failed it debits nothing (#391), and only one whose
-     *   check proves the profile restarts the dwell outright (#400). Strictly per frame,
+     *   check proves the profile restarts the dwell outright (#400). A frame the engine
+     *   declined to dispatch at all is neither, and refunds its own search instead (#392).
+     *   Strictly per frame,
      *   so unlike the two fields above it owes a profile change nothing: processFrame()
      *   re-stamps it on every dispatch and
      *   frame_sync_sps_hunt_note_handler_consumption() clears it on every read, so it
@@ -583,6 +594,7 @@ struct dsd_state {
     int sps_hunt_counter;
     uint32_t sps_hunt_symbolcnt_mark;
     int sps_hunt_last_frame_verdict;
+    int sps_hunt_counter_at_entry;
     int sps_hunt_idx;
     /* Parity toggle for the P25p1 modulation probe: which modulation the next hunt re-entry
      * into the 4800/4-level profile watches. Zero-init keeps the first re-entry on C4FM.

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -114,6 +114,22 @@ int dsd_frame_sync_suppress_tcp_no_signal_console(const dsd_opts* opts, const ds
 int dsd_frame_sync_sps_hunt_dwell_passes(const dsd_opts* opts, const dsd_state* state);
 
 /**
+ * @brief Give the active symbol profile a full dwell to prove itself on.
+ *
+ * For the sites that put the decoder somewhere new without going through the hunt -- a
+ * trunking grant retuning to a voice channel, say. The profile that arrives has not spent
+ * any of its own budget yet, and inheriting what the previous channel spent can retire it
+ * within symbols of the tune (#392).
+ *
+ * Resets the whole budget: the counter, the measurement anchor and the refund snapshot.
+ * Callers that assign dsd_state::sps_hunt_idx directly owe all three (#394); this is what
+ * they should call rather than zeroing the counter alone.
+ *
+ * @param state Decoder state; NULL is a no-op.
+ */
+void dsd_frame_sync_sps_hunt_restart_dwell(dsd_state* state);
+
+/**
  * @brief Return the symbol rate, in Hz, of the SPS hunt profile currently selected.
  *
  * The decoder's own timing authority on RTL-family FSK input: the front end applies

--- a/include/dsd-neo/engine/protocol_dispatch.h
+++ b/include/dsd-neo/engine/protocol_dispatch.h
@@ -41,6 +41,22 @@ extern "C" {
  * when a check the protocol ran says the signal on this profile is the protocol -- the
  * profile has re-earned its dwell, whatever the frame cost to read.
  *
+ * WITHHELD answers a third question, and it is about the engine rather than the protocol:
+ * the sync was real and the handler never got to see it. Trunked DMR skips the MS
+ * bootstrap and MS data paths outright, and a frame the retune generation makes
+ * undispatchable skips processFrame() entirely -- so the search that found the sync is
+ * charged and nothing is ever consumed to pay it back, and the hunt rotates off a channel
+ * the engine had just deliberately tuned (#392). A withheld frame makes its own search
+ * cycle budget-neutral: the charge is refunded, no more. It is not credit, because the
+ * engine's reason for declining says nothing about whether this is the right profile.
+ *
+ * That neutrality has a bounded cost in the other direction: a stream of false DMR MS
+ * syncs under trunking accrues nothing, so it cannot reach a dwell either. It stays
+ * bounded because every other protocol's false syncs still charge -- their handlers run
+ * and report UNPRODUCTIVE -- and because the undispatchable case resolves with the retune
+ * that caused it. Report WITHHELD only where the engine declined by policy, never where a
+ * handler ran and found nothing.
+ *
  * The numeric values are load-bearing. src/dsp reads the verdict out of
  * dsd_state::sps_hunt_last_frame_verdict without this header (the DSP layer includes no
  * engine headers), so frame_sync_sps_hunt_note_handler_consumption() compares against
@@ -52,6 +68,7 @@ typedef enum {
     DSD_FRAME_VERDICT_PRODUCTIVE = 0,     /**< default: assume the handler decoded a frame */
     DSD_FRAME_VERDICT_UNPRODUCTIVE = 1,   /**< consumed symbols, validated nothing */
     DSD_FRAME_VERDICT_PROFILE_PROVEN = 2, /**< a check passed: the profile re-earns its dwell */
+    DSD_FRAME_VERDICT_WITHHELD = 3,       /**< the engine declined to dispatch: budget-neutral */
 } dsd_frame_verdict;
 
 typedef struct dsd_protocol_handler {

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -3043,6 +3043,12 @@ frame_sync_apply_sps_hunt_profile(const dsd_opts* opts, dsd_state* state, int ne
          * spending the same dwell, so its budget must survive. */
         state->sps_hunt_counter = 0;
         state->sps_hunt_symbolcnt_mark = state->symbolcnt;
+        /* The refund snapshot belongs to the budget it was taken against. This helper can run
+         * after the snapshot has been stamped for the cycle in progress -- both adopt paths in
+         * frame_sync_ensure_enabled_sps_profile() do, immediately after
+         * frame_sync_sps_hunt_note_handler_consumption() -- so leaving it would let a withheld
+         * frame refund the incoming profile to a figure the outgoing one had. */
+        state->sps_hunt_counter_at_entry = 0;
     }
     frame_sync_normalize_profile_modulation(state, normalize_profile_modulation, profile_default_modulation);
 
@@ -3164,15 +3170,26 @@ frame_sync_sps_hunt_dwell_symbols(const dsd_opts* opts, const dsd_state* state) 
  * dwell, and one false proof buys exactly one dwell. Values are compared as literals because
  * the DSP layer includes no engine headers; anything this does not recognise is refused
  * credit, so an unhandled verdict degrades toward rotating rather than toward pinning.
+ *
+ * A withheld frame is measured by neither rule, because the engine declined to run the
+ * handler at all: trunked DMR skips the MS paths, and a frame the retune generation makes
+ * undispatchable skips processFrame(). Consumption is zero on both, so the credit path
+ * refuses the debit at its size floor and the search that found the sync stands charged --
+ * which is what rotated the hunt off channels the engine had just tuned (#392). The cycle is
+ * made neutral instead: the counter goes back to what it was when the cycle began. Not
+ * credit, because the reason for declining is about the engine's state and says nothing
+ * about the profile; and not a reserve, because a refund can only reach the value it
+ * started from.
  */
 static void
 frame_sync_sps_hunt_note_handler_consumption(dsd_state* state) {
     /* DSD_FRAME_VERDICT_* (engine/protocol_dispatch.h): 0 productive, 1 unproductive,
-     * 2 profile proven. Kept in step by FRAME_SYNC_SPS_HUNT_FALSE_SYNC, which drives this
-     * through getFrameSync() with the enumerators themselves. */
+     * 2 profile proven, 3 withheld. Kept in step by FRAME_SYNC_SPS_HUNT_FALSE_SYNC, which
+     * drives this through getFrameSync() with the enumerators themselves. */
     const int verdict = state->sps_hunt_last_frame_verdict;
     const int proven = verdict == 2;
-    const int unproductive = verdict != 0 && !proven;
+    const int withheld = verdict == 3;
+    const int unproductive = verdict != 0 && !proven && !withheld;
     /* One verdict answers for one handler call. processFrame() already re-stamps the field
      * on every dispatch, so this is belt and braces for the entries no handler precedes --
      * a no-sync return, or a frame the retune generation made undispatchable -- where a
@@ -3206,6 +3223,21 @@ frame_sync_sps_hunt_note_handler_consumption(dsd_state* state) {
          * jump guard above -- both of which exist to keep consumption honest -- have no say
          * in it. */
         state->sps_hunt_counter = 0;
+    } else if (withheld) {
+        /* Hand back this cycle's search and nothing else. Charging happens only inside
+         * frame_sync_advance_sync_window(), between the snapshot below being stamped and
+         * this read, so the snapshot is exactly what the counter held before the search
+         * that produced the withheld frame.
+         *
+         * Clamped rather than assigned, because the counter can legitimately be lower than
+         * the snapshot by now: a profile change, a retune, or a trunk-scan target switch
+         * inside dsd_trunk_scan_hook_tick() can zero it in between, and the last of those
+         * can even leave this stamp landing on a different target's budget. Every one of
+         * those is a reset this has no business undoing, so the refund is only ever allowed
+         * to lower the counter -- worst case it does nothing. */
+        if (state->sps_hunt_counter > state->sps_hunt_counter_at_entry) {
+            state->sps_hunt_counter = state->sps_hunt_counter_at_entry;
+        }
     } else if (!unproductive && consumed >= (uint32_t)DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS) {
         /* dsd_state::sps_hunt_counter only ever counts up from zero, so this is exact.
          * Sites outside the hunt park a profile by zeroing it; the floor at zero means
@@ -3214,6 +3246,7 @@ frame_sync_sps_hunt_note_handler_consumption(dsd_state* state) {
         state->sps_hunt_counter = (int)(consumed >= counter ? 0U : counter - consumed);
     }
     state->sps_hunt_symbolcnt_mark = state->symbolcnt;
+    state->sps_hunt_counter_at_entry = state->sps_hunt_counter;
 }
 
 #ifdef DSD_NEO_TEST_HOOKS
@@ -3227,6 +3260,16 @@ dsd_frame_sync_test_sps_hunt_note_handler_consumption(dsd_state* state) {
 static void
 frame_sync_sps_hunt_mark_return(dsd_state* state) {
     state->sps_hunt_symbolcnt_mark = state->symbolcnt;
+}
+
+void
+dsd_frame_sync_sps_hunt_restart_dwell(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    state->sps_hunt_counter = 0;
+    state->sps_hunt_symbolcnt_mark = state->symbolcnt;
+    state->sps_hunt_counter_at_entry = 0;
 }
 
 /**
@@ -3295,8 +3338,29 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
         return 0;
     }
     state->sps_hunt_counter = 0;
-    /* Reaching here is the trial's verdict: its dwell expired with nothing decoded. */
+    /* Reaching here is the trial's verdict: its dwell expired with nothing decoded. That is
+     * true whether or not the profile then rotates, and this is the only place the flag is
+     * cleared, so it must be cleared before the hold below returns -- a probe left active
+     * across a grant would pin rf_mod against the modulation votes for the whole call. */
     state->p25_p1_mod_probe_active = 0;
+
+    /* The hunt does not get to second-guess a channel the engine chose. On a trunked voice
+     * channel the profile came from the grant that tuned it, so rotating it is wrong however
+     * the budget reads: a call fading toward the noise floor credits less than the search
+     * between its syncs burns, and reaches the dwell while it is still decoding (#392).
+     *
+     * This holds the profile, not the channel, so it returns non-zero like any other dwell
+     * expiry. The caller owes the P25 SM the same no-sync accounting either way (#393) --
+     * VC no-sync pass, release check, no-carrier -- and that accounting is the only thing
+     * that gives a dead voice channel up when false syncs keep arriving often enough to
+     * stop the in-call timeout ever arming. Suppressing it here would leave nothing to drop
+     * trunk_is_tuned, which is the flag this reads: the hold would never end.
+     *
+     * Control channels are not tuned in this sense -- the CC tune path deliberately leaves
+     * the flag alone -- so the hunt still rotates and still probes there. */
+    if (opts->trunk_enable == 1 && opts->trunk_is_tuned == 1) {
+        return 1;
+    }
     const int preserve_modulation = opts->mod_cli_lock ? 1 : 0;
 
     /* Generic modulation locks retain their demodulator while rotating equal-timing protocol gates. A P25p2-specific

--- a/src/dsp/frame_sync_internal.h
+++ b/src/dsp/frame_sync_internal.h
@@ -60,9 +60,12 @@ void frame_sync_ensure_enabled_sps_profile(const dsd_opts* opts, dsd_state* stat
 /**
  * @brief Step the SPS hunt if the active profile has spent its symbol budget.
  *
- * @return 1 when the step changed the profile index or the modulation -- the caller's sync
- *         window is then stale and must be rebuilt -- and 0 when the profile still owes
- *         symbols, or when spending the budget left the timing and modulation untouched.
+ * @return 1 when the caller must take a no-sync exit: either the step changed the profile
+ *         index or the modulation -- the caller's sync window is then stale and must be
+ *         rebuilt -- or the budget expired on a trunked voice channel, where the profile is
+ *         deliberately held but the no-sync accounting is still owed (#392, #393). 0 when
+ *         the profile still owes symbols, or when spending the budget left the timing and
+ *         modulation untouched.
  */
 int frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state);
 double frame_sync_elapsed_seconds(double nowm, time_t now, double mono_stamp, time_t wall_stamp);

--- a/src/engine/dispatch/dispatch_dmr.c
+++ b/src/engine/dispatch/dispatch_dmr.c
@@ -59,55 +59,68 @@ dmr_close_mbe_out_if_open(dsd_opts* opts, dsd_state* state) {
     }
 }
 
-static void
+/*
+ * Trunking declines the direct-mode paths outright: a trunked system's traffic is on the
+ * channels the control channel grants, not on MS/DM. Nothing is read, so say the frame was
+ * withheld rather than let it read as a productive frame that happened to consume nothing --
+ * the SPS hunt refuses consumption credit below a frame's worth, so the search that found
+ * the sync would stand charged with nothing ever paying it back (#392).
+ */
+static dsd_frame_verdict
 dmr_bootstrap_ms_if_enabled(dsd_opts* opts, dsd_state* state) {
     dmr_open_mbe_out_if_needed(opts, state);
     if (opts->trunk_enable == 0) {
         dmrMSBootstrap(opts, state);
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
+    return DSD_FRAME_VERDICT_WITHHELD;
 }
 
-static void
+static dsd_frame_verdict
 dmr_bootstrap_mono(dsd_opts* opts, dsd_state* state) {
     if (opts->trunk_enable == 1 && DSD_SYNC_IS_DMR_BS(state->synctype)) {
         state->dmr_stereo = 1;
         dmrBSBootstrap(opts, state);
         state->dmr_stereo = 0;
-        return;
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
     state->dmr_mono_slot = 0;
     state->dmr_stereo = 0;
-    dmr_bootstrap_ms_if_enabled(opts, state);
+    return dmr_bootstrap_ms_if_enabled(opts, state);
 }
 
-static void
+static dsd_frame_verdict
 dmr_handle_voice(dsd_opts* opts, dsd_state* state) {
     DSD_SNPRINTF(state->fsubtype, sizeof(state->fsubtype), " VOICE        ");
     if (opts->dmr_mono == 1) {
         dmr_set_slot_lights(state);
-        dmr_bootstrap_mono(opts, state);
-        return;
+        return dmr_bootstrap_mono(opts, state);
     }
     if (opts->dmr_stereo == 0 && state->synctype < DSD_SYNC_DMR_MS_VOICE) {
         dmr_set_slot_lights(state);
-        dmr_bootstrap_ms_if_enabled(opts, state);
+        return dmr_bootstrap_ms_if_enabled(opts, state);
     }
     if (opts->dmr_stereo == 1) {
         state->dmr_stereo = 1;
         if (state->synctype >= DSD_SYNC_DMR_MS_VOICE) {
-            dmr_bootstrap_ms_if_enabled(opts, state);
-        } else {
-            dmrBSBootstrap(opts, state);
+            return dmr_bootstrap_ms_if_enabled(opts, state);
         }
+        dmrBSBootstrap(opts, state);
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
+    /* Stereo off on an MS voice sync with mono off: nothing above ran, and nothing read the
+     * frame. Productive is the status quo for a path that consumes nothing either way. */
+    return DSD_FRAME_VERDICT_PRODUCTIVE;
 }
 
-static void
+static dsd_frame_verdict
 dmr_handle_ms_data(dsd_opts* opts, dsd_state* state) {
     dmr_close_mbe_out_if_open(opts, state);
     if (opts->trunk_enable == 0) {
         dmrMSData(opts, state);
+        return DSD_FRAME_VERDICT_PRODUCTIVE;
     }
+    return DSD_FRAME_VERDICT_WITHHELD;
 }
 
 static void
@@ -132,11 +145,16 @@ dsd_dispatch_matches_dmr(int synctype) {
 }
 
 /*
- * Always productive. DMR's per-burst verdicts live in the colour-code lock and voice-open
- * counters of src/protocol/dmr/dmr_confidence.c, which answer "is this transmission real"
- * across bursts rather than "did this burst validate"; a burst that fails the lock is not
- * the same thing as a burst that decoded nothing, and mapping one onto the other would be
- * guesswork. Left productive until DMR grows a per-burst answer (#391).
+ * Productive wherever a burst is actually read. DMR's per-burst verdicts live in the colour-
+ * code lock and voice-open counters of src/protocol/dmr/dmr_confidence.c, which answer "is
+ * this transmission real" across bursts rather than "did this burst validate"; a burst that
+ * fails the lock is not the same thing as a burst that decoded nothing, and mapping one onto
+ * the other would be guesswork. Left productive until DMR grows a per-burst answer (#391).
+ *
+ * The direct-mode paths under trunking are a different question and do have an answer: they
+ * are not a burst this decoded badly, they are a burst it was told not to decode, so they
+ * report WITHHELD (#392). That distinction is the whole of what is claimed here -- it says
+ * where the symbols went, not whether the profile is right.
  */
 dsd_frame_verdict
 dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state) {
@@ -155,12 +173,10 @@ dsd_dispatch_handle_dmr(dsd_opts* opts, dsd_state* state) {
     state->nac = 0;
 
     if (dmr_is_voice_synctype(state->synctype)) {
-        dmr_handle_voice(opts, state);
-        return DSD_FRAME_VERDICT_PRODUCTIVE;
+        return dmr_handle_voice(opts, state);
     }
     if (dmr_is_ms_data_synctype(state->synctype)) {
-        dmr_handle_ms_data(opts, state);
-        return DSD_FRAME_VERDICT_PRODUCTIVE;
+        return dmr_handle_ms_data(opts, state);
     }
     dmr_handle_other_data(opts, state);
     return DSD_FRAME_VERDICT_PRODUCTIVE;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -23,6 +23,7 @@
 #include <dsd-neo/dsp/sps_filters.h>
 #include <dsd-neo/engine/engine.h>
 #include <dsd-neo/engine/frame_processing.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/engine/trunk_scan.h>
 #include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/fec/block_codes.h>
@@ -2423,6 +2424,13 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
             dsd_trunk_tuning_frame_is_dispatchable(dispatch_generation, engine_trunk_tuning_owner_active(opts));
         if (!frame_tune_generation || frame_dispatchable) {
             processFrame(opts, state);
+        } else {
+            /* A real sync the retune generation says is stale. Nothing consumes it, so
+             * without saying so the SPS hunt is charged for the search that found it and
+             * credited nothing -- and rotates the profile off the channel the retune was
+             * tuning to, mid-retune (#392). processFrame() is what normally stamps this
+             * field, so the skip has to stamp it itself. */
+            state->sps_hunt_last_frame_verdict = DSD_FRAME_VERDICT_WITHHELD;
         }
         p25_sm_tick_guard_leave();
         dsd_trunk_scan_hook_tick(opts, state);

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -415,6 +415,14 @@ dsd_engine_update_vc_tune_state(dsd_opts* opts, dsd_state* state, long int freq)
     state->p25_vc_freq[0] = state->p25_vc_freq[1] = freq;
     state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = freq;
     opts->trunk_is_tuned = 1;
+    /* The voice channel starts its symbol profile's dwell over. Without this it inherits
+     * whatever the control channel had already spent hunting, so a grant can land on a
+     * budget that is already at its dwell and be rotated off within symbols of the tune.
+     * dsd_engine_select_p25_sps_profile() does this for the P25 retunes it handles; every
+     * other system's grants -- DMR, NXDN, EDACS -- reach here and nothing else pays it
+     * (#392). Voice channels only: a control-channel tune is the hunt's business, and
+     * handing it a fresh dwell would keep it on a profile that is finding nothing. */
+    dsd_frame_sync_sps_hunt_restart_dwell(state);
     /* Reset activity timers so noCarrier() does not immediately force a return
      * to CC before we have a chance to acquire sync on the new VC. */
     state->last_vc_sync_time = time(NULL);

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -399,6 +399,61 @@ test_sps_hunt_budget_is_spent_in_symbols(void) {
 }
 
 /*
+ * Issue #392: the profile on a trunked voice channel came with the grant that tuned it, so
+ * an expired dwell holds it rather than rotating. The dwell still expired, though, and the
+ * caller is still owed its no-sync accounting (#393) -- that accounting is what gives a dead
+ * voice channel up, and suppressing it would leave nothing to clear trunk_is_tuned.
+ */
+static void
+test_sps_hunt_holds_the_profile_on_a_tuned_voice_channel(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    reset(&opts, &state);
+    opts.frame_dmr = 1;
+    opts.frame_dstar = 1;
+    opts.trunk_enable = 1;
+    opts.trunk_is_tuned = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    const int dwell = dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
+
+    /* The dwell expires: the profile stays, the budget restarts, and the caller is told to
+     * take its no-sync exit anyway. */
+    state.sps_hunt_counter = dwell;
+    assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 1);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state.sps_hunt_counter == 0);
+
+    /* Restarting the budget is what keeps the caller's loop from spinning: the next call is
+     * a whole dwell away from expiring again. */
+    assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 0);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+
+    /* A probe on trial when the grant arrived still has its verdict read. This is the only
+     * site that clears the flag, and while it is set the modulation votes cannot take the
+     * demodulator back -- leaving it latched would pin rf_mod for the whole call. */
+    state.p25_p1_mod_probe_active = 1;
+    state.sps_hunt_counter = dwell;
+    assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 1);
+    assert(state.p25_p1_mod_probe_active == 0);
+
+    /* Dropping either half of the condition hands the profile back to the hunt: a control
+     * channel is not tuned in this sense, and neither is a conventional receiver. */
+    opts.trunk_is_tuned = 0;
+    state.sps_hunt_counter = dwell;
+    assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 1);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
+
+    reset(&opts, &state);
+    opts.frame_dmr = 1;
+    opts.frame_dstar = 1;
+    opts.trunk_is_tuned = 1; /* stale flag with trunking off */
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.sps_hunt_counter = dwell;
+    assert(frame_sync_no_sync_sps_hunt(&opts, &state) == 1);
+    assert(state.sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_2);
+}
+
+/*
  * dsd_state::symbolcnt free-runs and wraps at 2^32 (issue #395). The hunt measures what a
  * handler consumed as a modular difference against its mark, so a rollover between the mark
  * and the next getFrameSync() entry must still yield the true symbol count -- and a reset to
@@ -503,7 +558,7 @@ test_sps_hunt_proven_verdict_restarts_the_dwell(void) {
     state.sps_hunt_counter = 5000;
     state.sps_hunt_symbolcnt_mark = 1000U;
     state.symbolcnt = 2000U;
-    state.sps_hunt_last_frame_verdict = DSD_FRAME_VERDICT_PROFILE_PROVEN + 1;
+    state.sps_hunt_last_frame_verdict = DSD_FRAME_VERDICT_WITHHELD + 1;
     dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
     assert(state.sps_hunt_counter == 5000);
 
@@ -524,6 +579,95 @@ test_sps_hunt_proven_verdict_restarts_the_dwell(void) {
     state.sps_hunt_last_frame_verdict = DSD_FRAME_VERDICT_PRODUCTIVE;
     dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
     assert(state.sps_hunt_counter == 5000 - 134);
+}
+
+/*
+ * Issue #392: a frame the engine declined to dispatch consumes nothing, so the credit path
+ * refuses it at the size floor and the search that found it stands charged. The cycle is made
+ * neutral instead -- the counter goes back to where the cycle began, and no further.
+ */
+static void
+test_sps_hunt_withheld_verdict_refunds_only_its_own_cycle(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* The search charged 400 symbols on top of a budget already at 5000; the refund hands
+     * back exactly those 400, with no consumption to read. */
+    reset(&opts, &state);
+    state.sps_hunt_counter_at_entry = 5000;
+    state.sps_hunt_counter = 5400;
+    state.sps_hunt_symbolcnt_mark = 1000U;
+    state.symbolcnt = 1000U;
+    state.sps_hunt_last_frame_verdict = DSD_FRAME_VERDICT_WITHHELD;
+    dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
+    assert(state.sps_hunt_counter == 5000);
+    /* The snapshot follows the counter, so the next cycle refunds against this one's result
+     * rather than against a figure two cycles old. */
+    assert(state.sps_hunt_counter_at_entry == 5000);
+    assert(state.sps_hunt_symbolcnt_mark == state.symbolcnt);
+
+    /* A refund can only ever lower the counter. Something outside the hunt -- a profile
+     * change, a retune, a trunk-scan target switch -- may have zeroed it since the snapshot
+     * was taken, and none of those is this function's to undo. */
+    reset(&opts, &state);
+    state.sps_hunt_counter_at_entry = 5000;
+    state.sps_hunt_counter = 12;
+    state.sps_hunt_last_frame_verdict = DSD_FRAME_VERDICT_WITHHELD;
+    dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
+    assert(state.sps_hunt_counter == 12);
+    assert(state.sps_hunt_counter_at_entry == 12);
+
+    /* One verdict answers for one handler call: the next entry finds the field cleared, so a
+     * withheld frame cannot refund a cycle it did not charge. */
+    state.sps_hunt_counter = 900;
+    dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
+    assert(state.sps_hunt_counter == 900);
+
+    /* Withheld beats consumption: the engine skipped the handler, so whatever the interval
+     * measures is not a frame this profile read and must not be credited as one. */
+    reset(&opts, &state);
+    state.sps_hunt_counter_at_entry = 5000;
+    state.sps_hunt_counter = 5400;
+    state.sps_hunt_symbolcnt_mark = 1000U;
+    state.symbolcnt = 3000U;
+    state.sps_hunt_last_frame_verdict = DSD_FRAME_VERDICT_WITHHELD;
+    dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
+    assert(state.sps_hunt_counter == 5000);
+
+    /* Every other verdict leaves the snapshot tracking the counter too, so the cycle after a
+     * proof or a debit refunds against what that left behind. */
+    reset(&opts, &state);
+    state.sps_hunt_counter = 5000;
+    state.sps_hunt_last_frame_verdict = DSD_FRAME_VERDICT_PROFILE_PROVEN;
+    dsd_frame_sync_test_sps_hunt_note_handler_consumption(&state);
+    assert(state.sps_hunt_counter == 0);
+    assert(state.sps_hunt_counter_at_entry == 0);
+}
+
+/*
+ * The whole budget, for the sites that move the decoder without going through the hunt.
+ * Zeroing the counter alone leaves the anchor where it was, which is the #394 half-reset;
+ * a voice-channel tune owes both, plus the refund snapshot they now share a cycle with.
+ */
+static void
+test_sps_hunt_restart_dwell_resets_the_whole_budget(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    state.sps_hunt_counter = 4321;
+    state.sps_hunt_counter_at_entry = 4000;
+    state.sps_hunt_symbolcnt_mark = 11U;
+    state.symbolcnt = 90210U;
+    dsd_frame_sync_sps_hunt_restart_dwell(&state);
+    assert(state.sps_hunt_counter == 0);
+    assert(state.sps_hunt_counter_at_entry == 0);
+    assert(state.sps_hunt_symbolcnt_mark == 90210U);
+    /* The profile itself is not the budget's business: this grants a dwell, it does not
+     * choose what spends it. */
+    assert(state.sps_hunt_idx == 0);
+
+    dsd_frame_sync_sps_hunt_restart_dwell(NULL);
 }
 
 /* Carrier no longer wipes the hunt's progress from the modulation-switch path. */
@@ -2359,6 +2503,9 @@ main(void) {
     test_sps_hunt_budget_is_spent_in_symbols();
     test_sps_hunt_consumption_is_exact_across_the_symbolcnt_wrap();
     test_sps_hunt_proven_verdict_restarts_the_dwell();
+    test_sps_hunt_withheld_verdict_refunds_only_its_own_cycle();
+    test_sps_hunt_restart_dwell_resets_the_whole_budget();
+    test_sps_hunt_holds_the_profile_on_a_tuned_voice_channel();
     test_carrier_does_not_reset_the_hunt_budget();
     test_binary_profiles_override_unlocked_qpsk();
     test_four_level_profiles_reset_inherited_modulation();

--- a/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
+++ b/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
@@ -587,6 +587,91 @@ fake_no_carrier(dsd_opts* opts, dsd_state* state) {
     g_no_carrier_order = ++g_hook_order;
 }
 
+/* #392: a sync the engine declined to dispatch consumes nothing, so the credit path refuses
+ * it at its size floor and the search that found it stands charged with nothing to pay it
+ * back. Trunked DMR skips the MS paths outright and a retune in flight skips processFrame()
+ * entirely, so those charges accumulated until the hunt rotated the profile off a channel
+ * the engine had just tuned. */
+static void
+test_withheld_syncs_do_not_rotate_a_profile(void) {
+    static const int withheld_only[] = {DSD_FRAME_VERDICT_WITHHELD};
+    const HuntCase tc = {
+        .label = "withheld syncs at 4800/4",
+        .marker = FALSE_SYNC_MARKER,
+        .marker_gap = 284,
+        .handler_symbols = 0, /* the gate ran no handler, so nothing was consumed */
+        .verdict_cycle = withheld_only,
+        .verdict_cycle_len = 1,
+        .symbol_budget = 400000,
+        .expect_step = 0,
+    };
+    const HuntResult r = drive_hunt(&tc);
+
+    /* Many dwells' worth of searching, every cycle of it withheld, and the profile the
+     * engine chose is still in force. */
+    assert(r.syncs_seen > 100);
+    assert(r.final_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(r.final_sps == HUNT_SPS_4800);
+}
+
+/* The refund is neutrality, not credit: it erases the search that produced the withheld
+ * frame and nothing else, so it cannot bank a reserve. Interleaving withheld frames with
+ * unproductive ones leaves the unproductive halves accumulating exactly as before, and a
+ * profile matching nothing is still given up -- the #388 direction this must not re-open. */
+static void
+test_withheld_syncs_do_not_hold_a_wrong_profile(void) {
+    static const int withheld_then_unproductive[] = {DSD_FRAME_VERDICT_WITHHELD, DSD_FRAME_VERDICT_UNPRODUCTIVE};
+    const HuntCase tc = {
+        .label = "withheld mixed with unproductive at 4800/4",
+        .marker = FALSE_SYNC_MARKER,
+        .marker_gap = 284,
+        .handler_symbols = 8,
+        .verdict_cycle = withheld_then_unproductive,
+        .verdict_cycle_len = 2,
+        .symbol_budget = 400000,
+        .expect_step = 1,
+    };
+    const HuntResult r = drive_hunt(&tc);
+
+    assert(r.syncs_seen > 10);
+    assert_auto_stepped_to_2400_4(&r);
+}
+
+/* A trunked voice channel the engine tuned on a grant. */
+static void
+configure_tuned_vc(dsd_opts* opts, dsd_state* state) {
+    (void)state;
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+}
+
+/* #392, the other half: the profile on a tuned voice channel came with the grant that tuned
+ * it, so the hunt holds it however the budget reads. A call fading toward the noise floor
+ * credits less than the search between its syncs burns and reaches the dwell while it is
+ * still decoding; rotating there takes the channel's timing away mid-call.
+ *
+ * This is test_unproductive_frames_never_buy_dwell()'s shape with one flag changed, so what
+ * it pins is the flag and nothing else: the same stream rotates when the tuner is not parked
+ * on a voice channel. */
+static void
+test_a_tuned_voice_channel_holds_its_profile(void) {
+    const HuntCase tc = {
+        .label = "tuned VC at 4800/4",
+        .marker = FALSE_SYNC_MARKER,
+        .marker_gap = 284,
+        .handler_symbols = 8,
+        .handler_unproductive = 1,
+        .symbol_budget = 400000,
+        .expect_step = 0,
+        .configure = configure_tuned_vc,
+    };
+    const HuntResult r = drive_hunt(&tc);
+
+    assert(r.syncs_seen > 100);
+    assert(r.final_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(r.final_sps == HUNT_SPS_4800);
+}
+
 /* A P25 voice channel the trunk SM has tuned, whose hangtime has already run out: the
  * shape in which frame_sync_no_sync_try_p25_release() has a release to make. */
 static void
@@ -602,8 +687,13 @@ configure_tuned_vc_past_hangtime(dsd_opts* opts, dsd_state* state) {
 
 /* #393: the budget exit is a no-sync exit like the timeout, so it owes the P25 SM the
  * same accounting in the same order -- VC no-sync pass, release check, then no-carrier.
- * Markers every 8 symbols keep the 1800-symbol timeout from ever arming, so only the
- * budget exit can step here. */
+ * Markers every 8 symbols keep the 1800-symbol timeout from ever arming, so the budget
+ * exit is the only path that can run them here.
+ *
+ * #392 holds the profile on a tuned voice channel, so this no longer rotates -- but the
+ * accounting is exactly what it must not take with it. These hooks are what gives a dead
+ * voice channel up; without them nothing would clear trunk_is_tuned and the hold would
+ * never end. */
 static void
 test_budget_exit_runs_the_no_sync_hooks(void) {
     g_hook_order = 0;
@@ -622,15 +712,15 @@ test_budget_exit_runs_the_no_sync_hooks(void) {
         .marker_gap = 0,
         .handler_symbols = 8,
         .symbol_budget = 40000,
-        .expect_step = 1,
+        .expect_step = 0,
         .configure = configure_tuned_vc_past_hangtime,
     };
     const HuntResult r = drive_hunt(&tc);
     dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){0});
 
-    /* Same AUTO step the other stepping cases assert: the budget exit is a different way out
-     * of the dwell, not a different rotation. */
-    assert_auto_stepped_to_2400_4(&r);
+    /* The profile the engine tuned is still the profile in force. */
+    assert(r.final_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(r.final_sps == HUNT_SPS_4800);
     assert(g_vc_no_sync_order > 0);
     assert(g_release_order > g_vc_no_sync_order);
     assert(g_no_carrier_order > g_release_order);
@@ -649,6 +739,9 @@ main(void) {
     test_a_verdict_is_read_once_and_cleared();
     test_idle_rotation_period_is_unchanged();
     test_locked_modulation_rotates_within_equal_timing();
+    test_withheld_syncs_do_not_rotate_a_profile();
+    test_withheld_syncs_do_not_hold_a_wrong_profile();
+    test_a_tuned_voice_channel_holds_its_profile();
     test_budget_exit_runs_the_no_sync_hooks();
     return 0;
 }

--- a/tests/engine/test_engine_protocol_dispatch.c
+++ b/tests/engine/test_engine_protocol_dispatch.c
@@ -229,6 +229,8 @@ check_verdict_default_is_productive(void) {
      * recognises 2 as the proof that restarts a dwell; renumbering here without changing it
      * there turns every proof into a refusal. */
     _Static_assert(DSD_FRAME_VERDICT_PROFILE_PROVEN == 2, "the DSP layer matches PROFILE_PROVEN as the literal 2");
+    /* #392: same rule for the verdict that makes a declined dispatch budget-neutral. */
+    _Static_assert(DSD_FRAME_VERDICT_WITHHELD == 3, "the DSP layer matches WITHHELD as the literal 3");
 }
 
 int
@@ -248,6 +250,10 @@ main(void) {
     run_dispatch_case_verdict(DSD_SYNC_YSF_POS, TEST_HANDLER_YSF, DSD_FRAME_VERDICT_PROFILE_PROVEN, 0);
     run_dispatch_case_verdict(DSD_SYNC_YSF_POS, TEST_HANDLER_YSF, DSD_FRAME_VERDICT_UNPRODUCTIVE,
                               DSD_FRAME_VERDICT_PROFILE_PROVEN);
+    /* #392: and so does a withheld frame, over any verdict the frame before it left. */
+    run_dispatch_case_verdict(DSD_SYNC_YSF_POS, TEST_HANDLER_YSF, DSD_FRAME_VERDICT_WITHHELD, 0);
+    run_dispatch_case_verdict(DSD_SYNC_YSF_POS, TEST_HANDLER_YSF, DSD_FRAME_VERDICT_PRODUCTIVE,
+                              DSD_FRAME_VERDICT_WITHHELD);
 
     printf("ENGINE_PROTOCOL_DISPATCH: OK\n");
     return 0;

--- a/tests/engine/test_engine_synced_trunk_scan_tick.c
+++ b/tests/engine/test_engine_synced_trunk_scan_tick.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/engine/engine.h>
+#include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/runtime/exitflag.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
@@ -29,6 +30,7 @@ static int g_get_frame_sync_calls = 0;
 static int g_outer_tick_calls = 0;
 static int g_synced_tick_calls = 0;
 static int g_process_frame_guard_failures = 0;
+static int g_withheld_verdicts = 0;
 static uint64_t g_pending_tune_request = 0U;
 static uint64_t g_failed_tune_request = 0U;
 static int g_failed_gate_seen = 0;
@@ -61,7 +63,14 @@ processFrame(dsd_opts* opts, dsd_state* state) { // NOLINT(misc-use-internal-lin
 int
 __wrap_getFrameSync(dsd_opts* opts, dsd_state* state) {
     (void)opts;
-    (void)state;
+    /* #392: a frame the retune generation makes undispatchable consumes nothing, so the
+     * skip has to tell the SPS hunt so itself -- processFrame(), which normally stamps this,
+     * never ran. Observed here because the real getFrameSync() is what reads the verdict,
+     * and it reads it once and clears it. */
+    if (state->sps_hunt_last_frame_verdict == DSD_FRAME_VERDICT_WITHHELD) {
+        g_withheld_verdicts++;
+    }
+    state->sps_hunt_last_frame_verdict = DSD_FRAME_VERDICT_PRODUCTIVE;
     g_get_frame_sync_calls++;
     if (g_get_frame_sync_calls == 1) {
         // Frames assembled before and during an asynchronous retune must stay
@@ -156,6 +165,14 @@ main(void) {
     if (g_process_frame_guard_failures != 0) {
         DSD_FPRINTF(stderr, "frame processing did not own the SM/scan guard failures=%d\n",
                     g_process_frame_guard_failures);
+        test_rc = 1;
+    }
+    /* #392: the four syncs the gate discarded each told the SPS hunt they were withheld, so
+     * the search that found them comes out budget-neutral instead of charged. Seven syncs
+     * are returned and three are dispatched, so this is the exact complement of the count
+     * above -- a skip that stamps nothing would leave it at zero. */
+    if (g_withheld_verdicts != 4) {
+        DSD_FPRINTF(stderr, "undispatchable frames did not report a withheld verdict count=%d\n", g_withheld_verdicts);
         test_rc = 1;
     }
     if (g_outer_tick_calls == 0) {

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -46,6 +46,7 @@ static long int g_last_setfreq_hz = 0;
 static bool g_setfreq_result = true;
 static bool g_setmod_result = true;
 static int g_frame_sync_reset_calls = 0;
+static int g_sps_hunt_restart_calls = 0;
 static int g_p25p2_frame_reset_calls = 0;
 static int g_rtl_tune_result = RTL_STREAM_TUNE_OK;
 static int g_rtl_cqpsk_enable = 0;
@@ -134,6 +135,20 @@ void
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 dsd_frame_sync_reset_mod_state(void) {
     g_frame_sync_reset_calls++;
+}
+
+/* Mirrors the real helper in src/dsp/dsd_frame_sync.c so the assertions below read the
+ * behavior rather than the stub. */
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_frame_sync_sps_hunt_restart_dwell(dsd_state* state) {
+    g_sps_hunt_restart_calls++;
+    if (!state) {
+        return;
+    }
+    state->sps_hunt_counter = 0;
+    state->sps_hunt_symbolcnt_mark = state->symbolcnt;
+    state->sps_hunt_counter_at_entry = 0;
 }
 
 void
@@ -711,10 +726,22 @@ main(void) {
     assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_2400_4);
     assert(state->sps_hunt_counter == 17);
 
+    /* The voice-channel tune keeps the NXDN48 profile but starts its dwell over: the grant
+     * put the decoder here, so the control channel's spend is not this channel's to inherit
+     * (#392). The profile index is the invariant this case is about, and it is untouched. */
     state->sps_hunt_counter = 23;
+    state->symbolcnt = 7000U;
+    state->sps_hunt_symbolcnt_mark = 1234U;
+    state->sps_hunt_counter_at_entry = 23;
+    g_sps_hunt_restart_calls = 0;
     assert(dsd_engine_trunk_tune_to_freq_request(opts, state, 451500000, 0, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
     assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_2400_4);
-    assert(state->sps_hunt_counter == 23);
+    assert(g_sps_hunt_restart_calls == 1);
+    assert(state->sps_hunt_counter == 0);
+    /* The anchor moves with the budget, so the fresh dwell is not immediately credited for
+     * symbols spent before the tune (#394). */
+    assert(state->sps_hunt_symbolcnt_mark == 7000U);
+    assert(state->sps_hunt_counter_at_entry == 0);
 
     /* Direct conventional scan retunes publish a new generation only after
      * the backend completes the target. */

--- a/tests/protocol/dmr/test_dmr_sync_dispatch.c
+++ b/tests/protocol/dmr/test_dmr_sync_dispatch.c
@@ -272,6 +272,94 @@ test_ms_data_routes_to_ms_data(void) {
     assert(close_right_calls == 1);
 }
 
+/* #392: trunking declines the direct-mode paths, and a declined path reads no symbols. The
+ * SPS hunt refuses consumption credit below a frame's worth, so reporting these as productive
+ * left the search that found the sync charged with nothing ever paying it back -- and the
+ * hunt rotated the profile off a channel the control channel had just granted. They report
+ * WITHHELD so the cycle comes out neutral instead. */
+static void
+test_trunked_direct_mode_paths_report_withheld(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* Stereo MS voice: the default shape, since initState() sets dmr_stereo. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+    opts.dmr_stereo = 1;
+    opts.trunk_enable = 1;
+    state.synctype = DSD_SYNC_DMR_MS_VOICE;
+    assert(dsd_dispatch_handle_dmr(&opts, &state) == DSD_FRAME_VERDICT_WITHHELD);
+    assert(ms_bootstrap_calls == 0);
+
+    /* MS data. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+    opts.dmr_stereo = 1;
+    opts.trunk_enable = 1;
+    state.synctype = DSD_SYNC_DMR_MS_DATA;
+    assert(dsd_dispatch_handle_dmr(&opts, &state) == DSD_FRAME_VERDICT_WITHHELD);
+    assert(ms_data_calls == 0);
+
+    /* Mono on a non-BS sync reaches the same gate through dmr_bootstrap_mono(). */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+    opts.dmr_mono = 1;
+    opts.dmr_stereo = 1;
+    opts.trunk_enable = 1;
+    state.synctype = DSD_SYNC_DMR_MS_VOICE;
+    assert(dsd_dispatch_handle_dmr(&opts, &state) == DSD_FRAME_VERDICT_WITHHELD);
+    assert(ms_bootstrap_calls == 0);
+    assert(bs_bootstrap_calls == 0);
+}
+
+/* The other direction, which is what keeps the claim narrow: wherever a burst is actually
+ * read, the verdict is productive and the profile is paid for what it read. */
+static void
+test_dispatched_dmr_paths_stay_productive(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* Untrunked MS voice and MS data both run their processors. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+    opts.dmr_stereo = 1;
+    state.synctype = DSD_SYNC_DMR_MS_VOICE;
+    assert(dsd_dispatch_handle_dmr(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
+    assert(ms_bootstrap_calls == 1);
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+    opts.dmr_stereo = 1;
+    state.synctype = DSD_SYNC_DMR_MS_DATA;
+    assert(dsd_dispatch_handle_dmr(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
+    assert(ms_data_calls == 1);
+
+    /* Base-station voice is never gated: trunked systems carry their traffic on it. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+    opts.dmr_stereo = 1;
+    opts.trunk_enable = 1;
+    state.synctype = DSD_SYNC_DMR_BS_VOICE_NEG;
+    assert(dsd_dispatch_handle_dmr(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
+    assert(bs_bootstrap_calls == 1);
+
+    /* Nor is the data-sync path every other DMR burst takes. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_calls();
+    opts.dmr_stereo = 1;
+    opts.trunk_enable = 1;
+    state.synctype = DSD_SYNC_DMR_BS_DATA_NEG;
+    assert(dsd_dispatch_handle_dmr(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
+    assert(data_sync_calls == 1);
+}
+
 static void
 test_rc_routes_to_rc_handler(void) {
     static dsd_opts opts;
@@ -335,6 +423,8 @@ main(void) {
     test_ms_data_routes_to_ms_data();
     test_rc_routes_to_rc_handler();
     test_bs_data_routes_to_data_sync();
+    test_trunked_direct_mode_paths_report_withheld();
+    test_dispatched_dmr_paths_stay_productive();
     printf("DMR_SYNC_DISPATCH: OK\n");
     return 0;
 }


### PR DESCRIPTION
Fixes #392. Refs #388, #391, #393, #394, #415.

## The defect

The SPS hunt charges its dwell one symbol per symbol searched and credits it back from what a frame handler consumes. Two engine gates produce **real syncs that consume nothing**, so nothing ever credits them:

| gate | site | what it skips |
|---|---|---|
| trunked DMR direct mode | `dispatch_dmr.c:65,108` | `dmrMSBootstrap()` / `dmrMSData()` when `trunk_enable == 1` |
| retune in flight | `engine.c:2424` | `processFrame()` while `dsd_trunk_tuning_frame_is_dispatchable()` is false |

Both reported `PRODUCTIVE`, which is only *permission* to debit — the credit path refuses anything below `DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS`. So the search that found each sync stood charged with nothing paying it back, and after a dwell (5400 symbols, ~1.1 s at 4800 sym/s) the hunt rotated the profile off the channel the engine had just tuned and ran the no-carrier teardown mid-call.

#436 narrowed the blast radius to the protocols that report no verdict; it did not reach either gate. Nothing on `main` referenced #392.

## The fix

**`DSD_FRAME_VERDICT_WITHHELD`** — the engine declined to dispatch. The cycle is made budget-neutral: the counter returns to `sps_hunt_counter_at_entry`, the value it held when the cycle began.

Restoring to a snapshot rather than subtracting a count is exact without a second counter — charging happens only inside `frame_sync_advance_sync_window()`, between the stamp and the read. The restore is **clamped so it can only lower the counter**: a profile change, a retune, or a trunk-scan target switch may have zeroed it in between, and none of those is the refund's to undo.

It is not credit (the engine's reason for declining says nothing about the profile) and not a reserve (a refund cannot pass the value it started from).

**Honest residual:** a stream of false DMR MS syncs under trunking now accrues nothing, so it cannot reach a dwell either — the #388 shape, re-opened for that subset. It stays bounded because every other protocol's false syncs still charge (their handlers run and report `UNPRODUCTIVE`) and because the undispatchable case resolves with the retune that caused it. Documented on the enum and pinned by `test_withheld_syncs_do_not_hold_a_wrong_profile`.

### Two adjacent gaps closed with it

- **A confirmed VC tune restarts the dwell for every system.** `dsd_engine_select_p25_sps_profile()` did this only for the P25 retunes it handles (`dsd_engine_cc_is_p25()` returns 0 for DMR/NXDN/EDACS), so those grants inherited whatever the control channel had spent hunting. `dsd_frame_sync_sps_hunt_restart_dwell()` resets the counter, the anchor **and** the snapshot — the first site to pay the #394 half-reset in full. Voice channels only: the existing pins that non-P25 CC returns leave the counter alone stay green.
- **The profile is held while parked on a trunked voice channel.** The grant chose it, and a call fading toward the noise floor credits less than the search between its syncs burns — the issue's NXDN96 arithmetic — so it reached the dwell while still decoding.

### The hold deliberately still returns non-zero

This is the part worth reviewing. The budget exit owes the P25 SM its no-sync accounting (#393), and **that accounting is the only thing that gives a dead voice channel up when false syncs arrive often enough to stop the in-call timeout ever arming** — exactly the shape `test_budget_exit_runs_the_no_sync_hooks()` drives. Suppressing it would leave nothing to clear `trunk_is_tuned`, and the hold would never end. My first cut returned 0 and that test caught it.

`p25_p1_mod_probe_active` is cleared *before* the hold for the same class of reason: that line is its only clear, and a probe left latched across a grant would pin `rf_mod` against the modulation votes for the whole call (`frame_sync_hold_validated_p25p1_modulation()`).

Control channels are never `trunk_is_tuned` (`trunk_tuning.c:719` says so explicitly), so AUTO still rotates and still probes there — #425 is untouched.

## Tests

Suite goes 578 → 578 (cases added to existing targets; no new binaries).

- `FRAME_SYNC_SPS_HUNT_FALSE_SYNC` — withheld syncs do not rotate; withheld mixed with unproductive still rotates; a tuned VC holds its profile. The first and third are **mutation-checked**: without the WITHHELD branch the hunt steps at 5414 symbols, matching the issue's predicted 5400-symbol dwell; without the hold it steps at 5526.
- `FRAME_SYNC_INTERNAL_HELPERS` — refund exactness, the min-clamp, read-once, withheld-beats-consumption, the restart helper's three fields, and the hold including the probe-flag clear and both halves of its condition.
- `ENGINE_SYNCED_TRUNK_SCAN_TICK` — the four frames the gate discards each report withheld (0 without the stamp).
- `DMR_SYNC_DISPATCH` — gated MS voice/data/mono report withheld with zero processor calls; BS voice, data-sync and untrunked MS stay productive with the processor called.
- `ENGINE_PROTOCOL_DISPATCH` — `_Static_assert` pinning the literal 3 the DSP layer matches, plus pass-through.
- `ENGINE_TRUNK_RETUNE_REGRESSION` — a non-P25 VC tune restarts counter and anchor; the CC-return pins are unchanged.

Three existing assertions changed, each for a stated reason: the #393 hook-ordering case now asserts the profile is *held* while the hooks still run in order; the "unknown verdict" sentinel moves from `PROFILE_PROVEN + 1` to `WITHHELD + 1` (3 is no longer unknown); and the NXDN VC-tune case asserts the restarted dwell while keeping its actual invariant, the preserved profile index.

## Verification

- `ctest --preset dev-debug` — 578/578
- Key tests green under `asan-ubsan-debug` and `tsan-debug`
- `ctest -L iq-decode` — 24 fixtures unchanged
- `tools/preflight_ci.sh` — exit 0 (arch rules OK, clang-tidy clean, cppcheck passed, IWYU 0 blocking, GCC `-fanalyzer` clean, semgrep 0 findings, lizard under thresholds)

`docs/cli.md` gains the withheld-frame and tuned-VC notes.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / **none**.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
