### PR TITLE
fix(dmr): try the bytes past a short LRRP length byte for a position (#453)

### DIFF
--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -1377,19 +1377,40 @@ dmr_lrrp_has_position_token(const uint8_t* pdu, size_t avail, size_t token_len) 
     return 0;
 }
 
+// Walk the token stream from each of the first few prefix offsets and keep the
+// best-scoring parse; `penalty` is subtracted from every candidate of this walk.
 static void
-dmr_lrrp_parse_best_response(const uint8_t* pdu, size_t avail, size_t token_len, dmr_lrrp_parse_result* best) {
+dmr_lrrp_parse_best_response_over(const uint8_t* pdu, size_t avail, size_t token_len, int penalty,
+                                  dmr_lrrp_parse_result* best, int* best_score) {
     const size_t max_skip = 6u;
-    int best_score = -1000000;
     for (size_t skip = 0; skip <= max_skip && skip <= token_len; skip++) {
         dmr_lrrp_parse_result cur;
         dmr_lrrp_parse_result_init(&cur);
         dmr_lrrp_parse_response_tokens(pdu, avail, 2u + skip, token_len - skip, &cur);
-        int score = dmr_lrrp_parse_score(&cur, skip);
-        if (score > best_score) {
-            best_score = score;
+        int score = dmr_lrrp_parse_score(&cur, skip) - penalty;
+        if (score > *best_score) {
+            *best_score = score;
             *best = cur;
         }
+    }
+}
+
+// Some senders put a length byte on a response that under-counts the tokens
+// behind it (#453). The declared length is trusted first; when the UDP payload
+// runs past it, the bytes up to the payload end are tried as a second candidate
+// carrying this penalty. It outweighs anything but a new position (+1000) or a
+// timestamp plus speed plus heading (+200), and unknown bytes cost the second
+// candidate a point each, so a conformant message never changes its decode
+// and junk past the declared length never buys a position.
+static const int DMR_LRRP_LENGTH_OVERRIDE_PENALTY = 100;
+
+static void
+dmr_lrrp_parse_best_response(const uint8_t* pdu, size_t avail, size_t token_len, size_t token_avail,
+                             dmr_lrrp_parse_result* best) {
+    int best_score = -1000000;
+    dmr_lrrp_parse_best_response_over(pdu, avail, token_len, 0, best, &best_score);
+    if (token_avail > token_len) {
+        dmr_lrrp_parse_best_response_over(pdu, avail, token_avail, DMR_LRRP_LENGTH_OVERRIDE_PENALTY, best, &best_score);
     }
 }
 
@@ -1554,7 +1575,7 @@ dmr_lrrp(const dsd_opts* opts, dsd_state* state, uint16_t len, uint32_t source, 
         want_response_parse = dmr_lrrp_has_position_token(DMR_PDU, avail, token_len);
     }
     if (want_response_parse) {
-        dmr_lrrp_parse_best_response(DMR_PDU, avail, token_len, &best);
+        dmr_lrrp_parse_best_response(DMR_PDU, avail, token_len, is_response ? token_avail : token_len, &best);
     }
     if (!source) {
         source = (uint32_t)state->dmr_lrrp_source[state->currentslot];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7277,6 +7277,33 @@ add_test(
     COMMAND dsd-neo_test_dmr_lrrp_empty_payload_type
 )
 
+# DMR LRRP: bytes past an under-counting length byte are a penalised second candidate (#453)
+add_executable(
+    dsd-neo_test_dmr_lrrp_declared_length_fallback
+    protocol/dmr/test_dmr_lrrp_declared_length_fallback.c
+    test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_lrrp_declared_length_fallback
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/dmr
+)
+target_include_directories(
+    dsd-neo_test_dmr_lrrp_declared_length_fallback
+    SYSTEM
+    PRIVATE ${_PUBLIC_INCLUDES}
+)
+target_link_libraries(
+    dsd-neo_test_dmr_lrrp_declared_length_fallback
+    PRIVATE dsd-neo_platform
+)
+add_test(
+    NAME DMR_LRRP_DECLARED_LENGTH_FALLBACK
+    COMMAND dsd-neo_test_dmr_lrrp_declared_length_fallback
+)
+
 # DMR SMS/TMS UTF-16 text: surrogate pairs combine, unpaired halves become U+FFFD
 add_executable(
     dsd-neo_test_dmr_pdu_utf16_text
@@ -9123,6 +9150,7 @@ set(_DSD_NEO_BIT_PACKING_TEST_TARGETS
     dsd-neo_test_dmr_grant_policy
     dsd-neo_test_dmr_locn_time_fallback
     dsd-neo_test_dmr_lrrp_crc_gating
+    dsd-neo_test_dmr_lrrp_declared_length_fallback
     dsd-neo_test_dmr_lrrp_empty_payload_type
     dsd-neo_test_dmr_lrrp_ip_udp_lengths
     dsd-neo_test_dmr_lrrp_position_token_precedence

--- a/tests/protocol/dmr/test_dmr_lrrp_declared_length_fallback.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_declared_length_fallback.c
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Regression (#453, second item): some senders put a length byte on an LRRP
+ * response that under-counts the tokens that follow. The length byte is still
+ * trusted first; the bytes up to the UDP payload end are a second, penalised
+ * candidate that wins only when it finds something the declared walk did not
+ * (a position, or a timestamp plus speed plus heading). Junk past the declared
+ * length never buys a position, and a conformant message decodes as before.
+ */
+
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/time_format.h>
+#include <dsd-neo/runtime/unicode.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+// Minimal stubs for direct link with dmr_pdu.c
+const char*
+dsd_degrees_glyph(void) {
+    return "";
+}
+
+int
+dsd_unicode_supported(void) {
+    return 0;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+lip_protocol_decoder(dsd_opts* opts, dsd_state* state, uint8_t* input) {
+    (void)opts;
+    (void)state;
+    (void)input;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+decode_cellocator(dsd_opts* opts, dsd_state* state, uint8_t* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+int
+dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
+                           const char* notice) {
+    (void)opts;
+    (void)state;
+    (void)observation->ota_source_id;
+    (void)observation->ota_target_id;
+    (void)notice;
+    (void)slot;
+    return 0;
+}
+
+// Deterministic system time (not used: file output disabled)
+int
+dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out, size_t out_size) {
+    (void)timestamp;
+    const char* value = (format == DSD_LOCAL_DATETIME_DATE_SLASH) ? "1999/01/02" : "11:22:33";
+    DSD_SNPRINTF(out, out_size, "%s", value);
+    return 1;
+}
+
+// Under test
+void dmr_lrrp(const dsd_opts* opts, dsd_state* state, uint16_t len, uint32_t source, uint32_t dest,
+              const uint8_t* DMR_PDU, uint8_t pdu_crc_ok);
+
+static int
+expect_has_point(const char* s, double exp_lat, double exp_lon, const char* tag) {
+    const char* p = strchr(s, '(');
+    if (!p) {
+        DSD_FPRINTF(stderr, "%s: no position in '%s'\n", tag, s);
+        return 1;
+    }
+    errno = 0;
+    char* end = NULL;
+    double lat = strtod(p + 1, &end);
+    if (end == p + 1 || errno == ERANGE) {
+        DSD_FPRINTF(stderr, "%s: failed to parse coordinates from '%s'\n", tag, s);
+        return 1;
+    }
+    while (*end == ' ' || *end == '\t') {
+        end++;
+    }
+    if (*end != ',') {
+        DSD_FPRINTF(stderr, "%s: missing coordinate separator in '%s'\n", tag, s);
+        return 1;
+    }
+    end++;
+    errno = 0;
+    double lon = strtod(end, &end);
+    if (errno == ERANGE) {
+        DSD_FPRINTF(stderr, "%s: failed to parse coordinates from '%s'\n", tag, s);
+        return 1;
+    }
+    double dlat = lat - exp_lat;
+    if (dlat < 0.0) {
+        dlat = -dlat;
+    }
+    double dlon = lon - exp_lon;
+    if (dlon < 0.0) {
+        dlon = -dlon;
+    }
+    if (dlat > 1e-5 || dlon > 1e-5) {
+        DSD_FPRINTF(stderr, "%s: got (%.8lf, %.8lf) expected (%.8lf, %.8lf)\n", tag, lat, lon, exp_lat, exp_lon);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_exact(const char* s, const char* expect, const char* tag) {
+    if (strcmp(s, expect) != 0) {
+        DSD_FPRINTF(stderr, "%s: got '%s' expected '%s'\n", tag, s, expect);
+        return 1;
+    }
+    return 0;
+}
+
+static size_t
+put_point_2d(uint8_t* pdu, size_t i, uint32_t lat_raw, uint32_t lon_raw) {
+    pdu[i++] = 0x66; // POINT_2D token id
+    pdu[i++] = (uint8_t)((lat_raw >> 24) & 0xFF);
+    pdu[i++] = (uint8_t)((lat_raw >> 16) & 0xFF);
+    pdu[i++] = (uint8_t)((lat_raw >> 8) & 0xFF);
+    pdu[i++] = (uint8_t)(lat_raw & 0xFF);
+    pdu[i++] = (uint8_t)((lon_raw >> 24) & 0xFF);
+    pdu[i++] = (uint8_t)((lon_raw >> 16) & 0xFF);
+    pdu[i++] = (uint8_t)((lon_raw >> 8) & 0xFF);
+    pdu[i++] = (uint8_t)(lon_raw & 0xFF);
+    return i;
+}
+
+int
+main(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state st;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&st, 0, sizeof st);
+    st.currentslot = 0;
+    opts.lrrp_file_output = 0;
+
+    const uint32_t lat_raw = 0x10000000u;
+    const uint32_t lon_raw = 0x20000000u;
+    const double exp_lat = ((double)((int32_t)lat_raw) * 90.0) / 2147483648.0;
+    const double exp_lon = ((double)((int32_t)lon_raw) * 180.0) / 2147483648.0;
+
+    // 1. Length byte says 0, a POINT_2D follows anyway: the position is recovered.
+    {
+        uint8_t pdu[32];
+        DSD_MEMSET(pdu, 0, sizeof pdu);
+        size_t i = 0;
+        pdu[i++] = 0x0D; // Triggered Location report
+        pdu[i++] = 0x00; // declared token length (wrong)
+        i = put_point_2d(pdu, i, lat_raw, lon_raw);
+        DSD_MEMSET(st.dmr_lrrp_gps[0], 0, sizeof st.dmr_lrrp_gps[0]);
+        dmr_lrrp(&opts, &st, (uint16_t)i, 123, 456, pdu, 1);
+        rc |= expect_has_point(st.dmr_lrrp_gps[0], exp_lat, exp_lon, "length 0, position follows");
+    }
+
+    // 2. Length byte covers only the identity token; the POINT_2D past it is recovered.
+    {
+        uint8_t pdu[32];
+        DSD_MEMSET(pdu, 0, sizeof pdu);
+        size_t i = 0;
+        pdu[i++] = 0x0D;
+        pdu[i++] = 0x02; // declared: identity token only
+        pdu[i++] = 0x22; // IDENTITY, zero-length request id
+        pdu[i++] = 0x00;
+        i = put_point_2d(pdu, i, lat_raw, lon_raw);
+        DSD_MEMSET(st.dmr_lrrp_gps[0], 0, sizeof st.dmr_lrrp_gps[0]);
+        dmr_lrrp(&opts, &st, (uint16_t)i, 123, 456, pdu, 1);
+        rc |= expect_has_point(st.dmr_lrrp_gps[0], exp_lat, exp_lon, "length 2, position follows");
+    }
+
+    // 3. Length byte says 0 and only junk follows: no position is invented.
+    {
+        static const uint8_t pdu[] = {0x0D, 0x00, 0x00, 0x00, 0x00};
+        DSD_MEMSET(st.dmr_lrrp_gps[0], 0, sizeof st.dmr_lrrp_gps[0]);
+        dmr_lrrp(&opts, &st, (uint16_t)sizeof pdu, 123, 456, pdu, 1);
+        rc |= expect_exact(st.dmr_lrrp_gps[0], "LRRP SRC: 123; Response to TGT: 456;", "length 0, junk follows");
+    }
+
+    // 4. Conformant message with two trailing bytes: decodes exactly as the declared walk does.
+    {
+        uint8_t pdu[32];
+        DSD_MEMSET(pdu, 0, sizeof pdu);
+        size_t i = 0;
+        pdu[i++] = 0x07; // Immediate Location Response
+        pdu[i++] = 0x09; // declared: exactly the POINT_2D
+        i = put_point_2d(pdu, i, lat_raw, lon_raw);
+        pdu[i++] = 0x00;
+        pdu[i++] = 0x00;
+        DSD_MEMSET(st.dmr_lrrp_gps[0], 0, sizeof st.dmr_lrrp_gps[0]);
+        dmr_lrrp(&opts, &st, (uint16_t)i, 123, 456, pdu, 1);
+        rc |= expect_has_point(st.dmr_lrrp_gps[0], exp_lat, exp_lon, "conformant, trailing bytes");
+    }
+
+    // 5. A request type never gets the fallback: a POINT_2D after a zero length stays unread.
+    {
+        uint8_t pdu[32];
+        DSD_MEMSET(pdu, 0, sizeof pdu);
+        size_t i = 0;
+        pdu[i++] = 0x05; // Immediate Location Request
+        pdu[i++] = 0x00;
+        i = put_point_2d(pdu, i, lat_raw, lon_raw);
+        DSD_MEMSET(st.dmr_lrrp_gps[0], 0, sizeof st.dmr_lrrp_gps[0]);
+        dmr_lrrp(&opts, &st, (uint16_t)i, 123, 456, pdu, 1);
+        rc |= expect_exact(st.dmr_lrrp_gps[0], "LRRP SRC: 123; Request from TGT: 456;", "request, no fallback");
+    }
+
+    return rc;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
## Summary

- Refs #453, second paragraph ("position reports whose length byte is not usable, so the token walk is cut short and the position is lost"). Stacked on #457 and needs it: the `0D 00` cases below only reach the parser once a zero length byte no longer short-circuits the summary.
- `dmr_lrrp()` clamps the token walk to the length byte, so a response whose length byte under-counts its tokens loses the position behind it. The length byte is still trusted first. When the UDP payload runs past it, the bytes up to the payload end are tried as a second candidate in the existing best-score search, carrying a penalty of 100: it wins only by finding a position (+1000) or a timestamp plus speed plus heading (+200), and every unknown byte costs it a further point. So a conformant message (`token_avail == token_len`) never enters the second walk, junk past the declared length cannot buy a position, and a CRC-failed PDU still has its position suppressed as before. Responses only; requests carry no position and unknown types keep the existing declared-length hunt.
- The UDP length already bounds the bytes handed to `dmr_lrrp()` (`DMR_LRRP_IP_UDP_LENGTHS`), so bytes past the declared length exist only when the sender put them there. sdrtrunk trusts the length byte; `lrrpdec.py` ignores it and walks to the UDP payload end. This sits between them.
- New regression `DMR_LRRP_DECLARED_LENGTH_FALLBACK`: (1) `0D 00` + POINT_2D recovers the position; (2) `0D 02 22 00` + POINT_2D recovers it; (3) `0D 00 00 00 00` stays a plain `Response to TGT`; (4) a conformant `07 09` + POINT_2D with two trailing bytes decodes as before; (5) `05 00` + POINT_2D stays `Request from TGT`.
- Evidence gate: the reporter could not demonstrate this half against stock dsd-neo, so the test bytes are synthetic. If a real under-counted packet can be shared on the issue, the test should carry those bytes instead.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: parser / network input (LRRP token walk over UDP payload; guarded by the score penalty and limited to response types).
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. (none added)
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (592 passed)
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes (not run; happy to if wanted before merge)
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes (n/a)
- [ ] `tools/osv_scan.sh` for dependency input changes (n/a)
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes (n/a)

## Risk

- Security/dependency impact: none. The second walk reads only bytes already bounded by the UDP length and the existing `avail` guard in `dmr_lrrp_parse_response_tokens()`.
- CLI/UI behavior impact: an LRRP response whose length byte under-counts a following position token now shows that position (and, with `-L`, writes it to the LRRP file when the PDU CRC is good). Conformant messages are unchanged.
- Compatibility or packaging impact: none.
