### PR TITLE
fix(io): default I/Q captures with no extension to .iq

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -229,7 +229,8 @@ DirWatch modes keep the WAV and JSON files because the watcher needs stable file
 
 ## IQ Capture And Replay
 
-- `--iq-capture <path>` Capture raw I/Q plus metadata sidecar.
+- `--iq-capture <path>` Capture raw I/Q plus metadata sidecar. When `<path>` has no extension, `.iq` is added, so
+  `--iq-capture mycap` writes `mycap.iq` and `mycap.iq.json`.
 - `--iq-capture-format <cu8|cf32>` Capture format request (`cu8` default).
 - `--iq-capture-max-mb <n>` Capture byte cap in MiB (`0` unlimited).
 - `--iq-replay <path>` Replay capture metadata/data through the RTL pipeline.

--- a/docs/iq-capture-replay.md
+++ b/docs/iq-capture-replay.md
@@ -27,8 +27,15 @@ Path handling:
 
 - If the supplied capture path ends in `.json`, it is treated as metadata path and data path becomes the same name
   without `.json`.
-- Otherwise the supplied capture path is treated as data path and metadata path becomes `<path>.json`.
-- `--iq-replay` and `--iq-info` accept either metadata path or data path.
+- Otherwise the supplied capture path is the data path, and metadata path becomes `<data path>.json`.
+- If the final component of that data path carries no extension, `.iq` is added first: `--iq-capture mycap` writes
+  `mycap.iq` and `mycap.iq.json`. A dot in a directory name does not count as an extension, and a leading dot belongs
+  to the name (`.hidden` gains `.iq`). The suffix is always `.iq` regardless of `--iq-capture-format`; the sample
+  format is recorded in the sidecar.
+- `--iq-replay` and `--iq-info` accept the metadata path, the data path, or the bare name given to `--iq-capture`.
+  A bare name resolves `<name>.json` first and then `<name>.iq.json`, so captures written before `.iq` was added
+  still replay.
+- The `.json` suffix is matched case-insensitively, so `mycap.iq.JSON` is recognised as a sidecar on Windows.
 
 ## Format Notes
 

