### PR TITLE
fix(dsp): keep the 4800/4 matchers off a transmission 2400/4 just proved (#445)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -376,6 +376,26 @@ Notes
   a sync the CQPSK chain carried closes the span rather than opening one, for the same reason. The span is re-armed
   by every P25p1 sync, so continuous traffic stays covered, and it lapses within a fifth of a second of P25 going
   quiet. It costs a real NXDN96 or M17 signal nothing, since neither produces P25p1 sync matches.
+- A transmission the hunt has stepped away from is protected the same way, for as long as it may still be running.
+  Both spans above cover one frame, which is no help across a profile change: under Auto the hunt can rotate off
+  2400/4 while an NXDN48 call is still on air, and by the time the rotation reaches 4800/4 the NXDN96 and M17
+  matchers there are offered that same 2400-baud signal read at twice its rate -- and take it, printing frames whose
+  content is noise. So a handler that proves its profile now records which profile it proved, and while a proof of
+  2400/4 is recent enough that its transmission could still be running, those two matchers stand down on 4800/4.
+  A proof is a passing check, never a sync: dPMR's CCH CRC-7 and the NXDN confirmation CRCs above, both of which a
+  real NXDN96 or M17 signal is incapable of producing, so neither can arm this against itself. Only the frame that
+  passed the check records one, so the noise syncs that follow a transmission cannot keep the guard armed. The span
+  runs one full rotation of the hunt from the last proof -- long enough that the guard is still standing through the
+  whole of the first 4800/4 dwell it reaches, and short enough that a transmission which has genuinely ended frees the
+  profile again within a few seconds. As with the P25p1 span, the NXDN window keeps contributing its level estimate
+  throughout; what is withheld is the sync.
+- Recording that proof is deliberately all it does. Making NXDN report the profile as *proven* to the hunt, the way
+  dPMR and P25 Phase 1 do when their own checks pass, would also restart the dwell and hold the rate against
+  rotation -- which sounds like the better fix and measured worse. Restarting the dwell keeps the hunt's budget away
+  from the exit that runs the end-of-call housekeeping, and on the four-channel NXDN48 capture behind this guard that
+  cost decoded calls: ten rotated replays per build scored 75 NXDN48 syncs and 11 voice calls without it against 66
+  and 9 with, every paired repeat worse. So Auto still rotates off a live NXDN48 call exactly as before; what changed
+  is only that the matchers it rotates onto no longer claim the call while it is still running.
 - All three Auto entry points install the complete matrix above: CLI `-fa`, config `decode = "auto"`, and the
   interactive Auto choice select the same decoder set. Only `-fa` also resets the demodulator to C4FM and the audio
   layout to stereo; the config path leaves those to its `demod` and `dmr_mono` keys, and the interactive path to the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -158,6 +158,29 @@ consumption, pins the profile and fails the case. dPMR itself has since left tha
 cover what it does now: at the real 384-symbol frame cadence, which is inside the arithmetic's reach, a carrier whose
 CCH decodes nothing still rotates, and one whose CCH decodes on three frames in four holds.
 
+There is no `-fa` case on `nxdn48` for issue #445 either, and for the same reason plus one of its own. The guard
+that issue added withholds the NXDN96 and M17 matchers on 4800/4 while a 2400/4 transmission has recently proved
+itself, so seeing it work in a replay needs the hunt to complete a rotation *after* a proof — and the `nxdn48`
+fixture is 6 s, about one full rotation, which is precisely the schedule-dependent regime that got the `dstar`
+reject case removed above. The change also leaves the hunt's own accounting untouched, so an `-fa` case would mostly
+re-assert rotation behaviour that did not move. The property is pinned exactly instead, in
+`FRAME_SYNC_INTERNAL_HELPERS` (the matchers stand down inside the span and are live again past it, the level blend
+still runs while the sync is withheld, the guard is scoped to its arming protocols and to the profile proved, and it
+survives the `symbolcnt` wrap) and in `FRAME_SYNC_POLICY` (the predicate's truth table and both span boundaries).
+`DECODE_IQ_NXDN48`, `DECODE_IQ_NXDN96`, `DECODE_IQ_M17` and `DECODE_IQ_M17_AUTO` are the guard that real acquisition
+still happens; none of them carries a 2400/4 proof, so they exercise the un-armed path.
+
+What that issue *did* measure is worth recording, because it says something about this suite's limits. The obvious
+root-cause fix — letting a passing NXDN CRC report `DSD_FRAME_VERDICT_PROFILE_PROVEN` so a live call holds its rate
+against rotation — makes the decoder worse, and no test here would have caught it. Restarting the dwell keeps
+`dsd_state::sps_hunt_counter` away from the budget exit in `getFrameSync()`, and that exit is what runs the no-sync
+hooks that end a call and clear the state the next one is assembled from. On the uncommitted 35 s four-channel
+NXDN48 capture from issue #373, ten rotated replays per build (`tools/replay_ab.sh`) scored 75 NXDN48 syncs and 11
+voice calls per run on `main` against 66 and 9 with the verdict change, every paired repeat worse. Single replays
+cannot see this: the same build scores anywhere from 57 to 94 NXDN48 syncs run to run under `-fa`, which is wider
+than the effect. Decode *volume* under the hunt is not covered by the `iq-decode` suite, which asks only whether a
+build still decodes.
+
 Known gaps and caveats:
 
 - **ProVoice** and **X2-TDMA** have no usable public sample and are untested here.

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -651,6 +651,32 @@ struct dsd_state {
      * symbolcnt rollover mid-frame stays exact. */
     uint32_t p25_p1_c4fm_frame_symbolcnt;
     uint8_t p25_p1_c4fm_frame_valid;
+    /* Which SPS profile a protocol last passed a content check on, when, and whether any has
+     * been recorded at all. The two spans above cover a frame another protocol is in the middle
+     * of; this one covers the transmission a protocol has been decoding, which is the case
+     * neither of them reaches: under AUTO the hunt rotates off 2400/4 while an NXDN48 call is
+     * still on air, and by the time it comes round to 4800/4 the NXDN96 and M17 matchers there
+     * claim the transmission that never stopped (#445).
+     *
+     * The flag, not the index, says whether anything is armed -- profile index 0 is 4800/4, so a
+     * zeroed state would otherwise read as a proof on that profile at symbol zero. Protocol-blind
+     * on purpose: dPMR's CCH CRC-7 and NXDN's confirmation CRCs both prove 2400/4, and a live
+     * transmission of either faces the same claimants on the profile the hunt steps to.
+     *
+     * Written by the protocol handlers through dsd_frame_sync_note_profile_proof(), deliberately
+     * not derived from DSD_FRAME_VERDICT_PROFILE_PROVEN: that verdict restarts the hunt's dwell,
+     * and measurement on the #445 capture showed doing so for NXDN costs more decoded calls than
+     * it wins (see src/engine/dispatch/dispatch_nxdn.c). Recording the proof is separable from
+     * acting on it, and only the recording is wanted here.
+     *
+     * Not cleared with the carrier, and must not be: every step of the hunt runs noCarrier(), so
+     * clearing it there would erase the stamp exactly when the transmission it vouches for is
+     * still on air. It expires on its own instead. Read by src/dsp only, through
+     * dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(); compared as a modular difference,
+     * so a symbolcnt rollover stays exact. */
+    int profile_proof_idx;
+    uint32_t profile_proof_symbolcnt;
+    uint8_t profile_proof_valid;
     int lastsynctype;
     int lastp25type;
     int offset;

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -120,6 +120,34 @@ int dsd_frame_sync_suppress_nxdn48_sync(const dsd_opts* opts, const dsd_state* s
 int dsd_frame_sync_suppress_4800_4_for_p25p1_frame(const dsd_opts* opts, const dsd_state* state);
 
 /**
+ * @brief Record that a protocol's own content check passed on the profile now active.
+ *
+ * Called from the frame handlers, which are the only place that knows a check ran and passed.
+ * Kept separate from the SPS hunt's dwell accounting on purpose: what the hunt does with a proof
+ * and what the matchers on another profile may infer from one are different questions, and #445
+ * measured that answering the first one for NXDN costs more than it wins.
+ */
+void dsd_frame_sync_note_profile_proof(dsd_state* state);
+
+/**
+ * @brief Return non-zero while a transmission that recently proved the 2400/4 profile may still
+ *        be on air.
+ *
+ * The span above covers one frame; this covers the gap a hunt step opens. Under AUTO the hunt can
+ * rotate off 2400/4 mid-transmission, and when it reaches 4800/4 the NXDN96 and M17 matchers there
+ * are offered a 2400-baud signal read at twice its rate, which they accept (#445). While a proof of
+ * 2400/4 is recent enough that its transmission may still be running, they are not.
+ *
+ * Armed only by a handler's own passing check, so a real NXDN96 or M17 signal cannot arm it against
+ * itself: neither proves the 2400/4 profile. On symbol-file input, where the profile gate stands
+ * open because stored symbols cannot be revisited after a hunt advance, no shipped configuration
+ * reaches this -- the NXDN matcher is limited to an unambiguous variant there, and a build with
+ * neither 2400/4 protocol enabled fails the gate -- and where it is reachable by hand, withholding
+ * the weak matchers from a proved 2400/4 transmission is the same right answer as on live input.
+ */
+int dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(const dsd_opts* opts, const dsd_state* state);
+
+/**
  * @brief Return non-zero when TCP no-signal diagnostics should stay off the console.
  */
 int dsd_frame_sync_suppress_tcp_no_signal_console(const dsd_opts* opts, const dsd_state* state);

--- a/include/dsd-neo/protocol/nxdn/nxdn.h
+++ b/include/dsd-neo/protocol/nxdn/nxdn.h
@@ -23,12 +23,20 @@ extern "C" {
 /**
  * @brief Decode one NXDN frame.
  *
- * @return 1 once the current transmission has produced CRC-verified content, 0 while it
- *         has not. This is nxdn_confirm_is_confirmed(), the sticky per-transmission flag
- *         rather than the per-frame one: a real call confirms on its first FACCH and every
- *         frame after it answers 1, while a stream of noise clearing the weak sync word and
- *         LICH never does. The SPS hunt refuses those frames the dwell their 182 symbols
- *         would otherwise buy (#391).
+ * @return 0 while the current transmission has produced no CRC-verified content, 1 once it
+ *         has, and 2 when this frame is itself one that checked out.
+ *
+ * The 0/1 boundary is nxdn_confirm_is_confirmed(), the sticky per-transmission flag rather
+ * than the per-frame one: a real call confirms on its first FACCH and every frame after it
+ * answers at least 1, while a stream of noise clearing the weak sync word and LICH never
+ * does. The SPS hunt refuses those frames the dwell their 182 symbols would otherwise buy
+ * (#391).
+ *
+ * The 2 separates out the frames that carried their own passing CRC, which is what the caller
+ * treats as proof of the profile the frame was read on (#445). It has to be this frame's own
+ * check and not the transmission's standing: a sticky answer would let the noise syncs between
+ * transmissions hold a profile that nothing is decoding on. A frame rejected before its body is
+ * read therefore cannot answer 2, however much the transmission has proved before now.
  */
 int nxdn_frame(dsd_opts* opts, dsd_state* state);
 
@@ -45,6 +53,15 @@ void nxdn_cipher_class_reset(dsd_state* state);
  * with the carrier; the rest of that module's interface is private to the protocol.
  */
 void nxdn_confirm_reset(dsd_state* state);
+
+/**
+ * @brief Whether the frame just closed carried a passing CRC of its own.
+ *
+ * Defined in src/protocol/nxdn/nxdn_confirm.c and declared here for the same reason as
+ * nxdn_confirm_reset(): the grading stays inside that module, and nxdn_frame() reports the
+ * answer outwards as its 2 (#445).
+ */
+int nxdn_confirm_frame_proved(const dsd_state* state);
 int nxdn_cipher_established_enc(const dsd_state* state);
 int nxdn_cipher_established_clear(const dsd_state* state);
 

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -1155,8 +1155,13 @@ frame_sync_try_m17(frame_sync_match_ctx* ctx) {
      * lapses. Unlike the NXDN window below, this one stands down completely: what it would
      * contribute is not a blend but a hard rewrite of every threshold from eight symbols of
      * whatever is in hand, which is worth having from a real preamble and worth nothing from
-     * P25 payload (#388). */
-    if (dsd_frame_sync_suppress_4800_4_for_p25p1_frame(opts, state)) {
+     * P25 payload (#388).
+     *
+     * A transmission the hunt has just stepped away from supplies the same thing: 2400-baud
+     * payload sliced at 4800 is as ready a source of alternating runs as P25's is, and it is
+     * still on air (#445). */
+    if (dsd_frame_sync_suppress_4800_4_for_p25p1_frame(opts, state)
+        || dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(opts, state)) {
         state->m17_pre_run = 0;
         frame_sync_age_m17_pre_candidate(state);
         return DSD_SYNC_NONE;
@@ -1657,9 +1662,15 @@ frame_sync_try_nxdn(frame_sync_match_ctx* ctx) {
      * costs P25p1: the symbols the handler would read, a slicer warm-started from P25 payload,
      * the control-channel timestamp, and the lastsynctype that keeps use_symbol()'s C4FM
      * threshold tracker engaged between one P25p1 sync and the next (#388). The offset is left
-     * alone for the same reason -- inside this span it belongs to the frame P25p1 opened. */
+     * alone for the same reason -- inside this span it belongs to the frame P25p1 opened.
+     *
+     * The second span withholds it for a transmission proved on 2400/4 that the hunt has since
+     * stepped off, which this matcher would otherwise read at twice its rate and accept as
+     * NXDN96 (#445). The profile term above is what keeps that guard off the NXDN48 arm on
+     * 2400/4: the transmission it protects is the one it must never mute. */
     if (frame_sync_match_profile_active(ctx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4)
-        && dsd_frame_sync_suppress_4800_4_for_p25p1_frame(opts, state)) {
+        && (dsd_frame_sync_suppress_4800_4_for_p25p1_frame(opts, state)
+            || dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(opts, state))) {
         return DSD_SYNC_NONE;
     }
 
@@ -2702,8 +2713,12 @@ frame_sync_nxdn_gfsk_ham(const dsd_opts* opts, const dsd_state* state, const fra
         /* Silent inside a P25p1 frame for the same reason the matcher is. Ten sign-sliced
          * symbols one error from an NXDN word score 3 on the 24-symbol axis these votes are
          * compared on, which is enough to carry the GFSK vote outright -- so P25 payload read
-         * through this window walks the demodulator off the chain that is decoding it (#388). */
-        if (dsd_frame_sync_suppress_4800_4_for_p25p1_frame(opts, state)) {
+         * through this window walks the demodulator off the chain that is decoding it (#388).
+         * Silent for a proved 2400/4 transmission too, whose payload read at 4800 supplies the
+         * same misleading score (#445). The 2400/4 branch below is left alone: there the vote
+         * is NXDN48's own, cast on the profile its transmission proved. */
+        if (dsd_frame_sync_suppress_4800_4_for_p25p1_frame(opts, state)
+            || dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(opts, state)) {
             return 24;
         }
         return frame_sync_best_nxdn_scaled_ham(rt->synctest10, 24);

--- a/src/dsp/frame_sync_internal.h
+++ b/src/dsp/frame_sync_internal.h
@@ -60,6 +60,26 @@ extern "C" {
  */
 #define DSD_FRAME_SYNC_P25P1_FRAME_SYMBOLS          900U
 
+/**
+ * @brief Symbols a proof of the 2400/4 profile keeps the weaker 4800/4 matchers at bay.
+ *
+ * One full rotation of the hunt at the default dwell: DSD_FRAME_SYNC_SPS_PROFILE_COUNT profiles
+ * of dsd_frame_sync_sps_hunt_dwell_passes() x DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS. That is what
+ * the span has to cover to do its job at all, and it is tight rather than padded: from the proof,
+ * the hunt spends at most one dwell finishing on 2400/4 -- the proof restarted that counter -- one
+ * each traversing 9600/2, 6000/4 and 4800/2, and the guard must still be standing through the
+ * whole of the first 4800/4 dwell, where the claimants are. Builds without some of those
+ * candidates simply arrive sooner.
+ *
+ * The other bound is what it costs a signal that is really there: a transmission that has genuinely
+ * ended frees 4800/4 for real NXDN96 and M17 within one rotation of its last proof, and a rotation
+ * is mostly spent on profiles neither of them uses. Where the dwell is longer -- an untuned P25
+ * trunk takes five passes -- the rotation outruns this span, so the guard thins out rather than
+ * over-reaching, and the profile hold that PROFILE_PROVEN itself buys stays the primary defence
+ * (see dsd_frame_sync_suppress_4800_4_for_2400_4_transmission()).
+ */
+#define DSD_FRAME_SYNC_PROVEN_2400_4_HOLD_SYMBOLS   27000U
+
 /** @brief One entry of the SPS hunt's rate/level table, indexed by dsd_state::sps_hunt_idx. */
 typedef struct {
     int symbol_rate_hz;

--- a/src/dsp/frame_sync_policy.c
+++ b/src/dsp/frame_sync_policy.c
@@ -52,6 +52,40 @@ dsd_frame_sync_suppress_4800_4_for_p25p1_frame(const dsd_opts* opts, const dsd_s
     return since < DSD_FRAME_SYNC_P25P1_FRAME_SYMBOLS;
 }
 
+void
+dsd_frame_sync_note_profile_proof(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    /* The index current at the call, which is the one the frame was read on: this runs from the
+     * protocol handler, inside the same getFrameSync() cycle that matched the sync. Re-stamped
+     * per proof and never extended, so a channel that stops proving releases the guard. */
+    state->profile_proof_idx = state->sps_hunt_idx;
+    state->profile_proof_symbolcnt = state->symbolcnt;
+    state->profile_proof_valid = 1;
+}
+
+int
+dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return 0;
+    }
+    /* Gated on the protocols that can prove 2400/4 at all -- the pair
+     * frame_sync_sps_profile_has_candidate() names for that profile -- so a build carrying
+     * neither behaves exactly as it did before. The arming is verdict-based rather than
+     * matcher-based, so the gate is their union rather than one protocol's flag. */
+    if (opts->frame_nxdn48 != 1 && opts->frame_dpmr != 1) {
+        return 0;
+    }
+    if (state->profile_proof_valid == 0 || state->profile_proof_idx != DSD_FRAME_SYNC_SPS_PROFILE_2400_4) {
+        return 0;
+    }
+    /* Modular difference, with the same failure direction as the two spans above: a backwards
+     * symbolcnt jump reads as a huge forward distance and ends the suppression early. */
+    const uint32_t since = state->symbolcnt - state->profile_proof_symbolcnt;
+    return since < DSD_FRAME_SYNC_PROVEN_2400_4_HOLD_SYMBOLS;
+}
+
 int
 dsd_frame_sync_suppress_tcp_no_signal_console(const dsd_opts* opts, const dsd_state* state) {
     if (!opts || !state) {

--- a/src/engine/dispatch/dispatch_dpmr.c
+++ b/src/engine/dispatch/dispatch_dpmr.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/dpmr/dpmr.h>
 #include <stdint.h>
@@ -91,6 +92,10 @@ dpmr_handle_voice_frame(dsd_opts* opts, dsd_state* state) {
     if (processdPMRvoice(opts, state) > 0) {
         state->dpmr_cch_evidence = 1;
         state->dpmr_cch_evidence_symbolcnt = state->symbolcnt;
+        /* The same pass, told to the matchers on the profile a hunt step lands on: dPMR is the
+         * other 2400/4 tenant, and a live dPMR transmission is offered to the weaker 4800/4
+         * matchers exactly as an NXDN48 one is (#445). */
+        dsd_frame_sync_note_profile_proof(state);
         return DSD_FRAME_VERDICT_PROFILE_PROVEN;
     }
     if (state->dpmr_cch_evidence != 0

--- a/src/engine/dispatch/dispatch_nxdn.c
+++ b/src/engine/dispatch/dispatch_nxdn.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/nxdn/nxdn.h>
 
@@ -16,10 +17,37 @@ dsd_dispatch_matches_nxdn(int synctype) {
     return DSD_SYNC_IS_NXDN(synctype);
 }
 
+/*
+ * One NXDN frame, its verdict, and what it proved about the profile it was read on.
+ *
+ * NXDN's sync word and LICH are weak enough that receiver noise clears both (#398), so a frame
+ * reaching the body proves nothing on its own. nxdn_frame() answers with the transmission's CRC
+ * confirmation, which noise never reaches, and that is the verdict: the SPS hunt credits a
+ * confirmed frame the symbols it read and refuses an unconfirmed one the dwell its 182 symbols
+ * would otherwise buy (#391).
+ *
+ * The verdict deliberately stops there. Reporting DSD_FRAME_VERDICT_PROFILE_PROVEN instead, the
+ * way dPMR and P25p1 do when their own checks pass, was measured on the #445 capture and made
+ * things worse: PROVEN restarts the dwell outright, which keeps dsd_state::sps_hunt_counter off
+ * the budget exit in getFrameSync(), and that exit is what runs the no-sync hooks that end a call
+ * and clear the superframe state the next one is assembled from. Ten rotated replays per build put
+ * it at 75 NXDN48 syncs and 11 voice calls without it against 66 and 9 with, every paired repeat
+ * negative -- so NXDN keeps the accounting it had, and #445 is answered by the guard below rather
+ * than by holding the profile harder.
+ *
+ * What a passing CRC does buy is a record of which profile it passed on. Nothing else can say
+ * that a 2400-baud transmission was live at a given moment, and the weaker matchers waiting on
+ * 4800/4 need exactly that to know the signal they are being offered belongs to someone else
+ * (dsd_frame_sync_suppress_4800_4_for_2400_4_transmission()). Only a frame that checked out
+ * itself stamps it -- a frame rejected before its body was read answers 0 or 1 however confirmed
+ * the transmission is -- so the noise syncs between transmissions cannot keep it armed.
+ */
 dsd_frame_verdict
 dsd_dispatch_handle_nxdn(dsd_opts* opts, dsd_state* state) {
-    /* NXDN's sync word and LICH are weak enough that receiver noise clears both (#398), so
-     * a frame reaching the body proves nothing on its own. nxdn_frame() answers with the
-     * transmission's CRC confirmation, which noise never reaches. */
-    return nxdn_frame(opts, state) != 0 ? DSD_FRAME_VERDICT_PRODUCTIVE : DSD_FRAME_VERDICT_UNPRODUCTIVE;
+    const int frame_result = nxdn_frame(opts, state);
+
+    if (frame_result == 2) {
+        dsd_frame_sync_note_profile_proof(state);
+    }
+    return frame_result != 0 ? DSD_FRAME_VERDICT_PRODUCTIVE : DSD_FRAME_VERDICT_UNPRODUCTIVE;
 }

--- a/src/protocol/nxdn/nxdn_confirm.c
+++ b/src/protocol/nxdn/nxdn_confirm.c
@@ -66,3 +66,8 @@ int
 nxdn_confirm_is_confirmed(const dsd_state* state) {
     return state && state->nxdn_confirmed != 0;
 }
+
+int
+nxdn_confirm_frame_proved(const dsd_state* state) {
+    return state && state->nxdn_confirmed != 0 && state->nxdn_confirm_frame_evidence != 0;
+}

--- a/src/protocol/nxdn/nxdn_confirm.h
+++ b/src/protocol/nxdn/nxdn_confirm.h
@@ -63,6 +63,17 @@ void nxdn_confirm_end_frame(dsd_state* state);
 /** @brief Whether the current transmission has proved itself. */
 int nxdn_confirm_is_confirmed(const dsd_state* state);
 
+/**
+ * @brief Whether the frame just closed carried a passing CRC of its own.
+ *
+ * Narrower than nxdn_confirm_is_confirmed(), which stays true across a confirmed
+ * transmission's empty frames. The SPS hunt needs the narrower answer: only a frame that
+ * checked out itself proves the profile it was read on, or the noise syncs that follow a
+ * transmission would go on holding a profile nothing is decoding on (#445). Read it after
+ * nxdn_confirm_end_frame().
+ */
+int nxdn_confirm_frame_proved(const dsd_state* state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/protocol/nxdn/nxdn_frame.c
+++ b/src/protocol/nxdn/nxdn_frame.c
@@ -605,6 +605,10 @@ nxdn_finalize_sync_reject(dsd_state* state) {
 int
 nxdn_frame(dsd_opts* opts, dsd_state* state) {
     nxdn_frame_ctx ctx;
+    /* Declared out here so every goto END path below carries the "proved nothing" answer:
+     * those bail before the frame body is read, so there is no CRC of this frame's own to
+     * report however much the transmission has proved before now (#445). */
+    int frame_proved = 0;
 
     nxdn_frame_ctx_init(&ctx);
     nxdn_collect_lich(opts, state, &ctx);
@@ -643,6 +647,7 @@ nxdn_frame(dsd_opts* opts, dsd_state* state) {
     nxdn_update_sacch_mode(state, ctx.lich);
     nxdn_decode_control_channels(opts, state, &ctx);
     nxdn_confirm_end_frame(state);
+    frame_proved = nxdn_confirm_frame_proved(state);
 
     if (nxdn_confirm_is_confirmed(state)) {
         nxdn_mark_carrier_sync_active(state);
@@ -664,6 +669,11 @@ END:
     nxdn_finalize_sync_reject(state);
     /* The sticky flag, not this frame's evidence: a confirmed transmission whose current
      * frame happens to carry no CRC still decoded, and reporting it unproductive would let
-     * the SPS hunt rotate off a live call. */
-    return nxdn_confirm_is_confirmed(state);
+     * the SPS hunt rotate off a live call.
+     *
+     * This frame's own evidence is reported alongside it as the 2, because the caller needs
+     * both answers: the sticky one says the call is live, and the per-frame one is what proves
+     * the profile the frame was read on -- a standing that the syncs between transmissions must
+     * not inherit, however confirmed the last call was (#445). */
+    return frame_proved ? 2 : nxdn_confirm_is_confirmed(state);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1037,12 +1037,14 @@ add_executable(
     test_support/call_state_stubs.c
     ${PROJECT_SOURCE_DIR}/src/engine/dispatch/dispatch_dpmr.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dpmr/dpmr_confirm.c
+    ${PROJECT_SOURCE_DIR}/src/dsp/frame_sync_policy.c
 )
 target_include_directories(
     dsd-neo_test_dpmr_sync_dispatch
     PRIVATE
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/src/protocol/dpmr
+        ${PROJECT_SOURCE_DIR}/src/dsp
 )
 add_test(NAME DPMR_SYNC_DISPATCH COMMAND dsd-neo_test_dpmr_sync_dispatch)
 
@@ -1394,10 +1396,11 @@ add_executable(
     dsd-neo_test_nxdn_sync_dispatch
     protocol/nxdn/test_nxdn_sync_dispatch.c
     ${PROJECT_SOURCE_DIR}/src/engine/dispatch/dispatch_nxdn.c
+    ${PROJECT_SOURCE_DIR}/src/dsp/frame_sync_policy.c
 )
 target_include_directories(
     dsd-neo_test_nxdn_sync_dispatch
-    PRIVATE ${PROJECT_SOURCE_DIR}/include
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/dsp
 )
 add_test(NAME NXDN_SYNC_DISPATCH COMMAND dsd-neo_test_nxdn_sync_dispatch)
 
@@ -7851,7 +7854,7 @@ add_test(NAME DSP_SYNC_HAMMING COMMAND dsd-neo_test_dsp_sync_hamming)
 add_executable(dsd-neo_test_frame_sync_policy dsp/test_frame_sync_policy.c)
 target_include_directories(
     dsd-neo_test_frame_sync_policy
-    PRIVATE ${PROJECT_SOURCE_DIR}/include
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/dsp
 )
 dsd_neo_link_dsp_test(dsd-neo_test_frame_sync_policy ${DSD_NEO_TEST_MATH_LIB})
 add_test(NAME FRAME_SYNC_POLICY COMMAND dsd-neo_test_frame_sync_policy)

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -1440,6 +1440,171 @@ test_a_p25p1_frame_suppresses_m17_candidates(void) {
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, M17_LSF, 8) == DSD_SYNC_M17_LSF_POS);
 }
 
+/* Issue #445. The spans above cover a frame; this covers the gap a hunt step opens. A proof of
+ * 2400/4 says a transmission is running there, and a step onto 4800/4 offers that same signal,
+ * read at twice its rate, to two matchers weak enough to take it. Armed by hand here: what the
+ * arming site records is pinned by test_a_proven_verdict_stamps_the_profile_it_was_read_on(). */
+static void
+arm_2400_4_proof(dsd_state* state, uint32_t at_symbolcnt) {
+    const int hunt_idx = state->sps_hunt_idx;
+    const uint32_t symbolcnt = state->symbolcnt;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state->symbolcnt = at_symbolcnt;
+    dsd_frame_sync_note_profile_proof(state);
+    state->sps_hunt_idx = hunt_idx;
+    state->symbolcnt = symbolcnt;
+}
+
+static void
+test_a_proven_2400_4_transmission_stands_down_the_4800_4_matchers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* NXDN96: refused, and -- as inside a P25p1 frame -- with no claim on lastsynctype. */
+    reset(&opts, &state);
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    arm_2400_4_proof(&state, 1000);
+
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype != DSD_SYNC_NXDN_POS);
+    state.symbolcnt = 1000 + DSD_FRAME_SYNC_PROVEN_2400_4_HOLD_SYMBOLS - 1u;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype != DSD_SYNC_NXDN_POS);
+
+    /* Once the transmission can no longer be running, the matcher is live again on its own
+     * two-hit terms. */
+    state.symbolcnt = 1000 + DSD_FRAME_SYNC_PROVEN_2400_4_HOLD_SYMBOLS;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
+
+    /* M17: the run latches nothing and the word behind it is refused, so no candidate is left
+     * to spend the moment the span lapses. */
+    reset(&opts, &state);
+    opts.frame_nxdn48 = 1;
+    opts.frame_m17 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    arm_2400_4_proof(&state, 1000);
+
+    state.symbolcnt = 1000 + 100;
+    feed_m17_preamble_run(&opts, &state, M17_PRE);
+    assert(state.m17_pre_candidate == 0);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, M17_LSF, 8) == DSD_SYNC_NONE);
+
+    state.symbolcnt = 1000 + DSD_FRAME_SYNC_PROVEN_2400_4_HOLD_SYMBOLS;
+    feed_m17_preamble_run(&opts, &state, M17_PRE);
+    assert(state.m17_pre_candidate != 0);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, M17_LSF, 8) == DSD_SYNC_M17_LSF_POS);
+}
+
+/* Withholding the sync must not withhold the level estimate, for the same reason as inside a
+ * P25p1 frame: the blend is the wideband reference the other protocols on 4800/4 lean on. */
+static void
+test_the_2400_4_proof_suppression_still_blends_levels(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    float fsw_levels[10];
+
+    reset(&opts, &state);
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    opts.msize = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    for (int i = 0; i < 10; i++) {
+        fsw_levels[i] = NXDN_FSW[i] == '3' ? -3.0f : 3.0f;
+    }
+    arm_2400_4_proof(&state, 0);
+    state.symbolcnt = 100;
+    state.max = 9.0f;
+    state.min = -9.0f;
+
+    assert(dsd_frame_sync_test_eval_window(&opts, &state, NXDN_FSW, fsw_levels, 10) == DSD_SYNC_NONE);
+    assert(fabsf(state.max - 6.0f) < 0.0001f);
+    assert(fabsf(state.min - (-6.0f)) < 0.0001f);
+    assert(state.lastsynctype != DSD_SYNC_NXDN_POS);
+}
+
+/* The guard is scoped three ways: to the profile it protects against, to the profile it was
+ * proved on, and to builds carrying a protocol that can prove 2400/4 at all. */
+static void
+test_the_2400_4_proof_suppression_is_scoped_to_its_arming_protocols(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* Neither 2400/4 protocol enabled: nothing could have proved that profile, so a stamp on
+     * it says nothing and NXDN96 syncs as before. */
+    reset(&opts, &state);
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    arm_2400_4_proof(&state, 1000);
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
+
+    /* A proof read on 4800/4 -- P25p1's, say -- is inert here: what this guard acts on is a
+     * transmission proved somewhere the hunt has since stepped away from. */
+    reset(&opts, &state);
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.symbolcnt = 1000;
+    dsd_frame_sync_note_profile_proof(&state);
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
+
+    /* And it never mutes the protocol whose transmission armed it: on 2400/4 itself, NXDN48
+     * syncs throughout on its own terms. */
+    reset(&opts, &state);
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    arm_2400_4_proof(&state, 1000);
+    state.symbolcnt = 1000 + 100;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NXDN_POS);
+}
+
+/* The stamp wraps with symbolcnt and is compared as a modular difference. */
+static void
+test_the_2400_4_proof_suppression_survives_symbolcnt_rollover(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+
+    reset(&opts, &state);
+    opts.frame_nxdn48 = 1;
+    opts.frame_nxdn96 = 1;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.min = -3.0f;
+    state.max = 3.0f;
+    arm_2400_4_proof(&state, UINT32_MAX - 100u);
+
+    state.symbolcnt = 49u;
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype != DSD_SYNC_NXDN_POS);
+
+    state.symbolcnt = (uint32_t)(UINT32_MAX - 100u + DSD_FRAME_SYNC_PROVEN_2400_4_HOLD_SYMBOLS);
+    assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, NXDN_FSW, 10) == DSD_SYNC_NONE);
+    assert(state.lastsynctype == DSD_SYNC_NXDN_POS);
+}
+
 /* A preamble is an alternating symbol run, which any 4800-baud signal can present, so it is
  * latched as a candidate rather than returned as a sync; the sync word that must follow it is
  * what the decoder acts on (#399). */
@@ -2794,6 +2959,10 @@ main(void) {
     test_the_p25p1_frame_suppression_is_scoped_to_its_own_profile();
     test_the_p25p1_frame_guard_survives_symbolcnt_rollover();
     test_a_p25p1_frame_suppresses_m17_candidates();
+    test_a_proven_2400_4_transmission_stands_down_the_4800_4_matchers();
+    test_the_2400_4_proof_suppression_still_blends_levels();
+    test_the_2400_4_proof_suppression_is_scoped_to_its_arming_protocols();
+    test_the_2400_4_proof_suppression_survives_symbolcnt_rollover();
     test_elapsed_seconds_prefers_monotonic_then_wall_time();
     test_p25_slot_activity_honors_ring_and_hangtime();
     test_hamming_helpers_find_best_patterns();

--- a/tests/dsp/test_frame_sync_policy.c
+++ b/tests/dsp/test_frame_sync_policy.c
@@ -9,9 +9,11 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <stddef.h>
+#include <stdint.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "frame_sync_internal.h"
 
 static void
 reset(dsd_opts* opts, dsd_state* state) {
@@ -75,6 +77,52 @@ main(void) {
 
     assert(dsd_frame_sync_sps_hunt_dwell_passes(NULL, &state) == 3);
     assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, NULL) == 3);
+
+    /* #445: while a protocol has recently proved the 2400/4 profile, the weaker matchers a
+     * hunt step onto 4800/4 would offer the same transmission stand down. */
+    reset(&opts, &state);
+    opts.frame_nxdn48 = 1;
+
+    /* A zeroed state is not armed. The stamp cannot say so on its own -- profile index 0 is
+     * 4800/4 and symbol 0 is a real symbol count -- which is what the valid flag is for. */
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, &state) == 0);
+
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state.symbolcnt = 1000U;
+    dsd_frame_sync_note_profile_proof(&state);
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, &state) == 1);
+
+    /* The span covers one full rotation of the hunt and then releases. */
+    state.symbolcnt = 1000U + DSD_FRAME_SYNC_PROVEN_2400_4_HOLD_SYMBOLS - 1U;
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, &state) == 1);
+    state.symbolcnt = 1000U + DSD_FRAME_SYNC_PROVEN_2400_4_HOLD_SYMBOLS;
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, &state) == 0);
+
+    /* A proof read on any other profile is inert: what it vouches for is 2400/4. */
+    state.symbolcnt = 1000U;
+    state.profile_proof_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, &state) == 0);
+    state.profile_proof_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+
+    /* Gated on the protocols that can arm a 2400/4 proof at all, so a build carrying neither
+     * behaves as it did before. Either one alone is enough. */
+    opts.frame_nxdn48 = 0;
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, &state) == 0);
+    opts.frame_dpmr = 1;
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, &state) == 1);
+    opts.frame_nxdn48 = 1;
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, &state) == 1);
+    opts.frame_dpmr = 0;
+
+    /* Modular difference, so the span is exact across the symbol counter's rollover. */
+    state.profile_proof_symbolcnt = UINT32_MAX - 100U;
+    state.symbolcnt = 49U;
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, &state) == 1);
+    state.symbolcnt = (uint32_t)(UINT32_MAX - 100U + DSD_FRAME_SYNC_PROVEN_2400_4_HOLD_SYMBOLS);
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, &state) == 0);
+
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(NULL, &state) == 0);
+    assert(dsd_frame_sync_suppress_4800_4_for_2400_4_transmission(&opts, NULL) == 0);
 
     return 0;
 }

