### PR TITLE
test(dsp): pin the bound on frame sync's remaining no-verdict handlers

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -321,7 +321,12 @@ Notes
   ProVoice frame whose transmission has not yet proved itself all buy no dwell however many symbols they consumed.
   Handlers that report no verdict are credited as before: every DMR, P25 Phase 2, dPMR and X2-TDMA frame is
   unconditionally productive, and a false match on one of those still delays the hunt in proportion to what it
-  swallows.
+  swallows. That delay is bounded rather than a hold, because the symbols a handler eats are symbols the search
+  never spends: a profile is held only where syncs arrive closer together than twice the block behind each one. Of
+  the four, only dPMR has a matcher noise reaches -- one 12-symbol pattern per polarity, against the 372 symbols an
+  FS2 frame reads -- so its hits would have to fall within 744 symbols to hold the profile, against the one per
+  ~2048 that noise produces. Telling that apart from a real dPMR carrier, which presents FS2 on schedule and is
+  meant to hold the profile, needs the integrity check dPMR does not yet have (issue #407).
 - A sync the decoder deliberately declines to process costs the profile nothing either way. Trunking skips the DMR
   direct-mode paths outright, and any frame arriving while a retune is still in flight is dropped rather than
   dispatched; neither reads a symbol, so neither can earn credit, and the search that found the sync used to stand

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -133,6 +133,18 @@ cases assert `Total audio errors: 0`, which is the count of vocoder frames the d
 \#398's confirmation gate this fixture produced 89 of them under `-fn` and 49 under `-fi`, decoded from nothing.
 They deliberately do not cover `-fa`, where dPMR still decodes noise.
 
+There is no `-fa` hunt case on `noise_floor`, and the measurement behind that is worth recording. Issue #391's
+remaining set — DMR, P25 Phase 2, dPMR and X2-TDMA, the handlers that report no verdict — is bounded by arithmetic
+rather than by a verdict, so a replay assertion cannot see it. Under `-fa` the fixture completes six rotations in its
+10 s; defeating the verdict gate in `frame_sync_sps_hunt_note_handler_consumption()` gives five, and every individual
+`SPS hunt: trying` line still prints in both. Only the rotation *count* separates them, and how far the hunt gets is
+exactly the schedule-dependent quantity that got the `dstar` reject case removed above. So the property is pinned
+where it can be stated exactly, in `FRAME_SYNC_SPS_HUNT_FALSE_SYNC`
+(`test_no_verdict_handlers_still_rotate_at_the_noise_cadence`): a handler consuming a dPMR FS2 frame's 372 symbols on
+the default productive verdict still reaches its dwell at the cadence that matcher reaches on noise. Both bounds are
+mutation-checked — raising the consumption past half the period, or tightening the period below twice the
+consumption, pins the profile and fails the case.
+
 Known gaps and caveats:
 
 - **ProVoice** and **X2-TDMA** have no usable public sample and are untested here.

--- a/src/engine/dispatch/dispatch_dpmr.c
+++ b/src/engine/dispatch/dispatch_dpmr.c
@@ -43,8 +43,14 @@ dsd_dispatch_matches_dpmr(int synctype) {
 }
 
 /*
- * Always productive. FS1/FS3/FS4 consume nothing beyond the sync itself, and the FS2 voice
- * path (processdPMRvoice) has no CRC or FEC verdict to report (#391).
+ * Always productive. FS1/FS3/FS4 consume nothing beyond the sync itself, and the FS2 voice path
+ * (processdPMRvoice) has no *sound* verdict to report (#391). Checks do run there and their
+ * results reach dsd_state -- dpmr_decode_cch_frames() leaves a CCH CRC-7 in CCHDataCrcOk and a
+ * Hamming(12,8) verdict in CCHDataHammingOk -- but neither can carry a verdict: the CRC-7 fails
+ * on every superframe of the committed dpmr fixture, the one capture in the tree that decodes,
+ * and the Hamming fallback accepts most random data. Reporting either would rotate the hunt off
+ * live traffic, which is the risk direction protocol_dispatch.h names. Left productive until
+ * dPMR has an integrity check that works; that is #407, and a verdict here follows from it.
  */
 dsd_frame_verdict
 dsd_dispatch_handle_dpmr(dsd_opts* opts, dsd_state* state) {

--- a/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
+++ b/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
@@ -342,8 +342,9 @@ test_consumed_frames_hold_the_profile(void) {
      * symbols per frame, P25p1 408, M17 184).
      *
      * On the default PRODUCTIVE verdict, which is what #391 leaves every protocol with no
-     * check of its own -- D-STAR voice, ProVoice, dPMR, X2-TDMA, P25p2, DMR. A frame's
-     * worth consumed still holds the profile for them, exactly as before. */
+     * check of its own -- DMR, P25 Phase 2, dPMR and X2-TDMA, since #429 gave D-STAR voice
+     * and ProVoice one. A frame's worth consumed still holds the profile for them, exactly
+     * as before. */
     const HuntCase tc = {
         .label = "decoded frames at 4800/4",
         .marker = FALSE_SYNC_MARKER,
@@ -388,6 +389,51 @@ test_unproductive_frames_never_buy_dwell(void) {
     const long dwell_symbols = (long)DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS * 3;
     assert(r.symbols_at_step >= dwell_symbols);
     assert(r.symbols_at_step < dwell_symbols * 6);
+}
+
+/* #391's residual, and the bound on it. Four handlers report no verdict at any point -- DMR,
+ * P25 Phase 2, dPMR and X2-TDMA -- so a false match on one is credited in full, as before.
+ * What stops that pinning a profile is arithmetic rather than a verdict: the symbols a handler
+ * eats are symbols the search never sees, so one cycle nets (period - 2 x consumption) onto the
+ * budget, and only a cadence tighter than twice the block it swallows can hold the profile.
+ *
+ * dPMR is the worst case of the four, and the only one whose matcher fires on noise at all:
+ * 372 symbols read before dpmr_decode_cch_frames() runs a check (src/protocol/dpmr/dpmr_voice.c)
+ * behind a single 12-symbol pattern per polarity. That puts its cliff at one sync per 744
+ * symbols and its rate on sign-sliced noise at 2/2^12, one per ~2048 -- and the margin between
+ * those two numbers is the whole reason the residual is a delay rather than a hold. The other
+ * three sit behind 20- and 24-symbol exact matchers that noise does not reach.
+ *
+ * Both cadences below are the matcher's own. Anything denser is a carrier presenting FS2 on
+ * schedule, which is a dPMR signal and is meant to hold the profile -- telling those apart
+ * needs the integrity check dPMR does not have, tracked as #407. The hunt's arithmetic does
+ * not vary by profile, so this drives it from the harness's 4800/4 start like every case here;
+ * what is modelled is dPMR's consumption and cadence, not its profile. */
+static void
+test_no_verdict_handlers_still_rotate_at_the_noise_cadence(void) {
+    /* The marker is part of the period, so these are the cadences less its 88 symbols. */
+    static const int gaps[] = {2048 - 88, 4096 - 88};
+
+    for (size_t i = 0; i < sizeof(gaps) / sizeof(gaps[0]); i++) {
+        const HuntCase tc = {
+            .label = "no-verdict handler at the dPMR noise cadence",
+            .marker = FALSE_SYNC_MARKER,
+            .marker_gap = gaps[i],
+            .handler_symbols = 372,    /* a dPMR FS2 frame, read in full before any check */
+            .handler_unproductive = 0, /* the default verdict, which is what those four report */
+            .symbol_budget = 400000,
+            .expect_step = 1,
+        };
+        const HuntResult r = drive_hunt(&tc);
+
+        assert(r.syncs_seen > 0);
+        assert_auto_stepped_to_2400_4(&r);
+        /* Held longer than an idle profile, because every match is credited in full -- but
+         * bounded, which is the property #391's remaining set turns on. */
+        const long dwell_symbols = (long)DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS * 3;
+        assert(r.symbols_at_step >= dwell_symbols);
+        assert(r.symbols_at_step < dwell_symbols * 3);
+    }
 }
 
 /* #391, the other half of the same rule: an unproductive lead does not condemn the
@@ -733,6 +779,7 @@ main(void) {
     test_sub_frame_consumption_never_buys_dwell();
     test_consumed_frames_hold_the_profile();
     test_unproductive_frames_never_buy_dwell();
+    test_no_verdict_handlers_still_rotate_at_the_noise_cadence();
     test_a_confirming_transmission_holds_its_profile();
     test_a_proven_verdict_holds_the_profile_through_failure_runs();
     test_a_proven_verdict_buys_one_dwell_and_no_more();


### PR DESCRIPTION
## Summary

Closes out #391. The dispatch refactor that issue asked for landed in #419, and #429 closed its
residual (#421), so **every consumer #391 names now has a verdict or has been shown not to need one**:

| #391's consumer | disposition |
|---|---|
| D-STAR voice, 1992 symbols | #429 — `dstar_confirm.c`, CRC-16/X.25 or a second frame |
| D-STAR data (`processDSTAR_HD`), 2652 | #419 — reports its header CRC |
| EDACS `eot_cc()`, 1920 | **not a dispatch path.** #419's correction, re-verified here |

This PR does not change behavior. It pins the property the issue turns on, and corrects two comments
that no longer describe the code.

## What is actually left, and why it is a delay rather than a hold

Four handlers report no verdict at any point — DMR, P25 Phase 2, dPMR and X2-TDMA. What keeps a false
match on those from pinning a profile is **arithmetic, not a verdict**: the symbols a handler eats are
symbols the search never spends, so one cycle nets `period - 2 x consumption` onto the budget, and only
a cadence tighter than *twice* the block behind each sync can hold the profile.

| handler | matcher | consumed per hit | cliff | reachable on noise? |
|---|---|---:|---:|---|
| **dPMR** | one 12-symbol pattern per polarity | 372 | one per 744 | **yes**, one per ~2048 — 2.75x margin |
| P25p2 | 20-symbol exact x2 | 700 | one per 1400 | no |
| DMR | 24-symbol exact x9 | 0–1700 (most paths gate at 0–5 live) | — | no |
| X2-TDMA | 24-symbol exact x4 | 120 / 1704 | — | no |

dPMR is the worst case and the only one whose matcher noise reaches. Anything denser than its noise rate
is a carrier presenting FS2 on schedule — which is a dPMR signal, and is *meant* to hold the profile.
Telling those apart needs the integrity check dPMR does not have, which is **#407**; a verdict here
follows from that fix rather than preceding it.

## Why a unit test and not an `-fa` replay case

Measured, because it decides the test design. On `noise_floor` under `-fa` the hunt completes **six**
rotations in the fixture's 10 s. With the verdict gate in `frame_sync_sps_hunt_note_handler_consumption()`
defeated it completes **five** — and every individual `SPS hunt: trying` line still prints in both:

```
baseline   20 sps | 5 sps | 8 sps | 10 sps | 10 sps | 20 sps
gate off   20 sps | 5 sps | 8 sps | 10 sps | 10 sps
```

So a replay assertion could only distinguish by counting rotations, and "how far the hunt gets" is exactly
the schedule-dependent quantity that got the `dstar` reject case removed (`docs/testing.md`). Asserting any
single line would be vacuous; asserting the count would be flaky. The property is pinned where it can be
stated exactly instead.

## Test

`FRAME_SYNC_SPS_HUNT_FALSE_SYNC` gains `test_no_verdict_handlers_still_rotate_at_the_noise_cadence`: a
handler consuming a dPMR FS2 frame's 372 symbols on the default productive verdict still reaches its dwell
at the two cadences that matcher reaches on noise. Suite 579 -> 579 (the case joins an existing binary).

**Both bounds mutation-checked**, each failing against the code it names:

- consumption raised past half the period (372 -> 1100): `stepped=0 after 400456 symbols (195 syncs)` — pins.
- period tightened below twice the consumption (2048 -> 700): `stepped=0 after 400068 symbols (571 syncs)` — pins.

Green on `dev-debug`, `asan-ubsan-debug` and `tsan-debug`.

## Also corrected

- **`dispatch_dpmr.c`** claimed the FS2 path "has no CRC or FEC verdict to report". Checks *do* run and
  their results reach `dsd_state` (`CCHDataCrcOk`, `CCHDataHammingOk`) — they are simply unsound: the CCH
  CRC-7 fails on every superframe of the committed `dpmr` fixture, the one capture in the tree that decodes,
  and the Hamming(12,8) fallback accepts most random data. Reporting either would rotate the hunt off live
  traffic, the risk direction `protocol_dispatch.h` names. Now says that, and points at #407.
- **`test_consumed_frames_hold_the_profile()`** still listed D-STAR voice and ProVoice among the handlers
  with no check of their own. #429 gave both one.
- `docs/cli.md` states the bound; `docs/testing.md` records the measurement above.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / **none**.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. *(none added)*
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` *(579/579)*
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [ ] `tools/cmake_format_check.sh` for CMake changes *(no CMake changes)*
- [ ] `tools/zizmor.sh` for workflow changes *(none)*
- [ ] `tools/osv_scan.sh` for dependency input changes *(none)*
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` *(via preflight)*

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: **none** — tests, comments and docs only. No `src/` logic changed; the one `src/`
  edit is a comment.
- Compatibility or packaging impact: none.

Closes #391. Refs #407, #419, #429.