--- a/include/dsd-neo/io/iq_capture.h
+++ b/include/dsd-neo/io/iq_capture.h
@@ -70,9 +70,14 @@ typedef struct dsd_iq_capture_writer dsd_iq_capture_writer;
 /**
  * @brief Resolve data and metadata paths from a user path.
  *
- * If @p path ends with `.json`, it is treated as metadata path and the data
- * path is derived by stripping `.json`. Otherwise @p path is treated as the
- * data path and metadata becomes `<path>.json`.
+ * If @p path ends with `.json` (matched case-insensitively), it is treated as the
+ * metadata path and the data path is derived by stripping `.json`. Otherwise @p path
+ * is the data path and metadata becomes `<data path>.json`.
+ *
+ * A path whose final component carries no extension gains the conventional `.iq`, so
+ * `mycap` yields `mycap.iq` plus `mycap.iq.json`. A dot in a directory name does not
+ * count as an extension, and a leading dot belongs to the name (`.hidden` has none).
+ * The suffix does not vary with the sample format; that is recorded in the sidecar.
  */
 int dsd_iq_capture_derive_paths(const char* path, char* out_data_path, size_t out_data_path_size,
                                 char* out_metadata_path, size_t out_metadata_path_size, char* err_buf,

--- a/src/io/iq/iq_capture.c
+++ b/src/io/iq/iq_capture.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/platform/atomic_compat.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/platform.h>
+#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/platform/threading.h>
 #include <dsd-neo/platform/timing.h>
 #include <errno.h>
@@ -129,6 +130,13 @@ copy_string_checked(const char* src, char* dst, size_t dst_size, char* err_buf, 
     return DSD_IQ_OK;
 }
 
+/** @brief Longest capture path handled here; matches dsd_iq_capture_config::data_path. */
+#define DSD_IQ_PATH_MAX     2048
+/** @brief Scratch room for a path plus the ".iq" default and the ".json" sidecar suffix. */
+#define DSD_IQ_PATH_SCRATCH (DSD_IQ_PATH_MAX + 16)
+
+static const char* metadata_data_basename(const char* path);
+
 static int
 has_suffix(const char* s, const char* suffix) {
     if (!s || !suffix) {
@@ -139,7 +147,27 @@ has_suffix(const char* s, const char* suffix) {
     if (s_len < suf_len) {
         return 0;
     }
-    return strcmp(s + (s_len - suf_len), suffix) == 0;
+    /* Case-insensitive: Windows filesystems preserve case without distinguishing it,
+       so "capture.iq.JSON" names the same sidecar as "capture.iq.json" and must take
+       the metadata branch rather than growing a second ".json". */
+    return dsd_strcasecmp(s + (s_len - suf_len), suffix) == 0;
+}
+
+/**
+ * @brief Report whether the final path component already carries an extension.
+ *
+ * Only the basename is inspected, so a dot in a directory name ("caps.v2/mycap")
+ * does not count. The scan starts one byte in, so a leading dot belongs to the name
+ * rather than an extension (".hidden" has none) while a trailing dot counts as one
+ * ("cap." is left alone).
+ */
+static int
+basename_has_extension(const char* path) {
+    const char* base = metadata_data_basename(path);
+    if (!base || base[0] == '\0') {
+        return 0;
+    }
+    return strchr(base + 1, '.') != NULL;
 }
 
 int
@@ -151,38 +179,43 @@ dsd_iq_capture_derive_paths(const char* path, char* out_data_path, size_t out_da
         return DSD_IQ_ERR_INVALID_ARG;
     }
 
+    size_t path_len = strlen(path);
+    if (path_len >= DSD_IQ_PATH_MAX) {
+        set_error(err_buf, err_buf_size, "capture path too long");
+        return DSD_IQ_ERR_INVALID_ARG;
+    }
+
+    /* Both in-tree callers alias `path` with one of the output buffers (see
+       capture_open_resolve_paths), so build the results in scratch space and copy them
+       out only once nothing reads `path` any more. */
+    char data_scratch[DSD_IQ_PATH_SCRATCH];
+    char meta_scratch[DSD_IQ_PATH_SCRATCH];
+
     if (has_suffix(path, ".json")) {
-        size_t meta_len = strlen(path);
-        if (meta_len + 1 > out_metadata_path_size) {
-            set_error(err_buf, err_buf_size, "metadata path too long");
+        size_t data_len = path_len - 5U;
+        if (data_len == 0) {
+            set_error(err_buf, err_buf_size, "derived data path is empty");
             return DSD_IQ_ERR_INVALID_ARG;
         }
-        DSD_MEMCPY(out_metadata_path, path, meta_len + 1);
-
-        size_t data_len = meta_len - 5U;
-        if (data_len == 0 || data_len + 1 > out_data_path_size) {
-            set_error(err_buf, err_buf_size, "derived data path too long");
-            return DSD_IQ_ERR_INVALID_ARG;
-        }
-        DSD_MEMCPY(out_data_path, path, data_len);
-        out_data_path[data_len] = '\0';
+        DSD_MEMCPY(meta_scratch, path, path_len + 1);
+        DSD_MEMCPY(data_scratch, path, data_len);
+        data_scratch[data_len] = '\0';
     } else {
-        size_t data_len = strlen(path);
-        if (data_len + 1 > out_data_path_size) {
-            set_error(err_buf, err_buf_size, "data path too long");
-            return DSD_IQ_ERR_INVALID_ARG;
-        }
-        DSD_MEMCPY(out_data_path, path, data_len + 1);
+        /* A path with no extension gets the conventional ".iq", so a capture is
+           self-describing however the name was typed. The suffix does not vary with
+           the sample format; that is recorded in the sidecar. */
+        const char* ext = basename_has_extension(path) ? "" : ".iq";
+        DSD_SNPRINTF(data_scratch, sizeof(data_scratch), "%s%s", path, ext);
+        DSD_SNPRINTF(meta_scratch, sizeof(meta_scratch), "%s%s", data_scratch, ".json");
+    }
 
-        {
-            const char* suffix = ".json";
-            size_t meta_len = data_len + strlen(suffix);
-            if (meta_len + 1 > out_metadata_path_size) {
-                set_error(err_buf, err_buf_size, "metadata path too long");
-                return DSD_IQ_ERR_INVALID_ARG;
-            }
-            DSD_SNPRINTF(out_metadata_path, out_metadata_path_size, "%s%s", path, suffix);
-        }
+    if (copy_string_checked(data_scratch, out_data_path, out_data_path_size, err_buf, err_buf_size, "data")
+        != DSD_IQ_OK) {
+        return DSD_IQ_ERR_INVALID_ARG;
+    }
+    if (copy_string_checked(meta_scratch, out_metadata_path, out_metadata_path_size, err_buf, err_buf_size, "metadata")
+        != DSD_IQ_OK) {
+        return DSD_IQ_ERR_INVALID_ARG;
     }
     return DSD_IQ_OK;
 }

--- a/src/io/iq/iq_replay.c
+++ b/src/io/iq/iq_replay.c
@@ -16,6 +16,7 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/io/iq_types.h"
 #include "dsd-neo/platform/platform.h"
+#include "dsd-neo/platform/posix_compat.h"
 
 struct dsd_iq_replay_source {
     FILE* fp;
@@ -87,7 +88,9 @@ has_suffix(const char* s, const char* suffix) {
     if (s_len < suf_len) {
         return 0;
     }
-    return strcmp(s + (s_len - suf_len), suffix) == 0;
+    /* Case-insensitive to match Windows, where "capture.iq.JSON" is the same file
+       as "capture.iq.json" and must be recognised as the sidecar. */
+    return dsd_strcasecmp(s + (s_len - suf_len), suffix) == 0;
 }
 
 static int
@@ -176,19 +179,27 @@ resolve_metadata_path(const char* path, char* out_metadata_path, size_t out_meta
     }
 
     size_t n = strlen(path);
-    if (n + 6U > out_metadata_path_size) {
+    if (n + 9U > out_metadata_path_size) {
         set_error(err_buf, err_buf_size, "metadata path too long");
         return DSD_IQ_ERR_INVALID_ARG;
     }
-    DSD_SNPRINTF(out_metadata_path, out_metadata_path_size, "%s.json", path);
 
+    /* Try the sidecar for the path exactly as given first, so captures written before
+       the ".iq" default still resolve and a data path like "mycap.iq" is found. Only
+       then try the name a bare capture now produces. */
     dsd_stat_t st;
-    if (dsd_stat_path(out_metadata_path, &st) != 0) {
-        set_error(err_buf, err_buf_size, "metadata sidecar not found for '%s' (expected '%s')", path,
-                  out_metadata_path);
-        return DSD_IQ_ERR_IO;
+    DSD_SNPRINTF(out_metadata_path, out_metadata_path_size, "%s.json", path);
+    if (dsd_stat_path(out_metadata_path, &st) == 0) {
+        return DSD_IQ_OK;
     }
-    return DSD_IQ_OK;
+    DSD_SNPRINTF(out_metadata_path, out_metadata_path_size, "%s.iq.json", path);
+    if (dsd_stat_path(out_metadata_path, &st) == 0) {
+        return DSD_IQ_OK;
+    }
+
+    set_error(err_buf, err_buf_size, "metadata sidecar not found for '%s' (tried '%s.json' and '%s.iq.json')", path,
+              path, path);
+    return DSD_IQ_ERR_IO;
 }
 
 static int

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -183,6 +183,7 @@ dsd_cli_usage_section_radio_and_encoder(void) {
     printf("      --rtl-udp-control <port>  Enable external RTL retune control on 127.0.0.1:<port>\n");
     printf("      --rtl-udp-control-bind <ipv4>  Bind RTL retune control to this numeric IPv4 address\n");
     printf("      --iq-capture <path>    Write I/Q capture data + metadata sidecar\n");
+    printf("                             (.iq is added when <path> has no extension)\n");
     printf("      --iq-capture-format <fmt>  Capture format (cu8|cf32)\n");
     printf("      --iq-capture-max-mb <n>  Capture size limit in MiB (0 = unlimited)\n");
     printf("      --iq-replay <path>     Replay I/Q capture metadata/data through RTL path (requires radio)\n");

--- a/tests/io/test_io_iq_capture_writer.c
+++ b/tests/io/test_io_iq_capture_writer.c
@@ -1568,6 +1568,123 @@ test_write_failure_is_counted_and_metadata_stays_readable(void) {
 }
 #endif /* !DSD_PLATFORM_WIN_NATIVE && RLIMIT_FSIZE */
 
+/*
+ * A bare --iq-capture name must land on disk as <name>.iq / <name>.iq.json, and
+ * replay/--iq-info must find that sidecar from the bare name. Captures written
+ * before the .iq default (<name> / <name>.json) must still resolve.
+ */
+static int
+test_bare_name_roundtrip_and_legacy_resolution(void) {
+    int rc = 0;
+    char dir[256];
+    char bare[512];
+    char data_path[512];
+    char metadata_path[512];
+    char err[256];
+
+    if (mk_temp_dir(dir, sizeof(dir)) != 0) {
+        return 1;
+    }
+    path_join(bare, sizeof(bare), dir, "mycap");
+
+    rc |= expect_int("derive bare capture",
+                     dsd_iq_capture_derive_paths(bare, data_path, sizeof(data_path), metadata_path,
+                                                 sizeof(metadata_path), err, sizeof(err)),
+                     DSD_IQ_OK);
+
+    {
+        char want_data[512];
+        char want_meta[512];
+        path_join(want_data, sizeof(want_data), dir, "mycap.iq");
+        path_join(want_meta, sizeof(want_meta), dir, "mycap.iq.json");
+        rc |= expect_true("bare capture data path", strcmp(data_path, want_data) == 0);
+        rc |= expect_true("bare capture metadata path", strcmp(metadata_path, want_meta) == 0);
+    }
+
+    dsd_iq_capture_config cfg;
+    fill_base_capture_cfg(&cfg, data_path, metadata_path, DSD_IQ_FORMAT_CU8);
+
+    dsd_iq_capture_writer* writer = NULL;
+    rc |= expect_int("open bare capture", dsd_iq_capture_open(&cfg, &writer, err, sizeof(err)), DSD_IQ_OK);
+    if (!writer) {
+        cleanup_capture(dir, data_path, metadata_path);
+        return rc;
+    }
+    {
+        uint8_t payload[4] = {1, 2, 3, 4};
+        rc |= expect_int("submit bare capture", dsd_iq_capture_submit(writer, payload, sizeof(payload)), DSD_IQ_OK);
+        dsd_iq_capture_final_stats stats;
+        DSD_MEMSET(&stats, 0, sizeof(stats));
+        dsd_iq_capture_close(writer, &stats);
+    }
+
+    /* The payload really landed under the .iq name, not the bare one. */
+    {
+        uint8_t got[16];
+        size_t got_n = 0;
+        uint8_t want[4] = {1, 2, 3, 4};
+        rc |= expect_int("read .iq data file", read_file_all(data_path, got, sizeof(got), &got_n), 0);
+        rc |= expect_u64("bare capture bytes", got_n, 4);
+        rc |= expect_true("bare capture payload", got_n == sizeof(want) && memcmp(got, want, sizeof(want)) == 0);
+        rc |= expect_true("bare name itself is not a file", read_file_all(bare, got, sizeof(got), &got_n) != 0);
+    }
+
+    /* The bare name the user typed still resolves, via the .iq.json fallback. */
+    {
+        dsd_iq_replay_config meta;
+        DSD_MEMSET(&meta, 0, sizeof(meta));
+        rc |= expect_int("resolve sidecar from bare name", dsd_iq_replay_read_metadata(bare, &meta, err, sizeof(err)),
+                         DSD_IQ_OK);
+        rc |= expect_true("bare name resolves to .iq data", strcmp(meta.data_path, data_path) == 0);
+        dsd_iq_replay_config_clear(&meta);
+    }
+
+    /* So does the data path itself. */
+    {
+        dsd_iq_replay_config meta;
+        DSD_MEMSET(&meta, 0, sizeof(meta));
+        rc |= expect_int("resolve sidecar from data path",
+                         dsd_iq_replay_read_metadata(data_path, &meta, err, sizeof(err)), DSD_IQ_OK);
+        rc |= expect_true("data path resolves to .iq data", strcmp(meta.data_path, data_path) == 0);
+        dsd_iq_replay_config_clear(&meta);
+    }
+
+    cleanup_capture(NULL, data_path, metadata_path);
+
+    /* Back-compat: a pre-.iq capture pair named <name> / <name>.json. */
+    {
+        char legacy_data[512];
+        char legacy_meta[512];
+        path_join(legacy_data, sizeof(legacy_data), dir, "legacy");
+        path_join(legacy_meta, sizeof(legacy_meta), dir, "legacy.json");
+
+        dsd_iq_capture_config legacy_cfg;
+        fill_base_capture_cfg(&legacy_cfg, legacy_data, legacy_meta, DSD_IQ_FORMAT_CU8);
+
+        dsd_iq_capture_writer* legacy_writer = NULL;
+        rc |= expect_int("open legacy capture", dsd_iq_capture_open(&legacy_cfg, &legacy_writer, err, sizeof(err)),
+                         DSD_IQ_OK);
+        if (legacy_writer) {
+            uint8_t payload[4] = {5, 6, 7, 8};
+            rc |= expect_int("submit legacy capture", dsd_iq_capture_submit(legacy_writer, payload, sizeof(payload)),
+                             DSD_IQ_OK);
+            dsd_iq_capture_final_stats stats;
+            DSD_MEMSET(&stats, 0, sizeof(stats));
+            dsd_iq_capture_close(legacy_writer, &stats);
+
+            dsd_iq_replay_config meta;
+            DSD_MEMSET(&meta, 0, sizeof(meta));
+            rc |= expect_int("resolve legacy sidecar from bare name",
+                             dsd_iq_replay_read_metadata(legacy_data, &meta, err, sizeof(err)), DSD_IQ_OK);
+            rc |= expect_true("legacy bare name resolves", strcmp(meta.data_path, legacy_data) == 0);
+            dsd_iq_replay_config_clear(&meta);
+        }
+        cleanup_capture(dir, legacy_data, legacy_meta);
+    }
+
+    return rc;
+}
+
 static int
 test_public_error_contracts(void) {
     int rc = 0;
@@ -1602,6 +1719,84 @@ test_public_error_contracts(void) {
         "derive rejects tiny metadata buffer",
         dsd_iq_capture_derive_paths("capture.iq", data_path, sizeof(data_path), metadata_path, 4, err, sizeof(err)),
         DSD_IQ_ERR_INVALID_ARG);
+
+    /* A path with no extension gains the conventional ".iq" so a capture is
+       self-describing however the name was typed. */
+    rc |= expect_int("derive defaults bare name to .iq",
+                     dsd_iq_capture_derive_paths("mycap", data_path, sizeof(data_path), metadata_path,
+                                                 sizeof(metadata_path), err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_true("derive bare data path", strcmp(data_path, "mycap.iq") == 0);
+    rc |= expect_true("derive bare metadata path", strcmp(metadata_path, "mycap.iq.json") == 0);
+
+    /* An extension the caller supplied is never second-guessed. */
+    rc |= expect_int("derive keeps .iq",
+                     dsd_iq_capture_derive_paths("mycap.iq", data_path, sizeof(data_path), metadata_path,
+                                                 sizeof(metadata_path), err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_true("derive .iq data path", strcmp(data_path, "mycap.iq") == 0);
+    rc |= expect_true("derive .iq metadata path", strcmp(metadata_path, "mycap.iq.json") == 0);
+
+    rc |= expect_int("derive keeps foreign extension",
+                     dsd_iq_capture_derive_paths("mycap.cu8", data_path, sizeof(data_path), metadata_path,
+                                                 sizeof(metadata_path), err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_true("derive cu8 data path", strcmp(data_path, "mycap.cu8") == 0);
+    rc |= expect_true("derive cu8 metadata path", strcmp(metadata_path, "mycap.cu8.json") == 0);
+
+    /* A leading dot belongs to the name, not an extension. */
+    rc |= expect_int("derive treats leading dot as name",
+                     dsd_iq_capture_derive_paths(".hidden", data_path, sizeof(data_path), metadata_path,
+                                                 sizeof(metadata_path), err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_true("derive hidden data path", strcmp(data_path, ".hidden.iq") == 0);
+    rc |= expect_true("derive hidden metadata path", strcmp(metadata_path, ".hidden.iq.json") == 0);
+
+    /* A dot in a directory must not suppress the default on the file itself. */
+    rc |= expect_int("derive ignores dotted directory",
+                     dsd_iq_capture_derive_paths("caps.v2/mycap", data_path, sizeof(data_path), metadata_path,
+                                                 sizeof(metadata_path), err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_true("derive dotted dir data path", strcmp(data_path, "caps.v2/mycap.iq") == 0);
+    rc |= expect_true("derive dotted dir metadata path", strcmp(metadata_path, "caps.v2/mycap.iq.json") == 0);
+
+    /* Windows names the same sidecar case-insensitively; ".JSON" must not grow a
+       second ".json". */
+    rc |= expect_int("derive accepts uppercase json suffix",
+                     dsd_iq_capture_derive_paths("mycap.iq.JSON", data_path, sizeof(data_path), metadata_path,
+                                                 sizeof(metadata_path), err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_true("derive uppercase json data path", strcmp(data_path, "mycap.iq") == 0);
+    rc |= expect_true("derive uppercase json metadata path", strcmp(metadata_path, "mycap.iq.JSON") == 0);
+
+    /* The added suffix is accounted for before the copy, not after. */
+    rc |= expect_int(
+        "derive rejects buffer too small for added suffix",
+        dsd_iq_capture_derive_paths("mycap", data_path, 6, metadata_path, sizeof(metadata_path), err, sizeof(err)),
+        DSD_IQ_ERR_INVALID_ARG);
+
+    /* capture_open_resolve_paths passes one buffer as both input and output; both
+       aliasing forms must agree with the non-aliased result. */
+    char alias_data[64];
+    char alias_meta[64];
+
+    DSD_SNPRINTF(alias_data, sizeof(alias_data), "%s", "mycap");
+    alias_meta[0] = '\0';
+    rc |= expect_int("derive alias on data buffer",
+                     dsd_iq_capture_derive_paths(alias_data, alias_data, sizeof(alias_data), alias_meta,
+                                                 sizeof(alias_meta), err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_true("derive alias data result", strcmp(alias_data, "mycap.iq") == 0);
+    rc |= expect_true("derive alias data metadata result", strcmp(alias_meta, "mycap.iq.json") == 0);
+
+    DSD_SNPRINTF(alias_meta, sizeof(alias_meta), "%s", "mycap.iq.json");
+    alias_data[0] = '\0';
+    rc |= expect_int("derive alias on metadata buffer",
+                     dsd_iq_capture_derive_paths(alias_meta, alias_data, sizeof(alias_data), alias_meta,
+                                                 sizeof(alias_meta), err, sizeof(err)),
+                     DSD_IQ_OK);
+    rc |= expect_true("derive alias metadata data result", strcmp(alias_data, "mycap.iq") == 0);
+    rc |= expect_true("derive alias metadata result", strcmp(alias_meta, "mycap.iq.json") == 0);
 
     rc |= expect_int("open rejects null cfg", dsd_iq_capture_open(NULL, &writer, err, sizeof(err)),
                      DSD_IQ_ERR_INVALID_ARG);
@@ -1682,6 +1877,7 @@ main(void) {
 #if !DSD_PLATFORM_WIN_NATIVE && defined(RLIMIT_FSIZE)
     rc |= test_write_failure_is_counted_and_metadata_stays_readable();
 #endif
+    rc |= test_bare_name_roundtrip_and_legacy_resolution();
     rc |= test_public_error_contracts();
     return rc ? 1 : 0;
 }


### PR DESCRIPTION
## Context

Captures shared between users kept arriving with no `.iq` extension, which looked like a Windows-specific bug. It is not — **nothing in the codebase ever added `.iq`, on any platform**.

`--iq-capture <path>` stored the user's string verbatim and `dsd_iq_capture_derive_paths()` treated it as the data path, appending only `.json` for the sidecar. So `--iq-capture mycap` wrote `mycap` + `mycap.json` on Linux, macOS and Windows alike. The `.iq` in the docs survived only because the example command types it, and neither `usage.c` nor `docs/cli.md` mentioned that an extension was expected. The only code in the repo that wrote `".iq"` was `tools/build_iq_fixtures.py`.

## Changes

**Default the extension.** A path whose final component carries no extension gains the conventional `.iq`: `mycap` → `mycap.iq` + `mycap.iq.json`. A dot in a *directory* name does not count (`caps.v2/mycap` → `caps.v2/mycap.iq`), and a leading dot belongs to the name (`.hidden` → `.hidden.iq`). The suffix does not vary with `--iq-capture-format`; the sample format is already recorded in the sidecar.

**Keep old captures working.** `resolve_metadata_path()` now tries `<path>.json` first and then `<path>.iq.json`, so captures written before this change still replay, and `--iq-replay`/`--iq-info` accept the bare name, the data path, or the sidecar path. The not-found error names both candidates.

**Fix a real Windows bug found along the way.** `has_suffix()` compared with `strcmp` in both `iq_capture.c` and `iq_replay.c`. Windows preserves case without distinguishing it, so `capture.iq.JSON` named the same sidecar but took the data-path branch and grew a second `.json`. Now compared with `dsd_strcasecmp`, as `dsd_audio.c:49` already does for `.wav`.

**Harden aliasing.** `dsd_iq_capture_derive_paths()` builds its results in scratch buffers before copying out. Both callers in `capture_open_resolve_paths()` pass one buffer as both input and output; that previously worked only because each branch happened to self-copy before reading the input, which appending in place would have broken.

## Testing

`IO_IQ_CAPTURE_WRITER` gains coverage for the bare-name default, preserved extensions (`.iq`, `.cu8`), the dotted-directory and leading-dot cases, the uppercase `.JSON` regression, truncation that accounts for the added suffix, both aliasing forms, and an end-to-end round trip asserting the payload lands under `mycap.iq` (and that the bare name is *not* a file) and resolves from the bare name — plus a legacy `<name>`/`<name>.json` pair that must still resolve.

- Full suite: **585/585 pass**
- `-L iq-decode` replay tests: **27/27 pass**
- Mutation-checked: forcing `basename_has_extension()` to always return 1 fails 10 assertions
- `tools/format.sh` and `tools/preflight_ci.sh` clean

Verified end to end against a checked-in fixture — all three forms resolve, and the bare name works only because of the new fallback (`p25p1_c4fm_cc.json` does not exist):

```
tests/fixtures/iq/p25p1_c4fm_cc        -> IQ Capture Info: ...   (new .iq.json fallback)
tests/fixtures/iq/p25p1_c4fm_cc.iq     -> IQ Capture Info: ...
tests/fixtures/iq/p25p1_c4fm_cc.iq.json -> IQ Capture Info: ...
/tmp/nope -> metadata sidecar not found for '/tmp/nope' (tried '/tmp/nope.json' and '/tmp/nope.iq.json')
```

## Compatibility

Scripts passing a bare name to `--iq-capture` will now produce `<name>.iq`/`<name>.iq.json` instead of `<name>`/`<name>.json`. Reading side is unaffected: existing capture pairs resolve unchanged.

Docs updated in `docs/cli.md`, `docs/iq-capture-replay.md`, the `--iq-capture` help text, and the `dsd_iq_capture_derive_paths()` header contract.