### PR TITLE
feat(dsp): make symbol timing observable, and measure the phase the grid settled on (#443)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -757,7 +757,27 @@ Debug (verbose/developer)
 
 - `DSD_NEO_DEBUG_SYNC=1` — verbose sync detection output
 - `DSD_NEO_DEBUG_CQPSK=1` — verbose CQPSK Gardner/Costas/FLL-band-edge state output
+- `DSD_NEO_DEBUG_SYMBOL_TIMING=1|2` — symbol-timing diagnostics on the decoder's symbol grid
 - `DSD_NEO_SYNC_WARMSTART=0` — disable sync warm-start calibration
+
+### Symbol timing (`DSD_NEO_DEBUG_SYMBOL_TIMING`)
+
+The decoder's sampling phase is fixed when a sync is acquired and held for the rest of the call, so a call decoded
+at a poor phase stays at that phase. Level `1` prints one line per accepted frame sync:
+
+```text
+SYMTIMING: sync=29 win=13113313 sps=20 jitter=-1 off=0 accum=0
+```
+
+- `sync` — accepted sync type id; `win` — the eight decided dibits the measurement correlated over
+- `sps` — `samplesPerSymbol` the grid is running; `jitter` — the latched zero-crossing index, `-1` when none
+- `off` — sub-symbol offset, in samples, between the grid's symbol boundary and the one the signal supports
+  (`0` is aligned, and `-` means the trace could not support a measurement — right after a retune, for instance)
+- `accum` — the RTL FSK fractional-sps accumulator
+
+Collect the `off` distribution over a call to see the phase the grid settled on, and compare runs to see whether it
+is stable. Level `2` additionally enables the per-sample `+ - O X` trace and the per-symbol jitter line; that is tens
+of thousands of characters per second, so prefer level `1` unless you need the within-symbol detail.
 
 ## Handy Examples
 

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -222,6 +222,9 @@ installs from `src/engine/trunk_tuning.c` in `src/engine/trunk_tuning_hooks_inst
   recovery, CQPSK helpers
   (matched/RRC), and SIMD helpers; exposes runtime-tunable parameters consumed by the UI
 - Build files: `src/dsp/CMakeLists.txt`
+- `symbol_timing_debug.c`: measures the sub-symbol offset the decoder's symbol grid settled on and reports it once
+  per accepted frame sync, behind `DSD_NEO_DEBUG_SYMBOL_TIMING` (see `docs/cli.md`). The sample trace it correlates
+  over is filled by `dsd_symbol.c` and owned by decoder-state setup/teardown in `src/core/util/dsd_init.c`.
 
 Runtime controls (via `include/dsd-neo/io/rtl_stream_c.h`):
 

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -97,7 +97,6 @@ struct dsd_opts {
     int onesymbol;
     int errorbars;
     int datascope;
-    int symboltiming;
     int verbose;
     int p25enc;
     int p25lc;

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -226,6 +226,25 @@ typedef struct {
 
 //end new filters
 
+/**
+ * @brief Post-filter sample trace used only by the symbol-timing diagnostic.
+ *
+ * `samples` holds the samples the symbol grid consumed, in order; `spans` holds
+ * how many of them each completed symbol took, so a reader can walk real symbol
+ * boundaries rather than assume a fixed samplesPerSymbol stride (the pre-sync
+ * timing nudge makes symbols consume samplesPerSymbol +/- 1). Decoder-state setup
+ * and teardown own both buffers, as they do the symbol history's; nothing is
+ * written to them unless DSD_NEO_DEBUG_SYMBOL_TIMING is on.
+ */
+typedef struct {
+    float* samples;
+    uint8_t* spans;
+    int sample_head;
+    int sample_count;
+    int span_head;
+    int span_count;
+} dsd_symbol_timing_trace;
+
 typedef struct {
     uint8_t F1;
     uint8_t F2;
@@ -1486,6 +1505,11 @@ struct dsd_state {
     int symbol_history_size;  /**< Circular-buffer size in symbols */
     int symbol_history_head;  /**< Write index into circular buffer */
     int symbol_history_count; /**< Symbols written (for underflow check) */
+
+    /** Post-filter sample trace backing the symbol-timing diagnostic;
+     *  written only while DSD_NEO_DEBUG_SYMBOL_TIMING is on.
+     *  See dsp/symbol_timing_debug.h. */
+    dsd_symbol_timing_trace timing_trace;
 
     // Advisory-only input level health for ncurses/status snapshots.
     dsd_input_level_snapshot input_level;

--- a/include/dsd-neo/dsp/symbol_timing_debug.h
+++ b/include/dsd-neo/dsp/symbol_timing_debug.h
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Runtime observability for the decoder's own symbol grid.
+ *
+ * The decoder's sampling phase is fixed when a sync is acquired and held for the
+ * whole call, but nothing printed it: the sub-symbol offset the grid settled on
+ * was only ever measurable with a throwaway build (issue #404). This module
+ * measures that offset from the samples the grid actually consumed and reports
+ * it once per accepted frame sync.
+ *
+ * Everything here is gated on DSD_NEO_DEBUG_SYMBOL_TIMING: with it unset nothing
+ * is recorded, measured, or printed, and the decode path is the one it would have
+ * taken anyway.
+ */
+
+#ifndef DSD_NEO_DSP_SYMBOL_TIMING_DEBUG_H
+#define DSD_NEO_DSP_SYMBOL_TIMING_DEBUG_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct dsd_state;
+
+/**
+ * Symbols of received sync the offset is measured over.
+ *
+ * Every protocol's sync word is at least this long (M17's eight is the
+ * shortest), so the trailing eight decided dibits at an accept are always inside
+ * the sync word whatever matched. That keeps the measurement free of a
+ * per-protocol window-length table, which would silently rot as matchers change.
+ */
+#define DSD_SYMBOL_TIMING_TEMPLATE_SYMS 8
+
+/** Largest samplesPerSymbol the decoder produces (dsd_opts_compute_sps_rate clamps to 64). */
+#define DSD_SYMBOL_TIMING_MAX_SPAN      64
+
+/** Samples a measurement reads: the template, plus a symbol of room to shift it over. */
+#define DSD_SYMBOL_TIMING_SPAN_SAMPLES  (DSD_SYMBOL_TIMING_MAX_SPAN * (DSD_SYMBOL_TIMING_TEMPLATE_SYMS + 1))
+
+/**
+ * @brief Current DSD_NEO_DEBUG_SYMBOL_TIMING level.
+ * @return 0 off, 1 one line per accepted sync, 2 additionally the per-sample trace.
+ */
+int dsd_symbol_timing_debug_level(void);
+
+/**
+ * @brief Record one post-filter sample the symbol grid consumed.
+ *
+ * The buffers belong to decoder-state setup and teardown, as the symbol history's
+ * do; this is a no-op until they exist. Safe to call with a NULL state.
+ */
+void dsd_symbol_timing_trace_push_sample(struct dsd_state* state, float sample);
+
+/**
+ * @brief Record how many samples the symbol just completed consumed.
+ * @param samples_consumed Sample count for that symbol; ignored when out of range.
+ */
+void dsd_symbol_timing_trace_push_span(struct dsd_state* state, int samples_consumed);
+
+/**
+ * @brief Drop the trace contents without releasing the buffers.
+ *
+ * Called wherever the sample stream is discontinuous (a retune, a cache flush, a
+ * symbol-rate change), so a measurement never correlates across the seam.
+ */
+void dsd_symbol_timing_trace_reset(struct dsd_state* state);
+
+/**
+ * @brief Measure which sub-symbol offset the samples best support.
+ *
+ * Correlates whole-symbol integrals of @p samples against the levels @p window
+ * says were received, once per candidate offset, and returns the offset scoring
+ * highest. Whole-symbol rather than the slicer's narrow window on purpose: a
+ * narrow window scores flat across the middle of a symbol and localises nothing.
+ *
+ * The last sum(spans) entries of @p samples are the template's symbols; anything
+ * before them is room to shift the template earlier.
+ *
+ * @param samples       Samples in the order the grid consumed them.
+ * @param sample_count  Entries in @p samples.
+ * @param spans         Samples each template symbol consumed, oldest first.
+ * @param span_count    Entries in @p spans, matching @p window's length.
+ * @param window        Decided dibits ('0'..'3') for those symbols, oldest first.
+ * @param out_offset    Receives the winning offset, in samples before the grid's boundary.
+ * @return 1 when a measurement was made, 0 when the input cannot support one.
+ */
+int dsd_symbol_timing_measure_sync_offset(const float* samples, int sample_count, const uint8_t* spans, int span_count,
+                                          const char* window, int* out_offset);
+
+/**
+ * @brief Print one measurement line for an accepted frame sync.
+ *
+ * @param state    Decoder state carrying the trace and the grid's timing.
+ * @param synctype Accepted sync type, reported numerically.
+ * @param window   Trailing decided dibits; at least DSD_SYMBOL_TIMING_TEMPLATE_SYMS of them.
+ */
+void dsd_symbol_timing_report_sync(const struct dsd_state* state, int synctype, const char* window);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_DSP_SYMBOL_TIMING_DEBUG_H */

--- a/include/dsd-neo/runtime/config.h
+++ b/include/dsd-neo/runtime/config.h
@@ -113,6 +113,10 @@ extern "C" {
  *
  * Debug/advanced knobs (centralized for maintainability)
  * - DSD_NEO_DEBUG_SYNC, DSD_NEO_DEBUG_CQPSK
+ * - DSD_NEO_DEBUG_SYMBOL_TIMING
+ *     Symbol-timing diagnostics on the decoder's own symbol grid.
+ *     Values: 0 off, 1 one measurement line per accepted frame sync (sub-symbol offset,
+ *     samplesPerSymbol, jitter), 2 additionally the per-sample +/-/O/X trace. Default: 0.
  * - DSD_NEO_CQPSK, DSD_NEO_CQPSK_SYNC_INV, DSD_NEO_CQPSK_SYNC_NEG
  * - DSD_NEO_FTZ_DAZ
  * - DSD_NEO_NO_BOOTSTRAP
@@ -129,6 +133,13 @@ extern "C" {
  * Cache/path knobs
  * - DSD_NEO_CACHE_DIR, DSD_NEO_CC_CACHE
  */
+
+/* Levels for DSD_NEO_DEBUG_SYMBOL_TIMING. */
+enum {
+    DSD_NEO_SYMBOL_TIMING_OFF = 0,
+    DSD_NEO_SYMBOL_TIMING_SYNC_LINE = 1,
+    DSD_NEO_SYMBOL_TIMING_TRACE = 2,
+};
 
 typedef enum DSD_ATTR_PACKED {
     DSD_NEO_DEEMPH_UNSET = 0,
@@ -218,6 +229,10 @@ typedef struct dsdneoRuntimeConfig {
     int debug_sync_enable;
     int debug_cqpsk_is_set;
     int debug_cqpsk_enable;
+    /* Level rather than a toggle: the two things this gates differ by orders of magnitude in
+     * volume. 1 is one line per accepted sync; 2 adds a character per input sample. */
+    int debug_symbol_timing_is_set;
+    int debug_symbol_timing;
 
     /* CQPSK runtime toggles */
     int cqpsk_is_set;

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -13,6 +13,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/symbol_timing_debug.h>
 #include <dsd-neo/dsp/sync_calibration.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/log.h>
@@ -72,7 +73,6 @@ init_opts_display_and_audio_defaults(dsd_opts* opts) {
     opts->show_keys = 0;                                 // redact radio keys/keystreams unless CLI explicitly opts in
     opts->p25_afc_status_gate_enable = 0;     // advisory by default; status-derived direction is not always reliable
     opts->frontend_display.show_channels = 0; // hide Channels section by default
-    opts->symboltiming = 0;
     opts->verbose = 2;
     opts->p25enc = 0;
     opts->p25lc = 0;
@@ -442,6 +442,23 @@ init_state_core_buffers(dsd_state* state) {
     }
     state->symbol_history_head = 0;
     state->symbol_history_count = 0;
+
+    // Post-filter sample trace for the symbol-timing diagnostic. Sized for the template the
+    // measurement correlates over plus a symbol of shift room; see dsp/symbol_timing_debug.h.
+    const size_t timing_sample_bytes = (size_t)DSD_SYMBOL_TIMING_SPAN_SAMPLES * sizeof(float);
+    const size_t timing_span_bytes = (size_t)DSD_SYMBOL_TIMING_TEMPLATE_SYMS * sizeof(uint8_t);
+    state->timing_trace.samples = dsd_aligned_alloc(64, timing_sample_bytes);
+    if (state->timing_trace.samples) {
+        DSD_MEMSET(state->timing_trace.samples, 0, timing_sample_bytes);
+    }
+    state->timing_trace.spans = dsd_aligned_alloc(64, timing_span_bytes);
+    if (state->timing_trace.spans) {
+        DSD_MEMSET(state->timing_trace.spans, 0, timing_span_bytes);
+    }
+    state->timing_trace.sample_head = 0;
+    state->timing_trace.sample_count = 0;
+    state->timing_trace.span_head = 0;
+    state->timing_trace.span_count = 0;
 
     state->repeat = 0;
 
@@ -1258,6 +1275,15 @@ freeState(dsd_state* state) {
     state->symbol_history_size = 0;
     state->symbol_history_head = 0;
     state->symbol_history_count = 0;
+
+    dsd_aligned_free(state->timing_trace.samples);
+    dsd_aligned_free(state->timing_trace.spans);
+    state->timing_trace.samples = NULL;
+    state->timing_trace.spans = NULL;
+    state->timing_trace.sample_head = 0;
+    state->timing_trace.sample_count = 0;
+    state->timing_trace.span_head = 0;
+    state->timing_trace.span_count = 0;
 
     dsd_aligned_free(state->dibit_buf);
     state->dibit_buf = NULL;

--- a/src/dsp/CMakeLists.txt
+++ b/src/dsp/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(
         sync_hamming.c
         dmr_sync.c
         sync_calibration.c
+        symbol_timing_debug.c
 )
 
 set(_dsd_neo_dsp_target_arch "${CMAKE_SYSTEM_PROCESSOR}")

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -33,6 +33,7 @@
 #include <dsd-neo/dsp/dmr_sync.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/symbol.h>
+#include <dsd-neo/dsp/symbol_timing_debug.h>
 #include <dsd-neo/dsp/sync_calibration.h>
 #include <dsd-neo/dsp/sync_hamming.h>
 #include <dsd-neo/platform/atomic_compat.h>
@@ -1750,7 +1751,7 @@ frame_sync_try_provoice_conventional(frame_sync_match_ctx* ctx) {
 #endif
 
 static int
-frame_sync_try_protocol_matches(frame_sync_match_ctx* ctx) {
+frame_sync_try_protocol_matches_inner(frame_sync_match_ctx* ctx) {
     int sync_type = frame_sync_try_p25p1(ctx);
     if (sync_type != DSD_SYNC_NONE) {
         return sync_type;
@@ -1802,6 +1803,22 @@ frame_sync_try_protocol_matches(frame_sync_match_ctx* ctx) {
     }
 
     return frame_sync_try_provoice_conventional(ctx);
+}
+
+/* Every accept the sync hunt makes passes through here, which is where the symbol-timing
+ * diagnostic measures the phase the grid settled on. The template is the trailing
+ * DSD_SYMBOL_TIMING_TEMPLATE_SYMS decided dibits rather than the matched sync word: those
+ * are inside the sync word whatever matched -- no protocol's word is shorter -- so no
+ * per-protocol window table has to be kept in step with the matchers above.
+ *
+ * In-frame resyncs a protocol handler does privately do not come through here. */
+static int
+frame_sync_try_protocol_matches(frame_sync_match_ctx* ctx) {
+    const int sync_type = frame_sync_try_protocol_matches_inner(ctx);
+    if (sync_type != DSD_SYNC_NONE && frame_sync_match_window_ready(ctx, DSD_SYMBOL_TIMING_TEMPLATE_SYMS)) {
+        dsd_symbol_timing_report_sync(ctx->state, sync_type, ctx->synctest8);
+    }
+    return sync_type;
 }
 
 static time_t g_p25_trunk_tick_last_tick = 0;

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -30,6 +30,7 @@
 #include <dsd-neo/dsp/sps_filters.h>
 #include <dsd-neo/dsp/symbol.h>
 #include <dsd-neo/dsp/symbol_levels.h>
+#include <dsd-neo/dsp/symbol_timing_debug.h>
 #include <dsd-neo/dsp/sync_calibration.h>
 #include <dsd-neo/platform/audio.h>
 #include <dsd-neo/platform/file_compat.h>
@@ -245,6 +246,11 @@ typedef struct {
     int symbol_span;
     int l_edge_pre;
     int r_edge_pre;
+    /* DSD_NEO_DEBUG_SYMBOL_TIMING, read once per symbol rather than per sample. */
+    int timing_level;
+    /* Samples this symbol has actually taken, which is not the span index: the
+       timing nudge moves that index and a stream flush restarts it. */
+    int timing_samples;
     unsigned int analog_out_cap;
 #ifdef USE_RADIO
     int rtl_output_kind;
@@ -270,6 +276,7 @@ symbol_work_ctx_init(symbol_work_ctx* work, const dsd_state* state) {
     }
     *work = (symbol_work_ctx){0};
     work->symbol_span = 1;
+    work->timing_level = dsd_symbol_timing_debug_level();
 #ifdef USE_RADIO
     work->rtl_symbol_levels = 4;
 #endif
@@ -279,14 +286,17 @@ symbol_work_ctx_init(symbol_work_ctx* work, const dsd_state* state) {
     work->analog_out_cap = (unsigned int)(sizeof(state->analog_out) / sizeof(state->analog_out[0]));
 }
 
+/* No have_sync term: the frame is exactly the window a timing question needs to see,
+   and gating it out is what made this trace useless to #404. lastsynctype still gates
+   it, so the pre-first-sync noise hunt stays quiet. */
 static inline int
-symbol_timing_debug_enabled(const dsd_opts* opts, const dsd_state* state, int have_sync) {
-    return opts->symboltiming == 1 && have_sync == 0 && state->lastsynctype != DSD_SYNC_NONE;
+symbol_timing_debug_enabled(const dsd_state* state, int timing_level) {
+    return timing_level >= DSD_NEO_SYMBOL_TIMING_TRACE && state->lastsynctype != DSD_SYNC_NONE;
 }
 
 static inline void
-symbol_timing_debug_char(const dsd_opts* opts, const dsd_state* state, int have_sync, char c) {
-    if (symbol_timing_debug_enabled(opts, state, have_sync)) {
+symbol_timing_debug_char(const dsd_state* state, int timing_level, char c) {
+    if (symbol_timing_debug_enabled(state, timing_level)) {
         DSD_FPRINTF(stderr, "%c", c);
     }
 }
@@ -354,41 +364,41 @@ symbol_apply_sync_clip(const dsd_state* state, int have_sync, float sample) {
 }
 
 static inline void
-symbol_jitter_above_center(const dsd_opts* opts, dsd_state* state, int have_sync, int i, float sample) {
+symbol_jitter_above_center(dsd_state* state, int timing_level, int i, float sample) {
     if (sample > (state->maxref * 1.25f)) {
         if ((state->jitter < 0) && (state->rf_mod == 1)) {
             state->jitter = i;
         }
-        symbol_timing_debug_char(opts, state, have_sync, 'O');
+        symbol_timing_debug_char(state, timing_level, 'O');
         return;
     }
-    symbol_timing_debug_char(opts, state, have_sync, '+');
+    symbol_timing_debug_char(state, timing_level, '+');
     if ((state->jitter < 0) && (state->lastsample < state->center) && (state->rf_mod != 1)) {
         state->jitter = i;
     }
 }
 
 static inline void
-symbol_jitter_below_center(const dsd_opts* opts, dsd_state* state, int have_sync, int i, float sample) {
+symbol_jitter_below_center(dsd_state* state, int timing_level, int i, float sample) {
     if (sample < (state->minref * 1.25f)) {
         if ((state->jitter < 0) && (state->rf_mod == 1)) {
             state->jitter = i;
         }
-        symbol_timing_debug_char(opts, state, have_sync, 'X');
+        symbol_timing_debug_char(state, timing_level, 'X');
         return;
     }
-    symbol_timing_debug_char(opts, state, have_sync, '-');
+    symbol_timing_debug_char(state, timing_level, '-');
     if ((state->jitter < 0) && (state->lastsample > state->center) && (state->rf_mod != 1)) {
         state->jitter = i;
     }
 }
 
 static inline void
-symbol_update_jitter(const dsd_opts* opts, dsd_state* state, int have_sync, int i, float sample) {
+symbol_update_jitter(dsd_state* state, int timing_level, int i, float sample) {
     if (sample > state->center) {
-        symbol_jitter_above_center(opts, state, have_sync, i, sample);
+        symbol_jitter_above_center(state, timing_level, i, sample);
     } else {
-        symbol_jitter_below_center(opts, state, have_sync, i, sample);
+        symbol_jitter_below_center(state, timing_level, i, sample);
     }
 }
 
@@ -1328,6 +1338,7 @@ symbol_reset_rtl_fsk_timing_if_needed(dsd_state* state, int output_rate_hz, int 
     state->rtl_fsk_sps_den = symbol_rate_hz;
     state->rtl_fsk_sps_accum = 0;
     state->jitter = -1;
+    dsd_symbol_timing_trace_reset(state);
     symbol_reset_rtl_fsk_discriminator_slicer(state);
     return 1;
 }
@@ -1585,7 +1596,7 @@ symbol_init_rtl_profile(const dsd_opts* opts, dsd_state* state, symbol_work_ctx*
 
 static int
 symbol_try_rtl_symbol_rate_fast_path(dsd_opts* opts, dsd_state* state, symbol_work_ctx* work) {
-    if (!work->rtl_symbol_rate_output || opts->symboltiming == 1) {
+    if (!work->rtl_symbol_rate_output) {
         return 0;
     }
     if (!state->rtl_ctx) {
@@ -1621,6 +1632,12 @@ symbol_try_rtl_symbol_rate_fast_path(dsd_opts* opts, dsd_state* state, symbol_wo
     }
     opts->rtl_pwr = dsd_rtl_stream_io_hook_return_pwr(state);
     state->lastsample = work->sample;
+    /* One sample per symbol here, which the measurement recognises as a grid with no
+       sub-symbol structure to report on. */
+    if (work->timing_level >= DSD_NEO_SYMBOL_TIMING_SYNC_LINE) {
+        dsd_symbol_timing_trace_push_sample(state, work->sample);
+        dsd_symbol_timing_trace_push_span(state, 1);
+    }
     dsd_symbol_history_push(state, work->sample);
     state->symbolcnt++;
     symbol_maybe_publish_rtl_input_level(opts, state);
@@ -1674,8 +1691,8 @@ symbol_prepare_span(const dsd_opts* opts, dsd_state* state, symbol_work_ctx* wor
 #endif
 
 static inline void
-symbol_print_timing_line(const dsd_opts* opts, dsd_state* state, int have_sync) {
-    if (!symbol_timing_debug_enabled(opts, state, have_sync)) {
+symbol_print_timing_line(const dsd_state* state, int timing_level) {
+    if (!symbol_timing_debug_enabled(state, timing_level)) {
         return;
     }
     if (state->jitter >= 0) {
@@ -1793,6 +1810,10 @@ symbol_process_live_samples(dsd_opts* opts, dsd_state* state, int have_sync, sym
                 work->symbol_span = state->samplesPerSymbol;
             }
             state->jitter = -1;
+            /* Same reasoning for the timing trace: correlating a sync word across a
+               stream seam would measure the flush, not the grid. */
+            dsd_symbol_timing_trace_reset(state);
+            work->timing_samples = 0;
             i = 0;
         }
 #endif
@@ -1808,25 +1829,37 @@ symbol_process_live_samples(dsd_opts* opts, dsd_state* state, int have_sync, sym
         work->sample =
             symbol_apply_matched_filter(opts, state, work->sample, rtl_symbol_rate_output, cqpsk_symbol_rate);
         work->sample = symbol_apply_sync_clip(state, have_sync, work->sample);
-        symbol_update_jitter(opts, state, have_sync, i, work->sample);
+        if (work->timing_level >= DSD_NEO_SYMBOL_TIMING_SYNC_LINE) {
+            dsd_symbol_timing_trace_push_sample(state, work->sample);
+            work->timing_samples++;
+        }
+        symbol_update_jitter(state, work->timing_level, i, work->sample);
         symbol_accumulate_sample(state, work, i, work->sample);
         state->lastsample = work->sample;
         i++;
     }
+    if (work->timing_level >= DSD_NEO_SYMBOL_TIMING_SYNC_LINE) {
+        dsd_symbol_timing_trace_push_span(state, work->timing_samples);
+    }
     return 1;
 }
 
+// apply_rtl_symbol_thresholds() writes through state in the USE_RADIO build, which is the
+// configuration this ships in; only the radio-less build could take a const pointer here.
+// cppcheck-suppress-begin constParameterPointer
 static inline float
-symbol_finalize_live_symbol(const dsd_opts* opts, dsd_state* state, int have_sync, const symbol_work_ctx* work) {
+symbol_finalize_live_symbol(dsd_state* state, const symbol_work_ctx* work) {
     float symbol = (work->count > 0) ? (work->sum / (float)work->count) : 0.0f;
 #ifdef USE_RADIO
     if (work->rtl_symbol_rate_output) {
         apply_rtl_symbol_thresholds(state, work->rtl_symbol_levels);
     }
 #endif
-    symbol_print_timing_line(opts, state, have_sync);
+    symbol_print_timing_line(state, work->timing_level);
     return symbol;
 }
+
+// cppcheck-suppress-end constParameterPointer
 
 #ifndef USE_RADIO
 static inline void
@@ -1898,7 +1931,7 @@ getSymbol(dsd_opts* opts, dsd_state* state, int have_sync) {
         return 0.0f;
     }
 
-    float symbol = symbol_finalize_live_symbol(opts, state, have_sync, &work);
+    float symbol = symbol_finalize_live_symbol(state, &work);
 
     symbol_apply_replay_overrides(opts, state, &symbol);
     return symbol_commit_symbol(opts, state, have_sync, &work, symbol);

--- a/src/dsp/symbol_timing_debug.c
+++ b/src/dsp/symbol_timing_debug.c
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Symbol-timing observability: sub-symbol offset measurement and reporting.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/dsp/symbol_timing_debug.h>
+#include <dsd-neo/runtime/config.h>
+#include "dsd-neo/core/state_fwd.h"
+
+/* Enough for the template plus a symbol of shift room, at any samplesPerSymbol
+   the decoder produces. Sized in symbols rather than samples so it does not have
+   to grow if the template does. */
+#define TRACE_CAPACITY DSD_SYMBOL_TIMING_SPAN_SAMPLES
+
+int
+dsd_symbol_timing_debug_level(void) {
+    const dsdneoRuntimeConfig* config = dsd_neo_get_config();
+    if (config == NULL) {
+        dsd_neo_config_init();
+        config = dsd_neo_get_config();
+    }
+    return config ? config->debug_symbol_timing : DSD_NEO_SYMBOL_TIMING_OFF;
+}
+
+void
+dsd_symbol_timing_trace_push_sample(dsd_state* state, float sample) {
+    if (state == NULL) {
+        return;
+    }
+    dsd_symbol_timing_trace* trace = &state->timing_trace;
+    if (trace->samples == NULL) {
+        return;
+    }
+
+    trace->samples[trace->sample_head] = sample;
+    trace->sample_head = (trace->sample_head + 1) % TRACE_CAPACITY;
+    if (trace->sample_count < TRACE_CAPACITY) {
+        trace->sample_count++;
+    }
+}
+
+void
+dsd_symbol_timing_trace_push_span(dsd_state* state, int samples_consumed) {
+    if (state == NULL) {
+        return;
+    }
+    dsd_symbol_timing_trace* trace = &state->timing_trace;
+    if (trace->spans == NULL || samples_consumed <= 0 || samples_consumed > DSD_SYMBOL_TIMING_MAX_SPAN) {
+        return;
+    }
+
+    trace->spans[trace->span_head] = (uint8_t)samples_consumed;
+    trace->span_head = (trace->span_head + 1) % DSD_SYMBOL_TIMING_TEMPLATE_SYMS;
+    if (trace->span_count < DSD_SYMBOL_TIMING_TEMPLATE_SYMS) {
+        trace->span_count++;
+    }
+}
+
+void
+dsd_symbol_timing_trace_reset(dsd_state* state) {
+    if (state == NULL) {
+        return;
+    }
+    state->timing_trace.sample_head = 0;
+    state->timing_trace.sample_count = 0;
+    state->timing_trace.span_head = 0;
+    state->timing_trace.span_count = 0;
+}
+
+/**
+ * @brief Level a decided dibit stands for, in the units P25's CQPSK raw fit uses.
+ * @return +/-1 for an inner symbol, +/-3 for an outer one; 0 when not a dibit.
+ */
+static int
+unit_level_for_dibit(char c) {
+    static const int units[4] = {1, 3, -1, -3};
+    if (c < '0' || c > '3') {
+        return 0;
+    }
+    return units[c - '0'];
+}
+
+/**
+ * @brief Total and largest sample counts the template's symbols occupy.
+ * @return 1 when every span and window symbol is usable.
+ */
+static int
+template_geometry(const uint8_t* spans, int span_count, const char* window, int* out_total, int* out_max_span) {
+    int total = 0;
+    int max_span = 0;
+    for (int k = 0; k < span_count; k++) {
+        const int span = (int)spans[k];
+        if (span <= 0 || unit_level_for_dibit(window[k]) == 0) {
+            return 0;
+        }
+        if (span > max_span) {
+            max_span = span;
+        }
+        total += span;
+    }
+    *out_total = total;
+    *out_max_span = max_span;
+    return 1;
+}
+
+/**
+ * @brief Correlate the template against the samples starting @p off earlier than the grid did.
+ * @return The correlation score; higher means the symbols line up better.
+ */
+static double
+score_template_at_offset(const float* samples, int lead, int off, const uint8_t* spans, int span_count,
+                         const char* window) {
+    double score = 0.0;
+    int pos = lead - off;
+    for (int k = 0; k < span_count; k++) {
+        const int span = (int)spans[k];
+        double sum = 0.0;
+        for (int n = 0; n < span; n++) {
+            sum += (double)samples[pos + n];
+        }
+        score += (double)unit_level_for_dibit(window[k]) * (sum / (double)span);
+        pos += span;
+    }
+    return score;
+}
+
+/**
+ * @brief Pick the offset scoring highest, or decline if no offset stands out.
+ * @return 1 when @p out_offset was written.
+ */
+static int
+search_best_offset(const float* samples, int lead, int max_shift, const uint8_t* spans, int span_count,
+                   const char* window, int* out_offset) {
+    double best_score = 0.0;
+    double worst_score = 0.0;
+    int best_offset = -1;
+
+    for (int off = 0; off <= max_shift; off++) {
+        const double score = score_template_at_offset(samples, lead, off, spans, span_count, window);
+        if (best_offset < 0 || score > best_score) {
+            best_score = score;
+            best_offset = off;
+        }
+        if (off == 0 || score < worst_score) {
+            worst_score = score;
+        }
+    }
+
+    /* A silent or flat trace (a symbol-file replay leaves the sample ring at zero,
+       since those inputs never hand the grid samples) has no argmax worth printing. */
+    if (best_offset < 0 || best_score <= 0.0 || !(best_score > worst_score)) {
+        return 0;
+    }
+
+    *out_offset = best_offset;
+    return 1;
+}
+
+int
+dsd_symbol_timing_measure_sync_offset(const float* samples, int sample_count, const uint8_t* spans, int span_count,
+                                      const char* window, int* out_offset) {
+    if (samples == NULL || spans == NULL || window == NULL || out_offset == NULL || span_count <= 0) {
+        return 0;
+    }
+
+    int template_samples = 0;
+    int max_span = 0;
+    if (!template_geometry(spans, span_count, window, &template_samples, &max_span)) {
+        return 0;
+    }
+
+    /* One sample per symbol is the CQPSK and RTL symbol-rate grid: there is no
+       sub-symbol structure left to localise, so decline rather than invent one. */
+    if (max_span < 2) {
+        return 0;
+    }
+
+    const int lead = sample_count - template_samples;
+    int max_shift = max_span - 1;
+    if (lead < max_shift) {
+        max_shift = lead;
+    }
+    if (max_shift < 1) {
+        return 0;
+    }
+
+    return search_best_offset(samples, lead, max_shift, spans, span_count, window, out_offset);
+}
+
+/**
+ * @brief Copy the newest @p want samples out of the ring, oldest first.
+ * @return Samples copied, which may be fewer than requested.
+ */
+static int
+trace_collect_samples(const dsd_symbol_timing_trace* trace, float* out, int want) {
+    int have = trace->sample_count;
+    if (have > want) {
+        have = want;
+    }
+    int index = trace->sample_head - have;
+    while (index < 0) {
+        index += TRACE_CAPACITY;
+    }
+    for (int i = 0; i < have; i++) {
+        out[i] = trace->samples[index];
+        index = (index + 1) % TRACE_CAPACITY;
+    }
+    return have;
+}
+
+/**
+ * @brief Copy the newest @p want spans out of the ring, oldest first.
+ * @return Spans copied, which may be fewer than requested.
+ */
+static int
+trace_collect_spans(const dsd_symbol_timing_trace* trace, uint8_t* out, int want) {
+    int have = trace->span_count;
+    if (have > want) {
+        have = want;
+    }
+    int index = trace->span_head - have;
+    while (index < 0) {
+        index += DSD_SYMBOL_TIMING_TEMPLATE_SYMS;
+    }
+    for (int i = 0; i < have; i++) {
+        out[i] = trace->spans[index];
+        index = (index + 1) % DSD_SYMBOL_TIMING_TEMPLATE_SYMS;
+    }
+    return have;
+}
+
+/**
+ * @brief Measure the offset for the trailing template, if the trace supports one.
+ * @return 1 when @p out_offset was written.
+ */
+static int
+trace_measure(const dsd_symbol_timing_trace* trace, const char* window, int* out_offset) {
+    if (trace->samples == NULL || trace->spans == NULL || window == NULL) {
+        return 0;
+    }
+
+    uint8_t spans[DSD_SYMBOL_TIMING_TEMPLATE_SYMS];
+    const int span_count = trace_collect_spans(trace, spans, DSD_SYMBOL_TIMING_TEMPLATE_SYMS);
+    if (span_count < DSD_SYMBOL_TIMING_TEMPLATE_SYMS) {
+        return 0;
+    }
+
+    /* The window's last span_count characters are the symbols the spans describe. */
+    const size_t window_len = strlen(window);
+    if (window_len < (size_t)span_count) {
+        return 0;
+    }
+    const char* window_tail = window + (window_len - (size_t)span_count);
+
+    float samples[TRACE_CAPACITY];
+    const int sample_count = trace_collect_samples(trace, samples, TRACE_CAPACITY);
+    return dsd_symbol_timing_measure_sync_offset(samples, sample_count, spans, span_count, window_tail, out_offset);
+}
+
+void
+dsd_symbol_timing_report_sync(const dsd_state* state, int synctype, const char* window) {
+    if (state == NULL || dsd_symbol_timing_debug_level() < DSD_NEO_SYMBOL_TIMING_SYNC_LINE) {
+        return;
+    }
+
+    int offset = -1;
+    const int measured = trace_measure(&state->timing_trace, window, &offset);
+
+    /* The sync type is numeric and the matched symbols are printed beside it: naming the
+       protocol here would mean calling into core, and core links this library. */
+    DSD_FPRINTF(stderr, "SYMTIMING: sync=%i win=%s sps=%i jitter=%i off=", synctype, window ? window : "?",
+                state->samplesPerSymbol, state->jitter);
+    if (measured) {
+        DSD_FPRINTF(stderr, "%i", offset);
+    } else {
+        DSD_FPRINTF(stderr, "-");
+    }
+    DSD_FPRINTF(stderr, " accum=%i\n", state->rtl_fsk_sps_accum);
+}

--- a/src/runtime/config.cpp
+++ b/src/runtime/config.cpp
@@ -139,6 +139,8 @@ config_snapshot_equals_block_b(const dsdneoRuntimeConfig& lhs, const dsdneoRunti
     CONFIG_EQ_FIELD(debug_sync_enable);
     CONFIG_EQ_FIELD(debug_cqpsk_is_set);
     CONFIG_EQ_FIELD(debug_cqpsk_enable);
+    CONFIG_EQ_FIELD(debug_symbol_timing_is_set);
+    CONFIG_EQ_FIELD(debug_symbol_timing);
     CONFIG_EQ_FIELD(cqpsk_is_set);
     CONFIG_EQ_FIELD(cqpsk_enable);
     CONFIG_EQ_FIELD(cqpsk_sync_inv_is_set);
@@ -634,6 +636,20 @@ config_init_bootstrap_and_debug(dsdneoRuntimeConfig& c) {
     const char* dcq = getenv("DSD_NEO_DEBUG_CQPSK");
     c.debug_cqpsk_is_set = env_is_set(dcq);
     c.debug_cqpsk_enable = c.debug_cqpsk_is_set ? (env_is_falsey(dcq) ? 0 : 1) : 0;
+
+    /* A level, so "2" selects the per-sample trace rather than reading as a plain truthy 1. */
+    const char* dst = getenv("DSD_NEO_DEBUG_SYMBOL_TIMING");
+    int symbol_timing_level = 0;
+    if (env_parse_int_range(dst, 0, DSD_NEO_SYMBOL_TIMING_TRACE, &symbol_timing_level)) {
+        c.debug_symbol_timing_is_set = 1;
+        c.debug_symbol_timing = symbol_timing_level;
+    } else if (env_is_truthy(dst)) {
+        c.debug_symbol_timing_is_set = 1;
+        c.debug_symbol_timing = DSD_NEO_SYMBOL_TIMING_SYNC_LINE;
+    } else if (env_is_falsey(dst)) {
+        c.debug_symbol_timing_is_set = 1;
+        c.debug_symbol_timing = DSD_NEO_SYMBOL_TIMING_OFF;
+    }
 }
 
 static void

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -676,6 +676,13 @@ dsd_neo_add_public_header_smoke_test(
 )
 
 dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_dsp_symbol_timing_debug
+  HEADERS_PUBLIC_DSP_SYMBOL_TIMING_DEBUG
+  dsd-neo/dsp/symbol_timing_debug.h
+  C
+)
+
+dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_io_m17_udp
   HEADERS_PUBLIC_IO_M17_UDP
   dsd-neo/io/m17_udp.h
@@ -7932,6 +7939,15 @@ target_include_directories(
 )
 dsd_neo_link_dsp_test(dsd-neo_test_sync_calibration ${DSD_NEO_TEST_MATH_LIB})
 add_test(NAME SYNC_CALIBRATION COMMAND dsd-neo_test_sync_calibration)
+
+# Symbol-timing sub-symbol offset measurement
+add_executable(dsd-neo_test_symbol_timing_debug dsp/test_symbol_timing_debug.c)
+target_include_directories(
+    dsd-neo_test_symbol_timing_debug
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+dsd_neo_link_dsp_test(dsd-neo_test_symbol_timing_debug ${DSD_NEO_TEST_MATH_LIB})
+add_test(NAME SYMBOL_TIMING_DEBUG COMMAND dsd-neo_test_symbol_timing_debug)
 
 # DMR resample-on-sync CACH re-digitization test
 add_executable(

--- a/tests/dsp/test_rtl_symbol_cache_generation.c
+++ b/tests/dsp/test_rtl_symbol_cache_generation.c
@@ -252,7 +252,6 @@ reset_decoder_fixture(dsd_opts* opts, dsd_state* state, void* rtl_context) {
     DSD_MEMSET(opts, 0, sizeof(*opts));
     DSD_MEMSET(state, 0, sizeof(*state));
     opts->audio_in_type = AUDIO_IN_RTL;
-    opts->symboltiming = 0;
     state->rf_mod = 2;
     state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
     state->rtl_ctx = (struct RtlSdrContext*)rtl_context;
@@ -267,7 +266,6 @@ main(void) {
     DSD_MEMSET(&opts, 0, sizeof(opts));
     DSD_MEMSET(&state, 0, sizeof(state));
     opts.audio_in_type = AUDIO_IN_RTL;
-    opts.symboltiming = 0;
     state.rf_mod = 1;
     state.rtl_ctx = (struct RtlSdrContext*)&fake_rtl_context;
 

--- a/tests/dsp/test_symbol_timing_debug.c
+++ b/tests/dsp/test_symbol_timing_debug.c
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * The symbol-timing diagnostic has to report the sub-symbol phase the decoder's
+ * grid settled on, because that phase is fixed at sync acquisition and held for
+ * the whole call -- under AUTO it starts wherever the previous profile left off,
+ * which is the mechanism #404 could only measure with a throwaway build.
+ *
+ * These cases drive the measurement over a synthetic four-level stream whose true
+ * symbol boundaries are known, once per sub-symbol phase the grid could have
+ * started on, and require the reported offset to be exactly the phase injected.
+ *
+ * Symbol transitions are ramped rather than square, as a filtered stream's are, so
+ * an off-centre window reads a blend of two symbols; that is what makes one
+ * alignment score highest instead of a plateau of equally good ones.
+ *
+ * The spans the measurement walks are deliberately irregular in two cases: the
+ * pre-sync timing nudge makes symbols consume samplesPerSymbol +/- 1, and a
+ * measurement that assumed a fixed stride would smear across a sync word.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/dsp/symbol_timing_debug.h>
+
+#define MAX_SYMS    32
+#define MAX_SAMPLES 4096
+
+/* Leading symbols exist only to give the measurement room to shift the template
+   earlier; the template itself is the trailing DSD_SYMBOL_TIMING_TEMPLATE_SYMS. */
+#define LEAD_SYMS   4
+
+static float g_waveform[MAX_SAMPLES];
+static int g_waveform_len;
+
+static float
+level_for_dibit(char dibit) {
+    switch (dibit) {
+        case '0': return 8000.0f;
+        case '1': return 24000.0f;
+        case '2': return -8000.0f;
+        case '3': return -24000.0f;
+        default: break;
+    }
+    return 0.0f;
+}
+
+/*
+ * Build a waveform whose symbol k occupies spans[k] samples, then smooth it with a
+ * boxcar so each boundary becomes a ramp. Variable spans are the point: they let a
+ * case describe a grid that nudged, and the measurement is handed the same spans.
+ */
+static void
+build_waveform(const char* dibits, const uint8_t* spans, int count, int ramp_samples) {
+    static float nrz[MAX_SAMPLES];
+    int n = 0;
+
+    for (int k = 0; k < count; k++) {
+        const float level = level_for_dibit(dibits[k]);
+        for (int s = 0; s < (int)spans[k]; s++) {
+            assert(n < MAX_SAMPLES);
+            nrz[n++] = level;
+        }
+    }
+
+    for (int i = 0; i < n; i++) {
+        float sum = 0.0f;
+        for (int k = 0; k < ramp_samples; k++) {
+            int idx = i + k - (ramp_samples / 2);
+            if (idx < 0) {
+                idx = 0;
+            }
+            if (idx >= n) {
+                idx = n - 1;
+            }
+            sum += nrz[idx];
+        }
+        g_waveform[i] = sum / (float)ramp_samples;
+    }
+    g_waveform_len = n;
+}
+
+/*
+ * Measure a grid that started `phase` samples after the true symbol boundaries and
+ * then consumed exactly `spans`. The reported offset is how far back the template
+ * had to move to fit, which is the phase that was injected.
+ */
+static int
+measure_with_phase(const char* dibits, const uint8_t* spans, int count, int phase, int* out_offset) {
+    int total = 0;
+    for (int k = 0; k < count; k++) {
+        total += (int)spans[k];
+    }
+    /* The grid reads `phase` samples late, so it needs that many beyond the last symbol. */
+    assert(phase + total <= g_waveform_len);
+
+    const int template_syms = DSD_SYMBOL_TIMING_TEMPLATE_SYMS;
+    assert(count > template_syms);
+
+    return dsd_symbol_timing_measure_sync_offset(&g_waveform[phase], total, &spans[count - template_syms],
+                                                 template_syms, &dibits[count - template_syms], out_offset);
+}
+
+/* Report which case failed before tripping the assert: every case runs the same
+   measurement, so the bare assertion would not say which phase went wrong. */
+static void
+expect_offset(int ok, int offset, int expected, const char* label, int sps) {
+    if (ok && offset == expected) {
+        return;
+    }
+    DSD_FPRINTF(stderr, "%s: sps=%i expected offset %i, got ok=%i offset=%i\n", label, sps, expected, ok, offset);
+    assert(0);
+}
+
+/* A sync-like run of outer symbols, as the sync search's binary slicer produces. */
+static const char kDibits[] = "13311313113313311331131311331131";
+
+static void
+fill_uniform_spans(uint8_t* spans, int count, int sps) {
+    for (int k = 0; k < count; k++) {
+        spans[k] = (uint8_t)sps;
+    }
+}
+
+static void
+test_uniform_spans_recover_phase(int sps) {
+    const int count = LEAD_SYMS + DSD_SYMBOL_TIMING_TEMPLATE_SYMS;
+    uint8_t spans[MAX_SYMS];
+    fill_uniform_spans(spans, count, sps);
+
+    /* One extra symbol of waveform so a late grid still has samples to read. */
+    uint8_t build_spans[MAX_SYMS];
+    fill_uniform_spans(build_spans, count + 1, sps);
+    build_waveform(kDibits, build_spans, count + 1, sps / 4 > 1 ? sps / 4 : 2);
+
+    /* Past half a symbol the slicer would decide the next symbol instead, so the
+       phase stops being this template's to report. */
+    for (int phase = 0; phase <= sps / 2; phase++) {
+        int offset = -1;
+        const int ok = measure_with_phase(kDibits, spans, count, phase, &offset);
+        expect_offset(ok, offset, phase, "uniform spans", sps);
+    }
+}
+
+static void
+test_nudged_spans_recover_phase(void) {
+    const int sps = 20;
+    const int count = LEAD_SYMS + DSD_SYMBOL_TIMING_TEMPLATE_SYMS;
+    uint8_t spans[MAX_SYMS];
+    uint8_t build_spans[MAX_SYMS];
+
+    /* The nudge moves a symbol by one sample either way; a fixed-stride correlation
+       would walk off the boundaries by the end of the template. */
+    for (int k = 0; k < count + 1; k++) {
+        int span = sps;
+        if ((k % 3) == 1) {
+            span = sps - 1;
+        } else if ((k % 3) == 2) {
+            span = sps + 1;
+        }
+        build_spans[k] = (uint8_t)span;
+        if (k < count) {
+            spans[k] = (uint8_t)span;
+        }
+    }
+    build_waveform(kDibits, build_spans, count + 1, sps / 4);
+
+    for (int phase = 0; phase <= sps / 2; phase++) {
+        int offset = -1;
+        const int ok = measure_with_phase(kDibits, spans, count, phase, &offset);
+        expect_offset(ok, offset, phase, "nudged spans", sps);
+    }
+}
+
+static void
+test_declines_degenerate_input(void) {
+    const int count = LEAD_SYMS + DSD_SYMBOL_TIMING_TEMPLATE_SYMS;
+    const int template_syms = DSD_SYMBOL_TIMING_TEMPLATE_SYMS;
+    uint8_t spans[MAX_SYMS];
+    int offset = -1;
+
+    fill_uniform_spans(spans, count + 1, 20);
+    build_waveform(kDibits, spans, count + 1, 5);
+
+    const float* samples = g_waveform;
+    const uint8_t* tail_spans = &spans[count - template_syms];
+    const char* tail_window = &kDibits[count - template_syms];
+    const int total = 20 * count;
+
+    /* Null arguments. */
+    assert(dsd_symbol_timing_measure_sync_offset(NULL, total, tail_spans, template_syms, tail_window, &offset) == 0);
+    assert(dsd_symbol_timing_measure_sync_offset(samples, total, NULL, template_syms, tail_window, &offset) == 0);
+    assert(dsd_symbol_timing_measure_sync_offset(samples, total, tail_spans, template_syms, NULL, &offset) == 0);
+    assert(dsd_symbol_timing_measure_sync_offset(samples, total, tail_spans, template_syms, tail_window, NULL) == 0);
+    assert(dsd_symbol_timing_measure_sync_offset(samples, total, tail_spans, 0, tail_window, &offset) == 0);
+
+    /* One sample per symbol: the CQPSK and RTL symbol-rate grids, which have no
+       sub-symbol structure left to localise. */
+    uint8_t unit_spans[MAX_SYMS];
+    fill_uniform_spans(unit_spans, count, 1);
+    assert(dsd_symbol_timing_measure_sync_offset(samples, count, unit_spans, template_syms, tail_window, &offset) == 0);
+
+    /* No room to shift the template: nothing to compare the one candidate against. */
+    assert(dsd_symbol_timing_measure_sync_offset(samples, 20 * template_syms, tail_spans, template_syms, tail_window,
+                                                 &offset)
+           == 0);
+
+    /* Silence, which is what a symbol-file replay leaves in the trace: those inputs
+       never hand the grid samples at all. Static, so it is already zeroed. */
+    static float silence[MAX_SAMPLES];
+    assert(dsd_symbol_timing_measure_sync_offset(silence, total, tail_spans, template_syms, tail_window, &offset) == 0);
+
+    /* A window that is not dibits describes no levels to correlate against. */
+    const char* bad_window = "abcdefgh";
+    assert(dsd_symbol_timing_measure_sync_offset(samples, total, tail_spans, template_syms, bad_window, &offset) == 0);
+}
+
+int
+main(void) {
+    /* Both ends of the range dsd_opts_compute_sps_rate produces, plus NXDN48's 20. */
+    test_uniform_spans_recover_phase(8);
+    test_uniform_spans_recover_phase(10);
+    test_uniform_spans_recover_phase(20);
+    test_uniform_spans_recover_phase(40);
+
+    test_nudged_spans_recover_phase();
+    test_declines_degenerate_input();
+
+    printf("SYMBOL_TIMING_DEBUG: OK\n");
+    return 0;
+}

--- a/tests/runtime/test_runtime_config_env.cpp
+++ b/tests/runtime/test_runtime_config_env.cpp
@@ -99,6 +99,7 @@ unset_all_runtime_env(void) {
         "DSD_NEO_CQPSK_SYNC_INV",
         "DSD_NEO_CQPSK_SYNC_NEG",
         "DSD_NEO_DEBUG_CQPSK",
+        "DSD_NEO_DEBUG_SYMBOL_TIMING",
         "DSD_NEO_DEBUG_SYNC",
         "DSD_NEO_DEEMPH",
         "DSD_NEO_DISABLE_FS4_SHIFT",
@@ -884,6 +885,61 @@ test_bootstrap_debug_env(void) {
     unsetenv("DSD_NEO_NO_BOOTSTRAP");
     unsetenv("DSD_NEO_DEBUG_SYNC");
     unsetenv("DSD_NEO_DEBUG_CQPSK");
+    return 0;
+}
+
+/* A level, not a toggle: 1 is one line per accepted sync, 2 adds the per-sample trace. */
+static int
+test_symbol_timing_debug_env(void) {
+    unsetenv("DSD_NEO_DEBUG_SYMBOL_TIMING");
+    dsd_neo_config_init();
+    const dsdneoRuntimeConfig* cfg = dsd_neo_get_config();
+    int rc = expect(cfg != NULL, 1400, "cfg NULL");
+    if (rc != 0) {
+        return rc;
+    }
+    rc = expect_int_eq(cfg->debug_symbol_timing_is_set, 0, 1401, "debug_symbol_timing_is_set (default)");
+    if (rc != 0) {
+        return rc;
+    }
+    rc = expect_int_eq(cfg->debug_symbol_timing, 0, 1402, "debug_symbol_timing (default)");
+    if (rc != 0) {
+        return rc;
+    }
+
+    static const struct {
+        const char* value;
+        int expect_is_set;
+        int expect_level;
+        int code;
+    } cases[] = {
+        {"1", 1, 1, 1403},
+        {"2", 1, 2, 1404},
+        {"0", 1, 0, 1405},
+        /* Truthy words select the quiet level rather than the firehose. */
+        {"true", 1, 1, 1406},
+        {"no", 1, 0, 1407},
+        /* Out of range and unparseable values are ignored, as the CQPSK toggle does. */
+        {"3", 0, 0, 1408},
+        {"banana", 0, 0, 1409},
+    };
+
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        setenv("DSD_NEO_DEBUG_SYMBOL_TIMING", cases[i].value, 1);
+        dsd_neo_config_init();
+        cfg = dsd_neo_get_config();
+        rc = expect_int_eq(cfg->debug_symbol_timing_is_set, cases[i].expect_is_set, cases[i].code,
+                           "debug_symbol_timing_is_set");
+        if (rc != 0) {
+            return rc;
+        }
+        rc = expect_int_eq(cfg->debug_symbol_timing, cases[i].expect_level, cases[i].code, "debug_symbol_timing");
+        if (rc != 0) {
+            return rc;
+        }
+    }
+
+    unsetenv("DSD_NEO_DEBUG_SYMBOL_TIMING");
     return 0;
 }
 
@@ -2406,6 +2462,10 @@ main(void) {
         return rc;
     }
     rc = test_bootstrap_debug_env();
+    if (rc != 0) {
+        return rc;
+    }
+    rc = test_symbol_timing_debug_env();
     if (rc != 0) {
         return rc;
     }


### PR DESCRIPTION
Closes #443.

## The problem

`opts->symboltiming` gated every symbol-timing diagnostic in the tree, and nothing could set it — no CLI flag, no environment variable, no config key. It was initialised to 0 and never assigned again, so:

- the per-sample `+ - O X` trace and the latched `state->jitter` line were dead code;
- a branch of `symbol_try_rtl_symbol_rate_fast_path()` was dead;
- the trace was *additionally* gated on `have_sync == 0`, so even reachable it would have gone silent for the duration of every frame — exactly the window #404 needed to see.

Nothing printed the sub-symbol phase the decoder's grid settled on. That phase is fixed at sync acquisition and held for the whole call, and #404 had to build a throwaway binary to measure it.

## What this does

Replaces the dead switch with `DSD_NEO_DEBUG_SYMBOL_TIMING`, wired alongside `DSD_NEO_DEBUG_SYNC` / `DSD_NEO_DEBUG_CQPSK`. It is a **level**, not a toggle, because the two things it gates differ by orders of magnitude in volume:

| value | output |
|---|---|
| `1` | one measurement line per accepted frame sync |
| `2` | additionally the per-sample `+ - O X` trace and per-symbol jitter line |

```text
SYMTIMING: sync=29 win=13113313 sps=20 jitter=-1 off=0 accum=0
```

`off` is the measured sub-symbol offset between the grid's symbol boundary and the one the signal supports. A new `src/dsp/symbol_timing_debug.c` correlates whole-symbol integrals of the samples the grid consumed against the levels the slicer decided, once per candidate offset, and reports the argmax. Whole-symbol rather than the slicer's narrow window on purpose: a narrow window scores flat across the middle of a symbol and localises nothing (#404's note).

The `have_sync == 0` gate is gone, so the revived trace now runs inside frames.

### Two details the measurement depends on

- **The template is the trailing eight decided dibits, not the matched sync word.** No protocol's sync word is shorter than eight symbols (M17's eight is the shortest), so those symbols are inside the sync word whatever matched. That avoids a per-protocol window-length table which would silently rot as matchers change — worth noting because the obvious table is wrong in two places (dPMR FS2 accepts on the 12-symbol window, and every M17 type accepts on the 8-symbol one, not 16).
- **The trace records how many samples each symbol consumed, not just the samples.** The pre-sync timing nudge makes symbols consume `samplesPerSymbol ± 1`, so a fixed-stride correlation would smear across a sync word. The measurement walks real boundaries.

The trace is cleared wherever the sample stream is discontinuous (retune, cache flush, symbol-rate change) so a measurement never correlates across the seam, and it declines to report rather than invent an argmax when the grid runs at one sample per symbol (CQPSK / RTL symbol-rate) or the trace is silent (symbol-file replay, which never hands the grid samples).

### Cost when off

Nothing is recorded, measured, or printed. Removing the `|| opts->symboltiming == 1` term from the RTL symbol-rate fast path changes no behaviour — the field was provably always 0 — and keeps the diagnostic from ever diverting the decode path.

The hook sits at `frame_sync_try_protocol_matches()`, which every hunt-path accept passes through; in-frame resyncs a protocol handler does privately do not, and that is documented in the code and in `docs/cli.md`.

## Verification

- Full suite: **587/587 pass**, including the 27 `iq-decode` content-asserting tests.
- `tools/preflight_ci.sh`: clean (clang-tidy, cppcheck, IWYU, semgrep, lizard, arch rules, format).
- **On #404's own capture** (`fiNXDN`, the reporter's 35 s NXDN48 scan), ~300 accepts per run produce the offset distribution that issue could not measure without a throwaway build:

  ```text
  -fi run1:  199 off=0   38 off=1   23 off=2   13 off=3   17 off=4   7 off=5   2 off=6   1 off=7
  -fi run2:  205 off=0   34 off=1   21 off=2   10 off=3   12 off=4   8 off=5   1 off=6   1 off=7
  ```
- Level `2` confirmed to emit the revived `+ - O X` stream.

## Tests

- `SYMBOL_TIMING_DEBUG` (new) drives the measurement over a synthetic four-level stream with known symbol boundaries at **every** sub-symbol phase, for four `samplesPerSymbol` values, and requires the reported offset to equal the injected phase exactly. Includes a case whose symbols consume irregular spans (the nudge), and pins each input the measurement must decline: one sample per symbol, no shift room, silence, and a non-dibit window.
- `RUNTIME_CONFIG_ENV` extended for the level parsing (`0`/`1`/`2`, truthy/falsey words, and out-of-range values being ignored).

## Docs

`docs/cli.md` gains a section explaining the line's fields and how to use the `off` distribution; `docs/code_map.md` lists the new module.
