### PR TITLE
fix(dsp): pay off the matched filter's delay when it switches on (#444)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -784,9 +784,9 @@ Debug (verbose/developer)
 ### Symbol timing (`DSD_NEO_DEBUG_SYMBOL_TIMING`)
 
 The decoder's sampling phase is fixed when a sync is acquired and held for the rest of the call, so a call decoded
-at a poor phase stays at that phase. The matched filter switching on at that same accept no longer moves the phase
-with it (#444), so `off` describes the grid rather than the switch. Level `1` prints one line per accepted frame
-sync:
+at a poor phase stays at that phase. The matched filter switching on at that accept, or off at the end of the
+call, no longer moves the phase with it (#444), so `off` describes the grid rather than the switch. Level `1`
+prints one line per accepted frame sync:
 
 ```text
 SYMTIMING: sync=29 win=13113313 sps=20 jitter=-1 off=0 accum=0

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -784,7 +784,9 @@ Debug (verbose/developer)
 ### Symbol timing (`DSD_NEO_DEBUG_SYMBOL_TIMING`)
 
 The decoder's sampling phase is fixed when a sync is acquired and held for the rest of the call, so a call decoded
-at a poor phase stays at that phase. Level `1` prints one line per accepted frame sync:
+at a poor phase stays at that phase. The matched filter switching on at that same accept no longer moves the phase
+with it (#444), so `off` describes the grid rather than the switch. Level `1` prints one line per accepted frame
+sync:
 
 ```text
 SYMTIMING: sync=29 win=13113313 sps=20 jitter=-1 off=0 accum=0

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -225,6 +225,13 @@ installs from `src/engine/trunk_tuning.c` in `src/engine/trunk_tuning_hooks_inst
 - `symbol_timing_debug.c`: measures the sub-symbol offset the decoder's symbol grid settled on and reports it once
   per accepted frame sync, behind `DSD_NEO_DEBUG_SYMBOL_TIMING` (see `docs/cli.md`). The sample trace it correlates
   over is filled by `dsd_symbol.c` and owned by decoder-state setup/teardown in `src/core/util/dsd_init.c`.
+- `dsd_filters.c` owns the per-protocol matched filters, selected by kind rather than by calling one of four
+  wrappers, because the symbol grid has to know when the stream it samples changes identity. It reads the raw
+  discriminator until a sync names a protocol and the filter's output afterwards, and that output describes the
+  signal one group delay in the past — 67 samples for NXDN48 at 20 samples per symbol. `dsd_symbol.c` therefore
+  primes the filter from the raw history it missed and consumes that delay once at the switch, so the grid neither
+  re-reads content it has already consumed nor sees a half-window transient (#444). `MATCHED_FILTER_SEAM` pins the
+  geometry that makes the delay knowable and the alignment that follows from paying it.
 - `dsd_symbol.c` owns the open-loop FSK symbol grid. Only the inter-frame sync search moves it, by a whole sample at
   a time, on the first zero crossing latched in the previous symbol — a bang-bang loop on one unfiltered sample
   index, and between frames the only thing tracking the sampling instant across a call. Issue #444 documents how

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -228,10 +228,16 @@ installs from `src/engine/trunk_tuning.c` in `src/engine/trunk_tuning_hooks_inst
 - `dsd_filters.c` owns the per-protocol matched filters, selected by kind rather than by calling one of four
   wrappers, because the symbol grid has to know when the stream it samples changes identity. It reads the raw
   discriminator until a sync names a protocol and the filter's output afterwards, and that output describes the
-  signal one group delay in the past — 67 samples for NXDN48 at 20 samples per symbol. `dsd_symbol.c` therefore
-  primes the filter from the raw history it missed and consumes that delay once at the switch, so the grid neither
-  re-reads content it has already consumed nor sees a half-window transient (#444). `MATCHED_FILTER_SEAM` pins the
-  geometry that makes the delay knowable and the alignment that follows from paying it.
+  signal one group delay in the past — 67 samples for NXDN48 at 20 samples per symbol. What the filter module
+  promises the symbolizer is small: the delay, stated without disturbing a running filter, and a way to push
+  history into a filter without reading an output. `MATCHED_FILTER_SEAM` pins that promise.
+- `dsd_symbol.c` pays for every switch so the grid does not move. It keeps the raw samples it has consumed
+  (`dsd_state::matched_filter`, see `core/state.h`); a filter switching on is primed from that history and fed its
+  delay's worth of samples whose outputs are discarded, one switching off hands back the samples it still had in
+  flight, which the grid re-reads before live input resumes, and between two filters only the difference in delay
+  is owed. Without that the switch-on rewound the grid by a third of a symbol on NXDN48 and half a symbol on
+  P25p1 roughly once per frame, and the switch-off skipped the same (#444). `SYMBOL_MATCHED_FILTER_SEAM` drives
+  `getSymbol()` across each kind of switch and checks the content position never moves.
 - `dsd_symbol.c` owns the open-loop FSK symbol grid. Only the inter-frame sync search moves it, by a whole sample at
   a time, on the first zero crossing latched in the previous symbol — a bang-bang loop on one unfiltered sample
   index, and between frames the only thing tracking the sampling instant across a call. Issue #444 documents how

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -328,11 +328,26 @@ Reading it:
 - Keep the machine otherwise idle: `--rate realtime` is wall-clock paced, so a
   build competing with a compile is measured under different conditions.
 
-- **A change can improve quality and decode fewer frames at once.** Paying off
-  the matched filter's group delay took errors per voice frame from 3.59 to 2.79
-  on `fiNXDN` (12 repeats, 12/12) while decoding about five fewer voice frames a
-  run. Total errors fell 27% against 6% fewer frames, so the per-frame gain is
-  real rather than an artefact of decoding less; report both numbers and say so.
+- **When the frame count moves, match payloads before calling it quality.**
+  Paying off the matched filter's group delay at every switch took errors per
+  voice frame from 3.63 to 2.34 on `fiNXDN` (12 repeats, 12/12), with total
+  errors down 41% and 9% fewer voice frames a run. That ratio alone does not say
+  which frames changed. Matching the AMBE payloads in `-Z` logs of the two
+  builds did: every subframe both builds decoded carried the same errors, and
+  the errors that went away sat in frames only `main` produced -- the first
+  frame after each switch-on, read from rewound samples, at four errors per
+  subframe against under one for the rest. The frame count fell because those
+  frames were never real decodes. Report both numbers, and say where the
+  difference sits. The same run is the one quoted in PR #454, so the two do not
+  drift apart.
+
+- **A unit test cannot see a call-order bug in its caller.** The first cut of
+  that seam recorded the sample in hand before priming from the history and then
+  fed it again, so every switch-on read one sample twice for a window; the
+  filter test passed because it primed in the right order itself. The property
+  has to be checked where the order is decided, which is why
+  `SYMBOL_MATCHED_FILTER_SEAM` drives `getSymbol()` rather than the filter
+  module.
 
 Issue #444 is the worked example, and the comment above `symbol_adjust_timing_nxdn()`
 in `src/dsp/dsd_symbol.c` records what it ruled out. A closed timing loop was

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -328,8 +328,19 @@ Reading it:
 - Keep the machine otherwise idle: `--rate realtime` is wall-clock paced, so a
   build competing with a compile is measured under different conditions.
 
+- **A change can improve quality and decode fewer frames at once.** Paying off
+  the matched filter's group delay took errors per voice frame from 3.59 to 2.79
+  on `fiNXDN` (12 repeats, 12/12) while decoding about five fewer voice frames a
+  run. Total errors fell 27% against 6% fewer frames, so the per-frame gain is
+  real rather than an artefact of decoding less; report both numbers and say so.
+
 Issue #444 is the worked example, and the comment above `symbol_adjust_timing_nxdn()`
-in `src/dsp/dsd_symbol.c` records what it ruled out.
+in `src/dsp/dsd_symbol.c` records what it ruled out. A closed timing loop was
+built and measured against that slip as part of the same issue and is not in the
+tree: on `fiNXDN` it was worth about 0.18 errors per voice frame, but the anchor
+it measures its phase against had to differ per protocol to work at all -- the
+window centroid for NXDN48, the span edge for DMR, each breaking the other -- so
+it replaced one fragile constant with two.
 
 ## Regression Test Requirement
 

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -1537,6 +1537,16 @@ struct dsd_state {
      *  See dsp/symbol_timing_debug.h. */
     dsd_symbol_timing_trace timing_trace;
 
+    /** Which matched filter the symbol grid is currently reading through, and at
+     *  which samples-per-symbol, as a `dsd_sps_filter_kind`. The grid runs
+     *  unfiltered until a sync names a protocol, so this changing marks a
+     *  discontinuity in the stream the grid is sampling: the filter's group
+     *  delay has to be paid off once or the decoder re-reads content it has
+     *  already consumed (issue #444). Zero is "unfiltered", which is also the
+     *  state a cleared `lastsynctype` puts the grid back into. */
+    int matched_filter_kind;
+    int matched_filter_sps;
+
     // Advisory-only input level health for ncurses/status snapshots.
     dsd_input_level_snapshot input_level;
     time_t input_level_last_toast_time;

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -1546,6 +1546,7 @@ struct dsd_state {
      *  state a cleared `lastsynctype` puts the grid back into. */
     int matched_filter_kind;
     int matched_filter_sps;
+    int matched_filter_delay;
 
     // Advisory-only input level health for ncurses/status snapshots.
     dsd_input_level_snapshot input_level;

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -245,6 +245,36 @@ typedef struct {
     int span_count;
 } dsd_symbol_timing_trace;
 
+/** Raw samples the symbol grid keeps behind it: enough to prime the longest
+ *  matched filter (DSD_SPS_FILTER_MAX_TAPS) after a switch-off has handed back
+ *  the samples the previous filter still had in flight. */
+#define DSD_MATCHED_FILTER_HISTORY 2048
+
+/**
+ * The matched filter the symbol grid is reading through, and what it takes to
+ * change it without moving the grid (issue #444).
+ *
+ * The grid reads the raw discriminator until a sync names a protocol and the
+ * filter's output afterwards, which describes the signal one group delay in the
+ * past. A change of `kind` or `sps` is therefore a discontinuity in the content
+ * the grid samples, and `src/dsp/dsd_symbol.c` pays for it here: a filter
+ * switching on is primed from `raw` and fed its delay's worth of samples whose
+ * outputs are discarded; one switching off hands back the samples it still had
+ * in flight, which the grid re-reads from `raw` (`replay` of them) before live
+ * input resumes. Zeroed by initState() and again by
+ * dsd_symbol_matched_filter_reset() alongside init_rrc_filter_memory(), since a
+ * cleared filter with this saying it is primed would be the transient all over.
+ */
+typedef struct {
+    int kind;  /**< A dsd_sps_filter_kind; an int because core does not see dsp headers. 0 is unfiltered. */
+    int sps;   /**< Samples per symbol `kind` was designed for. */
+    int delay; /**< Group delay of `kind` at `sps`, in samples; 0 when unfiltered. */
+    float raw[DSD_MATCHED_FILTER_HISTORY]; /**< Raw samples the grid consumed, newest last; a ring. */
+    int raw_head;                          /**< Next write index into `raw`. */
+    int raw_count;                         /**< Samples held, saturating at the ring size. */
+    int replay;                            /**< Samples still to be re-read from `raw` before live input. */
+} dsd_matched_filter_seam;
+
 typedef struct {
     uint8_t F1;
     uint8_t F2;
@@ -1537,16 +1567,9 @@ struct dsd_state {
      *  See dsp/symbol_timing_debug.h. */
     dsd_symbol_timing_trace timing_trace;
 
-    /** Which matched filter the symbol grid is currently reading through, and at
-     *  which samples-per-symbol, as a `dsd_sps_filter_kind`. The grid runs
-     *  unfiltered until a sync names a protocol, so this changing marks a
-     *  discontinuity in the stream the grid is sampling: the filter's group
-     *  delay has to be paid off once or the decoder re-reads content it has
-     *  already consumed (issue #444). Zero is "unfiltered", which is also the
-     *  state a cleared `lastsynctype` puts the grid back into. */
-    int matched_filter_kind;
-    int matched_filter_sps;
-    int matched_filter_delay;
+    /** The matched filter the symbol grid reads through and the raw history a
+     *  switch is paid from; see dsd_matched_filter_seam. */
+    dsd_matched_filter_seam matched_filter;
 
     // Advisory-only input level health for ncurses/status snapshots.
     dsd_input_level_snapshot input_level;

--- a/include/dsd-neo/dsp/sps_filters.h
+++ b/include/dsd-neo/dsp/sps_filters.h
@@ -15,11 +15,87 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Which per-protocol matched filter a sample is being shaped by.
+ *
+ * `DSD_SPS_FILTER_NONE` is the unfiltered stream the sync search runs on before
+ * a protocol is known, and is what makes the switch to a filter a discontinuity
+ * the symbol grid has to be told about.
+ */
+typedef enum {
+    DSD_SPS_FILTER_NONE = 0,
+    DSD_SPS_FILTER_DMR,
+    DSD_SPS_FILTER_P25,
+    DSD_SPS_FILTER_NXDN,
+    DSD_SPS_FILTER_DPMR,
+} dsd_sps_filter_kind;
+
+/** Largest history any of these filters keeps, and so the most a prime can use. */
+#define DSD_SPS_FILTER_MAX_TAPS 1024
+
 float dmr_filter(float sample, int samples_per_symbol);
 float nxdn_filter(float sample, int samples_per_symbol);
 float dpmr_filter(float sample, int samples_per_symbol);
 float p25_filter(float sample, int samples_per_symbol);
 void init_rrc_filter_memory(void);
+
+/**
+ * @brief Filter one sample through @p kind, or return it unchanged for NONE.
+ */
+float dsd_sps_filter_apply(dsd_sps_filter_kind kind, float sample, int samples_per_symbol);
+
+/**
+ * @brief Tap count @p kind uses at @p samples_per_symbol, designing it if needed.
+ * @return Taps, or 0 when the filter cannot be designed for that rate.
+ */
+int dsd_sps_filter_taps_len(dsd_sps_filter_kind kind, int samples_per_symbol);
+
+/**
+ * @brief Group delay of @p kind at @p samples_per_symbol, in samples.
+ *
+ * The taps are symmetric and odd-length, so this is exactly `(taps - 1) / 2`:
+ * the filter's output when sample n has just been fed describes the signal at
+ * n - delay.
+ *
+ * @return Delay in samples, or 0 when the filter is inactive at that rate.
+ */
+int dsd_sps_filter_group_delay(dsd_sps_filter_kind kind, int samples_per_symbol);
+
+/**
+ * @brief Push @p count samples through @p kind's history, discarding the output.
+ *
+ * Used to hand a filter the samples that ran past while it was switched off, so
+ * its first real output is computed from signal rather than from whatever the
+ * previous transmission left behind.
+ */
+void dsd_sps_filter_prime(dsd_sps_filter_kind kind, const float* samples, int count, int samples_per_symbol);
+
+/**
+ * @brief Record one raw, unfiltered sample the symbol grid has consumed.
+ *
+ * Kept so a filter switching on mid-stream can be primed with the history it
+ * missed. Cheap enough to call per sample.
+ */
+void dsd_sps_filter_note_raw(float sample);
+
+/** @brief Drop the recorded raw history, e.g. across a stream discontinuity. */
+void dsd_sps_filter_forget_raw(void);
+
+/**
+ * @brief Prime @p kind from the recorded raw history and report its delay.
+ *
+ * The caller must then push @p delay further samples through the filter and
+ * discard the outputs: those describe positions the grid has already read.
+ *
+ * @return The filter's group delay in samples, or 0 when it is inactive.
+ */
+int dsd_sps_filter_prime_from_history(dsd_sps_filter_kind kind, int samples_per_symbol);
+
+/**
+ * @brief Copy @p kind's designed taps at @p samples_per_symbol into @p out.
+ * @return Taps written, or 0 when they do not fit or the filter is inactive.
+ */
+int dsd_sps_filter_copy_taps(dsd_sps_filter_kind kind, int samples_per_symbol, float* out, int cap);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/dsp/sps_filters.h
+++ b/include/dsd-neo/dsp/sps_filters.h
@@ -45,57 +45,28 @@ void init_rrc_filter_memory(void);
 float dsd_sps_filter_apply(dsd_sps_filter_kind kind, float sample, int samples_per_symbol);
 
 /**
- * @brief Tap count @p kind uses at @p samples_per_symbol, designing it if needed.
- * @return Taps, or 0 when the filter cannot be designed for that rate.
- */
-int dsd_sps_filter_taps_len(dsd_sps_filter_kind kind, int samples_per_symbol);
-
-/**
  * @brief Group delay of @p kind at @p samples_per_symbol, in samples.
  *
- * The taps are symmetric and odd-length, so this is exactly `(taps - 1) / 2`:
+ * The taps are symmetric and odd in length, so this is exactly `(taps - 1) / 2`:
  * the filter's output when sample n has just been fed describes the signal at
- * n - delay.
+ * n - delay. A query only: it neither designs nor disturbs a running filter, so
+ * the symbolizer can ask about the filter it is switching to while the one it
+ * is leaving still runs.
  *
  * @return Delay in samples, or 0 when the filter is inactive at that rate.
  */
 int dsd_sps_filter_group_delay(dsd_sps_filter_kind kind, int samples_per_symbol);
 
 /**
- * @brief Push @p count samples through @p kind's history, discarding the output.
+ * @brief Push one sample into @p kind's history without computing an output.
  *
- * Used to hand a filter the samples that ran past while it was switched off, so
- * its first real output is computed from signal rather than from whatever the
- * previous transmission left behind.
+ * How a filter switching on mid-stream is handed the samples that ran past
+ * while it was off, oldest first, so its first real output is computed from
+ * signal rather than from whatever the previous transmission left behind.
+ * Designs the filter for @p samples_per_symbol if it is not already; a no-op
+ * for NONE.
  */
-void dsd_sps_filter_prime(dsd_sps_filter_kind kind, const float* samples, int count, int samples_per_symbol);
-
-/**
- * @brief Record one raw, unfiltered sample the symbol grid has consumed.
- *
- * Kept so a filter switching on mid-stream can be primed with the history it
- * missed. Cheap enough to call per sample.
- */
-void dsd_sps_filter_note_raw(float sample);
-
-/** @brief Drop the recorded raw history, e.g. across a stream discontinuity. */
-void dsd_sps_filter_forget_raw(void);
-
-/**
- * @brief Prime @p kind from the recorded raw history and report its delay.
- *
- * The caller must then push @p delay further samples through the filter and
- * discard the outputs: those describe positions the grid has already read.
- *
- * @return The filter's group delay in samples, or 0 when it is inactive.
- */
-int dsd_sps_filter_prime_from_history(dsd_sps_filter_kind kind, int samples_per_symbol);
-
-/**
- * @brief Copy @p kind's designed taps at @p samples_per_symbol into @p out.
- * @return Taps written, or 0 when they do not fit or the filter is inactive.
- */
-int dsd_sps_filter_copy_taps(dsd_sps_filter_kind kind, int samples_per_symbol, float* out, int cap);
+void dsd_sps_filter_prime(dsd_sps_filter_kind kind, float sample, int samples_per_symbol);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/dsp/symbol.h
+++ b/include/dsd-neo/dsp/symbol.h
@@ -22,6 +22,15 @@ extern "C" {
 
 float getSymbol(dsd_opts* opts, dsd_state* state, int have_sync);
 
+/**
+ * @brief Forget which matched filter the symbol grid was reading through.
+ *
+ * Pairs with init_rrc_filter_memory(): a cleared filter that the grid still
+ * believes it has primed would run from an empty history at the next sample,
+ * which is the transient the seam exists to prevent (issue #444).
+ */
+void dsd_symbol_matched_filter_reset(dsd_state* state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -460,6 +460,9 @@ init_state_core_buffers(dsd_state* state) {
     state->timing_trace.span_head = 0;
     state->timing_trace.span_count = 0;
 
+    // The matched filter the symbol grid reads through starts as "none", with no history behind it.
+    DSD_MEMSET(&state->matched_filter, 0, sizeof(state->matched_filter));
+
     state->repeat = 0;
 
     // RTL-SDR stream context (initialized to NULL; lifecycle managed by caller)
@@ -1284,6 +1287,9 @@ freeState(dsd_state* state) {
     state->timing_trace.sample_count = 0;
     state->timing_trace.span_head = 0;
     state->timing_trace.span_count = 0;
+
+    // The matched filter the symbol grid reads through starts as "none", with no history behind it.
+    DSD_MEMSET(&state->matched_filter, 0, sizeof(state->matched_filter));
 
     dsd_aligned_free(state->dibit_buf);
     state->dibit_buf = NULL;

--- a/src/dsp/dsd_filters.c
+++ b/src/dsp/dsd_filters.c
@@ -357,48 +357,22 @@ p25_filter(float sample, int samples_per_symbol) {
     return apply_sps_fir(&g_fir_p25, sample, samples_per_symbol);
 }
 
-/*
- * Raw samples the symbolizer has already consumed, newest last. A filter that
- * switches on mid-stream is handed these so its first output is computed from
- * signal rather than from the previous transmission's tail.
- */
-static float g_raw_hist[DSD_SPS_FILTER_MAX_TAPS];
-static int g_raw_head;  /* next write index */
-static int g_raw_count; /* samples held, saturating at the ring size */
-
 void
 init_rrc_filter_memory(void) {
     reset_sps_fir(&g_fir_p25);
     reset_sps_fir(&g_fir_dmr);
     reset_sps_fir(&g_fir_nxdn);
     reset_sps_fir(&g_fir_dpmr);
-    dsd_sps_filter_forget_raw();
-}
-
-void
-dsd_sps_filter_note_raw(float sample) {
-    g_raw_hist[g_raw_head] = sample;
-    g_raw_head = (g_raw_head + 1) % DSD_SPS_FILTER_MAX_TAPS;
-    if (g_raw_count < DSD_SPS_FILTER_MAX_TAPS) {
-        g_raw_count++;
-    }
-}
-
-void
-dsd_sps_filter_forget_raw(void) {
-    DSD_MEMSET(g_raw_hist, 0, sizeof(g_raw_hist));
-    g_raw_head = 0;
-    g_raw_count = 0;
 }
 
 /*
  * The symbol grid runs on the unfiltered stream until a sync names a protocol,
  * and on the filtered one afterwards. Those two streams are not the same signal:
- * a symmetric FIR of L taps reports the signal L/2 samples in the past, so the
- * moment the filter switches on the decoder starts re-reading content it has
- * already consumed. The helpers below let the symbolizer hand the filter the
- * history it missed and then pay off that delay once, so the switch costs
- * neither a transient nor a rewind (issue #444).
+ * a symmetric FIR of L taps reports the signal (L-1)/2 samples in the past, so
+ * the moment the filter switches on the decoder would start re-reading content
+ * it has already consumed. The symbolizer pays that off at the switch (issue
+ * #444); what it needs from here is the delay, stated without disturbing a
+ * running filter, and a way to hand a filter the history it missed.
  */
 static sps_fir*
 sps_fir_for_kind(dsd_sps_filter_kind kind) {
@@ -412,17 +386,9 @@ sps_fir_for_kind(dsd_sps_filter_kind kind) {
     }
 }
 
-/* Design on demand so callers can ask about geometry before any sample flows. */
-static sps_fir*
-sps_fir_ready_for(dsd_sps_filter_kind kind, int samples_per_symbol) {
-    sps_fir* f = sps_fir_for_kind(kind);
-    if (!f || samples_per_symbol <= 1) {
-        return NULL;
-    }
-    if (!f->ready || samples_per_symbol != f->last_sps) {
-        design_sps_fir(f, samples_per_symbol);
-    }
-    return (f->ready && f->taps_len > 0) ? f : NULL;
+static int
+sps_fir_can_design(const sps_fir* f, int samples_per_symbol) {
+    return f && f->base && f->base_len > 0 && f->base_sps > 0 && samples_per_symbol > 1;
 }
 
 float
@@ -435,73 +401,33 @@ dsd_sps_filter_apply(dsd_sps_filter_kind kind, float sample, int samples_per_sym
 }
 
 int
-dsd_sps_filter_taps_len(dsd_sps_filter_kind kind, int samples_per_symbol) {
-    const sps_fir* f = sps_fir_ready_for(kind, samples_per_symbol);
-    return f ? f->taps_len : 0;
-}
-
-int
 dsd_sps_filter_group_delay(dsd_sps_filter_kind kind, int samples_per_symbol) {
-    const int taps_len = dsd_sps_filter_taps_len(kind, samples_per_symbol);
+    const sps_fir* f = sps_fir_for_kind(kind);
+    if (!sps_fir_can_design(f, samples_per_symbol)) {
+        return 0;
+    }
+    /* The same arithmetic the design uses, so the answer matches what apply()
+       will run, without designing: that would clear a filter still in use. */
+    const int taps_len = sps_fir_compute_taps_len(f, samples_per_symbol);
     return taps_len > 0 ? (taps_len - 1) / 2 : 0;
 }
 
-/* One sample into the history, without computing an output. */
-static inline void
-sps_fir_push_history(sps_fir* f, float sample) {
+void
+dsd_sps_filter_prime(dsd_sps_filter_kind kind, float sample, int samples_per_symbol) {
+    sps_fir* f = sps_fir_for_kind(kind);
+    if (!sps_fir_can_design(f, samples_per_symbol)) {
+        return;
+    }
+    if (!f->ready || samples_per_symbol != f->last_sps) {
+        design_sps_fir(f, samples_per_symbol);
+    }
+    if (!f->ready || f->taps_len <= 0) {
+        return;
+    }
     int head = f->head + 1;
     if (head >= f->taps_len) {
         head = 0;
     }
     f->hist[head] = sample;
     f->head = head;
-}
-
-void
-dsd_sps_filter_prime(dsd_sps_filter_kind kind, const float* samples, int count, int samples_per_symbol) {
-    sps_fir* f = sps_fir_ready_for(kind, samples_per_symbol);
-    if (!f || !samples || count <= 0) {
-        return;
-    }
-    /* Only the newest taps_len samples can still be in the window. */
-    int start = 0;
-    if (count > f->taps_len) {
-        start = count - f->taps_len;
-    }
-    for (int n = start; n < count; n++) {
-        sps_fir_push_history(f, samples[n]);
-    }
-}
-
-int
-dsd_sps_filter_prime_from_history(dsd_sps_filter_kind kind, int samples_per_symbol) {
-    sps_fir* f = sps_fir_ready_for(kind, samples_per_symbol);
-    if (!f) {
-        return 0;
-    }
-    const int n = (f->taps_len < g_raw_count) ? f->taps_len : g_raw_count;
-    int idx = g_raw_head - n;
-    while (idx < 0) {
-        idx += DSD_SPS_FILTER_MAX_TAPS;
-    }
-    /* Oldest first, walking the ring. This runs once per filter switch, so the
-       wrap test per sample costs nothing worth splitting the loop for. */
-    for (int k = 0; k < n; k++) {
-        sps_fir_push_history(f, g_raw_hist[idx]);
-        idx++;
-        if (idx >= DSD_SPS_FILTER_MAX_TAPS) {
-            idx = 0;
-        }
-    }
-    return (f->taps_len - 1) / 2;
-}
-
-int
-dsd_sps_filter_copy_taps(dsd_sps_filter_kind kind, int samples_per_symbol, float* out, int cap) {
-    const sps_fir* f = sps_fir_ready_for(kind, samples_per_symbol);
-    if (!f || !out || cap < f->taps_len) {
-        return 0;
-    }
-    DSD_MEMCPY(out, f->taps, (size_t)f->taps_len * sizeof(float));
-    return f->taps_len;
 }

--- a/src/dsp/dsd_filters.c
+++ b/src/dsp/dsd_filters.c
@@ -446,6 +446,17 @@ dsd_sps_filter_group_delay(dsd_sps_filter_kind kind, int samples_per_symbol) {
     return taps_len > 0 ? (taps_len - 1) / 2 : 0;
 }
 
+/* One sample into the history, without computing an output. */
+static inline void
+sps_fir_push_history(sps_fir* f, float sample) {
+    int head = f->head + 1;
+    if (head >= f->taps_len) {
+        head = 0;
+    }
+    f->hist[head] = sample;
+    f->head = head;
+}
+
 void
 dsd_sps_filter_prime(dsd_sps_filter_kind kind, const float* samples, int count, int samples_per_symbol) {
     sps_fir* f = sps_fir_ready_for(kind, samples_per_symbol);
@@ -458,36 +469,31 @@ dsd_sps_filter_prime(dsd_sps_filter_kind kind, const float* samples, int count, 
         start = count - f->taps_len;
     }
     for (int n = start; n < count; n++) {
-        int head = f->head + 1;
-        if (head >= f->taps_len) {
-            head = 0;
-        }
-        f->hist[head] = samples[n];
-        f->head = head;
+        sps_fir_push_history(f, samples[n]);
     }
 }
 
 int
 dsd_sps_filter_prime_from_history(dsd_sps_filter_kind kind, int samples_per_symbol) {
-    const int taps_len = dsd_sps_filter_taps_len(kind, samples_per_symbol);
-    if (taps_len <= 0) {
+    sps_fir* f = sps_fir_ready_for(kind, samples_per_symbol);
+    if (!f) {
         return 0;
     }
-    int n = (taps_len < g_raw_count) ? taps_len : g_raw_count;
+    const int n = (f->taps_len < g_raw_count) ? f->taps_len : g_raw_count;
     int idx = g_raw_head - n;
     while (idx < 0) {
         idx += DSD_SPS_FILTER_MAX_TAPS;
     }
-    /* The ring wraps at most once across the window, so prime the two runs in
-       order rather than copying the whole thing out first. */
-    const int first = (n < DSD_SPS_FILTER_MAX_TAPS - idx) ? n : (DSD_SPS_FILTER_MAX_TAPS - idx);
-    if (first > 0) {
-        dsd_sps_filter_prime(kind, &g_raw_hist[idx], first, samples_per_symbol);
+    /* Oldest first, walking the ring. This runs once per filter switch, so the
+       wrap test per sample costs nothing worth splitting the loop for. */
+    for (int k = 0; k < n; k++) {
+        sps_fir_push_history(f, g_raw_hist[idx]);
+        idx++;
+        if (idx >= DSD_SPS_FILTER_MAX_TAPS) {
+            idx = 0;
+        }
     }
-    if (n > first) {
-        dsd_sps_filter_prime(kind, &g_raw_hist[0], n - first, samples_per_symbol);
-    }
-    return dsd_sps_filter_group_delay(kind, samples_per_symbol);
+    return (f->taps_len - 1) / 2;
 }
 
 int

--- a/src/dsp/dsd_filters.c
+++ b/src/dsp/dsd_filters.c
@@ -9,7 +9,7 @@
 #include "dsd-neo/core/safe_api.h"
 #include "m17_rrc_taps.h"
 
-#define FIR_MAX_TAPS          1024
+#define FIR_MAX_TAPS          DSD_SPS_FILTER_MAX_TAPS
 #define SPS_FIR_DESIGN_INTERP 0
 #define SPS_FIR_DESIGN_RRC    1
 
@@ -357,10 +357,145 @@ p25_filter(float sample, int samples_per_symbol) {
     return apply_sps_fir(&g_fir_p25, sample, samples_per_symbol);
 }
 
+/*
+ * Raw samples the symbolizer has already consumed, newest last. A filter that
+ * switches on mid-stream is handed these so its first output is computed from
+ * signal rather than from the previous transmission's tail.
+ */
+static float g_raw_hist[DSD_SPS_FILTER_MAX_TAPS];
+static int g_raw_head;  /* next write index */
+static int g_raw_count; /* samples held, saturating at the ring size */
+
 void
 init_rrc_filter_memory(void) {
     reset_sps_fir(&g_fir_p25);
     reset_sps_fir(&g_fir_dmr);
     reset_sps_fir(&g_fir_nxdn);
     reset_sps_fir(&g_fir_dpmr);
+    dsd_sps_filter_forget_raw();
+}
+
+void
+dsd_sps_filter_note_raw(float sample) {
+    g_raw_hist[g_raw_head] = sample;
+    g_raw_head = (g_raw_head + 1) % DSD_SPS_FILTER_MAX_TAPS;
+    if (g_raw_count < DSD_SPS_FILTER_MAX_TAPS) {
+        g_raw_count++;
+    }
+}
+
+void
+dsd_sps_filter_forget_raw(void) {
+    DSD_MEMSET(g_raw_hist, 0, sizeof(g_raw_hist));
+    g_raw_head = 0;
+    g_raw_count = 0;
+}
+
+/*
+ * The symbol grid runs on the unfiltered stream until a sync names a protocol,
+ * and on the filtered one afterwards. Those two streams are not the same signal:
+ * a symmetric FIR of L taps reports the signal L/2 samples in the past, so the
+ * moment the filter switches on the decoder starts re-reading content it has
+ * already consumed. The helpers below let the symbolizer hand the filter the
+ * history it missed and then pay off that delay once, so the switch costs
+ * neither a transient nor a rewind (issue #444).
+ */
+static sps_fir*
+sps_fir_for_kind(dsd_sps_filter_kind kind) {
+    switch (kind) {
+        case DSD_SPS_FILTER_DMR: return &g_fir_dmr;
+        case DSD_SPS_FILTER_P25: return &g_fir_p25;
+        case DSD_SPS_FILTER_NXDN: return &g_fir_nxdn;
+        case DSD_SPS_FILTER_DPMR: return &g_fir_dpmr;
+        case DSD_SPS_FILTER_NONE:
+        default: return NULL;
+    }
+}
+
+/* Design on demand so callers can ask about geometry before any sample flows. */
+static sps_fir*
+sps_fir_ready_for(dsd_sps_filter_kind kind, int samples_per_symbol) {
+    sps_fir* f = sps_fir_for_kind(kind);
+    if (!f || samples_per_symbol <= 1) {
+        return NULL;
+    }
+    if (!f->ready || samples_per_symbol != f->last_sps) {
+        design_sps_fir(f, samples_per_symbol);
+    }
+    return (f->ready && f->taps_len > 0) ? f : NULL;
+}
+
+float
+dsd_sps_filter_apply(dsd_sps_filter_kind kind, float sample, int samples_per_symbol) {
+    sps_fir* f = sps_fir_for_kind(kind);
+    if (!f) {
+        return sample;
+    }
+    return apply_sps_fir(f, sample, samples_per_symbol);
+}
+
+int
+dsd_sps_filter_taps_len(dsd_sps_filter_kind kind, int samples_per_symbol) {
+    const sps_fir* f = sps_fir_ready_for(kind, samples_per_symbol);
+    return f ? f->taps_len : 0;
+}
+
+int
+dsd_sps_filter_group_delay(dsd_sps_filter_kind kind, int samples_per_symbol) {
+    const int taps_len = dsd_sps_filter_taps_len(kind, samples_per_symbol);
+    return taps_len > 0 ? (taps_len - 1) / 2 : 0;
+}
+
+void
+dsd_sps_filter_prime(dsd_sps_filter_kind kind, const float* samples, int count, int samples_per_symbol) {
+    sps_fir* f = sps_fir_ready_for(kind, samples_per_symbol);
+    if (!f || !samples || count <= 0) {
+        return;
+    }
+    /* Only the newest taps_len samples can still be in the window. */
+    int start = 0;
+    if (count > f->taps_len) {
+        start = count - f->taps_len;
+    }
+    for (int n = start; n < count; n++) {
+        int head = f->head + 1;
+        if (head >= f->taps_len) {
+            head = 0;
+        }
+        f->hist[head] = samples[n];
+        f->head = head;
+    }
+}
+
+int
+dsd_sps_filter_prime_from_history(dsd_sps_filter_kind kind, int samples_per_symbol) {
+    const int taps_len = dsd_sps_filter_taps_len(kind, samples_per_symbol);
+    if (taps_len <= 0) {
+        return 0;
+    }
+    int n = (taps_len < g_raw_count) ? taps_len : g_raw_count;
+    int idx = g_raw_head - n;
+    while (idx < 0) {
+        idx += DSD_SPS_FILTER_MAX_TAPS;
+    }
+    /* The ring wraps at most once across the window, so prime the two runs in
+       order rather than copying the whole thing out first. */
+    const int first = (n < DSD_SPS_FILTER_MAX_TAPS - idx) ? n : (DSD_SPS_FILTER_MAX_TAPS - idx);
+    if (first > 0) {
+        dsd_sps_filter_prime(kind, &g_raw_hist[idx], first, samples_per_symbol);
+    }
+    if (n > first) {
+        dsd_sps_filter_prime(kind, &g_raw_hist[0], n - first, samples_per_symbol);
+    }
+    return dsd_sps_filter_group_delay(kind, samples_per_symbol);
+}
+
+int
+dsd_sps_filter_copy_taps(dsd_sps_filter_kind kind, int samples_per_symbol, float* out, int cap) {
+    const sps_fir* f = sps_fir_ready_for(kind, samples_per_symbol);
+    if (!f || !out || cap < f->taps_len) {
+        return 0;
+    }
+    DSD_MEMCPY(out, f->taps, (size_t)f->taps_len * sizeof(float));
+    return f->taps_len;
 }

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -251,6 +251,12 @@ typedef struct {
     /* Samples this symbol has actually taken, which is not the span index: the
        timing nudge moves that index and a stream flush restarts it. */
     int timing_samples;
+    /* The matched filter this sample goes through, a dsd_sps_filter_kind,
+       decided once per sample by the seam so the switch and the filtering agree. */
+    int matched_filter_kind;
+    /* Set when the sample came back out of the seam's raw history rather than
+       from the input: it is already recorded there and already captured. */
+    int sample_replayed;
     unsigned int analog_out_cap;
 #ifdef USE_RADIO
     int rtl_output_kind;
@@ -347,6 +353,62 @@ symbol_apply_matched_filter(const dsd_opts* opts, const dsd_state* state, float 
                             int cqpsk_symbol_rate) {
     const dsd_sps_filter_kind kind = symbol_matched_filter_kind(opts, state, rtl_symbol_rate_output, cqpsk_symbol_rate);
     return dsd_sps_filter_apply(kind, sample, state->samplesPerSymbol);
+}
+
+/* The raw history the seam works from: samples the grid consumed, newest last. */
+static inline void
+seam_note_raw(dsd_matched_filter_seam* seam, float sample) {
+    seam->raw[seam->raw_head] = sample;
+    seam->raw_head = (seam->raw_head + 1) % DSD_MATCHED_FILTER_HISTORY;
+    if (seam->raw_count < DSD_MATCHED_FILTER_HISTORY) {
+        seam->raw_count++;
+    }
+}
+
+/* The sample recorded @p back samples ago; 1 is the newest. */
+static inline float
+seam_raw_at(const dsd_matched_filter_seam* seam, int back) {
+    int idx = seam->raw_head - back;
+    while (idx < 0) {
+        idx += DSD_MATCHED_FILTER_HISTORY;
+    }
+    return seam->raw[idx];
+}
+
+/* Across a stream discontinuity: the history describes a transmission that is
+   gone, and nothing from it is owed back. */
+static inline void
+seam_forget(dsd_matched_filter_seam* seam) {
+    DSD_MEMSET(seam->raw, 0, sizeof(seam->raw));
+    seam->raw_head = 0;
+    seam->raw_count = 0;
+    seam->replay = 0;
+}
+
+/* Hand @p kind the newest history it can use, leaving out the newest @p skip
+   samples, so its first real output is computed from signal rather than from
+   whatever the previous transmission left in it. */
+static void
+seam_prime(const dsd_matched_filter_seam* seam, dsd_sps_filter_kind kind, int sps, int skip, int delay) {
+    if (kind == DSD_SPS_FILTER_NONE) {
+        return;
+    }
+    const int taps = 2 * delay + 1;
+    int n = seam->raw_count - skip;
+    if (n > taps) {
+        n = taps;
+    }
+    for (int back = skip + n; back > skip; back--) {
+        dsd_sps_filter_prime(kind, seam_raw_at(seam, back), sps);
+    }
+}
+
+void
+dsd_symbol_matched_filter_reset(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    DSD_MEMSET(&state->matched_filter, 0, sizeof(state->matched_filter));
 }
 
 #ifdef DSD_NEO_TEST_HOOKS
@@ -1594,6 +1656,16 @@ symbol_take_sample(dsd_opts* opts, dsd_state* state, symbol_work_ctx* work) {
     if (symbol_stop_after_shutdown(&work->sample)) {
         return 0;
     }
+    /* Samples a matched-filter switch handed back are read again, oldest first,
+       before live input resumes. */
+    dsd_matched_filter_seam* seam = &state->matched_filter;
+    if (seam->replay > 0) {
+        work->sample = seam_raw_at(seam, seam->replay);
+        seam->replay--;
+        work->sample_replayed = 1;
+        return 1;
+    }
+    work->sample_replayed = 0;
     if (dsd_pcm_input_uses_staged_resampler(opts) && opts->input_upsample_pos < opts->input_upsample_len) {
         work->sample = opts->input_upsample_buf[opts->input_upsample_pos++];
         return 1;
@@ -1824,24 +1896,43 @@ symbol_process_symbol_flt_input(dsd_opts* opts, float* symbol_out) {
     return 1;
 }
 
+/* Take the next sample and, when it is live rather than handed back, record it. */
+static int
+symbol_take_sample_into_history(dsd_opts* opts, dsd_state* state, symbol_work_ctx* work) {
+    if (!symbol_take_sample(opts, state, work)) {
+        return 0;
+    }
+    if (!work->sample_replayed) {
+        seam_note_raw(&state->matched_filter, work->sample);
+    }
+    return 1;
+}
+
 /*
  * The stream the grid samples changes identity when a sync names a protocol: up
  * to that point the grid reads the raw discriminator, afterwards the matched
  * filter's output, which describes the signal one group delay in the past. Left
  * alone that makes the decoder re-read content it has already consumed -- 3.35
  * symbols for NXDN48 at 20 samples per symbol, 4.5 for P25p1, and for P25p1 half
- * a symbol of phase on top -- once per transmission, on the first frame, which
- * is the frame that opens the call (issue #444).
+ * a symbol of phase on top -- at every accept, which noCarrier makes roughly
+ * once per frame rather than once per call (issue #444). Switching back is the
+ * mirror image: the samples the filter still had in flight would be skipped.
  *
- * So hand the filter the history it missed and then pay the delay off once, by
- * consuming that many samples and discarding what they produce: they describe
- * positions the grid has already read. What the caller filters next is then the
- * signal at the position it was about to read. A samples-per-symbol change is
- * the same discontinuity by another route, because the redesign clears the
- * filter's history.
+ * So treat every switch as a move of the content position and pay it off in
+ * samples. On the stream it is leaving, the sample in hand would have produced
+ * the position after the last one read; the new stream puts a different
+ * position under that same sample, and the difference is either consumed (a
+ * longer delay: prime the filter with the history it missed, then feed it that
+ * many samples and discard what they produce, since those describe positions
+ * already read) or handed back (a shorter delay, or none: re-read that many
+ * samples from the history through the new filter before live input resumes).
+ * Only the change in delay is owed, so between two filters, which is what AUTO
+ * does when the sync it accepts changes protocol, it is their difference. A
+ * samples-per-symbol change is the same discontinuity by another route, because
+ * the redesign clears the filter's history.
  */
 static int
-symbol_sync_matched_filter_seam(dsd_opts* opts, dsd_state* state, symbol_work_ctx* work) {
+symbol_sync_matched_filter_seam(dsd_opts* opts, dsd_state* state, int have_sync, symbol_work_ctx* work) {
 #ifdef USE_RADIO
     const int rtl_symbol_rate_output = work->rtl_symbol_rate_output;
     const int cqpsk_symbol_rate = work->cqpsk_symbol_rate;
@@ -1850,37 +1941,46 @@ symbol_sync_matched_filter_seam(dsd_opts* opts, dsd_state* state, symbol_work_ct
     const int cqpsk_symbol_rate = 0;
 #endif
     const dsd_sps_filter_kind kind = symbol_matched_filter_kind(opts, state, rtl_symbol_rate_output, cqpsk_symbol_rate);
+    work->matched_filter_kind = (int)kind;
+    dsd_matched_filter_seam* seam = &state->matched_filter;
     const int sps = state->samplesPerSymbol;
-    if ((int)kind == state->matched_filter_kind && sps == state->matched_filter_sps) {
+    if ((int)kind == seam->kind && sps == seam->sps) {
         return 1;
     }
 
-    const int previous_delay = state->matched_filter_delay;
-    state->matched_filter_kind = (int)kind;
-    state->matched_filter_sps = sps;
-    if (kind == DSD_SPS_FILTER_NONE) {
-        state->matched_filter_delay = 0;
-        return 1; /* Switching off costs nothing: the raw stream has no delay. */
-    }
+    const int previous_delay = seam->delay;
+    const int delay = dsd_sps_filter_group_delay(kind, sps);
+    seam->kind = (int)kind;
+    seam->sps = sps;
+    seam->delay = delay;
 
-    const int delay = dsd_sps_filter_prime_from_history(kind, sps);
-    state->matched_filter_delay = delay;
-    /* Only the change in delay is owed. Coming from the raw stream that is the
-       whole of it; between two filters, which is what AUTO does when the sync it
-       last accepted changes protocol, it is the difference. A filter that
-       reports the signal less far back than the one before it cannot be paid at
-       all -- that would mean un-reading samples -- so it is left to the loop
-       below to work off. */
-    int catch_up = delay - previous_delay;
-    if (catch_up < 0) {
-        catch_up = 0;
-    }
-    for (int j = 0; j < catch_up; j++) {
-        (void)dsd_sps_filter_apply(kind, work->sample, sps);
+    /* The sample in hand is the newest the history holds, unless a hand-back is
+       still being read out, in which case those come after it. */
+    const int newer_than_in_hand = seam->replay;
+    if (delay < previous_delay) {
+        int rewind = previous_delay - delay;
+        const int held_before_in_hand = seam->raw_count - newer_than_in_hand - 1;
+        if (rewind > held_before_in_hand) {
+            rewind = held_before_in_hand > 0 ? held_before_in_hand : 0;
+        }
+        seam->replay = newer_than_in_hand + 1 + rewind;
+        seam_prime(seam, kind, sps, seam->replay, delay);
+        /* The oldest handed-back sample replaces the one in hand, which is read
+           again in its turn. */
         if (!symbol_take_sample(opts, state, work)) {
             return 0;
         }
-        dsd_sps_filter_note_raw(work->sample);
+    } else {
+        seam_prime(seam, kind, sps, newer_than_in_hand + 1, delay);
+        for (int owed = delay - previous_delay; owed > 0; owed--) {
+            (void)dsd_sps_filter_apply(kind, work->sample, sps);
+            if (!work->sample_replayed) {
+                symbol_process_analog_capture(opts, state, work, have_sync);
+            }
+            if (!symbol_take_sample_into_history(opts, state, work)) {
+                return 0;
+            }
+        }
     }
     /* The crossing that was pending belonged to the stream that just ended. */
     state->jitter = -1;
@@ -1897,13 +1997,12 @@ symbol_process_live_samples(dsd_opts* opts, dsd_state* state, int have_sync, sym
     int i = 0;
     while (i < work->symbol_span) {
         symbol_adjust_timing_index(state, have_sync, work->symbol_span, &i);
-        if (!symbol_take_sample(opts, state, work)) {
+        if (!symbol_take_sample_into_history(opts, state, work)) {
             return 0;
         }
-        dsd_sps_filter_note_raw(work->sample);
         /* Before the span-restart check below, so a flush the catch-up runs into
            is handled by it rather than being swallowed here. */
-        if (!symbol_sync_matched_filter_seam(opts, state, work)) {
+        if (!symbol_sync_matched_filter_seam(opts, state, have_sync, work)) {
             return 0;
         }
 #ifdef USE_RADIO
@@ -1921,8 +2020,8 @@ symbol_process_live_samples(dsd_opts* opts, dsd_state* state, int have_sync, sym
             state->jitter = -1;
             /* The recorded raw history is from the stream that just ended, so it
                cannot prime a filter for the one starting here. */
-            dsd_sps_filter_forget_raw();
-            dsd_sps_filter_note_raw(work->sample);
+            seam_forget(&state->matched_filter);
+            seam_note_raw(&state->matched_filter, work->sample);
             /* Same reasoning for the timing trace: correlating a sync word across a
                stream seam would measure the flush, not the grid. */
             dsd_symbol_timing_trace_reset(state);
@@ -1931,16 +2030,11 @@ symbol_process_live_samples(dsd_opts* opts, dsd_state* state, int have_sync, sym
         }
 #endif
 
-        symbol_process_analog_capture(opts, state, work, have_sync);
-#ifdef USE_RADIO
-        int rtl_symbol_rate_output = work->rtl_symbol_rate_output;
-        int cqpsk_symbol_rate = work->cqpsk_symbol_rate;
-#else
-        int rtl_symbol_rate_output = 0;
-        int cqpsk_symbol_rate = 0;
-#endif
+        if (!work->sample_replayed) {
+            symbol_process_analog_capture(opts, state, work, have_sync);
+        }
         work->sample =
-            symbol_apply_matched_filter(opts, state, work->sample, rtl_symbol_rate_output, cqpsk_symbol_rate);
+            dsd_sps_filter_apply((dsd_sps_filter_kind)work->matched_filter_kind, work->sample, state->samplesPerSymbol);
         work->sample = symbol_apply_sync_clip(state, have_sync, work->sample);
         if (work->timing_level >= DSD_NEO_SYMBOL_TIMING_SYNC_LINE) {
             dsd_symbol_timing_trace_push_sample(state, work->sample);

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -1855,14 +1855,27 @@ symbol_sync_matched_filter_seam(dsd_opts* opts, dsd_state* state, symbol_work_ct
         return 1;
     }
 
+    const int previous_delay = state->matched_filter_delay;
     state->matched_filter_kind = (int)kind;
     state->matched_filter_sps = sps;
     if (kind == DSD_SPS_FILTER_NONE) {
+        state->matched_filter_delay = 0;
         return 1; /* Switching off costs nothing: the raw stream has no delay. */
     }
 
     const int delay = dsd_sps_filter_prime_from_history(kind, sps);
-    for (int j = 0; j < delay; j++) {
+    state->matched_filter_delay = delay;
+    /* Only the change in delay is owed. Coming from the raw stream that is the
+       whole of it; between two filters, which is what AUTO does when the sync it
+       last accepted changes protocol, it is the difference. A filter that
+       reports the signal less far back than the one before it cannot be paid at
+       all -- that would mean un-reading samples -- so it is left to the loop
+       below to work off. */
+    int catch_up = delay - previous_delay;
+    if (catch_up < 0) {
+        catch_up = 0;
+    }
+    for (int j = 0; j < catch_up; j++) {
         (void)dsd_sps_filter_apply(kind, work->sample, sps);
         if (!symbol_take_sample(opts, state, work)) {
             return 0;

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -307,39 +307,46 @@ symbol_timing_debug_char(const dsd_state* state, int timing_level, char c) {
  * from a cold history the moment a sync sets lastsynctype, and its group delay lands on the very
  * payload that sync introduces: it cost the LSF its CRC and the stream its LICH, which is why
  * AUTO could match M17 sync words and never decode a frame behind them (#399). */
-static inline float
-symbol_apply_matched_filter(const dsd_opts* opts, const dsd_state* state, float sample, int rtl_symbol_rate_output,
-                            int cqpsk_symbol_rate) {
+static inline dsd_sps_filter_kind
+symbol_matched_filter_kind(const dsd_opts* opts, const dsd_state* state, int rtl_symbol_rate_output,
+                           int cqpsk_symbol_rate) {
     if (!opts->use_cosine_filter || rtl_symbol_rate_output || cqpsk_symbol_rate) {
-        return sample;
+        return DSD_SPS_FILTER_NONE;
     }
     if (DSD_SYNC_IS_DMR_BS(state->lastsynctype) || DSD_SYNC_IS_DMR_MS(state->lastsynctype)
         || DSD_SYNC_IS_YSF(state->lastsynctype)) {
-        return dmr_filter(sample, state->samplesPerSymbol);
+        return DSD_SPS_FILTER_DMR;
     }
     if (DSD_SYNC_IS_P25P1(state->lastsynctype)) {
-        return p25_filter(sample, state->samplesPerSymbol);
+        return DSD_SPS_FILTER_P25;
     }
     if (DSD_SYNC_IS_DPMR(state->lastsynctype)) {
         if (opts->frame_dpmr == 1) {
-            return dpmr_filter(sample, state->samplesPerSymbol);
+            return DSD_SPS_FILTER_DPMR;
         }
-        return sample;
+        return DSD_SPS_FILTER_NONE;
     }
     if (DSD_SYNC_IS_NXDN(state->lastsynctype)) {
         const dsd_nxdn_variant variant = dsd_frame_sync_active_nxdn_variant(opts, state);
         if (variant == DSD_NXDN_VARIANT_48) {
-            return nxdn_filter(sample, state->samplesPerSymbol);
+            return DSD_SPS_FILTER_NXDN;
         }
         if (variant != DSD_NXDN_VARIANT_96) {
-            return sample;
+            return DSD_SPS_FILTER_NONE;
         }
         if (state->samplesPerSymbol == 8) {
-            return sample;
+            return DSD_SPS_FILTER_NONE;
         }
-        return dmr_filter(sample, state->samplesPerSymbol);
+        return DSD_SPS_FILTER_DMR;
     }
-    return sample;
+    return DSD_SPS_FILTER_NONE;
+}
+
+static inline float
+symbol_apply_matched_filter(const dsd_opts* opts, const dsd_state* state, float sample, int rtl_symbol_rate_output,
+                            int cqpsk_symbol_rate) {
+    const dsd_sps_filter_kind kind = symbol_matched_filter_kind(opts, state, rtl_symbol_rate_output, cqpsk_symbol_rate);
+    return dsd_sps_filter_apply(kind, sample, state->samplesPerSymbol);
 }
 
 #ifdef DSD_NEO_TEST_HOOKS
@@ -1817,6 +1824,57 @@ symbol_process_symbol_flt_input(dsd_opts* opts, float* symbol_out) {
     return 1;
 }
 
+/*
+ * The stream the grid samples changes identity when a sync names a protocol: up
+ * to that point the grid reads the raw discriminator, afterwards the matched
+ * filter's output, which describes the signal one group delay in the past. Left
+ * alone that makes the decoder re-read content it has already consumed -- 3.35
+ * symbols for NXDN48 at 20 samples per symbol, 4.5 for P25p1, and for P25p1 half
+ * a symbol of phase on top -- once per transmission, on the first frame, which
+ * is the frame that opens the call (issue #444).
+ *
+ * So hand the filter the history it missed and then pay the delay off once, by
+ * consuming that many samples and discarding what they produce: they describe
+ * positions the grid has already read. What the caller filters next is then the
+ * signal at the position it was about to read. A samples-per-symbol change is
+ * the same discontinuity by another route, because the redesign clears the
+ * filter's history.
+ */
+static int
+symbol_sync_matched_filter_seam(dsd_opts* opts, dsd_state* state, symbol_work_ctx* work) {
+#ifdef USE_RADIO
+    const int rtl_symbol_rate_output = work->rtl_symbol_rate_output;
+    const int cqpsk_symbol_rate = work->cqpsk_symbol_rate;
+#else
+    const int rtl_symbol_rate_output = 0;
+    const int cqpsk_symbol_rate = 0;
+#endif
+    const dsd_sps_filter_kind kind = symbol_matched_filter_kind(opts, state, rtl_symbol_rate_output, cqpsk_symbol_rate);
+    const int sps = state->samplesPerSymbol;
+    if ((int)kind == state->matched_filter_kind && sps == state->matched_filter_sps) {
+        return 1;
+    }
+
+    state->matched_filter_kind = (int)kind;
+    state->matched_filter_sps = sps;
+    if (kind == DSD_SPS_FILTER_NONE) {
+        return 1; /* Switching off costs nothing: the raw stream has no delay. */
+    }
+
+    const int delay = dsd_sps_filter_prime_from_history(kind, sps);
+    for (int j = 0; j < delay; j++) {
+        (void)dsd_sps_filter_apply(kind, work->sample, sps);
+        if (!symbol_take_sample(opts, state, work)) {
+            return 0;
+        }
+        dsd_sps_filter_note_raw(work->sample);
+    }
+    /* The crossing that was pending belonged to the stream that just ended. */
+    state->jitter = -1;
+    dsd_symbol_timing_trace_reset(state);
+    return 1;
+}
+
 /* A while loop rather than a for: the span index is not a plain counter. The
    timing nudge moves it before the first sample is taken, and a stream flush
    restarts the span from it, so every step it takes belongs in the body where
@@ -1827,6 +1885,12 @@ symbol_process_live_samples(dsd_opts* opts, dsd_state* state, int have_sync, sym
     while (i < work->symbol_span) {
         symbol_adjust_timing_index(state, have_sync, work->symbol_span, &i);
         if (!symbol_take_sample(opts, state, work)) {
+            return 0;
+        }
+        dsd_sps_filter_note_raw(work->sample);
+        /* Before the span-restart check below, so a flush the catch-up runs into
+           is handled by it rather than being swallowed here. */
+        if (!symbol_sync_matched_filter_seam(opts, state, work)) {
             return 0;
         }
 #ifdef USE_RADIO
@@ -1842,6 +1906,10 @@ symbol_process_live_samples(dsd_opts* opts, dsd_state* state, int have_sync, sym
                 work->symbol_span = state->samplesPerSymbol;
             }
             state->jitter = -1;
+            /* The recorded raw history is from the stream that just ended, so it
+               cannot prime a filter for the one starting here. */
+            dsd_sps_filter_forget_raw();
+            dsd_sps_filter_note_raw(work->sample);
             /* Same reasoning for the timing trace: correlating a sync word across a
                stream seam would measure the flush, not the grid. */
             dsd_symbol_timing_trace_reset(state);

--- a/src/dsp/dsd_symbol.c
+++ b/src/dsp/dsd_symbol.c
@@ -348,13 +348,6 @@ symbol_matched_filter_kind(const dsd_opts* opts, const dsd_state* state, int rtl
     return DSD_SPS_FILTER_NONE;
 }
 
-static inline float
-symbol_apply_matched_filter(const dsd_opts* opts, const dsd_state* state, float sample, int rtl_symbol_rate_output,
-                            int cqpsk_symbol_rate) {
-    const dsd_sps_filter_kind kind = symbol_matched_filter_kind(opts, state, rtl_symbol_rate_output, cqpsk_symbol_rate);
-    return dsd_sps_filter_apply(kind, sample, state->samplesPerSymbol);
-}
-
 /* The raw history the seam works from: samples the grid consumed, newest last. */
 static inline void
 seam_note_raw(dsd_matched_filter_seam* seam, float sample) {
@@ -375,8 +368,9 @@ seam_raw_at(const dsd_matched_filter_seam* seam, int back) {
     return seam->raw[idx];
 }
 
+#ifdef USE_RADIO
 /* Across a stream discontinuity: the history describes a transmission that is
-   gone, and nothing from it is owed back. */
+   gone, and nothing from it is owed back. Only the radio stream has seams. */
 static inline void
 seam_forget(dsd_matched_filter_seam* seam) {
     DSD_MEMSET(seam->raw, 0, sizeof(seam->raw));
@@ -384,6 +378,7 @@ seam_forget(dsd_matched_filter_seam* seam) {
     seam->raw_count = 0;
     seam->replay = 0;
 }
+#endif
 
 /* Hand @p kind the newest history it can use, leaving out the newest @p skip
    samples, so its first real output is computed from signal rather than from
@@ -415,7 +410,8 @@ dsd_symbol_matched_filter_reset(dsd_state* state) {
 float
 dsd_symbol_test_apply_matched_filter(const dsd_opts* opts, const dsd_state* state, float sample,
                                      int rtl_symbol_rate_output, int cqpsk_symbol_rate) {
-    return symbol_apply_matched_filter(opts, state, sample, rtl_symbol_rate_output, cqpsk_symbol_rate);
+    const dsd_sps_filter_kind kind = symbol_matched_filter_kind(opts, state, rtl_symbol_rate_output, cqpsk_symbol_rate);
+    return dsd_sps_filter_apply(kind, sample, state->samplesPerSymbol);
 }
 #endif
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -21,6 +21,7 @@
 #include <dsd-neo/core/vocoder.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/sps_filters.h>
+#include <dsd-neo/dsp/symbol.h>
 #include <dsd-neo/engine/engine.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/protocol_dispatch.h>
@@ -2850,6 +2851,7 @@ dsd_engine_run_with_lifecycle(dsd_opts* opts, dsd_state* state, const dsd_engine
     reset_device_io_caches();
     dsd_bootstrap_enable_ftz_daz_if_enabled();
     init_rrc_filter_memory();
+    dsd_symbol_matched_filter_reset(state);
     InitAllFecFunction();
     CNXDNConvolution_init();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3820,6 +3820,27 @@ dsd_neo_link_dsp_test(
 )
 add_test(NAME DSP_WAV_INPUT_EOF COMMAND dsd-neo_test_dsp_wav_input_eof)
 
+# The matched filter switching on, off, or to another filter must not move the
+# symbol grid's content position (issue #444); driven through getSymbol() from a WAV
+add_executable(
+    dsd-neo_test_symbol_matched_filter_seam
+    dsp/test_symbol_matched_filter_seam.c
+)
+target_include_directories(
+    dsd-neo_test_symbol_matched_filter_seam
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${LIBSNDFILE_INCLUDE_DIR}
+)
+dsd_neo_link_dsp_test(
+    dsd-neo_test_symbol_matched_filter_seam
+    dsd-neo_test_support
+    ${DSD_NEO_TEST_MATH_LIB}
+    ${LIBSNDFILE_LIBRARIES}
+)
+add_test(
+    NAME SYMBOL_MATCHED_FILTER_SEAM
+    COMMAND dsd-neo_test_symbol_matched_filter_seam
+)
+
 add_executable(dsd-neo_test_dsp_symbol_replay dsp/test_dsp_symbol_replay.c)
 target_include_directories(
     dsd-neo_test_dsp_symbol_replay

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7952,6 +7952,15 @@ target_include_directories(
 dsd_neo_link_dsp_test(dsd-neo_test_symbol_timing_debug ${DSD_NEO_TEST_MATH_LIB})
 add_test(NAME SYMBOL_TIMING_DEBUG COMMAND dsd-neo_test_symbol_timing_debug)
 
+# Matched-filter switch-on geometry and content alignment (issue #444)
+add_executable(dsd-neo_test_matched_filter_seam dsp/test_matched_filter_seam.c)
+target_include_directories(
+    dsd-neo_test_matched_filter_seam
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+dsd_neo_link_dsp_test(dsd-neo_test_matched_filter_seam ${DSD_NEO_TEST_MATH_LIB})
+add_test(NAME MATCHED_FILTER_SEAM COMMAND dsd-neo_test_matched_filter_seam)
+
 # DMR resample-on-sync CACH re-digitization test
 add_executable(
     dsd-neo_test_dmr_resample_on_sync

--- a/tests/dsp/test_matched_filter_seam.c
+++ b/tests/dsp/test_matched_filter_seam.c
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * The symbol grid reads the unfiltered discriminator stream until a sync names a
+ * protocol, and the matched-filtered one from the accept onward. Those are not
+ * the same signal: a symmetric FIR of L taps reports the signal (L-1)/2 samples
+ * in the past, so at the moment the filter switches on the decoder starts
+ * re-reading content it has already consumed -- 3.35 symbols for NXDN48 at 20
+ * samples per symbol, 4.5 for P25p1, and for P25p1 the leftover is exactly half
+ * a symbol of phase as well (issue #444).
+ *
+ * These cases pin the geometry that makes the delay knowable, and the property
+ * the fix has to have: after the switch, the value the grid reads for a position
+ * is the filtered signal at that position, with no rewind and no transient.
+ */
+
+#include <assert.h>
+#include <dsd-neo/dsp/sps_filters.h>
+#include <math.h>
+#include <stdio.h>
+#include "dsd-neo/core/safe_api.h"
+
+#define MAX_TAPS DSD_SPS_FILTER_MAX_TAPS
+
+static const char*
+kind_name(dsd_sps_filter_kind kind) {
+    switch (kind) {
+        case DSD_SPS_FILTER_DMR: return "dmr";
+        case DSD_SPS_FILTER_P25: return "p25";
+        case DSD_SPS_FILTER_NXDN: return "nxdn";
+        case DSD_SPS_FILTER_DPMR: return "dpmr";
+        default: return "none";
+    }
+}
+
+static const dsd_sps_filter_kind kKinds[] = {DSD_SPS_FILTER_DMR, DSD_SPS_FILTER_P25, DSD_SPS_FILTER_NXDN,
+                                             DSD_SPS_FILTER_DPMR};
+static const int kSps[] = {20, 10, 8, 5, 4, 3, 2};
+
+/*
+ * The delay is only knowable because the taps are symmetric and odd in length.
+ * A design that broke either would make the seam correction a guess.
+ */
+static void
+test_taps_are_symmetric_and_odd(void) {
+    static float taps[MAX_TAPS];
+    for (unsigned k = 0; k < sizeof(kKinds) / sizeof(kKinds[0]); k++) {
+        for (unsigned s = 0; s < sizeof(kSps) / sizeof(kSps[0]); s++) {
+            const int sps = kSps[s];
+            const int len = dsd_sps_filter_copy_taps(kKinds[k], sps, taps, MAX_TAPS);
+            DSD_FPRINTF(stderr, "%s sps=%d taps=%d delay=%d\n", kind_name(kKinds[k]), sps, len,
+                        dsd_sps_filter_group_delay(kKinds[k], sps));
+            assert(len > 0);
+            assert((len & 1) == 1);
+            assert(dsd_sps_filter_taps_len(kKinds[k], sps) == len);
+            assert(dsd_sps_filter_group_delay(kKinds[k], sps) == (len - 1) / 2);
+            for (int i = 0; i < len / 2; i++) {
+                const float a = taps[i];
+                const float b = taps[len - 1 - i];
+                const float scale = fabsf(a) > 1e-6f ? fabsf(a) : 1e-6f;
+                assert(fabsf(a - b) <= 1e-5f * scale);
+            }
+        }
+    }
+}
+
+/* An inactive filter has no geometry and must not claim any. */
+static void
+test_none_and_degenerate_rates_have_no_delay(void) {
+    static float taps[MAX_TAPS];
+    assert(dsd_sps_filter_group_delay(DSD_SPS_FILTER_NONE, 20) == 0);
+    assert(dsd_sps_filter_taps_len(DSD_SPS_FILTER_NONE, 20) == 0);
+    assert(dsd_sps_filter_copy_taps(DSD_SPS_FILTER_NONE, 20, taps, MAX_TAPS) == 0);
+    assert(dsd_sps_filter_group_delay(DSD_SPS_FILTER_NXDN, 1) == 0);
+    assert(dsd_sps_filter_group_delay(DSD_SPS_FILTER_NXDN, 0) == 0);
+    /* A buffer that cannot hold the taps gets nothing rather than a prefix. */
+    assert(dsd_sps_filter_copy_taps(DSD_SPS_FILTER_NXDN, 20, taps, 4) == 0);
+    /* Priming is a no-op for a filter that is not running. */
+    const float probe[4] = {1.0f, 2.0f, 3.0f, 4.0f};
+    dsd_sps_filter_prime(DSD_SPS_FILTER_NONE, probe, 4, 20);
+    assert(dsd_sps_filter_apply(DSD_SPS_FILTER_NONE, 7.5f, 20) == 7.5f);
+}
+
+/* A deterministic, non-repeating stimulus: every position is distinguishable,
+   so a rewind or a skip of even one sample shows up as a mismatch. */
+static float
+stimulus(int n) {
+    return sinf(0.13f * (float)n) * 8000.0f + cosf(0.021f * (float)n) * 3000.0f + 11.0f * (float)(n % 7);
+}
+
+/*
+ * The property the seam fix has to have. After the switch-on the grid's next
+ * read must return the filtered signal at the position it was about to read,
+ * computed from a full window of real samples.
+ */
+static void
+test_prime_and_catch_up_aligns_content(void) {
+    static float taps[MAX_TAPS];
+    static float ring[MAX_TAPS];
+
+    for (unsigned k = 0; k < sizeof(kKinds) / sizeof(kKinds[0]); k++) {
+        for (unsigned s = 0; s < sizeof(kSps) / sizeof(kSps[0]); s++) {
+            const dsd_sps_filter_kind kind = kKinds[k];
+            const int sps = kSps[s];
+            const int len = dsd_sps_filter_copy_taps(kind, sps, taps, MAX_TAPS);
+            assert(len > 0);
+            const int delay = (len - 1) / 2;
+            const int n0 = MAX_TAPS + 64; /* the first position read through the filter */
+
+            /* Whatever the previous transmission left in the history must not
+               reach the output; start from something that is not the signal. */
+            init_rrc_filter_memory();
+            for (int n = 0; n < 96; n++) {
+                (void)dsd_sps_filter_apply(kind, -20000.0f, sps);
+            }
+
+            /* The grid consumed n0 raw samples; the symbolizer keeps the tail. */
+            for (int i = 0; i < len; i++) {
+                ring[i] = stimulus(n0 - len + i);
+            }
+            dsd_sps_filter_prime(kind, ring, len, sps);
+
+            /* Pay off the delay once: these outputs describe samples the grid
+               has already consumed, so they are discarded. */
+            for (int j = 0; j < delay; j++) {
+                (void)dsd_sps_filter_apply(kind, stimulus(n0 + j), sps);
+            }
+
+            /* From here on, read k returns the filtered signal at n0 + k. */
+            for (int p = 0; p < 40; p++) {
+                const float got = dsd_sps_filter_apply(kind, stimulus(n0 + delay + p), sps);
+                double want = 0.0;
+                for (int i = 0; i < len; i++) {
+                    want += (double)taps[i] * (double)stimulus(n0 + delay + p - (len - 1) + i);
+                }
+                const double tol = 1e-3 * (fabs(want) + 1.0);
+                if (fabs((double)got - want) > tol) {
+                    DSD_FPRINTF(stderr, "%s sps=%d p=%d: got %.6f want %.6f\n", kind_name(kind), sps, p, (double)got,
+                                want);
+                }
+                assert(fabs((double)got - want) <= tol);
+            }
+        }
+    }
+}
+
+/*
+ * Without the prime, the same switch-on reads a window half full of whatever
+ * came before. This is the transient the fix removes; if it ever stops being
+ * measurable the prime has become unnecessary and this test should say so.
+ */
+static void
+test_unprimed_switch_on_is_measurably_wrong(void) {
+    static float taps[MAX_TAPS];
+    const dsd_sps_filter_kind kind = DSD_SPS_FILTER_NXDN;
+    const int sps = 20;
+    const int len = dsd_sps_filter_copy_taps(kind, sps, taps, MAX_TAPS);
+    assert(len > 0);
+    const int delay = (len - 1) / 2;
+    const int n0 = MAX_TAPS + 64;
+
+    init_rrc_filter_memory();
+    for (int n = 0; n < 96; n++) {
+        (void)dsd_sps_filter_apply(kind, -20000.0f, sps);
+    }
+    for (int j = 0; j < delay; j++) {
+        (void)dsd_sps_filter_apply(kind, stimulus(n0 + j), sps);
+    }
+    const float got = dsd_sps_filter_apply(kind, stimulus(n0 + delay), sps);
+    double want = 0.0;
+    for (int i = 0; i < len; i++) {
+        want += (double)taps[i] * (double)stimulus(n0 + delay - (len - 1) + i);
+    }
+    DSD_FPRINTF(stderr, "unprimed first output: got %.1f want %.1f\n", (double)got, want);
+    assert(fabs((double)got - want) > 1.0);
+}
+
+int
+main(void) {
+    test_taps_are_symmetric_and_odd();
+    test_none_and_degenerate_rates_have_no_delay();
+    test_prime_and_catch_up_aligns_content();
+    test_unprimed_switch_on_is_measurably_wrong();
+    DSD_FPRINTF(stderr, "matched filter seam: OK\n");
+    return 0;
+}

--- a/tests/dsp/test_matched_filter_seam.c
+++ b/tests/dsp/test_matched_filter_seam.c
@@ -12,9 +12,11 @@
  * samples per symbol, 4.5 for P25p1, and for P25p1 the leftover is exactly half
  * a symbol of phase as well (issue #444).
  *
- * These cases pin the geometry that makes the delay knowable, and the property
- * the fix has to have: after the switch, the value the grid reads for a position
- * is the filtered signal at that position, with no rewind and no transient.
+ * These cases pin what the filter module promises the symbolizer: the delay it
+ * reports is the delay its output really has, asking for it disturbs nothing,
+ * and a filter primed with the history it missed and then fed its delay's worth
+ * of samples reads, from then on, exactly what it would have read had it been
+ * running all along. The symbolizer's use of that is SYMBOL_MATCHED_FILTER_SEAM.
  */
 
 #include <assert.h>
@@ -24,6 +26,7 @@
 #include "dsd-neo/core/safe_api.h"
 
 #define MAX_TAPS DSD_SPS_FILTER_MAX_TAPS
+#define SIGNAL   (2 * MAX_TAPS + 256)
 
 static const char*
 kind_name(dsd_sps_filter_kind kind) {
@@ -40,28 +43,71 @@ static const dsd_sps_filter_kind kKinds[] = {DSD_SPS_FILTER_DMR, DSD_SPS_FILTER_
                                              DSD_SPS_FILTER_DPMR};
 static const int kSps[] = {20, 10, 8, 5, 4, 3, 2};
 
+/* A deterministic, non-repeating stimulus: every position is distinguishable,
+   so a rewind or a skip of even one sample shows up as a mismatch. */
+static float
+stimulus(int n) {
+    return sinf(0.13f * (float)n) * 8000.0f + cosf(0.021f * (float)n) * 3000.0f + 11.0f * (float)(n % 7);
+}
+
 /*
- * The delay is only knowable because the taps are symmetric and odd in length.
- * A design that broke either would make the seam correction a guess.
+ * What @p kind produces at each position when it has been running since the
+ * start of the stimulus: the reference every seam case is held to. Indexed by
+ * position, so feeding sample n fills entry n - delay.
  */
 static void
-test_taps_are_symmetric_and_odd(void) {
-    static float taps[MAX_TAPS];
+reference(dsd_sps_filter_kind kind, int sps, float* ref) {
+    const int delay = dsd_sps_filter_group_delay(kind, sps);
+    init_rrc_filter_memory();
+    for (int n = 0; n < SIGNAL; n++) {
+        const float y = dsd_sps_filter_apply(kind, stimulus(n), sps);
+        if (n - delay >= 0) {
+            ref[n - delay] = y;
+        }
+    }
+    for (int p = SIGNAL - delay; p < SIGNAL; p++) {
+        ref[p] = 0.0f;
+    }
+    init_rrc_filter_memory();
+}
+
+static int
+close_enough(float got, float want) {
+    return fabsf(got - want) <= 1e-3f * (fabsf(want) + 1.0f);
+}
+
+/*
+ * The delay is only knowable because the impulse response is symmetric about
+ * it and ends exactly one delay after it. A design that broke either would make
+ * the seam correction a guess.
+ */
+static void
+test_impulse_response_is_symmetric_about_the_delay(void) {
+    static float y[MAX_TAPS + 16];
     for (unsigned k = 0; k < sizeof(kKinds) / sizeof(kKinds[0]); k++) {
         for (unsigned s = 0; s < sizeof(kSps) / sizeof(kSps[0]); s++) {
+            const dsd_sps_filter_kind kind = kKinds[k];
             const int sps = kSps[s];
-            const int len = dsd_sps_filter_copy_taps(kKinds[k], sps, taps, MAX_TAPS);
-            DSD_FPRINTF(stderr, "%s sps=%d taps=%d delay=%d\n", kind_name(kKinds[k]), sps, len,
-                        dsd_sps_filter_group_delay(kKinds[k], sps));
-            assert(len > 0);
-            assert((len & 1) == 1);
-            assert(dsd_sps_filter_taps_len(kKinds[k], sps) == len);
-            assert(dsd_sps_filter_group_delay(kKinds[k], sps) == (len - 1) / 2);
-            for (int i = 0; i < len / 2; i++) {
-                const float a = taps[i];
-                const float b = taps[len - 1 - i];
+            const int delay = dsd_sps_filter_group_delay(kind, sps);
+            DSD_FPRINTF(stderr, "%s sps=%d delay=%d\n", kind_name(kind), sps, delay);
+            assert(delay > 0);
+            assert(2 * delay + 1 <= MAX_TAPS);
+
+            init_rrc_filter_memory();
+            const int outputs = 2 * delay + 1 + 8;
+            y[0] = dsd_sps_filter_apply(kind, 1.0f, sps);
+            for (int n = 1; n < outputs; n++) {
+                y[n] = dsd_sps_filter_apply(kind, 0.0f, sps);
+            }
+            for (int i = 0; i <= delay; i++) {
+                const float a = y[delay - i];
+                const float b = y[delay + i];
                 const float scale = fabsf(a) > 1e-6f ? fabsf(a) : 1e-6f;
                 assert(fabsf(a - b) <= 1e-5f * scale);
+            }
+            /* Nothing past 2 * delay: the response is exactly 2 * delay + 1 long. */
+            for (int n = 2 * delay + 1; n < outputs; n++) {
+                assert(fabsf(y[n]) <= 1e-7f);
             }
         }
     }
@@ -70,25 +116,44 @@ test_taps_are_symmetric_and_odd(void) {
 /* An inactive filter has no geometry and must not claim any. */
 static void
 test_none_and_degenerate_rates_have_no_delay(void) {
-    static float taps[MAX_TAPS];
     assert(dsd_sps_filter_group_delay(DSD_SPS_FILTER_NONE, 20) == 0);
-    assert(dsd_sps_filter_taps_len(DSD_SPS_FILTER_NONE, 20) == 0);
-    assert(dsd_sps_filter_copy_taps(DSD_SPS_FILTER_NONE, 20, taps, MAX_TAPS) == 0);
     assert(dsd_sps_filter_group_delay(DSD_SPS_FILTER_NXDN, 1) == 0);
     assert(dsd_sps_filter_group_delay(DSD_SPS_FILTER_NXDN, 0) == 0);
-    /* A buffer that cannot hold the taps gets nothing rather than a prefix. */
-    assert(dsd_sps_filter_copy_taps(DSD_SPS_FILTER_NXDN, 20, taps, 4) == 0);
-    /* Priming is a no-op for a filter that is not running. */
-    const float probe[4] = {1.0f, 2.0f, 3.0f, 4.0f};
-    dsd_sps_filter_prime(DSD_SPS_FILTER_NONE, probe, 4, 20);
-    assert(dsd_sps_filter_apply(DSD_SPS_FILTER_NONE, 7.5f, 20) == 7.5f);
+    /* Priming is a no-op for a filter that is not running, and NONE passes
+       samples through untouched. */
+    dsd_sps_filter_prime(DSD_SPS_FILTER_NONE, 1.0f, 20);
+    const float through = dsd_sps_filter_apply(DSD_SPS_FILTER_NONE, 7.5f, 20);
+    assert(fabsf(through - 7.5f) <= 1e-6f);
 }
 
-/* A deterministic, non-repeating stimulus: every position is distinguishable,
-   so a rewind or a skip of even one sample shows up as a mismatch. */
-static float
-stimulus(int n) {
-    return sinf(0.13f * (float)n) * 8000.0f + cosf(0.021f * (float)n) * 3000.0f + 11.0f * (float)(n % 7);
+/*
+ * Asking about geometry is a query. The seam asks for the delay of the filter it
+ * is switching to while the one it is leaving is still running, so the question
+ * must not redesign anything, or the answer costs a window of history.
+ */
+static void
+test_group_delay_query_does_not_disturb_a_running_filter(void) {
+    static float ref[SIGNAL];
+    const dsd_sps_filter_kind kind = DSD_SPS_FILTER_NXDN;
+    const int sps = 20;
+    reference(kind, sps, ref);
+    const int delay = dsd_sps_filter_group_delay(kind, sps);
+    const int n0 = MAX_TAPS + 64;
+
+    for (int n = 0; n < n0; n++) {
+        (void)dsd_sps_filter_apply(kind, stimulus(n), sps);
+    }
+    /* Another rate, as the seam asks for at a samples-per-symbol change. */
+    assert(dsd_sps_filter_group_delay(kind, 10) > 0);
+    assert(dsd_sps_filter_group_delay(kind, 8) > 0);
+    for (int p = 0; p < 40; p++) {
+        const float got = dsd_sps_filter_apply(kind, stimulus(n0 + p), sps);
+        const float want = ref[n0 + p - delay];
+        if (!close_enough(got, want)) {
+            DSD_FPRINTF(stderr, "after a delay query: p=%d got %.6f want %.6f\n", p, (double)got, (double)want);
+        }
+        assert(close_enough(got, want));
+    }
 }
 
 /*
@@ -98,50 +163,40 @@ stimulus(int n) {
  */
 static void
 test_prime_and_catch_up_aligns_content(void) {
-    static float taps[MAX_TAPS];
-    static float ring[MAX_TAPS];
-
+    static float ref[SIGNAL];
     for (unsigned k = 0; k < sizeof(kKinds) / sizeof(kKinds[0]); k++) {
         for (unsigned s = 0; s < sizeof(kSps) / sizeof(kSps[0]); s++) {
             const dsd_sps_filter_kind kind = kKinds[k];
             const int sps = kSps[s];
-            const int len = dsd_sps_filter_copy_taps(kind, sps, taps, MAX_TAPS);
-            assert(len > 0);
-            const int delay = (len - 1) / 2;
-            const int n0 = MAX_TAPS + 64; /* the first position read through the filter */
+            reference(kind, sps, ref);
+            const int delay = dsd_sps_filter_group_delay(kind, sps);
+            const int taps = 2 * delay + 1;
+            const int n0 = MAX_TAPS + 64; /* the position the grid was about to read */
 
             /* Whatever the previous transmission left in the history must not
                reach the output; start from something that is not the signal. */
-            init_rrc_filter_memory();
             for (int n = 0; n < 96; n++) {
                 (void)dsd_sps_filter_apply(kind, -20000.0f, sps);
             }
-
-            /* The grid consumed n0 raw samples; the symbolizer keeps the tail. */
-            for (int i = 0; i < len; i++) {
-                ring[i] = stimulus(n0 - len + i);
+            /* The grid consumed everything before n0; hand the filter the tail
+               that can still be in its window, oldest first. */
+            for (int n = n0 - taps; n < n0; n++) {
+                dsd_sps_filter_prime(kind, stimulus(n), sps);
             }
-            dsd_sps_filter_prime(kind, ring, len, sps);
-
-            /* Pay off the delay once: these outputs describe samples the grid
-               has already consumed, so they are discarded. */
+            /* Pay off the delay once: these outputs describe positions the grid
+               has already read, so they are discarded. */
             for (int j = 0; j < delay; j++) {
                 (void)dsd_sps_filter_apply(kind, stimulus(n0 + j), sps);
             }
-
-            /* From here on, read k returns the filtered signal at n0 + k. */
+            /* From here on, read p returns the filtered signal at n0 + p. */
             for (int p = 0; p < 40; p++) {
                 const float got = dsd_sps_filter_apply(kind, stimulus(n0 + delay + p), sps);
-                double want = 0.0;
-                for (int i = 0; i < len; i++) {
-                    want += (double)taps[i] * (double)stimulus(n0 + delay + p - (len - 1) + i);
-                }
-                const double tol = 1e-3 * (fabs(want) + 1.0);
-                if (fabs((double)got - want) > tol) {
+                const float want = ref[n0 + p];
+                if (!close_enough(got, want)) {
                     DSD_FPRINTF(stderr, "%s sps=%d p=%d: got %.6f want %.6f\n", kind_name(kind), sps, p, (double)got,
-                                want);
+                                (double)want);
                 }
-                assert(fabs((double)got - want) <= tol);
+                assert(close_enough(got, want));
             }
         }
     }
@@ -154,15 +209,13 @@ test_prime_and_catch_up_aligns_content(void) {
  */
 static void
 test_unprimed_switch_on_is_measurably_wrong(void) {
-    static float taps[MAX_TAPS];
+    static float ref[SIGNAL];
     const dsd_sps_filter_kind kind = DSD_SPS_FILTER_NXDN;
     const int sps = 20;
-    const int len = dsd_sps_filter_copy_taps(kind, sps, taps, MAX_TAPS);
-    assert(len > 0);
-    const int delay = (len - 1) / 2;
+    reference(kind, sps, ref);
+    const int delay = dsd_sps_filter_group_delay(kind, sps);
     const int n0 = MAX_TAPS + 64;
 
-    init_rrc_filter_memory();
     for (int n = 0; n < 96; n++) {
         (void)dsd_sps_filter_apply(kind, -20000.0f, sps);
     }
@@ -170,18 +223,16 @@ test_unprimed_switch_on_is_measurably_wrong(void) {
         (void)dsd_sps_filter_apply(kind, stimulus(n0 + j), sps);
     }
     const float got = dsd_sps_filter_apply(kind, stimulus(n0 + delay), sps);
-    double want = 0.0;
-    for (int i = 0; i < len; i++) {
-        want += (double)taps[i] * (double)stimulus(n0 + delay - (len - 1) + i);
-    }
-    DSD_FPRINTF(stderr, "unprimed first output: got %.1f want %.1f\n", (double)got, want);
-    assert(fabs((double)got - want) > 1.0);
+    const float want = ref[n0];
+    DSD_FPRINTF(stderr, "unprimed first output: got %.1f want %.1f\n", (double)got, (double)want);
+    assert(!close_enough(got, want));
 }
 
 int
 main(void) {
-    test_taps_are_symmetric_and_odd();
+    test_impulse_response_is_symmetric_about_the_delay();
     test_none_and_degenerate_rates_have_no_delay();
+    test_group_delay_query_does_not_disturb_a_running_filter();
     test_prime_and_catch_up_aligns_content();
     test_unprimed_switch_on_is_measurably_wrong();
     DSD_FPRINTF(stderr, "matched filter seam: OK\n");

--- a/tests/dsp/test_symbol_matched_filter_seam.c
+++ b/tests/dsp/test_symbol_matched_filter_seam.c
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * The symbol grid reads the raw discriminator until a sync names a protocol and
+ * the matched filter's output afterwards, and those describe different instants:
+ * a symmetric FIR of L taps reports the signal (L-1)/2 samples in the past. These
+ * cases drive getSymbol() from a WAV across every switch the grid can make --
+ * raw to a filter, a filter to a shorter one, to a longer one, and back to raw --
+ * and check one property at each: the content position the grid reads continues
+ * without a rewind or a skip, and what it reads there is what a filter that had
+ * been running all along would have produced at that position (issue #444).
+ *
+ * The switch is keyed on lastsynctype, which frame sync sets at an accept and
+ * noCarrier clears, always between symbols; flipping it between getSymbol()
+ * calls is the real sequence. have_sync is 1 throughout so the inter-frame
+ * timing nudge stays out of the way and the grid moves one span per symbol.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/audio_filters.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/power.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/sps_filters.h>
+#include <dsd-neo/dsp/symbol.h>
+#include <dsd-neo/io/rigctl_client.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/runtime/exitflag.h>
+#include <dsd-neo/runtime/shutdown.h>
+#include <math.h>
+#include <sndfile.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
+
+dsd_socket_t
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+Connect(char* hostname, int portno) {
+    (void)hostname;
+    (void)portno;
+    return (dsd_socket_t)0;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+openAudioInput(dsd_opts* opts) {
+    (void)opts;
+    return -1;
+}
+
+int
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_audio_reconfigure_output_for_input_policy(dsd_opts* opts) {
+    (void)opts;
+    return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_request_shutdown(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    exitflag = 1;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+dsd_audio_rescale_symbol_timing(dsd_state* state, int old_rate_hz, int new_rate_hz) {
+    (void)state;
+    (void)old_rate_hz;
+    (void)new_rate_hz;
+}
+
+double
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+pwr_to_dB(double mean_power) {
+    (void)mean_power;
+    return 0.0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+lpf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+hpf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+pbf_f(dsd_state* state, float* input, int len) {
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+analog_gain_f(const dsd_opts* opts, dsd_state* state, float* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+agsm_f(dsd_opts* opts, dsd_state* state, float* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+#define SPS        10
+#define CENTER     4
+#define TOTAL      6000 /* samples in the WAV: far more than any sequence reads */
+#define PHASE_SYMS 20   /* symbols read in each phase of a sequence */
+#define MAX_KINDS  3
+
+/* Deterministic and non-repeating, so a rewind or a skip of one sample shows. */
+static short
+stimulus(int n) {
+    const float v = sinf(0.13f * (float)n) * 6000.0f + cosf(0.021f * (float)n) * 2500.0f + 11.0f * (float)(n % 7);
+    return (short)lrintf(v);
+}
+
+static short g_raw[TOTAL];
+/* What each filter would have produced at every content position, had it been
+   running from the start. Index is the position, not the feed count. */
+static float g_ref[MAX_KINDS][TOTAL];
+
+static int
+kind_slot(dsd_sps_filter_kind kind) {
+    switch (kind) {
+        case DSD_SPS_FILTER_NONE: return 0;
+        case DSD_SPS_FILTER_P25: return 1;
+        case DSD_SPS_FILTER_DMR: return 2;
+        default: assert(0); return 0;
+    }
+}
+
+static const char*
+kind_name(dsd_sps_filter_kind kind) {
+    switch (kind) {
+        case DSD_SPS_FILTER_P25: return "p25";
+        case DSD_SPS_FILTER_DMR: return "dmr";
+        default: return "raw";
+    }
+}
+
+static void
+build_references(void) {
+    for (int n = 0; n < TOTAL; n++) {
+        g_raw[n] = stimulus(n);
+        g_ref[0][n] = (float)g_raw[n];
+    }
+    const dsd_sps_filter_kind kinds[] = {DSD_SPS_FILTER_P25, DSD_SPS_FILTER_DMR};
+    for (unsigned k = 0; k < sizeof(kinds) / sizeof(kinds[0]); k++) {
+        const int delay = dsd_sps_filter_group_delay(kinds[k], SPS);
+        assert(delay > 0);
+        init_rrc_filter_memory();
+        for (int n = 0; n < TOTAL; n++) {
+            /* Feeding sample n yields the filtered signal at position n - delay. */
+            const float y = dsd_sps_filter_apply(kinds[k], (float)g_raw[n], SPS);
+            if (n - delay >= 0) {
+                g_ref[kind_slot(kinds[k])][n - delay] = y;
+            }
+        }
+    }
+    init_rrc_filter_memory();
+}
+
+static int
+write_wav(char* out_path, size_t out_path_size) {
+    int fd = dsd_test_mkstemp(out_path, out_path_size, "dsdneo_seam");
+    if (fd < 0) {
+        return -1;
+    }
+    dsd_close(fd);
+    SF_INFO info;
+    DSD_MEMSET(&info, 0, sizeof(info));
+    info.samplerate = 48000;
+    info.channels = 1;
+    info.format = SF_FORMAT_WAV | SF_FORMAT_PCM_16;
+    SNDFILE* wav = sf_open(out_path, SFM_WRITE, &info);
+    if (wav == NULL) {
+        return -1;
+    }
+    const int ok = sf_write_short(wav, g_raw, TOTAL) == TOTAL;
+    sf_close(wav);
+    return ok ? 0 : -1;
+}
+
+typedef struct {
+    dsd_opts* opts;
+    dsd_state* state;
+    int position; /* content position of the next symbol's first sample */
+} grid;
+
+static void
+grid_open(grid* g, dsd_opts* opts, dsd_state* state, const char* wav_path) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_file_info = (SF_INFO*)calloc(1, sizeof(*opts->audio_in_file_info));
+    assert(opts->audio_in_file_info != NULL);
+    opts->audio_in_file = sf_open(wav_path, SFM_READ, opts->audio_in_file_info);
+    assert(opts->audio_in_file != NULL);
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->audio_out_type = 1;
+    opts->input_volume_multiplier = 1;
+    opts->wav_sample_rate = 48000;
+    opts->use_cosine_filter = 1;
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof(opts->audio_in_dev), "%s", wav_path);
+
+    state->samplesPerSymbol = SPS;
+    state->symbolCenter = CENTER;
+    state->rf_mod = 0;
+    state->center = 0.0f;
+    state->min = -32768.0f; /* the synced clip must not touch anything */
+    state->max = 32767.0f;
+    state->synctype = DSD_SYNC_NONE;
+    state->lastsynctype = DSD_SYNC_NONE;
+    state->jitter = -1;
+    exitflag = 0;
+    init_rrc_filter_memory();
+
+    g->opts = opts;
+    g->state = state;
+    g->position = 0;
+}
+
+static void
+grid_close(grid* g) {
+    if (g->opts->audio_in_file) {
+        sf_close(g->opts->audio_in_file);
+        g->opts->audio_in_file = NULL;
+    }
+    free(g->opts->audio_in_file_info);
+    g->opts->audio_in_file_info = NULL;
+}
+
+/* The C4FM decision window the symbolizer uses for this lastsynctype. */
+static void
+window_for(int lastsynctype, int* l, int* r) {
+    *l = DSD_SYNC_IS_DMR_BS(lastsynctype) ? 1 : 2;
+    *r = 2;
+}
+
+/*
+ * Read @p symbols symbols with the grid told that @p lastsynctype is the stream
+ * it is on, and count the ones that are not the mean of @p kind's reference
+ * over the decision window at the positions the grid should be reading.
+ */
+static int
+run_symbols(grid* g, int lastsynctype, dsd_sps_filter_kind kind, int symbols, const char* label) {
+    g->state->lastsynctype = lastsynctype;
+    int l = 0;
+    int r = 0;
+    window_for(lastsynctype, &l, &r);
+    const float* ref = g_ref[kind_slot(kind)];
+    int mismatches = 0;
+    for (int m = 0; m < symbols; m++) {
+        const float got = getSymbol(g->opts, g->state, 1);
+        assert(exitflag == 0);
+        float want = 0.0f;
+        for (int i = CENTER - l; i <= CENTER + r; i++) {
+            want += ref[g->position + i];
+        }
+        want /= (float)(l + r + 1);
+        const float tol = 1e-3f * (fabsf(want) + 1.0f);
+        if (fabsf(got - want) > tol) {
+            if (mismatches < 3) {
+                DSD_FPRINTF(stderr, "  %s: %s symbol %d at position %d: got %.2f want %.2f\n", label, kind_name(kind),
+                            m, g->position, (double)got, (double)want);
+            }
+            mismatches++;
+        }
+        g->position += SPS;
+    }
+    DSD_FPRINTF(stderr, "%s: %s phase, %d of %d symbols off\n", label, kind_name(kind), mismatches, symbols);
+    return mismatches;
+}
+
+static int
+run_phase(grid* g, int lastsynctype, dsd_sps_filter_kind kind, const char* label) {
+    return run_symbols(g, lastsynctype, kind, PHASE_SYMS, label);
+}
+
+/* Sanity: with no filter in play the grid reads contiguous raw positions, which
+   is what every other case's bookkeeping assumes. */
+static void
+test_raw_grid_reads_contiguous_positions(const char* wav_path) {
+    static dsd_opts opts;
+    static dsd_state state;
+    grid g;
+    grid_open(&g, &opts, &state, wav_path);
+    assert(run_phase(&g, DSD_SYNC_NONE, DSD_SPS_FILTER_NONE, "raw only") == 0);
+    grid_close(&g);
+}
+
+/* Raw to a filter: the classic switch-on at a sync accept. The first symbol
+   after it must already be the filtered signal at the position the grid was
+   about to read, from a full window of real history. */
+static void
+test_switch_on_from_raw_continues_the_position(const char* wav_path) {
+    static dsd_opts opts;
+    static dsd_state state;
+    grid g;
+    grid_open(&g, &opts, &state, wav_path);
+    assert(run_phase(&g, DSD_SYNC_NONE, DSD_SPS_FILTER_NONE, "switch-on") == 0);
+    assert(run_phase(&g, DSD_SYNC_P25P1_POS, DSD_SPS_FILTER_P25, "switch-on") == 0);
+    grid_close(&g);
+}
+
+/* A filter back to raw: noCarrier. The filter was reporting the signal a group
+   delay in the past, so the raw stream has to resume from there, not from the
+   live sample, or the grid skips that much content. */
+static void
+test_switch_off_to_raw_continues_the_position(const char* wav_path) {
+    static dsd_opts opts;
+    static dsd_state state;
+    grid g;
+    grid_open(&g, &opts, &state, wav_path);
+    assert(run_phase(&g, DSD_SYNC_NONE, DSD_SPS_FILTER_NONE, "switch-off") == 0);
+    assert(run_phase(&g, DSD_SYNC_P25P1_POS, DSD_SPS_FILTER_P25, "switch-off") == 0);
+    assert(run_phase(&g, DSD_SYNC_NONE, DSD_SPS_FILTER_NONE, "switch-off") == 0);
+    grid_close(&g);
+}
+
+/* A longer filter to a shorter one, which AUTO does when the sync it accepts
+   changes protocol: the shorter one reports less far back, so the difference
+   has to be re-read, not skipped. */
+static void
+test_switch_to_shorter_filter_continues_the_position(const char* wav_path) {
+    static dsd_opts opts;
+    static dsd_state state;
+    grid g;
+    grid_open(&g, &opts, &state, wav_path);
+    assert(run_phase(&g, DSD_SYNC_NONE, DSD_SPS_FILTER_NONE, "shorter") == 0);
+    assert(run_phase(&g, DSD_SYNC_P25P1_POS, DSD_SPS_FILTER_P25, "shorter") == 0);
+    assert(run_phase(&g, DSD_SYNC_DMR_BS_VOICE_POS, DSD_SPS_FILTER_DMR, "shorter") == 0);
+    grid_close(&g);
+}
+
+/* A shorter filter to a longer one: only the difference in delay is owed. */
+static void
+test_switch_to_longer_filter_continues_the_position(const char* wav_path) {
+    static dsd_opts opts;
+    static dsd_state state;
+    grid g;
+    grid_open(&g, &opts, &state, wav_path);
+    assert(run_phase(&g, DSD_SYNC_NONE, DSD_SPS_FILTER_NONE, "longer") == 0);
+    assert(run_phase(&g, DSD_SYNC_DMR_BS_VOICE_POS, DSD_SPS_FILTER_DMR, "longer") == 0);
+    assert(run_phase(&g, DSD_SYNC_P25P1_POS, DSD_SPS_FILTER_P25, "longer") == 0);
+    grid_close(&g);
+}
+
+/* A sync accept can land while a switch-off is still handing samples back: the
+   P25 filter's 45 span four and a half symbols, and noCarrier clears the sync
+   between frames. The filter switching on then has to prime from before the
+   samples still owed and consume them, in order, as part of its catch-up. */
+static void
+test_switch_on_while_handing_back_continues_the_position(const char* wav_path) {
+    static dsd_opts opts;
+    static dsd_state state;
+    grid g;
+    grid_open(&g, &opts, &state, wav_path);
+    assert(run_phase(&g, DSD_SYNC_NONE, DSD_SPS_FILTER_NONE, "handing back") == 0);
+    assert(run_phase(&g, DSD_SYNC_P25P1_POS, DSD_SPS_FILTER_P25, "handing back") == 0);
+    assert(run_symbols(&g, DSD_SYNC_NONE, DSD_SPS_FILTER_NONE, 2, "handing back") == 0);
+    assert(g.state->matched_filter.replay > 0);
+    assert(run_phase(&g, DSD_SYNC_P25P1_POS, DSD_SPS_FILTER_P25, "handing back") == 0);
+    assert(run_symbols(&g, DSD_SYNC_NONE, DSD_SPS_FILTER_NONE, 1, "handing back") == 0);
+    assert(g.state->matched_filter.replay > 0);
+    assert(run_phase(&g, DSD_SYNC_DMR_BS_VOICE_POS, DSD_SPS_FILTER_DMR, "handing back") == 0);
+    grid_close(&g);
+}
+
+typedef struct {
+    const char* name;
+    void (*run)(const char* wav_path);
+} seam_case;
+
+static const seam_case kCases[] = {
+    {"raw", test_raw_grid_reads_contiguous_positions},
+    {"switch-on", test_switch_on_from_raw_continues_the_position},
+    {"switch-off", test_switch_off_to_raw_continues_the_position},
+    {"shorter", test_switch_to_shorter_filter_continues_the_position},
+    {"longer", test_switch_to_longer_filter_continues_the_position},
+    {"handing-back", test_switch_on_while_handing_back_continues_the_position},
+};
+
+/* An optional argument names one case to run alone, for watching it fail. */
+int
+main(int argc, char** argv) {
+    build_references();
+    char wav_path[DSD_TEST_PATH_MAX];
+    assert(write_wav(wav_path, sizeof(wav_path)) == 0);
+
+    int ran = 0;
+    for (unsigned c = 0; c < sizeof(kCases) / sizeof(kCases[0]); c++) {
+        if (argc > 1 && strcmp(argv[1], kCases[c].name) != 0) {
+            continue;
+        }
+        kCases[c].run(wav_path);
+        ran++;
+    }
+    assert(ran > 0);
+
+    remove(wav_path);
+    DSD_FPRINTF(stderr, "symbol matched filter seam: OK\n");
+    return 0;
+}


### PR DESCRIPTION
Closes #444. What that issue asked for was measured and is recorded in the closing comment there; what it was
actually seeing is fixed here.

## What this fixes

The symbol grid reads the raw discriminator until a sync names a protocol, and the matched filter's output from
that accept onward. Those are not the same signal. A symmetric FIR of L taps reports the signal `(L-1)/2` samples
in the past, so at the switch the decoder starts re-reading content it has already consumed, from a history half
full of whatever the previous transmission left behind:

| filter | sps | taps | group delay | of which sub-symbol |
|---|---|---|---|---|
| NXDN48 / dPMR | 20 | 135 | 67 samples | 7 (0.35 symbol) |
| P25p1 | 10 | 91 | 45 samples | 5 (half a symbol) |
| DMR | 10 | 61 | 30 samples | 0 |

`use_cosine_filter` is on by default, so this is normal operation. It is also not once per call: `noCarrier`
clears `lastsynctype`, so on the `fiNXDN` capture the filter switches on and off **179 times in 40 seconds**,
roughly once per frame. Each switch-on rewound the grid by that delay, and each switch-off skipped the same
amount, because the samples the filter still had in flight were never read.

## The fix

Every switch is treated as a move of the content position and paid for in samples, so the grid does not move:

- **Switching on**, or to a longer filter: the filter is primed from the raw samples it missed, then fed the
  difference in delay and those outputs discarded, since they describe positions the grid has already read.
- **Switching off**, or to a shorter filter: the samples the old filter still had in flight are handed back and
  re-read from the raw history, through the new filter if there is one, before live input resumes.

The raw history and the bookkeeping live in `dsd_state::matched_filter`, owned by the symbolizer; the filter
module promises only the delay, stated without disturbing a running filter, and a way to push history into a
filter. Filtering is selected as a kind once per sample, so the switch and the filtering cannot disagree.

## Measurement

`tools/replay_ab.sh`, 12 rotated repeats, realtime pacing, `fiNXDN` (`-fi`), machine idle:

|  | main | this branch | paired |
|---|---|---|---|
| errors per decoded voice frame | 3.63 | **2.34** | **-1.30 +/- 0.10**, 12/12 better |
| total errors | 274.2 | 160.7 | -113.6 +/- 7.3 (-41%) |
| decoded voice frames | 75.5 | 68.8 | -6.75 +/- 1.11 (-9%) |
| syncs | 109.9 | 105.2 | -4.7 +/- 2.2 (-4%) |

The voice-frame count is worth stating plainly rather than burying, and this time it was worth finding out what it
is. Matching the AMBE payloads in `-Z` logs of one replay through each build: every subframe both builds decoded
carried the same errors (106 against 105 over about 240 subframes). The errors that went away sit in frames only
`main` produces: the first frame after each switch-on, read from samples rewound by a third of a symbol, which
decodes as voice with about four errors per subframe against under one for the rest of the call, and shows up as
`PF X/4` because its SACCH cannot be read either. The frame count fell because those were never real decodes; the
frames inside calls are the same set, decoded the same. `docs/testing.md` records the method.

The first cut of this branch, before the review fixes below, measured 2.80 in the same run (-0.83 +/- 0.14
against `main`); the fixes are worth a further -0.46 +/- 0.13 (11/12), most of it the switch-off.

## Tests

- `MATCHED_FILTER_SEAM` pins what the filter module promises: the impulse response is symmetric about the delay
  and ends exactly one delay after it, asking for the delay disturbs nothing, and a primed filter reads what a
  continuously running one would have, for four filters across seven rates. It also asserts the unprimed
  switch-on is measurably wrong, so the prime cannot be quietly dropped.
- `SYMBOL_MATCHED_FILTER_SEAM` drives `getSymbol()` from a WAV across each kind of switch: raw to a filter, back
  to raw, to a shorter filter, to a longer one, and a sync accept landing while a switch-off is still handing
  samples back. Each checks that the content position never moves and that every read is what a filter running
  all along would have produced there. The first cut of this seam had a call-order bug that the filter test could
  not see; this is the test that would have caught it.

`ctest` full suite green on `dev-debug`; `iq-decode` green; `preflight_ci.sh` clean.

## What is not here

A closed timing loop to replace the open-loop +/-1 slip, which is the direction #444 pointed at, was built and
measured against it on the same capture and is **not** in this branch. It was worth about 0.18 errors per voice
frame on `fiNXDN`, at the noise floor, and the anchor it measures phase against had to differ per protocol to
work at all. The closing comment on #444 records the numbers so nobody has to rebuild it to learn that.
