### PR TITLE
fix(dsp): keep the weaker 4800/4 matchers out of a P25p1 frame

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -357,6 +357,17 @@ Notes
   decoding corrupted dPMR identities on captures the `-fm` preset reads cleanly. The suppression lasts one frame and
   is re-armed per FS2, so it costs a real NXDN48 signal nothing -- such a signal produces no FS2 matches at all -- and
   it does not apply to NXDN96, which lives on 4800/4 where dPMR cannot match, nor to any build with dPMR disabled.
+- The 4800/4 profile carries P25p1, DMR, NXDN96, YSF and M17 together, and the same imbalance applies there: P25p1's
+  sync is one of two exact 24-symbol patterns, while NXDN96's is the ten-symbol word above and M17's preamble is an
+  alternating run that any 4800-baud signal presents. So for the span of the frame an accepted P25p1 sync opened,
+  neither of those two can take a sync on the profile -- a false frame inside it consumes the symbols the next sync
+  needed, warm-starts the slicer from P25 payload, and takes the `lastsynctype` that keeps the C4FM threshold tracker
+  running between one P25p1 frame and the next. Under Auto that had left a P25 Phase 1 C4FM control channel decoding
+  no NAC at all where its own `-f1` preset reads 26. Two deliberate limits: the NXDN window still contributes its
+  level estimate while inside the span, because that blend is the wideband reference the CQPSK chain depends on, and
+  a sync the CQPSK chain carried closes the span rather than opening one, for the same reason. The span is re-armed
+  by every P25p1 sync, so continuous traffic stays covered, and it lapses within a fifth of a second of P25 going
+  quiet. It costs a real NXDN96 or M17 signal nothing, since neither produces P25p1 sync matches.
 - All three Auto entry points install the complete matrix above: CLI `-fa`, config `decode = "auto"`, and the
   interactive Auto choice select the same decoder set. Only `-fa` also resets the demodulator to C4FM and the audio
   layout to stereo; the config path leaves those to its `demod` and `dmr_mono` keys, and the interactive path to the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,9 +87,28 @@ frame unproductive drops the payload from 23 hits to 13 and steps the hunt to 20
 handler's credit is bounded by what it read, and P25p1 reads 33 symbols when the NID fails against 134 of a
 ~180-symbol slot when a one-block TSDU decodes, so a channel that was decoding still lost the profile to the failures
 between its frames. The `p25p1_cqpsk_vc` capture is already registered under `-f1`; under `-fa` it steps to 20 sps
