### PR TITLE
fix(dsp): keep the NXDN48 matcher out of a dPMR frame it cannot own

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -349,6 +349,14 @@ Notes
   PICH/TCH, a full SACCH superframe) is proof on its own; the 6- and 7-bit CRCs on SACCH and SCCH have to repeat on
   two consecutive frames. A real call confirms on its first FACCH, or within two frames when only SACCH is passing,
   so the cost is at most one frame of audio at the very start of a transmission.
+- dPMR and NXDN48 share the 2400/4 profile, and their sync matchers are not comparable in strength: dPMR's Frame Sync
+  2 is a single exact 12-symbol pattern, while NXDN's takes five variants per polarity over ten symbols sliced on sign
+  alone and so fires on roughly one arbitrary window in a hundred. The 372 dibits behind an accepted FS2 are dPMR's
+  frame, so for that frame's span the NXDN48 matcher stays off the profile: an NXDN match inside it would consume
+  symbols the frame needed and warm-start the slicer thresholds from ten symbols of dPMR payload, which left Auto
+  decoding corrupted dPMR identities on captures the `-fm` preset reads cleanly. The suppression lasts one frame and
+  is re-armed per FS2, so it costs a real NXDN48 signal nothing -- such a signal produces no FS2 matches at all -- and
+  it does not apply to NXDN96, which lives on 4800/4 where dPMR cannot match, nor to any build with dPMR disabled.
 - All three Auto entry points install the complete matrix above: CLI `-fa`, config `decode = "auto"`, and the
   interactive Auto choice select the same decoder set. Only `-fa` also resets the demodulator to C4FM and the audio
   layout to stereo; the config path leaves those to its `demod` and `dmr_mono` keys, and the interactive path to the

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -603,6 +603,18 @@ struct dsd_state {
      * anything -- entering GFSK needs a single vote, which is a few dozen symbols. */
     int p25_p1_mod_probe_next_qpsk;
     int p25_p1_mod_probe_active;
+    /* Where the last accepted dPMR FS2 sync sat in dsd_state::symbolcnt, and whether one has
+     * been seen at all. dPMR and NXDN48 are the two candidates on the 2400/4 profile, and their
+     * matchers are not comparable: FS2 is one exact 12-symbol pattern, while the NXDN matcher
+     * takes five variants per polarity over ten sign-sliced symbols and so fires on about 1% of
+     * arbitrary windows. The 372 dibits behind an accepted FS2 are dPMR's frame, and an NXDN
+     * accept inside them consumes symbols that frame needed and warm-starts the slicer from ten
+     * symbols of dPMR payload -- which is what left AUTO decoding corrupted dPMR identities that
+     * the native preset reads cleanly (#374). The span is read by src/dsp only, through
+     * dsd_frame_sync_suppress_nxdn48_sync(); the stamp wraps with symbolcnt and is compared as a
+     * modular difference, so a rollover mid-frame stays exact. */
+    uint32_t dpmr_fs2_frame_symbolcnt;
+    uint8_t dpmr_fs2_frame_valid;
     int lastsynctype;
     int lastp25type;
     int offset;

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -104,6 +104,14 @@ dsd_nxdn_variant dsd_frame_sync_active_nxdn_variant(const dsd_opts* opts, const 
 int dsd_frame_sync_suppress_p25_alt_sync(const dsd_opts* opts, const dsd_state* state);
 
 /**
+ * @brief Return non-zero while an accepted dPMR FS2 frame owns the 2400/4 profile.
+ *
+ * dPMR and NXDN48 share that profile with matchers of very different strength, so the frame a
+ * 12-symbol FS2 opened is not offered to the looser one (#374).
+ */
+int dsd_frame_sync_suppress_nxdn48_sync(const dsd_opts* opts, const dsd_state* state);
+
+/**
  * @brief Return non-zero when TCP no-signal diagnostics should stay off the console.
  */
 int dsd_frame_sync_suppress_tcp_no_signal_console(const dsd_opts* opts, const dsd_state* state);

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -819,6 +819,19 @@ frame_sync_try_p25p2(frame_sync_match_ctx* ctx) {
 #endif
 }
 
+/**
+ * @brief Record that an FS2 sync just opened a dPMR frame on the 2400/4 profile.
+ *
+ * The stamp is what dsd_frame_sync_suppress_nxdn48_sync() measures the frame's span from, so it
+ * is taken on every accepted FS2 -- including one arriving inside the previous frame's span,
+ * which re-arms the window rather than extending it indefinitely.
+ */
+static void
+frame_sync_note_dpmr_fs2_frame(dsd_state* state) {
+    state->dpmr_fs2_frame_symbolcnt = state->symbolcnt;
+    state->dpmr_fs2_frame_valid = 1;
+}
+
 static int
 frame_sync_try_dpmr(frame_sync_match_ctx* ctx) {
     const dsd_opts* opts = ctx->opts;
@@ -830,6 +843,7 @@ frame_sync_try_dpmr(frame_sync_match_ctx* ctx) {
 
     if (opts->inverted_dpmr == 0 && strcmp(ctx->synctest12, DPMR_FRAME_SYNC_2) == 0) {
         frame_sync_set_basic_lock(ctx);
+        frame_sync_note_dpmr_fs2_frame(state);
         DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "dPMR ");
         if (opts->errorbars == 1) {
             printFrameSync(opts, state, "+dPMR ", ctx->synctest_pos + 1, ctx->modulation);
@@ -841,6 +855,7 @@ frame_sync_try_dpmr(frame_sync_match_ctx* ctx) {
 
     if (opts->inverted_dpmr == 1 && strcmp(ctx->synctest12, INV_DPMR_FRAME_SYNC_2) == 0) {
         frame_sync_set_basic_lock(ctx);
+        frame_sync_note_dpmr_fs2_frame(state);
         DSD_SNPRINTF(state->ftype, sizeof(state->ftype), "dPMR ");
         if (opts->errorbars == 1) {
             printFrameSync(opts, state, "-dPMR ", ctx->synctest_pos + 1, ctx->modulation);
@@ -1588,9 +1603,13 @@ frame_sync_try_nxdn(frame_sync_match_ctx* ctx) {
         /* Symbol captures carry no rate metadata, so an enabled variant must be unambiguous. */
         nxdn_profile_enabled = (opts->frame_nxdn48 == 1) != (opts->frame_nxdn96 == 1);
     } else {
+        /* Only the 2400/4 term yields to dPMR: that is the profile the two share, and the frame
+         * a 12-symbol FS2 opened is not this matcher's to re-open (#374). NXDN96 on 4800/4 is
+         * untouched, and so is every build with dPMR disabled. */
         nxdn_profile_enabled =
             (opts->frame_nxdn96 == 1 && frame_sync_match_profile_active(ctx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4))
-            || (opts->frame_nxdn48 == 1 && frame_sync_match_profile_active(ctx, DSD_FRAME_SYNC_SPS_PROFILE_2400_4));
+            || (opts->frame_nxdn48 == 1 && frame_sync_match_profile_active(ctx, DSD_FRAME_SYNC_SPS_PROFILE_2400_4)
+                && !dsd_frame_sync_suppress_nxdn48_sync(opts, state));
     }
     if (!nxdn_profile_enabled || !frame_sync_match_window_ready(ctx, 10)) {
         return DSD_SYNC_NONE;

--- a/src/dsp/frame_sync_internal.h
+++ b/src/dsp/frame_sync_internal.h
@@ -37,6 +37,16 @@ extern "C" {
  */
 #define DSD_FRAME_SYNC_MIN_FRAME_SYMBOLS            16
 
+/**
+ * @brief Symbols one dPMR FS2 frame occupies, sync word included.
+ *
+ * processdPMRvoice() reads 372 dibits behind the 12-symbol FS2 sync: two 36-dibit CCH halves,
+ * two groups of four 36-dibit AMBE frames, and the 12-dibit channel code. That span is the
+ * frame FS2 opened, and it is how long the weaker NXDN48 matcher stays off the 2400/4 profile
+ * (see dsd_frame_sync_suppress_nxdn48_sync()).
+ */
+#define DSD_FRAME_SYNC_DPMR_FS2_FRAME_SYMBOLS       384U
+
 /** @brief One entry of the SPS hunt's rate/level table, indexed by dsd_state::sps_hunt_idx. */
 typedef struct {
     int symbol_rate_hz;

--- a/src/dsp/frame_sync_policy.c
+++ b/src/dsp/frame_sync_policy.c
@@ -7,9 +7,11 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <stdint.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "frame_sync_internal.h"
 
 int
 dsd_frame_sync_suppress_p25_alt_sync(const dsd_opts* opts, const dsd_state* state) {
@@ -17,6 +19,22 @@ dsd_frame_sync_suppress_p25_alt_sync(const dsd_opts* opts, const dsd_state* stat
         return 0;
     }
     return opts->trunk_enable == 1 && state->carrier == 1 && DSD_SYNC_IS_P25(state->lastsynctype);
+}
+
+int
+dsd_frame_sync_suppress_nxdn48_sync(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return 0;
+    }
+    if (opts->frame_dpmr != 1 || state->dpmr_fs2_frame_valid == 0) {
+        return 0;
+    }
+    /* Modular difference, so the span stays exact across the symbol counter's rollover. A
+     * backwards jump -- nxdn_reset_after_cac_fail() and initState() both zero symbolcnt --
+     * reads as a huge forward distance and simply ends the suppression early, which is the
+     * safe way for it to fail. */
+    const uint32_t since = state->symbolcnt - state->dpmr_fs2_frame_symbolcnt;
+    return since < DSD_FRAME_SYNC_DPMR_FS2_FRAME_SYMBOLS;
 }
 
 int

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -1018,6 +1018,74 @@ test_provoice_candidate_does_not_shadow_dstar_or_nxdn(void) {
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
 }
 
+/* dPMR's FS2 is one exact 12-symbol match against a single pattern -- 2^-12 on a sign-sliced
+ * stream -- while NXDN48 shares the profile with a matcher two orders of magnitude looser. The
+ * 372 dibits behind an accepted FS2 are dPMR's frame, so nothing weaker gets to match inside
+ * them: an NXDN accept there consumes symbols the frame needed and warm-starts the thresholds
+ * from ten symbols of another protocol's payload (#374). Same shape as the P25 suppression in
+ * dsd_frame_sync_suppress_p25_alt_sync(). */
+static void
+test_a_dpmr_frame_is_not_reopened_by_the_nxdn_matcher(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_dpmr = 1;
+    opts.frame_nxdn48 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.symbolcnt = 1000;
+
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, DPMR_FRAME_SYNC_2, 12) == DSD_SYNC_DPMR_FS2_POS);
+
+    /* Inside the frame the FS2 opened, NXDN never even latches a candidate. */
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype != DSD_SYNC_NXDN_POS);
+    state.symbolcnt = 1000 + 380;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype != DSD_SYNC_NXDN_POS);
+
+    /* Past the frame the matcher is live again, on its own two-hit terms. */
+    state.symbolcnt = 1000 + DSD_FRAME_SYNC_DPMR_FS2_FRAME_SYMBOLS;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
+}
+
+/* The suppression is dPMR's frame, not a mute switch: NXDN96 lives on 4800/4 where dPMR cannot
+ * match at all, and a build with dPMR disabled must behave exactly as it did before. */
+static void
+test_the_dpmr_frame_suppression_is_scoped_to_its_own_profile(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_dpmr = 0;
+    opts.frame_nxdn48 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.dpmr_fs2_frame_symbolcnt = 1000;
+    state.dpmr_fs2_frame_valid = 1;
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+
+    reset(&opts, &state);
+    opts.frame_dpmr = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.dpmr_fs2_frame_symbolcnt = 1000;
+    state.dpmr_fs2_frame_valid = 1;
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+}
+
 static void
 test_symbol_replay_bypasses_sps_profile_gating(void) {
     static const int symbol_input_types[] = {AUDIO_IN_SYMBOL_BIN, AUDIO_IN_SYMBOL_FLT};
@@ -2521,6 +2589,8 @@ main(void) {
     test_m17_candidate_expires_without_a_following_sync();
     test_short_m17_window_estimates_levels_without_warm_start_history();
     test_m17_alternating_runs_alone_are_never_a_sync();
+    test_a_dpmr_frame_is_not_reopened_by_the_nxdn_matcher();
+    test_the_dpmr_frame_suppression_is_scoped_to_its_own_profile();
     test_elapsed_seconds_prefers_monotonic_then_wall_time();
     test_p25_slot_activity_honors_ring_and_hangtime();
     test_hamming_helpers_find_best_patterns();


### PR DESCRIPTION
## What

dPMR and NXDN48 are the two candidates on the 2400/4 SPS profile, and their sync matchers are not comparable in strength:

| matcher | shape | hit rate on arbitrary windows |
|---|---|---|
| dPMR FS2 | one exact 12-symbol pattern | ~2⁻¹² (0.02%) |
| NXDN | 5 variants × 2 polarities, 10 symbols, sign-sliced | ~1% |

The 372 dibits behind an accepted FS2 are dPMR's frame, but nothing stopped the looser matcher from accepting inside them. This records where an accepted FS2 sat and keeps the NXDN48 matcher off the profile for that frame's span — the same shape as the existing `dsd_frame_sync_suppress_p25_alt_sync()`.

## Why

Each NXDN accept inside a dPMR frame consumes 8 or 182 symbols the frame needed, and runs `dsd_sync_warm_start_thresholds_outer_only()` on ten symbols of dPMR payload on the assumption they are outer levels. Measured on the committed `dpmr` fixture, replaying the identical capture:

| frame | `-fm` (NXDN disabled) | `-fa` before | `-fa` with this change |
|---|---|---|---|
| 2nd CCH pair | `id=BEA5D6` | `id=BEA5E6` | `id=BEA5D6` |
| 3rd CCH pair | `id=C68FF6` | `id=C70FF6` | `id=C68FF6` |

So AUTO was publishing talkgroup identities the native preset never produces. The suppression restores the `-fm` values exactly.

## Scope and cost

- Only the 2400/4 term yields. NXDN96 on 4800/4, where dPMR cannot match, is untouched; so is any build with dPMR disabled. Both pinned by tests.
- Costs a real NXDN48 signal **nothing**: that capture produces no FS2 matches at all. `nxdn48.iq` decodes identically before and after — 3× `Src=901` under `-fi`, 5× under `-fa` realtime.
- The window is re-armed per FS2 rather than extended, and the span is a modular difference so it stays exact across the symbol counter's rollover. A backwards jump in `symbolcnt` (`nxdn_reset_after_cac_fail()`, `initState()`) reads as a large forward distance and simply ends the suppression early, which is the safe failure direction.

## What this does *not* do

It does **not** make the `dpmr` fixture decode `Src=1601621` under `-fa`, and I did not add a `DECODE_IQ_DPMR_AUTO` case. Whether the single Src-bearing frame lands inside a 2400/4 dwell is round-robin phase — the duty-cycle limit already described in #374, and unchanged here. I verified this separately: with the hunt **force-pinned** to 2400/4 *and* NXDN suppressed, the fixture still does not produce that identity, so the residual is not a convergence or arbitration problem.

Investigation notes for #374 (falsified hypotheses for a dPMR confirm gate, and a correction on #388) follow in a comment on the issue.

## Tests

New cases in `tests/dsp/test_frame_sync_internal_helpers.c`, both verified red before the fix and green after:

- `test_a_dpmr_frame_is_not_reopened_by_the_nxdn_matcher` — inside the frame NXDN never even latches a candidate; past it the matcher is live again on its own two-hit terms. Fails without the gate with `state.lastsynctype != DSD_SYNC_NXDN_POS`.
- `test_the_dpmr_frame_suppression_is_scoped_to_its_own_profile` — dPMR disabled, and NXDN96 on 4800/4, both behave exactly as before.

Full suite: **578/578 pass** on `dev-debug`; `asan-ubsan-debug` green on the frame-sync/dPMR tests and the whole `iq-decode` label. `tools/preflight_ci.sh` exits 0 (IWYU fatal=0, GCC analyzer fatal=0).

## Closing #374

This closes #374 by decomposition, not because it makes the `dpmr` fixture decode. The rationale is laid out in
https://github.com/arancormonk/dsd-neo/issues/374#issuecomment-5483381131 — in short:

- **Convergence** (the reported symptom: hunt never reaching 9600/2, 6000/4, 4800/2) — fixed by #387.
- **NXDN48 under `-fa`** — verified fixed: 5x `Src=901` at realtime vs 3x under native `-fi`. The `fast` count
  of 0 is the documented `--iq-replay-rate` harness artifact, not a live bug.
- **dPMR identity corruption under `-fa`** — fixed by this PR.
- **dPMR never reaching `Src=1601621` under `-fa`** — moved to #407. Proven not to be a hunt problem: with the
  hunt force-pinned to 2400/4 *and* NXDN suppressed it still does not decode, and CRC-7 fails on every frame of
  the good capture even under `-fm`, so identity publication rides entirely on the Hamming(12,8) fallback. That
  is decode margin plus a missing integrity check, which is #407's scope.
- **Co-located starvation at 4800/4** — #388, re-scoped to that alone.

Closes #374
