### PR TITLE
docs(dsp): measure the FSK timing nudge instead of damping it (#444)

### DIFF
--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -225,6 +225,12 @@ installs from `src/engine/trunk_tuning.c` in `src/engine/trunk_tuning_hooks_inst
 - `symbol_timing_debug.c`: measures the sub-symbol offset the decoder's symbol grid settled on and reports it once
   per accepted frame sync, behind `DSD_NEO_DEBUG_SYMBOL_TIMING` (see `docs/cli.md`). The sample trace it correlates
   over is filled by `dsd_symbol.c` and owned by decoder-state setup/teardown in `src/core/util/dsd_init.c`.
+- `dsd_symbol.c` owns the open-loop FSK symbol grid. Only the inter-frame sync search moves it, by a whole sample at
+  a time, on the first zero crossing latched in the previous symbol — a bang-bang loop on one unfiltered sample
+  index, and between frames the only thing tracking the sampling instant across a call. Issue #444 documents how
+  sensitive that is; the comment above `symbol_adjust_timing_nxdn()` records the five ways of damping it that were
+  A/B'd on real captures and measured worse, so change it only with `tools/replay_ab.sh` evidence
+  (`docs/testing.md`). The CQPSK path does not use any of this: it has a real timing loop in `costas.cpp`.
 
 Runtime controls (via `include/dsd-neo/io/rtl_stream_c.h`):
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -270,6 +270,44 @@ SDR-backend combinations — `both`, `rtl_only`, `soapy_only` and `neither` — 
 pull requests as well as pushes, so the radio-off build is proven before a merge
 rather than after one.
 
+## Decode-Quality A/B on Real Captures
+
+The `iq-decode` suite answers whether a change still decodes; it does not answer
+whether it decodes *as well*. Symbol-timing, slicer and demodulator changes need
+the second question answered, and one replay cannot answer it: decoding runs on a
+threaded pipeline, so how much of a capture gets decoded varies run to run by more
+than the effect being looked for.
+
+`tools/replay_ab.sh` replays one I/Q capture through two or more builds and
+`tools/replay_ab_report.py` reports the result:
+
+```sh
+cmake --build --preset dev-debug -j --target dsd-neo
+cp build/dev-debug/apps/dsd-cli/dsd-neo /tmp/dsd-neo.after   # and one for 'before'
+
+tools/replay_ab.sh --capture ~/captures/nxdn.json --mode -fi --reps 12 \
+    --out /tmp/ab /tmp/dsd-neo.before /tmp/dsd-neo.after
+tools/replay_ab_report.py /tmp/ab/summary.tsv
+```
+
+Reading it:
+
+- **Errors per decoded voice frame**, never the raw error total. A build that
+  loses sync decodes fewer frames and accrues fewer errors without being better,
+  so watch the `voice` column alongside the error rate.
+- **Paired per repeat.** Builds run round-robin with the order rotated each
+  repeat, because a fixed order credits the better slot to whichever build holds
+  it. The report compares within a repeat for the same reason.
+- **Run the baseline against itself first.** That control establishes the noise
+  floor for the machine and the capture; a difference smaller than it has not
+  been measured. On the captures behind issue #444 the floor was about
+  0.1 errors per voice frame over 12 repeats.
+- Keep the machine otherwise idle: `--rate realtime` is wall-clock paced, so a
+  build competing with a compile is measured under different conditions.
+
+Issue #444 is the worked example, and the comment above `symbol_adjust_timing_nxdn()`
+in `src/dsp/dsd_symbol.c` records what it ruled out.
+
 ## Regression Test Requirement
 
 At least 50% of bugs fixed in the last six months should include regression

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -465,6 +465,38 @@ symbol_accumulate_sample(const dsd_state* state, symbol_work_ctx* work, int i, f
     }
 }
 
+/*
+ * The bands below decide which way the open-loop FSK grid slips, from the index
+ * of the first centre crossing the previous symbol produced. It is a bang-bang
+ * loop driven by one unfiltered sample index, with no averaging and no
+ * confidence, and issue #444 documents what that costs: which crossing happens
+ * to reach it moves decode quality on a real call by 3x.
+ *
+ * Everything about that is true and the constants still stand, because they were
+ * measured. Five ways of making the loop more careful were A/B'd against this
+ * code on two real NXDN48 captures (tools/replay_ab.sh, 12 rotated repeats each,
+ * errors per decoded voice frame, paired per repeat):
+ *
+ *   requiring 2 agreeing crossings before slipping   +0.94 +/- 0.21, lost sync
+ *   requiring 3                                      +2.18 +/- 0.60, lost sync
+ *   freezing the grid once a call is up              +4.43 +/- 0.68, lost sync
+ *   acting only on symbols that crossed exactly once +1.17 +/- 0.11, lost sync
+ *   widening these bands to cover the whole symbol   +1.39 +/- 0.18
+ *
+ * All five are worse, none is within noise, and a control of the unmodified code
+ * against itself came in at -0.07 +/- 0.08. The first four also decoded ~10 fewer
+ * voice frames per run, which is the mechanism: between frames this is the only
+ * thing tracking the sampling instant, so a grid it stops correcting drifts until
+ * the next sync word is missed and the call ends early. Widening the bands keeps
+ * sync and degrades quality instead, so the dead zone is not slack either.
+ *
+ * The loop is therefore at a local optimum, and the cheap directions #444 lists
+ * are spent. Making it better means replacing it with a real timing loop -- a
+ * measured phase error through a loop filter, as op25_gardner_cc() already gives
+ * the CQPSK path -- not making this one more cautious. Anything tried here needs
+ * measuring the same way, on a real capture: none of these variants is visible in
+ * the iq-decode suite, which they all pass.
+ */
 static inline void
 symbol_adjust_timing_nxdn(const dsd_state* state, int* i) {
     if ((state->jitter >= 7) && (state->jitter <= 10)) {

--- a/tools/replay_ab.sh
+++ b/tools/replay_ab.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+set -euo pipefail
+
+# A/B two dsd-neo builds by replaying the same I/Q capture through both and
+# reporting the decode quality each achieved.
+#
+# Why this exists: a change to the symbol timing, the slicer or the demodulator
+# cannot be judged from one replay. Decoding runs on a threaded pipeline, so how
+# much of a capture gets decoded varies run to run, and the difference between two
+# builds is easily smaller than that variation. Issue #444 asked for exactly this
+# -- several runs of a real capture, not one number -- and there was no way to do
+# it. Two properties this handles that a hand-rolled loop usually does not:
+#
+#   * Round-robin, not blocked. Running all of build A and then all of build B
+#     measures whatever else the machine was doing as if it were the build.
+#   * Rotated order within each repeat. A fixed order inside a repeat credits the
+#     better slot to whichever build holds it; a control of one build against
+#     itself scored the two slots 0.26 err/frame apart.
+#
+# Report errors per decoded voice frame, never the raw error total: a build that
+# loses sync decodes fewer frames and accrues fewer errors without being better.
+#
+# Usage:
+#   tools/replay_ab.sh --capture <capture.json> --mode <flags> [options] <build>...
+#
+# Each <build> is a path to a dsd-neo binary; its basename names it in the report.
+#
+# Options:
+#   --capture <path>   I/Q capture sidecar JSON to replay (required)
+#   --mode <flags>     Decoder flags, e.g. "-fi" (required; quote if several)
+#   --reps <n>         Repeats per build (default 12)
+#   --rate <mode>      --iq-replay-rate value: realtime (default) or fast
+#   --out <dir>        Where to write logs and summary.tsv (default: mktemp -d)
+#
+# Example:
+#   tools/replay_ab.sh --capture ~/captures/nxdn.json --mode -fi --reps 12 \
+#       /tmp/dsd-neo.before ./build/dev-debug/apps/dsd-cli/dsd-neo
+#   tools/replay_ab_report.py <out>/summary.tsv
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
+
+usage() {
+  sed -n '/^# Usage:/,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+capture=""
+mode=""
+reps=12
+rate=realtime
+out=""
+builds=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --capture)
+      capture="${2:-}"
+      shift 2
+      ;;
+    --mode)
+      mode="${2:-}"
+      shift 2
+      ;;
+    --reps)
+      reps="${2:-}"
+      shift 2
+      ;;
+    --rate)
+      rate="${2:-}"
+      shift 2
+      ;;
+    --out)
+      out="${2:-}"
+      shift 2
+      ;;
+    -h | --help) usage 0 ;;
+    --)
+      shift
+      builds+=("$@")
+      break
+      ;;
+    -*)
+      echo "unknown option: $1" >&2
+      usage 1
+      ;;
+    *)
+      builds+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$capture" ] || [ -z "$mode" ] || [ "${#builds[@]}" -lt 2 ]; then
+  echo "error: --capture, --mode and at least two builds are required" >&2
+  usage 1
+fi
+if [ ! -r "$capture" ]; then
+  echo "error: cannot read capture '$capture'" >&2
+  exit 1
+fi
+for b in "${builds[@]}"; do
+  if [ ! -x "$b" ]; then
+    echo "error: '$b' is not an executable dsd-neo build" >&2
+    exit 1
+  fi
+done
+
+if [ -z "$out" ]; then
+  out=$(mktemp -d "${TMPDIR:-/tmp}/dsd-neo-replay-ab.XXXXXX")
+fi
+mkdir -p "$out"
+summary="$out/summary.tsv"
+printf 'variant\tcase\trep\terrs\tvoice\tsync\n' > "$summary"
+
+# Quoted flags are several arguments, not one.
+read -r -a mode_args <<< "$mode"
+nbuilds=${#builds[@]}
+
+echo "replaying $(basename "$capture") through $nbuilds builds, $reps repeats each, $rate pacing"
+echo "results: $out"
+
+for r in $(seq 1 "$reps"); do
+  for ((k = 0; k < nbuilds; k++)); do
+    build="${builds[$(((k + r - 1) % nbuilds))]}"
+    name=$(basename "$build")
+    log="$out/${name}__r${r}.log"
+    set +e
+    timeout 900 "$build" --frontend none "${mode_args[@]}" \
+      --iq-replay "$capture" --iq-replay-rate "$rate" -o null > "$log" 2>&1
+    rc=$?
+    set -e
+    errs=$(grep -oE 'Total audio errors: [0-9]+' "$log" | tail -1 | grep -oE '[0-9]+$' || true)
+    voice=$(grep -c 'Voice' "$log" || true)
+    sync=$(grep -cE 'Sync: ' "$log" || true)
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$name" "$(basename "$capture")-$rate" "$r" "${errs:-NA}" "$voice" "$sync" >> "$summary"
+    printf '  r%-3s %-24s errs=%-6s voice=%-5s sync=%-5s%s\n' \
+      "$r" "$name" "${errs:-NA}" "$voice" "$sync" "$([ "$rc" -ne 0 ] && echo " (exit $rc)")"
+  done
+done
+
+echo
+echo "wrote $summary"
+echo "report with: $ROOT_DIR/tools/replay_ab_report.py $summary"

--- a/tools/replay_ab_report.py
+++ b/tools/replay_ab_report.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""Summarise a tools/replay_ab.sh run.
+
+Repeats are matched blocks: every build replays the same capture inside the same
+repeat, under the same machine conditions. The comparison that survives the
+pipeline's run-to-run variation is therefore the per-repeat difference, not the
+difference of the means -- on the captures behind issue #444 the within-build
+spread was large enough to reverse a blocked comparison.
+
+Errors are reported per decoded voice frame. A build that loses sync decodes
+fewer frames and accrues fewer errors without being better, so the raw total
+flatters exactly the regressions worth catching.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def load(path: Path) -> dict[int, dict[str, tuple[float, int, int]]]:
+    """Read summary.tsv into {repeat: {build: (err_per_voice, errs, voice)}}."""
+    by_rep: dict[int, dict[str, tuple[float, int, int]]] = defaultdict(dict)
+    with path.open() as handle:
+        header = handle.readline().rstrip("\n").split("\t")
+        if header[:1] != ["variant"]:
+            raise SystemExit(f"{path}: not a replay_ab summary (unexpected header)")
+        for line in handle:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 6 or parts[3] == "NA":
+                continue
+            build, _case, rep, errs, voice, _sync = parts[:6]
+            if int(voice) == 0:
+                continue
+            by_rep[int(rep)][build] = (int(errs) / int(voice), int(errs), int(voice))
+    return by_rep
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("summary", type=Path, help="summary.tsv written by tools/replay_ab.sh")
+    parser.add_argument("--baseline", help="build to compare against (default: the first one seen)")
+    args = parser.parse_args()
+
+    by_rep = load(args.summary)
+    if not by_rep:
+        raise SystemExit(f"{args.summary}: no usable rows")
+
+    reps = sorted(by_rep)
+    builds = sorted({b for row in by_rep.values() for b in row})
+    baseline = args.baseline or by_rep[reps[0]].keys().__iter__().__next__()
+    if baseline not in builds:
+        raise SystemExit(f"baseline '{baseline}' not present; have: {', '.join(builds)}")
+
+    print(f"repeats: {len(reps)}   baseline: {baseline}\n")
+    print(f"{'build':>24}  {'err/voice':>9} {'median':>7} {'sd':>6}  {'voice':>6}  "
+          f"{'paired vs baseline':>20}  {'better':>7}")
+    for build in builds:
+        vals = [by_rep[r][build][0] for r in reps if build in by_rep[r]]
+        voices = [by_rep[r][build][2] for r in reps if build in by_rep[r]]
+        diffs = [by_rep[r][build][0] - by_rep[r][baseline][0]
+                 for r in reps if build in by_rep[r] and baseline in by_rep[r]]
+        sd = statistics.stdev(vals) if len(vals) > 1 else 0.0
+        if build != baseline and diffs:
+            mean_d = statistics.fmean(diffs)
+            half = 1.96 * statistics.stdev(diffs) / math.sqrt(len(diffs)) if len(diffs) > 1 else 0.0
+            paired = f"{mean_d:+.2f} +/- {half:.2f}"
+            better = f"{sum(1 for d in diffs if d < 0)}/{len(diffs)}"
+        else:
+            paired, better = "-", "-"
+        print(f"{build:>24}  {statistics.fmean(vals):9.2f} {statistics.median(vals):7.2f} {sd:6.2f}  "
+              f"{statistics.fmean(voices):6.1f}  {paired:>20}  {better:>7}")
+
+    print("\nPaired column is the mean per-repeat difference in errors per voice frame,")
+    print("with a 95% interval. Negative beats the baseline; an interval spanning 0 means")
+    print("the run did not resolve a difference. Watch the voice column too: a build that")
+    print("decodes noticeably fewer frames is losing sync, whatever its error rate says.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**This does not fix #444, and #444 should stay open.** The reported defect is
unchanged: decode quality still moves on which zero crossing reaches the nudge.
What this lands is the evidence that the three fixes the issue proposes are all
harmful, so the next person starts from the closed loop instead of from them.

## What this is

#444 records that the ±1 nudge owning the FSK symbol grid is a bang-bang loop
driven by a single unfiltered zero-crossing index, and that decode quality on one
call swings 3× on which crossing happens to reach it. It lists three cheap
directions to try before anything larger, and warns that the obvious fix may be
worse than the disease.

I implemented and measured all three, plus the opposite of them. **They are all
worse.** This PR lands that result and the harness that produced it. There is no
decode behaviour change — the `src/` diff is comment-only.

## Measurements

A/B against unmodified `main` on the reporter's NXDN48 captures (`-fi`, realtime
replay pacing), 12 rotated repeats per variant, **errors per decoded voice frame**,
paired per repeat:

| variant | vs main | repeats better | voice frames |
|---|---|---|---|
| require 2 agreeing crossings before slipping | **+0.94 ± 0.21** | 1/12 | 71.7 |
| require 3 | **+2.18 ± 0.60** | 0/12 | 70.8 |
| freeze the grid once a call is locked | **+4.43 ± 0.68** | 0/12 | 66.4 |
| act only on symbols that crossed centre once | **+1.17 ± 0.11** | 0/6 | 67.3 |
| widen the bands over the whole symbol | **+1.39 ± 0.18** | 0/6 | 75.7 |
| _control: main against itself_ | _−0.07 ± 0.08_ | _8/12_ | _77.2_ |

Positive is worse. The control run establishes the noise floor (~0.1), so every
variant except the control is resolved well outside it.

## Why they fail

The first four also decode about **ten fewer voice frames per run**. That is the
mechanism, and it is the part #444's framing misses: between frames this nudge is
the *only* thing tracking the sampling instant across a call. A grid it stops
correcting drifts until a sync word is missed and the call ends early — so damping
it does not trade quality for stability, it loses sync.

Widening the bands instead (the opposite direction, motivated by #444's "wide dead
zone" note) keeps sync and degrades quality, so the dead zone is not slack either.

The constants are a local optimum that was measured rather than guessed. The cheap
directions are spent; improving on this means the closed loop #444 already
describes — a measured phase error through a loop filter, as `op25_gardner_cc()`
gives the CQPSK path. #444 should stay open for that.

## What lands

- The five results recorded above `symbol_adjust_timing_nxdn()` in
  `src/dsp/dsd_symbol.c`, where the next person reads the bands, so the
  experiments are not repeated.
- `tools/replay_ab.sh` + `tools/replay_ab_report.py`: replay one capture through
  several builds and report the difference. #444 asks that any change here be
  judged on several runs of a real capture rather than one number, and there was
  no way to do that. Two things it gets right that a hand-rolled loop does not —
  both cost me a wrong conclusion first:
  - **Round-robin, not blocked.** My first sweep ran each build in a block, and a
    variant that happened to run while the machine was busy was measured under
    different conditions.
  - **Rotated order within a repeat.** With a fixed order, one build against
    itself scored the two slots 0.26 apart — enough to invent a significant
    result. Reversing the order flipped it.
  - It reports **errors per decoded voice frame**, never the raw total: a build
    that loses sync accrues fewer errors without being better.
- `docs/testing.md` explains when to reach for it and how to read it;
  `docs/code_map.md` points at the constraint.

## Testing

- `ctest --preset dev-debug`: 587/587 pass.
- `tools/preflight_ci.sh`: clean.
- Worth noting: **none of the five variants is visible in the `iq-decode` suite** —
  they all pass it. That suite asks whether a build still decodes, not whether it
  decodes as well, which is exactly the gap the new harness fills.

## Limitations

Measured on NXDN48 (2400 baud, 20 sps) only, which is the capture the issue was
filed against. The nudge is shared with the other FSK protocols, so the *shape* of
the result should carry, but the numbers are NXDN's. The `-fa` capture agrees
directionally but with much wider spread (retunes make the decoded amount vary),
so the table above is the `-fi` capture.

