### PR TITLE
ci: retry the Arch toolchain image pull before running the container

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,23 @@ target_include_directories(
 )
 target_link_libraries(dsd-neo_test_support INTERFACE dsd-neo_platform)
 
+# Shell tools under tools/ run CI on our behalf; the ones with retry or give-up
+# logic get a bash-driven test that fakes the program they wrap. Bash only: the
+# scripts themselves are bash, so nothing is lost by skipping them where it is
+# missing.
+if(NOT WIN32)
+    find_program(DSD_NEO_BASH_EXECUTABLE bash)
+    if(DSD_NEO_BASH_EXECUTABLE)
+        add_test(
+            NAME TOOLS_CI_ARCH_TOOLCHAIN_PULL_RETRY
+            COMMAND
+                ${DSD_NEO_BASH_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/tests/tools/test_ci_arch_toolchain_pull_retry.sh
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        )
+    endif()
+endif()
+
 add_library(
     dsd-neo_test_call_state_support
     STATIC

--- a/tests/tools/test_ci_arch_toolchain_pull_retry.sh
+++ b/tests/tools/test_ci_arch_toolchain_pull_retry.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+#
+# tools/ci_arch_toolchain.sh must survive a transient registry failure: Docker
+# Hub answering the image manifest fetch with a 5xx failed a CI job whose only
+# step is this wrapper, and a manual re-run was the only recovery. A fake
+# `docker` on PATH counts pulls and runs, so the wrapper's retry and its give-up
+# are both observable without a daemon.
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/docker" << 'FAKE'
+#!/usr/bin/env bash
+# Fake docker: `pull` fails until FAKE_DOCKER_PULL_FAILURES pulls have been
+# refused, then succeeds; `run` records its image argument and exits 0.
+set -euo pipefail
+log="$FAKE_DOCKER_LOG"
+case "$1" in
+  pull)
+    n=$(( $(cat "$log.pulls" 2>/dev/null || echo 0) + 1 ))
+    echo "$n" > "$log.pulls"
+    if [[ "$n" -le "${FAKE_DOCKER_PULL_FAILURES:-0}" ]]; then
+      echo "docker: Error response from daemon: received unexpected HTTP status: 500 Internal Server Error" >&2
+      exit 1
+    fi
+    ;;
+  run)
+    printf '%s\n' "$@" > "$log.run"
+    ;;
+  *)
+    echo "fake docker: unexpected subcommand $1" >&2
+    exit 99
+    ;;
+esac
+FAKE
+chmod +x "$WORK/docker"
+
+failures=0
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+run_wrapper() {
+  # Backoff pinned to zero so a five-attempt retry costs nothing here.
+  env PATH="$WORK:$PATH" FAKE_DOCKER_LOG="$WORK/log" \
+    CI_ARCH_PULL_BACKOFF_S=0 "$@" \
+    bash "$ROOT_DIR/tools/ci_arch_toolchain.sh" true > "$WORK/out" 2> "$WORK/err"
+}
+
+# --- Two transient failures, then success: the wrapper keeps pulling and runs. ---
+rm -f "$WORK/log.pulls" "$WORK/log.run"
+if ! run_wrapper env FAKE_DOCKER_PULL_FAILURES=2 CI_ARCH_PULL_ATTEMPTS=5; then
+  fail "the wrapper gave up although the third pull succeeded"
+fi
+pulls=$(cat "$WORK/log.pulls" 2> /dev/null || echo 0)
+[[ "$pulls" == "3" ]] || fail "expected 3 pull attempts, saw $pulls"
+[[ -f "$WORK/log.run" ]] || fail "docker run never happened after the pull succeeded"
+if [[ -f "$WORK/log.run" ]]; then
+  # shellcheck source=tools/ci-dependency-pins.env
+  # shellcheck disable=SC1091
+  source "$ROOT_DIR/tools/ci-dependency-pins.env"
+  grep -qxF "$ARCHLINUX_BASE_DEVEL_IMAGE" "$WORK/log.run" || fail "docker run did not receive the pinned image"
+fi
+grep -q "retrying" "$WORK/err" || fail "a retried pull was not reported on stderr"
+
+# --- Every pull fails: the wrapper gives up after its attempt budget, without running. ---
+rm -f "$WORK/log.pulls" "$WORK/log.run"
+if run_wrapper env FAKE_DOCKER_PULL_FAILURES=99 CI_ARCH_PULL_ATTEMPTS=2; then
+  fail "the wrapper reported success although every pull failed"
+fi
+pulls=$(cat "$WORK/log.pulls" 2> /dev/null || echo 0)
+[[ "$pulls" == "2" ]] || fail "expected exactly 2 pull attempts before giving up, saw $pulls"
+[[ ! -f "$WORK/log.run" ]] || fail "docker run happened although the image never arrived"
+grep -q "failed after 2 attempts" "$WORK/err" || fail "the give-up message is missing"
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "$failures failure(s)" >&2
+  exit 1
+fi
+echo "OK"

