### PR TITLE
fix(dmr): label a zero-length LRRP message by its type (#453)

### DIFF
--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -1495,15 +1495,12 @@ typedef struct {
     uint8_t lrrp_type;
 } dmr_lrrp_emit_context;
 
+// A zero-length message reaches here with an empty `best`: no details print,
+// nothing is written to the LRRP file, and the summary is chosen by the type
+// byte alone (sdrtrunk and lrrpdec.py label it the same way, #453).
 static void
 dmr_lrrp_emit_payload(const dsd_opts* opts, dsd_state* state, uint8_t slot, const dmr_lrrp_parse_result* best,
-                      uint8_t payload_len, uint8_t pdu_crc_ok, const dmr_lrrp_emit_context* ctx) {
-    if (payload_len == 0) {
-        DSD_SNPRINTF(state->dmr_lrrp_gps[slot], sizeof state->dmr_lrrp_gps[slot],
-                     "LRRP SRC: %0d; Unknown Format %02X; TGT: %d;", ctx->source, ctx->lrrp_type, ctx->dest);
-        DSD_FPRINTF(stderr, "\n %s", state->dmr_lrrp_gps[slot]);
-        return;
-    }
+                      uint8_t pdu_crc_ok, const dmr_lrrp_emit_context* ctx) {
     dmr_lrrp_scaled s = dmr_lrrp_compute_scaled(best);
     DSD_FPRINTF(stderr, "%s", KYEL);
     dmr_lrrp_print_details(best, &s, pdu_crc_ok);
@@ -1563,7 +1560,7 @@ dmr_lrrp(const dsd_opts* opts, dsd_state* state, uint16_t len, uint32_t source, 
         source = (uint32_t)state->dmr_lrrp_source[state->currentslot];
     }
     dmr_lrrp_emit_context emit_ctx = {source, dest, is_request, is_response, lrrp_type};
-    dmr_lrrp_emit_payload(opts, state, slot, &best, payload_len, pdu_crc_ok, &emit_ctx);
+    dmr_lrrp_emit_payload(opts, state, slot, &best, pdu_crc_ok, &emit_ctx);
     DSD_FPRINTF(stderr, "%s", KNRM);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7250,6 +7250,33 @@ target_link_libraries(
 )
 add_test(NAME DMR_LRRP_CRC_GATING COMMAND dsd-neo_test_dmr_lrrp_crc_gating)
 
+# DMR LRRP: a zero-length message keeps its request/response label (#453)
+add_executable(
+    dsd-neo_test_dmr_lrrp_empty_payload_type
+    protocol/dmr/test_dmr_lrrp_empty_payload_type.c
+    test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_lrrp_empty_payload_type
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/dmr
+)
+target_include_directories(
+    dsd-neo_test_dmr_lrrp_empty_payload_type
+    SYSTEM
+    PRIVATE ${_PUBLIC_INCLUDES}
+)
+target_link_libraries(
+    dsd-neo_test_dmr_lrrp_empty_payload_type
+    PRIVATE dsd-neo_platform
+)
+add_test(
+    NAME DMR_LRRP_EMPTY_PAYLOAD_TYPE
+    COMMAND dsd-neo_test_dmr_lrrp_empty_payload_type
+)
+
 # DMR SMS/TMS UTF-16 text: surrogate pairs combine, unpaired halves become U+FFFD
 add_executable(
     dsd-neo_test_dmr_pdu_utf16_text
@@ -9096,6 +9123,7 @@ set(_DSD_NEO_BIT_PACKING_TEST_TARGETS
     dsd-neo_test_dmr_grant_policy
     dsd-neo_test_dmr_locn_time_fallback
     dsd-neo_test_dmr_lrrp_crc_gating
+    dsd-neo_test_dmr_lrrp_empty_payload_type
     dsd-neo_test_dmr_lrrp_ip_udp_lengths
     dsd-neo_test_dmr_lrrp_position_token_precedence
     dsd-neo_test_dmr_lrrp_response_token_lengths

--- a/tests/protocol/dmr/test_dmr_lrrp_empty_payload_type.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_empty_payload_type.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Regression (#453): an LRRP message whose length byte is zero is still a
+ * message of the type its first byte declares. A triggered-location report
+ * or a stop acknowledgement with no tokens must be labelled "Response to
+ * TGT" and an immediate location request with no tokens "Request from TGT",
+ * exactly as the same types are labelled when tokens follow. Only a type the
+ * classifier does not know keeps the "Unknown Format" label.
+ */
+
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/time_format.h>
+#include <dsd-neo/runtime/unicode.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+// Minimal stubs for direct link with dmr_pdu.c
+const char*
+dsd_degrees_glyph(void) {
+    return "";
+}
+
+int
+dsd_unicode_supported(void) {
+    return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+lip_protocol_decoder(dsd_opts* opts, dsd_state* state, uint8_t* input) {
+    (void)opts;
+    (void)state;
+    (void)input;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+decode_cellocator(dsd_opts* opts, dsd_state* state, uint8_t* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+int
+dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
+                           const char* notice) {
+    (void)opts;
+    (void)state;
+    (void)observation->ota_source_id;
+    (void)observation->ota_target_id;
+    (void)notice;
+    (void)slot;
+    return 0;
+}
+
+// Deterministic system time (not used: file output disabled)
+int
+dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out, size_t out_size) {
+    (void)timestamp;
+    const char* value = (format == DSD_LOCAL_DATETIME_DATE_SLASH) ? "1999/01/02" : "11:22:33";
+    DSD_SNPRINTF(out, out_size, "%s", value);
+    return 1;
+}
+
+// Under test
+void dmr_lrrp(const dsd_opts* opts, dsd_state* state, uint16_t len, uint32_t source, uint32_t dest,
+              const uint8_t* DMR_PDU, uint8_t pdu_crc_ok);
+
+typedef struct {
+    const uint8_t* pdu;
+    uint16_t len;
+    const char* expect;
+    const char* tag;
+} lrrp_case;
+
+// Type byte, length byte, then tokens. Source 123, target 456 in every case.
+static const uint8_t k_triggered_report_empty[] = {0x0D, 0x00};
+static const uint8_t k_triggered_report_with_id[] = {0x0D, 0x02, 0x22, 0x01};
+static const uint8_t k_stop_response_empty[] = {0x11, 0x00};
+static const uint8_t k_immediate_request_empty[] = {0x05, 0x00};
+static const uint8_t k_unknown_type_empty[] = {0x33, 0x00};
+
+static const lrrp_case k_cases[] = {
+    {k_triggered_report_empty, sizeof k_triggered_report_empty, "LRRP SRC: 123; Response to TGT: 456;",
+     "0x0D triggered location, zero length"},
+    {k_triggered_report_with_id, sizeof k_triggered_report_with_id, "LRRP SRC: 123; Response to TGT: 456;",
+     "0x0D triggered location, identity token (control)"},
+    {k_stop_response_empty, sizeof k_stop_response_empty, "LRRP SRC: 123; Response to TGT: 456;",
+     "0x11 triggered location stop response, zero length"},
+    {k_immediate_request_empty, sizeof k_immediate_request_empty, "LRRP SRC: 123; Request from TGT: 456;",
+     "0x05 immediate location request, zero length"},
+    {k_unknown_type_empty, sizeof k_unknown_type_empty, "LRRP SRC: 123; Unknown Format 33; TGT: 456;",
+     "0x33 unknown type, zero length (control)"},
+};
+
+int
+main(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&st, 0, sizeof st);
+    st.currentslot = 0;
+    opts.lrrp_file_output = 0;
+
+    int rc = 0;
+    for (size_t i = 0; i < sizeof k_cases / sizeof k_cases[0]; i++) {
+        const lrrp_case* c = &k_cases[i];
+        DSD_MEMSET(st.dmr_lrrp_gps[0], 0, sizeof st.dmr_lrrp_gps[0]);
+        dmr_lrrp(&opts, &st, c->len, /*src*/ 123, /*dst*/ 456, c->pdu, /*pdu_crc_ok*/ 1);
+        if (strcmp(st.dmr_lrrp_gps[0], c->expect) != 0) {
+            DSD_FPRINTF(stderr, "%s: got '%s' expected '%s'\n", c->tag, st.dmr_lrrp_gps[0], c->expect);
+            rc = 1;
+        }
+    }
+    return rc;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
## Summary

- Fixes #453 (the demonstrated part). `dmr_lrrp()` classifies the LRRP type byte into request/response before it reads the length byte, but `dmr_lrrp_emit_payload()` returned early with `Unknown Format XX` whenever the length byte was zero, so a token-less triggered-location report, stop acknowledgement or immediate request was reported as unrecognised even though its type was known.
- Delete that early return (and its now-unused `payload_len` parameter). With an empty parse result the shared `dmr_lrrp_build_summary()` already prints `Request from TGT` / `Response to TGT`, and still prints `Unknown Format` for a type the classifier does not know. Nothing is written to the LRRP file and no details print, exactly as before, because `best` is empty.
- The rule was dsd-neo's own: dsd-fme's catch-all `else` in `dmr_lrrp()`, carried through the #95 refactor. The official LRRP specification is licensed-only, so the behaviour was checked against two public decoders: sdrtrunk (`LRRPPacketType`, `LRRPPacket.toString()` labels the type with zero tokens) and `XTR1984/lrrpdec` (labels the type before reading any token). Both agree with the existing type table.
- New regression `DMR_LRRP_EMPTY_PAYLOAD_TYPE` drives `dmr_lrrp()` with the issue's three packets plus a `0x11` stop response and an unknown `0x33` control:

| payload | before | after |
|---|---|---|
| `0D 00` | `Unknown Format 0D` | `Response to TGT` |
| `0D 02 22 01` | `Response to TGT` | `Response to TGT` |
| `11 00` | `Unknown Format 11` | `Response to TGT` |
| `05 00` | `Unknown Format 05` | `Request from TGT` |
| `33 00` | `Unknown Format 33` | `Unknown Format 33` |

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: parser / network input (LRRP over UDP; the change only removes a branch ahead of the existing summary builder).
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. (none added)
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (592 passed)
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes (not run: single-branch removal)
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes (n/a)
- [ ] `tools/osv_scan.sh` for dependency input changes (n/a)
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes (n/a)

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: the LRRP summary line (console, ncurses data field, event history) for a zero-length message of a known type now reads `Request from TGT: n;` / `Response to TGT: n;` instead of `Unknown Format XX;`. Unknown types are unchanged. The line is now preceded by the same colour code as every other LRRP summary.
- Compatibility or packaging impact: none.
