### PR TITLE
fix(dsp): drop the zero crossing a sync warm-start invalidates (#404)

### DIFF
--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -252,6 +252,9 @@ typedef struct {
     int rtl_symbol_rate_output;
     int rtl_fsk_discriminator_output;
     int rtl_profile_changed;
+    /* Set when the cache handed back a discontinuity: the samples already taken
+       for this symbol came off a stream that is gone. */
+    int rtl_span_restart;
     int rtl_channel_profile;
     int rtl_symbol_rate_hz;
     int rtl_symbol_levels;
@@ -1398,6 +1401,7 @@ symbol_read_cached_rtl_sample(dsd_opts* opts, dsd_state* state, float* sample_ou
             dsd_request_shutdown(opts, state);
             return 0;
         }
+        work->rtl_span_restart = 1;
         symbol_refresh_rtl_profile(state, work);
         if (!work->rtl_fsk_discriminator_output) {
             return 0;
@@ -1771,6 +1775,22 @@ symbol_process_live_samples(dsd_opts* opts, dsd_state* state, int have_sync, sym
         if (!symbol_take_sample(opts, state, work)) {
             return 0;
         }
+#ifdef USE_RADIO
+        /* This sample opens a new stream: every retune and replay RESET bumps
+           the stream generation, which flushes whatever was cached. Averaging it
+           with what the old stream left in this symbol would make the symbol
+           depend on how full the cache happened to be when the flush landed. */
+        if (work->rtl_span_restart) {
+            work->rtl_span_restart = 0;
+            work->sum = 0.0f;
+            work->count = 0;
+            if (work->rtl_fsk_discriminator_output && state->samplesPerSymbol > 1) {
+                work->symbol_span = state->samplesPerSymbol;
+            }
+            state->jitter = -1;
+            i = 0;
+        }
+#endif
 
         symbol_process_analog_capture(opts, state, work, have_sync);
 #ifdef USE_RADIO

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -1768,9 +1768,14 @@ symbol_process_symbol_flt_input(dsd_opts* opts, float* symbol_out) {
     return 1;
 }
 
+/* A while loop rather than a for: the span index is not a plain counter. The
+   timing nudge moves it before the first sample is taken, and a stream flush
+   restarts the span from it, so every step it takes belongs in the body where
+   it reads as one. */
 static int
 symbol_process_live_samples(dsd_opts* opts, dsd_state* state, int have_sync, symbol_work_ctx* work) {
-    for (int i = 0; i < work->symbol_span; i++) {
+    int i = 0;
+    while (i < work->symbol_span) {
         symbol_adjust_timing_index(state, have_sync, work->symbol_span, &i);
         if (!symbol_take_sample(opts, state, work)) {
             return 0;
@@ -1806,6 +1811,7 @@ symbol_process_live_samples(dsd_opts* opts, dsd_state* state, int have_sync, sym
         symbol_update_jitter(opts, state, have_sync, i, work->sample);
         symbol_accumulate_sample(state, work, i, work->sample);
         state->lastsample = work->sample;
+        i++;
     }
     return 1;
 }

--- a/src/dsp/sync_calibration.c
+++ b/src/dsp/sync_calibration.c
@@ -215,6 +215,14 @@ dsd_sync_warm_start_thresholds_outer_only(const dsd_opts* opts, dsd_state* state
     state->maxref = state->max * 0.80f;
     state->minref = state->min * 0.80f;
 
+    /* The pending zero crossing was measured against the thresholds just
+       replaced, so it no longer describes anything (#404). It would otherwise
+       outlive the frame this sync opens -- symbol_adjust_timing_index() does not
+       run while a frame is being read and nothing else clears it -- and slip the
+       symbol grid once the next sync search begins, on where a crossing fell
+       against a calibration and a symbol that are both long gone. */
+    state->jitter = -1;
+
     /* Pre-fill rolling buffers to skip warmup period */
     if (opts != NULL) {
         int fill_count = opts->msize;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6569,6 +6569,29 @@ if(DSD_HAS_RADIO)
         COMMAND dsd-neo_test_frame_sync_p25p2_rtl
     )
 
+    # Real frame-sync + symbol + dibit chain on the RTL sample path: the payload
+    # must decode the same whatever sub-symbol phase the grid started on.
+    add_executable(
+        dsd-neo_test_frame_sync_nxdn_fsk_phase
+        dsp/test_frame_sync_nxdn_fsk_phase.c
+        test_support/frame_sync_dsp_stubs.c
+        ${PROJECT_SOURCE_DIR}/src/core/frames/dsd_dibit.c
+    )
+    target_include_directories(
+        dsd-neo_test_frame_sync_nxdn_fsk_phase
+        PRIVATE ${PROJECT_SOURCE_DIR}/include
+    )
+    dsd_neo_link_dsp_test(dsd-neo_test_frame_sync_nxdn_fsk_phase
+      dsd-neo_test_call_state_support
+      dsd-neo_test_support
+      ${DSD_NEO_TEST_MATH_LIB}
+      ${LIBSNDFILE_LIBRARIES}
+    )
+    add_test(
+        NAME FRAME_SYNC_NXDN_FSK_PHASE
+        COMMAND dsd-neo_test_frame_sync_nxdn_fsk_phase
+    )
+
     add_executable(
         dsd-neo_test_frame_sync_m17
         dsp/test_frame_sync_m17.c

--- a/tests/dsp/test_frame_sync_nxdn_fsk_phase.c
+++ b/tests/dsp/test_frame_sync_nxdn_fsk_phase.c
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * NXDN48 payload decoding must not depend on the sub-symbol phase the decoder's
+ * symbol grid happened to start on.
+ *
+ * Symbol timing on the RTL FSK discriminator path is decoder-side and open loop:
+ * getSymbol() consumes samplesPerSymbol samples per symbol, so the symbol
+ * boundary is nothing but "samples consumed since the grid was last reset, mod
+ * sps". A profile switch or a stream flush leaves that boundary wherever the
+ * consumed-sample count happened to land, and the sync search then accepts the
+ * first phase whose dibits match rather than the best one, so the phase a frame
+ * is read at varies with history the signal knows nothing about.
+ *
+ * These cases drive the real getFrameSync()/getSymbol()/getDibitSoft() chain --
+ * nothing else covers that chain on the RTL sample path -- over a synthetic
+ * 2400-baud four-level stream, once per starting sample offset and cache read
+ * size, and require the payload to decode to the transmitted dibits for two
+ * frames running whatever phase the search settled on.
+ *
+ * Symbol transitions are shaped over most of a symbol, as a filtered 2400-baud
+ * stream's are, so an off-centre window reads a blend of two symbols rather than
+ * a clean one and a phase that drifted shows up as wrong dibits.
+ */
+
+#include <dsd-neo/core/dibit.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/io/rtl_stream_c.h>
+#include <dsd-neo/runtime/rtl_stream_io_hooks.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "frame_sync_state_buffers.h"
+
+#define NXDN48_SPS       20
+#define NXDN_FSW         "3131331131"
+#define NXDN_FSW_LEN     10
+#define NXDN_FRAME       192
+#define NXDN_PAYLOAD_LEN (NXDN_FRAME - NXDN_FSW_LEN)
+#define FRAME_COUNT      16
+#define PREAMBLE_DIBITS  32
+
+/* Mixed inner/outer payload: outer runs stay short so no window of it can look
+   like an all-outer frame sync word. */
+static const char kPayloadCycle[] = "0132230110322301";
+
+static size_t g_ramp_samples = 8U;
+static float* g_waveform;
+static size_t g_waveform_len;
+static size_t g_waveform_pos;
+static size_t g_read_chunk = 512U;
+static int g_waveform_exhausted;
+
+static char g_dibits[PREAMBLE_DIBITS + (FRAME_COUNT * NXDN_FRAME) + 1];
+static size_t g_dibit_count;
+
+static float
+level_for_dibit(char dibit) {
+    switch (dibit) {
+        case '0': return 8000.0f;
+        case '1': return 24000.0f;
+        case '2': return -8000.0f;
+        case '3': return -24000.0f;
+        default: break;
+    }
+    return 0.0f;
+}
+
+static void
+build_dibit_stream(void) {
+    size_t n = 0;
+    for (size_t i = 0; i < PREAMBLE_DIBITS; i++) {
+        g_dibits[n++] = (i % 2U) ? '3' : '1';
+    }
+    const size_t cycle_len = sizeof(kPayloadCycle) - 1U;
+    for (size_t f = 0; f < FRAME_COUNT; f++) {
+        for (size_t i = 0; i < NXDN_FSW_LEN; i++) {
+            g_dibits[n++] = NXDN_FSW[i];
+        }
+        for (size_t i = 0; i < NXDN_PAYLOAD_LEN; i++) {
+            g_dibits[n++] = kPayloadCycle[(f + i) % cycle_len];
+        }
+    }
+    g_dibits[n] = '\0';
+    g_dibit_count = n;
+}
+
+/* Ideal NRZ smoothed by a boxcar, so every symbol boundary becomes a ramp
+   RAMP_SAMPLES wide. A square wave would decode the same at any phase. */
+static int
+build_waveform(size_t ramp_samples) {
+    g_ramp_samples = ramp_samples;
+    free(g_waveform);
+    g_waveform = NULL;
+    const size_t n = g_dibit_count * NXDN48_SPS;
+    float* nrz = (float*)calloc(n, sizeof(float));
+    g_waveform = (float*)calloc(n, sizeof(float));
+    if (!nrz || !g_waveform) {
+        free(nrz);
+        free(g_waveform);
+        g_waveform = NULL;
+        return 0;
+    }
+    for (size_t d = 0; d < g_dibit_count; d++) {
+        const float level = level_for_dibit(g_dibits[d]);
+        for (size_t s = 0; s < NXDN48_SPS; s++) {
+            nrz[(d * NXDN48_SPS) + s] = level;
+        }
+    }
+    for (size_t i = 0; i < n; i++) {
+        float sum = 0.0f;
+        for (size_t k = 0; k < g_ramp_samples; k++) {
+            long idx = (long)i + (long)k - (long)(g_ramp_samples / 2U);
+            if (idx < 0) {
+                idx = 0;
+            }
+            if (idx >= (long)n) {
+                idx = (long)n - 1;
+            }
+            sum += nrz[idx];
+        }
+        g_waveform[i] = sum / (float)g_ramp_samples;
+    }
+    g_waveform_len = n;
+    free(nrz);
+    return 1;
+}
+
+static int
+fake_rtl_read(void* rtl_ctx, float* out, size_t count, int* out_got) {
+    (void)rtl_ctx;
+    if (!out || !out_got || count == 0U) {
+        return -1;
+    }
+    if (g_waveform_pos >= g_waveform_len) {
+        g_waveform_exhausted = 1;
+        *out_got = 0;
+        return -1;
+    }
+    size_t want = (count < g_read_chunk) ? count : g_read_chunk;
+    if (want > (g_waveform_len - g_waveform_pos)) {
+        want = g_waveform_len - g_waveform_pos;
+    }
+    for (size_t i = 0; i < want; i++) {
+        out[i] = g_waveform[g_waveform_pos++];
+    }
+    *out_got = (int)want;
+    return 0;
+}
+
+static double
+fake_rtl_pwr(const void* rtl_ctx) {
+    (void)rtl_ctx;
+    return 0.0;
+}
+
+static int
+fake_output_kind(void) {
+    return RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+}
+
+static unsigned int
+fake_output_rate_hz(void) {
+    return 48000U;
+}
+
+static int
+fake_symbol_profile(int* out_symbol_rate_hz, int* out_levels, int* out_channel_profile) {
+    if (out_symbol_rate_hz) {
+        *out_symbol_rate_hz = 2400;
+    }
+    if (out_levels) {
+        *out_levels = 4;
+    }
+    if (out_channel_profile) {
+        *out_channel_profile = RTL_STREAM_CHANNEL_PROFILE_6K25;
+    }
+    return 0;
+}
+
+static uint32_t
+fake_stream_generation(void) {
+    return 1U;
+}
+
+/* Decode one frame's payload and report how many dibits missed. The frame the
+   decoder locked onto is identified by its first payload dibit, so a phase that
+   costs a whole symbol is reported as a mismatch rather than silently aligned. */
+static int
+check_payload(dsd_opts* opts, dsd_state* state, size_t frame_index, int* out_first_bad) {
+    const size_t cycle_len = sizeof(kPayloadCycle) - 1U;
+    int bad = 0;
+    if (out_first_bad) {
+        *out_first_bad = -1;
+    }
+    for (size_t i = 0; i < NXDN_PAYLOAD_LEN; i++) {
+        dsd_dibit_soft_t soft;
+        int dibit = getDibitSoft(opts, state, &soft);
+        int expect = kPayloadCycle[(frame_index + i) % cycle_len] - '0';
+        if (dibit != expect) {
+            if (bad == 0 && out_first_bad) {
+                *out_first_bad = (int)i;
+            }
+            bad++;
+        }
+    }
+    return bad;
+}
+
+static int
+run_phase_case(int sample_offset, size_t read_chunk, size_t* out_frame_index) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static int fake_rtl_context;
+
+    g_waveform_pos = (size_t)sample_offset;
+    g_waveform_exhausted = 0;
+    g_read_chunk = read_chunk;
+    dsd_frame_sync_reset_mod_state();
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    if (!init_state_buffers(&state)) {
+        DSD_FPRINTF(stderr, "failed to allocate frame-sync state buffers\n");
+        return 1;
+    }
+
+    opts.audio_in_type = AUDIO_IN_RTL;
+    opts.frame_nxdn48 = 1;
+    opts.msize = 1;
+    opts.ssize = 128;
+
+    state.rf_mod = 2;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
+
+    dsd_rtl_stream_io_hooks_set((dsd_rtl_stream_io_hooks){
+        .read = fake_rtl_read,
+        .return_pwr = fake_rtl_pwr,
+    });
+    dsd_rtl_stream_metrics_hooks metrics_hooks = {
+        .output_kind = fake_output_kind,
+        .output_rate_hz = fake_output_rate_hz,
+        .symbol_profile = fake_symbol_profile,
+        .stream_generation = fake_stream_generation,
+    };
+    dsd_rtl_stream_metrics_hooks_set(&metrics_hooks);
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+
+    int rc = 0;
+    int sync = DSD_SYNC_NONE;
+    for (int attempt = 0; attempt < 4 && !g_waveform_exhausted; attempt++) {
+        sync = getFrameSync(&opts, &state);
+        if (sync == DSD_SYNC_NXDN_POS) {
+            break;
+        }
+    }
+    if (sync != DSD_SYNC_NXDN_POS) {
+        DSD_FPRINTF(stderr, "offset %d ramp %zu chunk %zu: no NXDN48 sync (got %d, exhausted=%d)\n", sample_offset,
+                    g_ramp_samples, read_chunk, sync, g_waveform_exhausted);
+        rc = 1;
+    } else {
+        state.synctype = sync;
+        /* Which transmitted frame the FSW belongs to: the samples consumed so
+           far locate it, and the payload cycle is rotated per frame. */
+        size_t consumed_dibits = (g_waveform_pos - (size_t)sample_offset) / NXDN48_SPS;
+        size_t frame_index = 0;
+        if (consumed_dibits > PREAMBLE_DIBITS) {
+            frame_index = (consumed_dibits - PREAMBLE_DIBITS) / NXDN_FRAME;
+        }
+        if (out_frame_index) {
+            *out_frame_index = frame_index;
+        }
+        int first_bad = -1;
+        int bad = check_payload(&opts, &state, frame_index, &first_bad);
+        if (bad != 0) {
+            DSD_FPRINTF(stderr, "offset %d ramp %zu chunk %zu: %d/%d payload dibits wrong (first at %d)\n",
+                        sample_offset, g_ramp_samples, read_chunk, bad, NXDN_PAYLOAD_LEN, first_bad);
+            rc = 1;
+        }
+
+        /* The next frame must re-accept and decode just as cleanly, on the same
+           grid: a phase held only for the frame it was acquired on is not held. */
+        sync = getFrameSync(&opts, &state);
+        if (sync != DSD_SYNC_NXDN_POS) {
+            DSD_FPRINTF(stderr, "offset %d ramp %zu chunk %zu: second frame did not sync (got %d)\n", sample_offset,
+                        g_ramp_samples, read_chunk, sync);
+            rc = 1;
+        } else {
+            state.synctype = sync;
+            first_bad = -1;
+            bad = check_payload(&opts, &state, frame_index + 1U, &first_bad);
+            if (bad != 0) {
+                DSD_FPRINTF(stderr, "offset %d ramp %zu chunk %zu: frame 2 %d/%d payload dibits wrong (first at %d)\n",
+                            sample_offset, g_ramp_samples, read_chunk, bad, NXDN_PAYLOAD_LEN, first_bad);
+                rc = 1;
+            }
+        }
+    }
+
+    dsd_rtl_stream_io_hooks_set((dsd_rtl_stream_io_hooks){0});
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    dsd_rtl_stream_metrics_hook_symbol_cache_pending_reset();
+    free_state_buffers(&state);
+    return rc;
+}
+
+int
+main(void) {
+    build_dibit_stream();
+
+    int failures = 0;
+    /* Two transition shapes: at 8 samples the search-time nudge settles wherever
+       the starting offset left it, at 14 it settles on a fixed bias. Neither is
+       the transmitted clock. Two read chunk sizes vary how much sits in the
+       decoder's cache when a symbol is composed. */
+    static const size_t kRamps[] = {8U, 14U};
+    static const size_t kChunks[] = {512U, 37U};
+    for (size_t r = 0; r < sizeof(kRamps) / sizeof(kRamps[0]); r++) {
+        if (!build_waveform(kRamps[r])) {
+            DSD_FPRINTF(stderr, "failed to build NXDN48 phase fixture\n");
+            return 1;
+        }
+        for (size_t c = 0; c < sizeof(kChunks) / sizeof(kChunks[0]); c++) {
+            for (int off = 0; off < NXDN48_SPS; off++) {
+                size_t frame_index = 0;
+                if (run_phase_case(off, kChunks[c], &frame_index) != 0) {
+                    failures++;
+                }
+            }
+        }
+    }
+
+    free(g_waveform);
+    g_waveform = NULL;
+    if (failures != 0) {
+        DSD_FPRINTF(stderr, "NXDN48 symbol path: %d cases decoded wrongly\n", failures);
+        return 1;
+    }
+    return 0;
+}

--- a/tests/dsp/test_rtl_symbol_cache_generation.c
+++ b/tests/dsp/test_rtl_symbol_cache_generation.c
@@ -35,6 +35,7 @@ static float g_read_base = 1000.0f;
 static float g_read_base_step = 0.0f;
 static int g_read_calls = 0;
 static int g_bump_generation_during_read = 0;
+static float g_read_base_after_bump = 0.0f;
 static int g_output_kind_after_bump = -1;
 static int g_symbol_rate_hz_after_bump = 0;
 static int g_symbol_levels_after_bump = 0;
@@ -172,6 +173,11 @@ fake_rtl_read(void* rtl_ctx, float* out, size_t count, int* out_got) {
             g_channel_profile = g_channel_profile_after_bump;
             g_channel_profile_after_bump = -1;
         }
+        if (g_read_base_after_bump > 0.0f) {
+            g_read_base = g_read_base_after_bump;
+            read_base = g_read_base;
+            g_read_base_after_bump = 0.0f;
+        }
         g_bump_generation_during_read = 0;
     }
     for (int i = 0; i < 4; i++) {
@@ -229,6 +235,7 @@ reset_stream_fixture(void) {
     g_read_base_step = 0.0f;
     g_read_calls = 0;
     g_bump_generation_during_read = 0;
+    g_read_base_after_bump = 0.0f;
     g_output_kind_after_bump = -1;
     g_symbol_rate_hz_after_bump = 0;
     g_symbol_levels_after_bump = 0;
@@ -551,6 +558,46 @@ main(void) {
     state.rf_mod = 1;
     assert(getSymbol(&opts, &state, 1) == 4100.0f);
     assert(g_cleanup_calls == 0);
+
+    /*
+     * Every retune and replay RESET bumps the stream generation, which flushes
+     * whatever the decoder had cached. A symbol in flight when that happens must
+     * restart on the new stream instead of averaging samples from both, so what
+     * comes out does not depend on how full the cache happened to be -- the
+     * decoder-side half of the sampling nondeterminism in issue #404.
+     */
+    float restart_symbol = 0.0f;
+    for (int prefill = 0; prefill < 3; prefill++) {
+        reset_stream_fixture();
+        reset_decoder_fixture(&opts, &state, &fake_rtl_context);
+        g_output_kind = RTL_STREAM_OUTPUT_FSK_DISCRIMINATOR;
+        g_output_rate_hz = 48000U;
+        g_symbol_rate_hz = 4800;
+        g_symbol_levels = 4;
+        g_channel_profile = RTL_STREAM_CHANNEL_PROFILE_12K5;
+        state.rf_mod = 0;
+        g_read_base = 4000.0f;
+        g_read_base_step = 100.0f;
+
+        for (int s = 0; s < prefill; s++) {
+            (void)getSymbol(&opts, &state, 1);
+        }
+
+        g_bump_generation_during_read = 1;
+        g_read_base_after_bump = 9000.0f;
+        float symbol = getSymbol(&opts, &state, 1);
+        if (symbol < 9000.0f) {
+            DSD_FPRINTF(stderr, "generation bump at prefill %d mixed streams: symbol %.4f\n", prefill, symbol);
+        }
+        assert(symbol >= 9000.0f);
+        if (prefill == 0) {
+            restart_symbol = symbol;
+        } else if (fabsf(symbol - restart_symbol) >= 0.01f) {
+            DSD_FPRINTF(stderr, "generation bump at prefill %d gave %.4f, prefill 0 gave %.4f\n", prefill, symbol,
+                        restart_symbol);
+            assert(fabsf(symbol - restart_symbol) < 0.01f);
+        }
+    }
 
     /*
      * Read failures should surface as the existing empty-symbol path, trigger

--- a/tests/dsp/test_sync_calibration.c
+++ b/tests/dsp/test_sync_calibration.c
@@ -163,6 +163,57 @@ test_warm_start_ideal(void) {
 }
 
 /**
+ * @brief A re-seeded slicer must not leave the crossing measured against the old one.
+ *
+ * state->jitter holds the index of the first zero crossing inside a symbol, and
+ * symbol_adjust_timing_index() slips the symbol grid by a sample on it. It is
+ * measured against center/maxref/minref -- exactly what warm-start replaces --
+ * and it is assigned only while negative, so a value left here survives the whole
+ * frame this sync opens (the slip does not run inside a frame) and is then handed
+ * to the first symbol of the next sync search. That symbol would move the grid on
+ * a crossing measured against a calibration that no longer exists (issue #404).
+ */
+static void
+test_warm_start_drops_stale_crossing(void) {
+    printf("=== test_warm_start_drops_stale_crossing ===\n");
+
+    static struct dsd_state state;
+    DSD_MEMSET(&state, 0, sizeof(state));
+    static float history[64];
+
+    static struct dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.msize = 64;
+
+    attach_history_fixture(&state, history, 64);
+    for (int i = 0; i < 24; i++) {
+        dsd_symbol_history_push(&state, (i % 2 == 0) ? +3.0f : -3.0f);
+    }
+
+    /* A crossing latched against the thresholds the warm-start is about to
+       replace, in the band that slips the grid. */
+    state.jitter = 9;
+
+    dsd_warm_start_result_t result = dsd_sync_warm_start_thresholds_outer_only(&opts, &state, 24);
+    check_int("warm_start result", DSD_WARM_START_OK, result);
+    check_int("stale crossing dropped", -1, state.jitter);
+
+    /* A warm-start that does not re-seed anything must leave the crossing alone:
+       it is still measured against the thresholds in force. */
+    DSD_MEMSET(&state, 0, sizeof(state));
+    attach_history_fixture(&state, history, 64);
+    for (int i = 0; i < 4; i++) {
+        dsd_symbol_history_push(&state, +3.0f);
+    }
+    state.jitter = 9;
+    result = dsd_sync_warm_start_thresholds_outer_only(&opts, &state, 24);
+    check_int("no-history result", DSD_WARM_START_NO_HISTORY, result);
+    check_int("crossing kept when nothing was re-seeded", 9, state.jitter);
+
+    printf("test_warm_start_drops_stale_crossing: passed\n\n");
+}
+
+/**
  * @brief Test warm-start with DC offset.
  */
 static void
@@ -574,6 +625,7 @@ main(void) {
     test_history_basic_ops();
     test_history_wraparound();
     test_warm_start_ideal();
+    test_warm_start_drops_stale_crossing();
     test_warm_start_dc_offset();
     test_center_only_warm_start();
     test_center_only_large_bias();


### PR DESCRIPTION
Fixes #404.

## What was wrong

`state->jitter` holds the index of the first zero crossing inside a symbol, and `symbol_adjust_timing_index()`
(`src/dsp/dsd_symbol.c`) slips the open-loop FSK symbol grid by one sample on it. The crossing is decided against
`center`, `maxref` and `minref` — exactly what `dsd_sync_warm_start_thresholds_outer_only()` re-seeds from the sync
word it has just accepted — and `symbol_update_jitter()` only ever assigns it while it is negative. So the value the
sync search left behind survived the re-seed.

Nothing cleared it after that either. The slip does not run while a frame is being read (it returns early on
`have_sync`), so the crossing outlived the whole 192-symbol frame the sync opened and was handed to the first symbol
of the next sync search, which moved the grid on where a crossing fell against a calibration and a symbol that were
both long gone. Applied once per frame boundary for the length of a call, that walks the sampling instant into
whichever orbit the history happened to pick.

## What the measurements say

On the reporter's NXDN48 capture the same 132-frame call decoded into three bit-identical outcomes — 42, 55 or 118
corrected AMBE errors — and which one was not reproducible under `-fa`. It was never `-fa` specific: `-fi` is
bit-exact per replay pacing mode but lands a different outcome under `fast` pacing than under `realtime`, so it was
deterministic rather than right.

The issue proposed that `-fa` acquires a *wrong* sampling phase. That turned out not to be the case. Instrumenting
the acquired phase (correlating each accepted sync word against the samples the grid consumed) showed the grid's
offset from the transmitted symbol clock averaging zero with a spread of about two samples, in good and bad runs
alike. The phase was never systematically wrong — only what the nudge did with a stale measurement of it. An
ablation confirmed it: with the stale crossing dropped and nothing else changed, `-fa` decoded the call bit-exactly
to the `-fi` reference; with it kept, the same build reproduced the 55 and 118 outcomes.

| cell | before | after |
|---|---|---|
| `-fa` realtime, call 3 | 42 ×2, 55 ×7, **118 ×1** (10 runs) | 42 ×6, 55 ×12, **no 118** (18 runs) |
| `-fi` realtime, call 3 | 42, 42, 42 | 42, 42, 42 (unchanged, bit for bit) |
| `-fi` fast, call 3 | 62 | 45, 45 |

In the runs that still land on 55, quarters 2–4 are now bit-identical to the good reference and only the first
quarter differs: those runs acquire the call about four frames earlier (136 frames against 132) and so decode the
transmission's noisier onset as well. The whole-call error multiplier this issue reports is gone; what is left is
acquisition timing, which belongs to the #374 family.

## The changes

**`fix(dsp): drop the zero crossing a sync warm-start invalidates`** — clear `state->jitter` where the thresholds it
was measured against are replaced. The grid then only ever moves on crossings the current calibration produced. One
line of behaviour, in the one place that owns the invariant, so it holds for every protocol that warm-starts rather
than just NXDN48.

**`fix(dsp): restart the symbol a stream flush lands in the middle of`** — an adjacent determinism defect found while
investigating. Every retune and replay RESET bumps the RTL output generation, which flushes the decoder's sample
cache; `symbol_process_live_samples()` kept its span index across that flush, so one symbol per retune was the mean
of however many samples the old stream had left plus enough from the new one to finish the span, and where that split
fell depended on how full the cache happened to be. Not the cause of #404 (an ablation kept the bimodality with this
alone), but a real defect on the same path.

## Tests

- `test_warm_start_drops_stale_crossing` (`SYNC_CALIBRATION`) — pins that a re-seed drops the crossing, and that a
  warm start which re-seeds nothing leaves it alone. Fails without the fix (`expected -1, got 9`).
- Three cases in `RTL_SYMBOL_CACHE_GENERATION` — a generation bump mid-symbol must compose the symbol from the new
  stream only, and identically whatever the cache held. Fails without the fix (same stream gave 9161.6 or 9121.2
  depending on cache fill).
- `FRAME_SYNC_NXDN_FSK_PHASE` (new) — the first test to drive the real `getFrameSync()` + `getSymbol()` +
  `getDibitSoft()` chain on the RTL sample path; 80 configurations (two pulse shapings × two cache read sizes × 20
  starting sample offsets) requiring the payload to decode identically whatever sub-symbol phase the search settled
  on. A guard for the loop the span restart touches, not a reproducer.

`ctest --preset dev-debug` 585/585 (including the 27 `iq-decode` cases across DMR, P25, NXDN, dPMR, YSF, EDACS and
M17), `ctest --preset asan-ubsan-debug` 585/585, `tools/preflight_ci.sh` clean.