--- a/tools/ci_arch_toolchain.sh
+++ b/tools/ci_arch_toolchain.sh
@@ -13,6 +13,8 @@ Environment:
   CI_ARCH_EXTRA_PACKAGES     Extra pacman packages to install before running.
   CI_ARCH_IWYU_SHA           Expected include-what-you-use commit SHA.
   CI_ARCH_TOOLCHAIN_PREFIX   Container path for cached Arch-only tools.
+  CI_ARCH_PULL_ATTEMPTS      Image pull attempts before giving up (default: 5).
+  CI_ARCH_PULL_BACKOFF_S     Seconds before the first retry, doubled each time (default: 5).
 USAGE
 }
 
@@ -92,6 +94,29 @@ for name in GITHUB_EVENT_NAME CPPCHECK_BUILD_DIR; do
     ENV_ARGS+=(--env "$name=${!name}")
   fi
 done
+
+# Pull the image up front, with a short backoff. Docker Hub answers a manifest fetch with
+# a transient 5xx often enough that an implicit pull inside `docker run` has failed a
+# job whose only step is this wrapper, and a manual re-run was the only recovery. A
+# flake now costs seconds; a real outage still fails, after the attempt budget, with the
+# registry's own message on stderr.
+pull_image() {
+  local attempts="${CI_ARCH_PULL_ATTEMPTS:-5}"
+  local delay="${CI_ARCH_PULL_BACKOFF_S:-5}"
+  local attempt=1
+  while ! docker pull --quiet "$IMAGE"; do
+    if ((attempt >= attempts)); then
+      echo "docker pull $IMAGE failed after $attempt attempts." >&2
+      return 1
+    fi
+    echo "docker pull $IMAGE failed (attempt $attempt/$attempts); retrying in ${delay}s." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
+pull_image
 
 docker run --rm \
   --volume "$ROOT_DIR:/workspace" \


### PR DESCRIPTION
## Summary

- `tools/ci_arch_toolchain.sh` now pulls the pinned `archlinux:base-devel` image before `docker run`, with a
  short doubling backoff (5 attempts from 5 s; `CI_ARCH_PULL_ATTEMPTS` / `CI_ARCH_PULL_BACKOFF_S` override).
  A transient registry error costs seconds instead of the job; a real outage still fails after the budget with
  Docker's own message on stderr.
- Motivation: on #459 the clang-tidy job failed in 24 s with Docker Hub answering the manifest fetch
  `500 Internal Server Error` (docker exit 125) while the sibling analyzer jobs, using the same wrapper, pulled
  the image fine. The only recovery was a manual re-run.
- New CTest case `TOOLS_CI_ARCH_TOOLCHAIN_PULL_RETRY` (`tests/tools/test_ci_arch_toolchain_pull_retry.sh`) fakes
  `docker` on PATH and pins both halves: two refused pulls then success runs the container once with the pinned
  image; a never-succeeding pull gives up after the attempt budget without running anything. Registered in
  `tests/CMakeLists.txt`, bash-only (skipped where bash is missing).

No workflow YAML, pins, or dependency inputs change.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human. (This PR.)
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are
      documented. (Small CI-only change; the new test is the guardrail.)
- [x] High-risk areas touched are marked: workflow (a CI helper script; no workflow file or pin changes).
- [ ] Outside review was requested when available, or unavailability is documented. (Not available.)
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include
      focused tests. (Retry/give-up behaviour is pinned by the new bash test.)
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. (None added.)
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow
      permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (`TOOLS_CI_ARCH_TOOLCHAIN_PULL_RETRY` passes; seen failing
      first against the old wrapper)
- [x] `tools/preflight_ci.sh` (shell lint, gersemi, workflow lint all clean)
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes (not broad)
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes (no workflow YAML changed)
- [ ] `tools/osv_scan.sh` for dependency input changes (none)
- [ ] security-sensitive workflow/release checks (pins untouched)

## Risk

- Security/dependency impact: none; the image reference and its digest pin are unchanged.
- CLI/UI behavior impact: none.
- Compatibility or packaging impact: none; CI-only. A run against an unreachable registry now takes up to
  5+10+20+40 s longer to fail.