-partway through on `main` and finishes in dPMR, so the encrypted HDU behind those failures is a payload only the held
-profile reaches — which is what makes the assertion the fix rather than the fixture. Both halves were confirmed
-stable over repeated runs on `dev-debug`, `asan-ubsan-debug` and `tsan-debug` before the case was added.
+partway through on `main` and finishes in dPMR, so holding the profile is what the negative half of this case pins.
+Both halves were confirmed stable over repeated runs on `dev-debug`, `asan-ubsan-debug` and `tsan-debug`.
+
+Its payload assertion changed in issue #388, and the reason is worth recording: it had been
+`ALG ID: 0xC0 KEY ID: 0x3900`, which is not in this capture. The `-f1` preset emits no `0xC0` anywhere in it, reading
+three clear-voice headers (`ALG ID: 0x80 KEY ID: 0x0000`) and six `Group Voice Channel User` grants. What `-fa`
+produced was a corrupted read of one of those clear headers — the run decoded zero grants, two headers and 127 header
+errors — and the case had been asserting that artifact. Holding the 4800/4 co-tenants off the frame brings the `-fa`
+run in line with the native one (seven grants, four clear headers, irrecoverable header errors 3 → 0), so the
+assertion is now the same real payload `DECODE_IQ_P25P1_CQPSK_VOICE` asserts under `-f1`. The lesson generalizes: an
+AUTO case should assert a payload the native preset also produces, or it can end up pinning the corruption it was
+meant to catch.
+
+`DECODE_IQ_P25P1_C4FM_CC_AUTO_HUNT` covers issue #388 proper. P25 Phase 1 C4FM's own profile is where the hunt
+starts, so the `p25p1_c4fm_cc` capture needs no rotation and gets none — the failure was entirely the company 4800/4
+keeps. NXDN96's ten-symbol sync word and M17's alternating-run preamble both fire on P25 payload, and each false
+frame consumes symbols the next sync needed, warm-starts the slicer from that payload, and takes the `lastsynctype`
+that keeps the C4FM threshold tracker engaged between frames: 26 decoded NACs under `-f1` became none under `-fa`,
+every P25p1 sync reading `NAC: 000 duid:EE`. With the span guard the capture decodes 23 of those 26 under `-fa`. The
+three still missing are the frames ahead of the first accepted P25p1 sync, which is the earliest point anything can
+know P25p1 is on the channel — an evidence-based guard cannot cover its own bootstrap. The case asserts presence
+rather than a count, per the policy above, plus the absence of any hunt rotation.
 
 `DECODE_IQ_M17_AUTO` covers issue #399. M17's own profile is where the hunt starts, so the `m17` capture needs no
 rotation and gets none: it must publish the same identity under `-fa` that `DECODE_IQ_M17` asserts under `-fz`.

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -615,6 +615,23 @@ struct dsd_state {
      * modular difference, so a rollover mid-frame stays exact. */
     uint32_t dpmr_fs2_frame_symbolcnt;
     uint8_t dpmr_fs2_frame_valid;
+    /* The same idea one profile up, where 4800/4 carries P25p1, DMR, NXDN96, YSF and M17 at once.
+     * P25p1's sync is one of two exact 24-symbol patterns, so it fires on noise about once per
+     * 8.4 million windows; NXDN96's takes five variants per polarity over ten sign-sliced symbols
+     * and fires on roughly 1%, and M17's preamble is any alternating run at all. Inside the frame
+     * a P25p1 sync opened, those two are wrong by construction, and what they cost is measurable:
+     * on tests/fixtures/iq/p25p1_c4fm_cc.iq.json the native preset decodes 26 NIDs and AUTO
+     * decoded none, every sync reading NAC 000 duid:EE, because the false accepts consume the
+     * symbols the frame needed, warm-start the slicer from P25 payload, and clobber the
+     * lastsynctype that keeps use_symbol()'s C4FM threshold tracker engaged between syncs (#388).
+     * Stamped only when the C4FM chain carried the sync: on CQPSK the NID is sliced by the QPSK
+     * chain and the NXDN matcher's level blend is the wideband tracker that chain relies on, so a
+     * CQPSK accept clears the span instead of opening one. A GFSK vote landing mid-span leaves it
+     * standing -- the flap is what the span exists to survive. Read by src/dsp only, through
+     * dsd_frame_sync_suppress_4800_4_for_p25p1_frame(); compared as a modular difference, so a
+     * symbolcnt rollover mid-frame stays exact. */
+    uint32_t p25_p1_c4fm_frame_symbolcnt;
+    uint8_t p25_p1_c4fm_frame_valid;
     int lastsynctype;
     int lastp25type;
     int offset;

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -112,6 +112,14 @@ int dsd_frame_sync_suppress_p25_alt_sync(const dsd_opts* opts, const dsd_state* 
 int dsd_frame_sync_suppress_nxdn48_sync(const dsd_opts* opts, const dsd_state* state);
 
 /**
+ * @brief Return non-zero while a P25p1 frame the C4FM chain accepted owns the 4800/4 profile.
+ *
+ * P25p1 shares that profile with NXDN96 and M17, whose matchers are far weaker than its own
+ * exact 24-symbol sync, so the frame that sync opened is not offered to either of them (#388).
+ */
+int dsd_frame_sync_suppress_4800_4_for_p25p1_frame(const dsd_opts* opts, const dsd_state* state);
+
+/**
  * @brief Return non-zero when TCP no-signal diagnostics should stay off the console.
  */
 int dsd_frame_sync_suppress_tcp_no_signal_console(const dsd_opts* opts, const dsd_state* state);

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -596,6 +596,18 @@ frame_sync_accept_p25p1(frame_sync_match_ctx* ctx, int synctype, const char* lab
     }
 #endif
     frame_sync_set_basic_lock(ctx);
+    /* Open the span this frame owns, or close any span still standing, according to which chain
+     * carried the sync. Only CQPSK closes it: there the NID is sliced by the QPSK chain and the
+     * NXDN matcher's blend is the wideband level tracker that chain leans on. GFSK opens it like
+     * C4FM does, because a P25p1 sync arriving under rf_mod 2 means the modulation votes have
+     * flapped off a C4FM signal -- which the loose NXDN window is itself what does here -- and
+     * that is precisely when the frame behind the sync most needs the profile to itself (#388). */
+    if (state->rf_mod == 1) {
+        state->p25_p1_c4fm_frame_valid = 0;
+    } else {
+        state->p25_p1_c4fm_frame_symbolcnt = state->symbolcnt;
+        state->p25_p1_c4fm_frame_valid = 1;
+    }
     state->dmrburstR = 17;
     state->payload_algidR = 0;
     state->dmr_stereo = 1;
@@ -1135,6 +1147,20 @@ frame_sync_try_m17(frame_sync_match_ctx* ctx) {
         return DSD_SYNC_NONE;
     }
 
+    /* The frame an accepted P25p1 sync opened is not this matcher's to read either. An M17
+     * preamble is an alternating run, which P25 payload supplies readily, and the candidate it
+     * latches is spendable on any sync word within one error -- so the run is dropped and a
+     * candidate already in hand is aged out rather than left to spend the moment the span
+     * lapses. Unlike the NXDN window below, this one stands down completely: what it would
+     * contribute is not a blend but a hard rewrite of every threshold from eight symbols of
+     * whatever is in hand, which is worth having from a real preamble and worth nothing from
+     * P25 payload (#388). */
+    if (dsd_frame_sync_suppress_4800_4_for_p25p1_frame(opts, state)) {
+        state->m17_pre_run = 0;
+        frame_sync_age_m17_pre_candidate(state);
+        return DSD_SYNC_NONE;
+    }
+
     int ham_pre = dsd_sync_hamming_distance(ctx->synctest8, M17_PRE, 8);
     int ham_piv = dsd_sync_hamming_distance(ctx->synctest8, M17_PIV, 8);
     int ham_lsf = dsd_sync_hamming_distance(ctx->synctest8, M17_LSF, 8);
@@ -1603,9 +1629,8 @@ frame_sync_try_nxdn(frame_sync_match_ctx* ctx) {
         /* Symbol captures carry no rate metadata, so an enabled variant must be unambiguous. */
         nxdn_profile_enabled = (opts->frame_nxdn48 == 1) != (opts->frame_nxdn96 == 1);
     } else {
-        /* Only the 2400/4 term yields to dPMR: that is the profile the two share, and the frame
-         * a 12-symbol FS2 opened is not this matcher's to re-open (#374). NXDN96 on 4800/4 is
-         * untouched, and so is every build with dPMR disabled. */
+        /* The 2400/4 term yields to dPMR outright: that is the profile the two share, and the
+         * frame a 12-symbol FS2 opened is not this matcher's to re-open (#374). */
         nxdn_profile_enabled =
             (opts->frame_nxdn96 == 1 && frame_sync_match_profile_active(ctx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4))
             || (opts->frame_nxdn48 == 1 && frame_sync_match_profile_active(ctx, DSD_FRAME_SYNC_SPS_PROFILE_2400_4)
@@ -1620,9 +1645,24 @@ frame_sync_try_nxdn(frame_sync_match_ctx* ctx) {
         return DSD_SYNC_NONE;
     }
 
-    state->offset = ctx->synctest_pos;
     state->max = ((state->max) + ctx->lmax) / 2;
     state->min = ((state->min) + ctx->lmin) / 2;
+
+    /* 4800/4 is the one profile where this matcher cannot simply stand down inside the frame it
+     * is intruding on. The blend above is the wideband level estimate the other protocols there
+     * lean on -- withdraw it for the span and the CQPSK voice capture stops decoding its HDU
+     * altogether -- so what the span withholds is the sync, not the levels. Refusing here rather
+     * than at the profile gate keeps the estimate flowing while denying the accept everything it
+     * costs P25p1: the symbols the handler would read, a slicer warm-started from P25 payload,
+     * the control-channel timestamp, and the lastsynctype that keeps use_symbol()'s C4FM
+     * threshold tracker engaged between one P25p1 sync and the next (#388). The offset is left
+     * alone for the same reason -- inside this span it belongs to the frame P25p1 opened. */
+    if (frame_sync_match_profile_active(ctx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4)
+        && dsd_frame_sync_suppress_4800_4_for_p25p1_frame(opts, state)) {
+        return DSD_SYNC_NONE;
+    }
+
+    state->offset = ctx->synctest_pos;
     if (state->lastsynctype == synctype) {
         frame_sync_note_cc_sync(ctx);
         dsd_sync_warm_start_thresholds_outer_only(opts, state, 10);
@@ -2642,6 +2682,13 @@ frame_sync_nxdn_gfsk_ham(const dsd_opts* opts, const dsd_state* state, const fra
         return 24;
     }
     if (state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4 && opts->frame_nxdn96 == 1) {
+        /* Silent inside a P25p1 frame for the same reason the matcher is. Ten sign-sliced
+         * symbols one error from an NXDN word score 3 on the 24-symbol axis these votes are
+         * compared on, which is enough to carry the GFSK vote outright -- so P25 payload read
+         * through this window walks the demodulator off the chain that is decoding it (#388). */
+        if (dsd_frame_sync_suppress_4800_4_for_p25p1_frame(opts, state)) {
+            return 24;
+        }
         return frame_sync_best_nxdn_scaled_ham(rt->synctest10, 24);
     }
     if (state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_2400_4 && opts->frame_nxdn48 == 1) {

--- a/src/dsp/frame_sync_internal.h
+++ b/src/dsp/frame_sync_internal.h
@@ -47,6 +47,19 @@ extern "C" {
  */
 #define DSD_FRAME_SYNC_DPMR_FS2_FRAME_SYMBOLS       384U
 
+/**
+ * @brief Symbols an accepted P25p1 sync owns on the 4800/4 profile, sync word included.
+ *
+ * P25p1's longest frame is an LDU at 864 symbols, and the status symbols interleaved through it
+ * add about 25 more. Rounding up to 900 covers the longest frame the sync can have opened while
+ * staying short enough that a channel which has gone quiet releases the profile inside a fifth of
+ * a second. Shorter frames re-arm the span on their own next sync -- a control channel's TSDUs
+ * arrive every ~360 symbols -- so continuous traffic stays covered without the span having to
+ * name a length it cannot know at sync time (see
+ * dsd_frame_sync_suppress_4800_4_for_p25p1_frame()).
+ */
+#define DSD_FRAME_SYNC_P25P1_FRAME_SYMBOLS          900U
+
 /** @brief One entry of the SPS hunt's rate/level table, indexed by dsd_state::sps_hunt_idx. */
 typedef struct {
     int symbol_rate_hz;

--- a/src/dsp/frame_sync_policy.c
+++ b/src/dsp/frame_sync_policy.c
@@ -38,6 +38,21 @@ dsd_frame_sync_suppress_nxdn48_sync(const dsd_opts* opts, const dsd_state* state
 }
 
 int
+dsd_frame_sync_suppress_4800_4_for_p25p1_frame(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return 0;
+    }
+    if (opts->frame_p25p1 != 1 || state->p25_p1_c4fm_frame_valid == 0) {
+        return 0;
+    }
+    /* Modular difference, for the same reason and with the same failure direction as the FS2
+     * span above: a backwards symbolcnt jump reads as a huge forward distance and ends the
+     * suppression early rather than extending it. */
+    const uint32_t since = state->symbolcnt - state->p25_p1_c4fm_frame_symbolcnt;
+    return since < DSD_FRAME_SYNC_P25P1_FRAME_SYMBOLS;
+}
+
+int
 dsd_frame_sync_suppress_tcp_no_signal_console(const dsd_opts* opts, const dsd_state* state) {
     if (!opts || !state) {
         return 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9131,15 +9131,26 @@ if(DSD_HAS_RADIO)
     # here with failing NIDs between the frames that decode, and consumption credit is bounded
     # by what a handler read -- 33 symbols for a failed NID, 134 of a ~180-symbol slot for a
     # one-block TSDU -- so the budget climbed on a channel that was decoding and the hunt
-    # rotated off it. On main this capture steps to 20 sps partway through and finishes in
-    # dPMR; holding the profile decodes the encrypted HDU behind those failures instead, which
-    # is what makes the payload assertion here the fix rather than the fixture. Both hold
-    # across dev-debug, asan-ubsan-debug and tsan-debug.
+    # rotated off it. Holding the profile is what this case pins, and the negative assertion
+    # below is the half that says so.
+    #
+    # The payload assertion was "ALG ID: 0xC0 KEY ID: 0x3900" until #388. That string was a
+    # misdecode, not the capture: the native -f1 preset never emits 0xC0 anywhere in this
+    # fixture, reading three clear-voice headers (ALG ID: 0x80 KEY ID: 0x0000) and six
+    # "Group Voice Channel User" grants. Under -fa the 4800/4 co-tenants were corrupting the
+    # frames behind those syncs badly enough that the run produced zero grants, two HDUs and
+    # 127 header errors, one of which read as an encrypted header with a key id -- and that
+    # artifact was what the case had been asserting. With the co-tenants held off the frame
+    # (#388) this capture decodes under -fa what it decodes natively: seven grants, four clear
+    # headers, and irrecoverable header errors down from 3 to 0. So the assertion is now the
+    # same real payload its -f1 sibling above asserts, which is the thing a hunt that holds
+    # the profile is supposed to deliver. Both halves hold across dev-debug, asan-ubsan-debug
+    # and tsan-debug.
     dsd_neo_add_iq_decode_test(
         DECODE_IQ_P25P1_CQPSK_VOICE_AUTO_HUNT
         p25p1_cqpsk_vc
         -fa
-        "ALG ID: 0xC0 KEY ID: 0x3900"
+        "Group Voice Channel User"
         "SPS hunt: trying"
     )
     # Two-ray simulcast impairment (62.5 us delay spread, -4.4 dB second ray,
@@ -9220,6 +9231,27 @@ if(DSD_HAS_RADIO)
         m17
         -fa
         "SRC: N0CALL"
+    )
+
+    # Issue #388: P25 Phase 1 C4FM on its own profile, which is where AUTO starts -- the hunt
+    # performs no rotation on this capture and needs none. What it used to fail on is the
+    # company 4800/4 keeps: NXDN96's matcher takes five variants per polarity over ten
+    # sign-sliced symbols and M17's preamble is any alternating run, so both fire on P25
+    # payload, and the frames they open consume the symbols the next sync needed, warm-start
+    # the slicer from that payload and take the lastsynctype that keeps the C4FM threshold
+    # tracker engaged. The native preset decoded 26 NACs here and AUTO decoded none, every
+    # P25p1 sync reading NAC 000 duid:EE. Holding both off the frame an accepted P25p1 sync
+    # opened brings AUTO back to 23 of those 26; the three still missing are the frames ahead
+    # of the first accepted sync, which is the earliest anything can know P25p1 is here.
+    # A presence assertion rather than a count, per the fixture policy in docs/testing.md, and
+    # the negative half pins that this capture never needs the hunt to move. Both hold across
+    # dev-debug, asan-ubsan-debug and tsan-debug.
+    dsd_neo_add_iq_decode_test(
+        DECODE_IQ_P25P1_C4FM_CC_AUTO_HUNT
+        p25p1_c4fm_cc
+        -fa
+        "NAC/CC: 140"
+        "SPS hunt: trying"
     )
 
     # The other direction, which is the one issue #391 warns about: a handler that reports

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -1086,6 +1086,171 @@ test_the_dpmr_frame_suppression_is_scoped_to_its_own_profile(void) {
     assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
 }
 
+/* The 4800/4 counterpart (#388). P25p1's sync is one of two exact 24-symbol patterns; NXDN96's
+ * takes five variants per polarity over ten sign-sliced symbols. Inside the frame the stronger
+ * one opened, the weaker must not take a sync -- but it must still take its level estimate,
+ * which is the wideband reference the other protocols on the profile lean on. */
+static void
+test_a_p25p1_frame_is_not_reopened_by_the_nxdn96_matcher(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.symbolcnt = 1000;
+
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P1_SYNC, 24) == DSD_SYNC_P25P1_POS);
+    assert(state.p25_p1_c4fm_frame_valid == 1);
+
+    /* Inside the frame: no sync, and -- the half that keeps use_symbol()'s C4FM threshold
+     * tracker engaged between P25p1 syncs -- no claim on lastsynctype either. */
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_P25P1_POS);
+    state.symbolcnt = 1000 + 899;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_P25P1_POS);
+
+    /* Past the frame the matcher is live again, on its own two-hit terms. */
+    state.symbolcnt = 1000 + DSD_FRAME_SYNC_P25P1_FRAME_SYMBOLS;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
+}
+
+/* Withholding the sync must not withhold the level estimate: the CQPSK voice capture stops
+ * decoding its headers altogether if this blend goes away for the span (#388). Driven through
+ * the window evaluator, which is the seam that carries real symbol levels. */
+static void
+test_a_suppressed_nxdn96_window_still_blends_levels(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    float fsw_levels[10];
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_nxdn96 = 1;
+    opts.msize = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    for (int i = 0; i < 10; i++) {
+        fsw_levels[i] = NXDN_FSW[i] == '3' ? -3.0f : 3.0f;
+    }
+
+    /* Arm the span by hand: the point here is what the NXDN window does inside one. */
+    state.p25_p1_c4fm_frame_symbolcnt = 0;
+    state.p25_p1_c4fm_frame_valid = 1;
+    state.symbolcnt = 100;
+    state.max = 9.0f;
+    state.min = -9.0f;
+
+    assert(dsd_frame_sync_test_eval_window(&opts, &state, NXDN_FSW, fsw_levels, 10) == DSD_SYNC_NONE);
+    /* Blended halfway from 9 toward the window's own outer rails, exactly as an unsuppressed
+     * hit would, while the sync itself is refused. */
+    assert(fabsf(state.max - 6.0f) < 0.0001f);
+    assert(fabsf(state.min - (-6.0f)) < 0.0001f);
+    assert(state.lastsynctype != DSD_SYNC_NXDN_POS);
+}
+
+/* CQPSK closes the span rather than opening one: there the NID is sliced by the QPSK chain, and
+ * the NXDN blend is the level reference that chain depends on. A GFSK vote landing mid-span is
+ * the flap the span exists to survive, so it leaves an armed span standing. */
+static void
+test_the_p25p1_frame_guard_is_scoped_to_the_c4fm_chain(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.symbolcnt = 1000;
+    state.rf_mod = 1;
+
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P1_SYNC, 24) == DSD_SYNC_P25P1_POS);
+    assert(state.p25_p1_c4fm_frame_valid == 0);
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+
+    /* Armed on C4FM, then flapped to GFSK: the span stands. */
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.symbolcnt = 1000;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P1_SYNC, 24) == DSD_SYNC_P25P1_POS);
+    state.rf_mod = 2;
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_P25P1_POS);
+}
+
+/* The span is P25p1's frame, not a mute switch: NXDN48 lives on 2400/4, where P25p1 cannot match
+ * at all, and a build with P25p1 disabled must behave exactly as it did before. */
+static void
+test_the_p25p1_frame_suppression_is_scoped_to_its_own_profile(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 0;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.p25_p1_c4fm_frame_symbolcnt = 1000;
+    state.p25_p1_c4fm_frame_valid = 1;
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_nxdn48 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.p25_p1_c4fm_frame_symbolcnt = 1000;
+    state.p25_p1_c4fm_frame_valid = 1;
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+}
+
+/* The stamp wraps with symbolcnt and is compared as a modular difference. */
+static void
+test_the_p25p1_frame_guard_survives_symbolcnt_rollover(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.p25_p1_c4fm_frame_symbolcnt = UINT32_MAX - 100u;
+    state.p25_p1_c4fm_frame_valid = 1;
+
+    /* 150 symbols past the stamp, across the wrap. */
+    state.symbolcnt = 49u;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype != DSD_SYNC_NXDN_POS);
+
+    /* Past the span, still across the wrap. */
+    state.symbolcnt = (uint32_t)(UINT32_MAX - 100u + DSD_FRAME_SYNC_P25P1_FRAME_SYMBOLS);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+}
+
 static void
 test_symbol_replay_bypasses_sps_profile_gating(void) {
     static const int symbol_input_types[] = {AUDIO_IN_SYMBOL_BIN, AUDIO_IN_SYMBOL_FLT};
@@ -1241,6 +1406,38 @@ feed_m17_preamble_run(dsd_opts* opts, dsd_state* state, const char* marker) {
     for (int i = 0; i < DSD_FRAME_SYNC_M17_PRE_RUN_SYMBOLS; i++) {
         assert(dsd_frame_sync_test_try_protocol_matches(opts, state, marker, 8) == DSD_SYNC_NONE);
     }
+}
+
+/* M17's preamble is an alternating run, which P25 payload supplies readily, so inside a P25p1
+ * frame the run is dropped rather than latched -- and a candidate already in hand is aged out
+ * rather than left to spend the moment the span lapses. */
+static void
+test_a_p25p1_frame_suppresses_m17_candidates(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_p25p1 = 1;
+    opts.frame_m17 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.symbolcnt = 1000;
+
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P1_SYNC, 24) == DSD_SYNC_P25P1_POS);
+
+    /* Inside the frame a full preamble run latches nothing and the sync word behind it is
+     * refused. */
+    state.symbolcnt = 1000 + 100;
+    feed_m17_preamble_run(&opts, &state, M17_PRE);
+    assert(state.m17_pre_candidate == 0);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, M17_LSF, 8) == DSD_SYNC_NONE);
+
+    /* Past the frame the run re-earns its candidate and the word spends it. */
+    state.symbolcnt = 1000 + DSD_FRAME_SYNC_P25P1_FRAME_SYMBOLS;
+    feed_m17_preamble_run(&opts, &state, M17_PRE);
+    assert(state.m17_pre_candidate != 0);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, M17_LSF, 8) == DSD_SYNC_M17_LSF_POS);
 }
 
 /* A preamble is an alternating symbol run, which any 4800-baud signal can present, so it is
@@ -2591,6 +2788,12 @@ main(void) {
     test_m17_alternating_runs_alone_are_never_a_sync();
     test_a_dpmr_frame_is_not_reopened_by_the_nxdn_matcher();
     test_the_dpmr_frame_suppression_is_scoped_to_its_own_profile();
+    test_a_p25p1_frame_is_not_reopened_by_the_nxdn96_matcher();
+    test_a_suppressed_nxdn96_window_still_blends_levels();
+    test_the_p25p1_frame_guard_is_scoped_to_the_c4fm_chain();
+    test_the_p25p1_frame_suppression_is_scoped_to_its_own_profile();
+    test_the_p25p1_frame_guard_survives_symbolcnt_rollover();
+    test_a_p25p1_frame_suppresses_m17_candidates();
     test_elapsed_seconds_prefers_monotonic_then_wall_time();
     test_p25_slot_activity_honors_ring_and_hangtime();
     test_hamming_helpers_find_best_patterns();


### PR DESCRIPTION
Fixes #388 (consequence B, the remaining scope).

## What was happening

The 4800/4 profile carries P25p1, DMR, NXDN96, YSF and M17 together, and their sync matchers are not comparable in strength:

| matcher | window | patterns | tolerance | fires on |
|---|---:|---:|---|---|
| P25p1 | 24 | 2 | exact | ~1 window in 8.4M |
| NXDN96 | 10 | 10 | exact | ~1 window in 100 |
| M17 preamble | 8 | 2 | Hamming ≤ 1 | any alternating run |

Under AUTO both weaker matchers fire on P25 payload. Each false frame consumes the symbols the next sync needed, warm-starts the slicer from that payload, and takes the `lastsynctype` that keeps `use_symbol()`'s C4FM threshold refresh engaged between one P25p1 frame and the next. Sync detection is sign-sliced and immune to all of that; the 33-dibit NID behind it is sliced through `center`/`umid`/`lmid` and is not — which is how a capture syncs repeatedly and decodes nothing.

On `p25p1_c4fm_cc.iq.json`, whose own profile is where AUTO starts (the hunt performs zero rotations on it and needs none):

```
-f1   26x "NAC/CC: 140"
-fa   0, every one of 12 P25p1 syncs reading NAC: 000 duid:EE,
      interleaved with 7 NXDN96 and 16 M17 false syncs
```

## Attribution

Measured by replay with each matcher removed from the AUTO set in turn:

| AUTO set | `NAC/CC: 140` | modulation switches |
|---|---:|---:|
| baseline | 0 | 36 |
| minus M17 | 0 | 58 |
| minus NXDN96 | 23 | 0 |
| minus both | **26** | 0 |
| native `-f1` | 26 | 0 |

NXDN96 accounts for 23 of the 26, M17 for the remaining 3, and the ceiling for suppression is the full 26. Repeating the matrix under `-mc` (modulation locked, no votes at all) reproduces it exactly, so the 18 GFSK flaps those windows also cause are a symptom, not the mechanism.

## The fix

For the span of the frame an accepted P25p1 sync opened, neither weak matcher may take a sync on the profile, and the NXDN window is silent in the modulation vote as well — one error in ten symbols scores 3 on the 24-symbol axis the votes are compared on, which carries the GFSK vote outright. Same shape as the dPMR FS2 span (#374): a stamped `symbolcnt` plus a `frame_sync_policy.c` predicate compared as a modular difference. The span is 900 symbols (an LDU plus its status symbols), re-armed by every sync so continuous traffic stays covered, and released within a fifth of a second of P25 going quiet.

Two limits are deliberate:

- **The NXDN window still contributes its level blend while suppressed.** That estimate is the wideband reference the CQPSK chain depends on — the issue flags it as load-bearing, and it is: withdrawing it for the span stops the CQPSK voice capture decoding headers at all. So the refusal sits *after* the blend rather than at the profile gate. M17 stands down completely instead, because what it contributes is not a blend but a hard rewrite of every threshold from eight symbols, which is worth nothing taken from P25 payload.
- **A sync the CQPSK chain carried closes the span instead of opening one**, for the same reason. A GFSK vote landing mid-span leaves an armed span standing, since that flap is what the span exists to survive.

**Result: AUTO decodes 23 of the 26.** The three still missing are the frames ahead of the first accepted P25p1 sync — the earliest point anything can know P25p1 is on the channel, which an evidence-based guard cannot cover.

## ⚠️ One existing test assertion changes, and it is worth a look

`DECODE_IQ_P25P1_CQPSK_VOICE_AUTO_HUNT` asserted `ALG ID: 0xC0 KEY ID: 0x3900`. **That string is not in the capture.** The `-f1` preset emits no `0xC0` anywhere in it:

| | native `-f1` | `-fa` before | `-fa` after |
|---|---|---|---|
| ALG ID | 3x `0x80 / 0x0000` (clear) | 1x `0xC0 / 0x3900` | 4x `0x80 / 0x0000` |
| `0xC0` anywhere | **0** | 1 | 0 |
| `Group Voice Channel User` | 6 | **0** | 7 |
| irrecoverable header errors | 2 | 3 | **0** |

What `-fa` produced was a corrupted read of one of those clear headers, from a run that decoded zero voice grants and 127 header errors — and the case had been asserting that artifact. With the co-tenants held off the frame the `-fa` run matches the native one, so the assertion is now the same real payload its `-f1` sibling asserts. The negative half (the hunt never rotates) is unchanged and still covers #400.

The generalizable lesson is recorded in `docs/testing.md`: an AUTO case should assert a payload the native preset also produces, or it can end up pinning the corruption it was meant to catch.

## Tests

- New `DECODE_IQ_P25P1_C4FM_CC_AUTO_HUNT` — the flagship reproduction, asserting `NAC/CC: 140` under `-fa` and no hunt rotation.
- Six new cases in `FRAME_SYNC_INTERNAL_HELPERS`: NXDN96 refused inside the span with `lastsynctype` preserved and live again past it; **a suppressed window still blends levels** (driven through `dsd_frame_sync_test_eval_window`, the seam that carries real symbol levels); CQPSK closes the span while a GFSK flap leaves it standing; scoping to the profile and to `frame_p25p1`; `symbolcnt` rollover.

## Verification

- All **579** tests pass on `dev-debug`.
- The `iq-decode` label passes **3x each** on `dev-debug`, `asan-ubsan-debug` and `tsan-debug`.
- `tools/preflight_ci.sh` exits 0; `tools/semgrep.sh --strict` reports 0 findings.
- Every other fixture is unchanged versus `main` under both its native preset and `-fa`: `nxdn96` 36, `m17` 11, `ysf` 24, `nxdn48` 3, `dstar`, `edacs` 42, `dmr_voice` 9, and both noise-floor rejects still silent. `dpmr -fa` stays within its existing 3–4 run-to-run spread (measured 5 runs each way).

## Out of scope

- **The bootstrap window.** The first ~1200 symbols, before any P25p1 sync has been accepted, are still open to false syncs. Closing it needs a matcher-strength change, which the issue thread measured as costing dPMR its dwell.
- **The DSP-layer `frame_sync_note_cc_sync()` at an accepted NXDN sync**, which still refreshes the scan hold before any CRC has passed — a gap #406 left at the protocol layer. It affects `-Y` holds rather than this fixture; worth its own issue.
- Extending the stamp to DMR and YSF accepts, which are also 4800/4 residents with exact matchers. No measured failure calls for it.