--- a/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
+++ b/tests/dsp/test_frame_sync_sps_hunt_false_sync.c
@@ -497,9 +497,11 @@ test_no_verdict_handlers_still_rotate_at_the_noise_cadence(void) {
 
 /* #391, the other half of the same rule: an unproductive lead does not condemn the
  * transmission behind it. A transmission that starts with frames the protocol cannot yet
- * confirm -- NXDN before its first FACCH, YSF before its first FICH CRC -- and then decodes
- * must hold its profile from the frame it confirms on. This pins the hunt's arithmetic, not
- * the clear: every sync here stamps a verdict of its own, as processFrame() does. */
+ * confirm -- YSF before its first FICH CRC -- and then decodes must hold its profile from
+ * the frame it confirms on. This pins the hunt's arithmetic, not the clear: every sync here
+ * stamps a verdict of its own, as processFrame() does. The protocols that answer a passing
+ * check with PROFILE_PROVEN rather than PRODUCTIVE -- P25p1, dPMR, and NXDN since #445 --
+ * hold their profile the stronger way, pinned by the proven cases below. */
 static void
 test_a_confirming_transmission_holds_its_profile(void) {
     const HuntCase tc = {

--- a/tests/protocol/nxdn/test_nxdn_confirm.c
+++ b/tests/protocol/nxdn/test_nxdn_confirm.c
@@ -40,6 +40,13 @@ run_frame(dsd_state* state, int evidence) {
     nxdn_confirm_end_frame(state);
 }
 
+/** @brief One frame as run_frame(), answering what the SPS hunt reads back from it. */
+static int
+run_frame_proved(dsd_state* state, int evidence) {
+    run_frame(state, evidence);
+    return nxdn_confirm_frame_proved(state);
+}
+
 int
 main(void) {
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
@@ -98,12 +105,28 @@ main(void) {
     nxdn_confirm_end_frame(state);
     expect("strong evidence overrides a pending streak", nxdn_confirm_is_confirmed(state), 1);
 
+    /* What the SPS hunt reads back: which frames carried a passing CRC of their own, as
+     * opposed to which transmissions have been confirmed at some point. Only the former
+     * proves the profile the frame was read on (#445), so the two answers have to come
+     * apart on a confirmed transmission's empty frames. */
+    nxdn_confirm_reset(state);
+    expect("a fresh frame has proved nothing", nxdn_confirm_frame_proved(state), 0);
+    expect("one weak frame has not proved the profile", run_frame_proved(state, NXDN_EVIDENCE_WEAK), 0);
+    expect("the frame completing a weak streak proves it", run_frame_proved(state, NXDN_EVIDENCE_WEAK), 1);
+    expect("a confirmed transmission's empty frame proves nothing", run_frame_proved(state, 0), 0);
+    expect("a later weak frame proves it again", run_frame_proved(state, NXDN_EVIDENCE_WEAK), 1);
+
+    nxdn_confirm_reset(state);
+    expect("one strong frame proves the profile", run_frame_proved(state, NXDN_EVIDENCE_STRONG), 1);
+    expect("the frame after it proves nothing", run_frame_proved(state, 0), 0);
+
     /* NULL is tolerated: the gate is called from paths that run before state exists. */
     nxdn_confirm_reset(NULL);
     nxdn_confirm_begin_frame(NULL);
     nxdn_confirm_note_evidence(NULL, NXDN_EVIDENCE_STRONG);
     nxdn_confirm_end_frame(NULL);
     expect("null state is not confirmed", nxdn_confirm_is_confirmed(NULL), 0);
+    expect("null state has proved nothing", nxdn_confirm_frame_proved(NULL), 0);
 
     free(state);
     if (g_failures == 0) {

--- a/tests/protocol/nxdn/test_nxdn_frame_routing.c
+++ b/tests/protocol/nxdn/test_nxdn_frame_routing.c
@@ -461,6 +461,20 @@ test_public_frame_entry_lich_collection(void) {
     rc |= expect_int("frame parity rejects sync", g_state.lastsynctype, DSD_SYNC_NONE);
     rc |= expect_int("frame parity clears carrier", g_state.carrier, 0);
 
+    /* A frame rejected at the LICH never opens a frame of its own, so the per-frame evidence
+     * it would be graded on is still whatever the last frame to reach the body left behind.
+     * It must not be able to answer 2 off that: the caller reads the 2 as proof of the profile,
+     * and a run of these would go on proving one that nothing is decoding on (#445). */
+    reset_state();
+    g_state.carrier = 1;
+    g_state.synctype = DSD_SYNC_NXDN_POS;
+    g_state.lastsynctype = DSD_SYNC_NXDN_POS;
+    g_state.nxdn_confirmed = 1;
+    g_state.nxdn_confirm_frame_evidence = 2;
+    prepare_frame_stream(0x01U, 1);
+    rc |= expect_int("frame parity cannot prove the profile", nxdn_frame(&g_opts, &g_state), 1);
+    rc |= expect_int("frame parity still consumed lich only", (int)g_dibit_stream_pos, 8);
+
     return rc;
 }
 

--- a/tests/protocol/nxdn/test_nxdn_sync_dispatch.c
+++ b/tests/protocol/nxdn/test_nxdn_sync_dispatch.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/protocol_dispatch.h>
 #include <dsd-neo/protocol/nxdn/nxdn.h>
 #include <stdio.h>
@@ -21,7 +22,8 @@ dsd_frame_verdict dsd_dispatch_handle_nxdn(dsd_opts* opts, dsd_state* state);
 
 static int frame_calls;
 
-/* The stubbed CRC confirmation dsd_dispatch_handle_nxdn() must pass through. */
+/* The stubbed nxdn_frame() answer dsd_dispatch_handle_nxdn() must act on: 0 unconfirmed,
+ * 1 confirmed, 2 confirmed by a CRC this frame carried itself. */
 static int frame_confirmed = 1;
 
 int
@@ -94,12 +96,67 @@ test_unconfirmed_frame_reports_unproductive(void) {
     frame_confirmed = 1;
 }
 
+/* #445: a frame that passes a CRC of its own records the profile it was read on, so the weaker
+ * matchers waiting on 4800/4 can tell that a 2400-baud transmission was live a moment ago. The
+ * verdict is deliberately not changed by it -- reporting PROFILE_PROVEN measured worse, see
+ * dispatch_nxdn.c -- so recording the proof and acting on it stay separate. */
+static void
+test_dispatch_records_the_profile_a_crc_passed_on(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.synctype = DSD_SYNC_NXDN_POS;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+
+    /* A frame carrying its own CRC stamps the profile, and still reports the verdict it always
+     * did: the hunt's dwell accounting is untouched by this. */
+    frame_confirmed = 2;
+    state.symbolcnt = 1000U;
+    assert(dsd_dispatch_handle_nxdn(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
+    assert(state.profile_proof_valid == 1);
+    assert(state.profile_proof_idx == DSD_FRAME_SYNC_SPS_PROFILE_2400_4);
+    assert(state.profile_proof_symbolcnt == 1000U);
+
+    /* A confirmed frame that carried no CRC of its own leaves the stamp alone, so a run of them
+     * cannot hold the guard open on a transmission that has stopped proving. */
+    frame_confirmed = 1;
+    state.symbolcnt = 1192U;
+    assert(dsd_dispatch_handle_nxdn(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
+    assert(state.profile_proof_symbolcnt == 1000U);
+
+    /* So does an unconfirmed one, which is what the noise between transmissions produces. */
+    frame_confirmed = 0;
+    state.symbolcnt = 1384U;
+    assert(dsd_dispatch_handle_nxdn(&opts, &state) == DSD_FRAME_VERDICT_UNPRODUCTIVE);
+    assert(state.profile_proof_symbolcnt == 1000U);
+
+    /* The next real pass moves it, wherever the hunt has got to by then. */
+    frame_confirmed = 2;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    state.symbolcnt = 5000U;
+    assert(dsd_dispatch_handle_nxdn(&opts, &state) == DSD_FRAME_VERDICT_PRODUCTIVE);
+    assert(state.profile_proof_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state.profile_proof_symbolcnt == 5000U);
+
+    /* A zeroed state records nothing, which is what the valid flag is for: index 0 is a real
+     * profile and symbol 0 a real count. */
+    DSD_MEMSET(&state, 0, sizeof(state));
+    state.synctype = DSD_SYNC_NXDN_POS;
+    frame_confirmed = 0;
+    assert(dsd_dispatch_handle_nxdn(&opts, &state) == DSD_FRAME_VERDICT_UNPRODUCTIVE);
+    assert(state.profile_proof_valid == 0);
+
+    frame_confirmed = 1;
+}
+
 int
 main(void) {
     test_sync_pattern_lengths();
     test_synctype_helpers();
     test_dispatch_calls_frame();
     test_unconfirmed_frame_reports_unproductive();
+    test_dispatch_records_the_profile_a_crc_passed_on();
     printf("NXDN_SYNC_DISPATCH: OK\n");
     return 0;
 }


### PR DESCRIPTION
Fixes #445.

## The defect

Under `-fa` the SPS hunt rotates off `2400_4` while an NXDN48 call is still on air. When the round-robin reaches `4800_4`, the NXDN96 and M17 matchers there are offered the same 2400-baud signal read at twice its rate, and take it — printing M17 BERT/LSF frames whose content is noise, and an NXDN96 line reading `RDCH Voice RAN 21`.

## Approach

The two existing span guards (#374, #388) each cover *one frame* another protocol is mid-way through, which is no help across a profile change. This one covers the *transmission*: a handler that passes its own content check records which profile it passed on, and while that record is recent enough that the transmission could still be running, the NXDN96 and M17 matchers stand down on `4800_4`.

- **Span**: one full hunt rotation from the last proof (`5 profiles × 3 passes × 1800 symbols`) — long enough to still be standing through the whole of the first `4800_4` dwell it reaches, short enough that an ended transmission frees the profile within a few seconds.
- **Arming**: only a frame that *passed a check* records a proof, so the noise syncs between transmissions cannot hold the guard open. `nxdn_frame()` now separates "this frame carried a CRC" from the sticky per-transmission confirmation it already reported; a frame rejected before its body is read cannot claim the former. dPMR's CCH CRC-7 arms the same guard — it is the other `2400_4` tenant and faces the same claimants.
- **Refusal sites** are the three #388 already uses, for its reasons: M17 stands down completely and drops any latched preamble candidate; the NXDN window keeps contributing its level blend and is refused only the sync; the GFSK vote goes neutral so the false window cannot walk the demodulator off the chain that is decoding.

A real NXDN96 or M17 signal cannot arm this against itself — neither proves the `2400_4` profile.

## Measurements

Ten rotated replays per build via `tools/replay_ab.sh` on the 35 s four-channel capture from #373 (paired, order-rotated; a single replay cannot see effects this size — the same build scores 57–94 NXDN48 syncs run to run under `-fa`):

| metric | main | this PR | paired Δ | |
|---|---:|---:|---:|---|
| M17 accepts after first proof | 11.7 | 8.3 | **−3.4** | 10/10 runs better |
| NXDN96 accepts after first proof | 1.4 | 1.0 | −0.4 | 4 better, 0 worse |
| NXDN48 syncs | 73.7 | 75.6 | +1.9 | 8/10 better |
| Voice calls | 10.7 | 11.6 | +0.9 | 7 better, 0 worse |
| Hunt steps | 19.7 | 19.4 | ~0 | unchanged |

The accepts *before* a transmission's first proof are untouched, as in #388 — an evidence-based guard cannot cover its own bootstrap, and on this capture most M17 hits arrive in the very first `4800_4` dwell, before the hunt has ever reached `2400_4`.

## What is deliberately not done

The obvious root-cause fix — letting a passing NXDN CRC report `DSD_FRAME_VERDICT_PROFILE_PROVEN` so a live call holds its rate against rotation, as dPMR and P25p1 do — was implemented and **measured worse**. Restarting the dwell keeps `sps_hunt_counter` away from the budget exit in `getFrameSync()`, and that exit is what runs the no-sync hooks that end a call and clear the state the next one is assembled from. Ten rotated replays: 66 NXDN48 syncs / 9 voice calls against 75 / 11 without it, **every paired repeat worse**. Recording a proof and acting on it are separable; only the recording earns its place here, so the hunt's accounting is left byte-for-byte as it was.

Two side findings recorded in the issue thread: the vocoder-reaching accept #445 describes is already blocked by #398's confirmation gate (the `Voice`/`RAN 21` text is an ungated banner over retained display state), and `-fa` on this capture is not run-stable, contrary to the issue's note.

## Tests

- `FRAME_SYNC_INTERNAL_HELPERS` — the span holds and releases, scoping to the arming protocols and to the profile proved, the level blend surviving a withheld sync, M17 candidate teardown, `symbolcnt` wrap.
- `FRAME_SYNC_POLICY` — predicate truth table, both span boundaries, NULL and zeroed-state rows, rollover.
- `NXDN_SYNC_DISPATCH` / `NXDN_CONFIRM` / `NXDN_FRAME_ROUTING` — per-frame recording, and that a LICH-rejected frame cannot claim a proof off the previous frame's evidence.
- No `-fa` replay case: the `nxdn48` fixture is about one hunt rotation, which `docs/testing.md` records as exactly the schedule-dependent regime such assertions must stay out of, and the hunt's behaviour did not change. Reasoning recorded in `docs/testing.md`.

Full suite (587 tests), `tools/preflight_ci.sh`, and three `iq-decode` runs each on `asan-ubsan-debug` and `tsan-debug` are clean.