### PR TITLE
feat(core): per-row keys for -Y channel-map rows and trunk-scan targets (#382)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -430,7 +430,9 @@ Notes
 - Conventional scan mode: `-Y` (not trunking; scans for sync on enabled decoders). For NXDN the hold is refreshed
   only by frames whose content passed a CRC, so an open squelch on an empty channel no longer parks the scan.
   A channel map with a `name` column (see `docs/csv-formats.md`) names the row being listened to in the Scan Mode
-  row, in Call Info, and on the event history rows recorded while it is tuned.
+  row, in Call Info, and on the event history rows recorded while it is tuned. A map with `keys_hex_csv`/`keys_dec_csv`
+  columns loads a per-row key set instead of the global keyring while that row is tuned; leaving `-Y` (scanner
+  toggle, trunk set, tuner release) hands the foreground keyring back to the global keys.
   While scanning, the terminal's Trunking menu and hotkeys hold the scan on the channel on air (`Y`), avoid it for the
   rest of the session (`b`), step to the next channel (`L`, skipping avoided rows) and clear all avoids; see
   `docs/ui-terminal.md`.
@@ -440,7 +442,8 @@ Notes
   - Requires a live retuning path: RTL-family input opened by DSD-neo, or rigctl control such as `-U 4532`.
   - Use per-target `chan_csv` entries in the target CSV; global `-C` is rejected in this mode.
   - Optional per-target `modulation` and `rtl_gain` columns can override demod hints and RTL-family tuner gain for the
-    active target.
+    active target. Optional `keys_hex_csv`/`keys_dec_csv` columns load a per-target key set while the target is
+    parked; leaving the target restores the global keys.
   - Cannot be combined with conventional `-Y` scan mode or IQ replay.
   - Idle dwell: `--trunk-scan-dwell-ms <250..600000>` (default `3000`).
   - Conventional DMR/NXDN activity hold (both NXDN rates): `--trunk-scan-activity-hold-ms <250..600000>`
@@ -618,6 +621,10 @@ those values for the current CLI run only.
   one-off manual keystream experiments.
 - Import keys CSV (decimal): `-k <file>`
 - Import keys CSV (hex): `-K <file>`
+- A runtime key import or clear (Keys menu, `IMPORT_KEYS_*` commands) edits the global keys even while a keyed
+  `-Y` row or trunk-scan target is parked, so the change survives the next hop. Scalar key commands (`-b`/`-1`/
+  `-H`/`-R` style entries) are not preserved this way: they disarm the keyloader and a keyed row overwrites them
+  on the next hop.
 - Force key over identifiers: `-4` (DMR BP/NXDN scrambler), `-0` (DMR RC4 when PI/LE missing),
   `--dmr-force-algid <hex>` (DMR ALGID when PI/LE missing; a fallback only — an ALG ID or KEY ID
   received over the air via PI header/LE always takes precedence; `-M` is reserved for M17 in DSD-neo).

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -82,7 +82,9 @@ Every parked target keeps its own snapshot of decoder state — channel map, tru
 metadata, the encrypted-target lockout ledger, and the NXDN missing-channel ledger from
 `<dsd-neo/protocol/nxdn/nxdn_trunk_diag.h>` — so a channel number or learned control-channel state from one system is
 never reused on another. That is also why trunk scan rejects a global `-C` channel map and imports each target's
-`chan_csv` through throwaway options.
+`chan_csv` through throwaway options. The keyring is not snapshotted: each target instead carries a static
+`dsd_key_set` (`keys_hex_csv`/`keys_dec_csv` columns) that the switch installs through the scan key swap in
+`<dsd-neo/core/key_set.h>`, restoring the globals on unkeyed targets and at shutdown without touching the key epoch.
 
 Tests: `tests/engine/test_engine_trunk_scan.c` (`ENGINE_TRUNK_SCAN`) and
 `tests/engine/test_engine_synced_trunk_scan_tick.c` (`ENGINE_SYNCED_TRUNK_SCAN_TICK`).
@@ -115,10 +117,12 @@ Tests: `tests/engine/test_engine_trunk_scan.c` (`ENGINE_TRUNK_SCAN`) and
 - API note: `<dsd-neo/core/channel_label.h>`'s `dsd_channel_label_current()` resolves the one label a frontend
   should show for the channel being listened to: the active `--trunk-scan` target id, else the name of the `-Y`
   scan-list row the receiver is parked on; `dsd_channel_label_current_source()` says which of the two it is, so a
-  frontend words it as a target or a channel and never names both at once. Those names come from a channel-map CSV that opts in with a `name`
-  header column and live in a heap store beside the scan list, reached through
+  frontend words it as a target or a channel and never names both at once. Those names come from a channel-map CSV
+  that opts in with a `name` header column and live in a heap store beside the scan list, reached through
   `dsd_state_trunk_lcn_name_get()`/`_set()`/`_reserve()`/`_free()` in `src/core/util/dsd_state_trunk_lcn.c` and
-  released by `dsd_state_trunk_lcn_free()`
+  released by `dsd_state_trunk_lcn_free()`. Per-row key sets (`keys_hex_csv`/`keys_dec_csv` columns, `-Y` only) live
+  in a sibling store with the same shape (`dsd_state_trunk_lcn_keys_*`), swapped by `dsd_scan_keys_enter()`/
+  `dsd_scan_keys_leave()` in `src/core/util/key_set.c`, and are likewise never deep-copied into the UI snapshot.
 - API note: text arriving as UTF-16 code units (DMR UDT/SMS, talker aliases) is decoded with
   `<dsd-neo/core/utf16.h>` and printed one scalar value at a time through `dsd_unicode_fput_scalar()` in
   `<dsd-neo/runtime/unicode.h>`. Never pass a code unit to `%lc`: a lone surrogate has no encoding, and the

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -94,6 +94,18 @@ Notes:
   stores no name either.
 - A row skipped for an unusable frequency keeps its name in the file's numbering but is never shown, because the
   scanner parks on the frequency it is already on rather than tuning such a row.
+- Two more optional columns carry per-row keys for the `-Y` scanner: `keys_hex_csv` (loaded like `-K`) and
+  `keys_dec_csv` (loaded like `-k`). They opt in by header name at any column position past the frequency (like
+  `name`, matched case-insensitively); a duplicated key header rejects the file. A row may fill both columns;
+  they load into one per-row key set.
+- Each key cell names a key file path, resolved relative to the channel map. Blank cells store nothing, and a row
+  whose channel number does not parse takes no slot and stores nothing. Paths cannot contain commas: the splitter
+  does no quote handling.
+- Row keys take effect only under `-Y`: hopping onto a keyed row installs its set, hopping back onto an unkeyed
+  row restores the global keys. Under plain trunking `-C` they are stored but never applied (one warning); under
+  trunk-scan per-target `chan_csv` they are discarded, like `name`.
+- Validation opens the key files, so an unloadable key path fails validation. The Qt/Android picker flow (which
+  copies files) does not support per-row key files.
 - Where a name shows: the end of the `-Y` conventional scanner's **Scan Mode** row, a `Channel:` line at the top of
   the Call Info panel, and as a prefix on the event history rows recorded while that channel is tuned. Encrypted
   traffic that reports no talkgroup still says which channel it was heard on. While a `--trunk-scan` target is on
@@ -120,6 +132,15 @@ Example with names (`examples/conventional_scan_named.csv`):
 channel,frequency_hz,name
 1,462562500,GMRS 1
 2,462587500,GMRS 2
+```
+
+Example with per-row keys (`examples/conventional_scan_keyed.csv`):
+
+```csv
+channel,frequency_hz,name,keys_hex_csv,keys_dec_csv
+1,462562500,System A,multi_key_hex.csv,
+2,462587500,System B,,multi_key.csv
+3,462612500,Shared,,
 ```
 
 ## Trunk Scan Target CSV (`--trunk-scan <file>` / `[trunk_scan] targets_csv`)
@@ -152,6 +173,8 @@ Columns:
 | `notes` | No | Ignored. Use for local notes. |
 | `modulation` | No | Per-target demod hint. Empty preserves global/default handling. `auto` uses target defaults and overrides global `-m` locks for that target. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR and both NXDN rates accept `auto`, `gfsk`. |
 | `rtl_gain` | No | Per-target RTL-family tuner gain. Empty uses the global/default gain. `0` or `auto` requests device automatic gain. `1..49` requests manual dB gain. Ignored for non-RTL retuning paths. |
+| `keys_hex_csv` | No | Per-target hex key file (`-K` format), resolved relative to this CSV. A row may fill both key columns; they load into one per-target key set. Empty uses the global keys. |
+| `keys_dec_csv` | No | Per-target decimal key file (`-k` format), resolved relative to this CSV. Empty uses the global keys. |
 
 Validation notes:
 
@@ -252,6 +275,8 @@ Notes:
 - The value is stored as a 40-bit quantity (higher bits are discarded).
 - If `key_id` exceeds 16 bits, it is truncated to 24 bits and hashed down to 16 bits for storage.
 - Extra columns are ignored.
+- A channel-map row (`keys_dec_csv`) or trunk-scan target (`keys_dec_csv`) can name a file in this format to
+  override the global keyring on that row or target; see the Channel Map and Trunk Scan Target sections above.
 
 Example:
 
@@ -280,6 +305,8 @@ Notes:
 
 - Each `valueN` is parsed as a hex integer. For long keys, DSD-neo stores the additional parts at internal offsets.
 - Extra columns beyond these are ignored.
+- A channel-map row (`keys_hex_csv`) or trunk-scan target (`keys_hex_csv`) can name a file in this format to
+  override the global keyring on that row or target; see the Channel Map and Trunk Scan Target sections above.
 
 Example:
 

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -56,10 +56,14 @@ Column behavior:
 | `notes` | No | Ignored by DSD-neo. Use it for local notes. |
 | `modulation` | No | Demod hint for this target. Empty preserves global/default handling. `auto` uses target defaults even when a global `-m` lock is set. P25 accepts `auto`, `c4fm`, `cqpsk`; DMR and both NXDN rates accept `auto`, `gfsk`. |
 | `rtl_gain` | No | RTL-family tuner gain for this target. Empty uses the global/default gain. `0` or `auto` requests device automatic gain. `1..49` requests manual dB gain. |
+| `keys_hex_csv` | No | Per-target hex key file (`-K` format), resolved relative to the target CSV. Parking the target installs its set; leaving it restores the global keys. A row may fill both key columns; they load into one set. Empty uses the global keys. |
+| `keys_dec_csv` | No | Per-target decimal key file (`-k` format), resolved relative to the target CSV. Empty uses the global keys. |
 
 A target's `chan_csv` may carry the optional `name` column described in [csv-formats.md](csv-formats.md), and it
 parses, but trunk scan discards the names. Each target's channel map is parked in a per-target snapshot that carries
 the frequencies positionally and no names, so a name kept from one target would sit beside the next target's list.
+Per-row `keys_hex_csv`/`keys_dec_csv` columns in a `chan_csv` are discarded the same way: keys arrive per
+trunk-scan target, not per channel-map row, and a kept set would install on the wrong target's hop.
 Under `--trunk-scan` the channel being heard is labelled by the target `id` instead.
 
 Target list limits and validation:
@@ -75,6 +79,8 @@ Target list limits and validation:
   values above `LONG_MAX`.
 - Duplicate `id` values are rejected.
 - Duplicate `(type, frequency_hz)` pairs are rejected.
+- A duplicated `keys_hex_csv` or `keys_dec_csv` header is rejected, and an unloadable key path fails the
+  whole import the way a bad `-K`/`-k` does.
 - `chan_csv` is only valid for `p25-trunk`, `dmr-trunk`, and `nxdn-trunk` targets.
 - `modulation` values are target-type specific: `cqpsk`/`c4fm` are P25-only, and `gfsk` is valid for DMR and both NXDN
   target rates.
@@ -202,6 +208,9 @@ During scanning:
   to the CSV. The Trunk Scan row shows `HOLD`, `Avoided: N`, and `[avoided]` when every alternate failed to retune and
   the receiver fell back onto a target that was avoided.
 - A non-empty target `modulation` value overrides global CLI/config modulation locks for that target only.
+- A keyed target installs its key set on park and restores the global keys when the scan leaves it. Runtime
+  key imports and clears edit the globals underneath the parked target, so they survive the next hop; the
+  encrypted-lockout ledger is per target, so switches never invalidate it.
 - A target `rtl_gain` value is applied at the retune boundary. Manual per-target gain temporarily suspends supervisory
   tuner autogain; `auto` and global-auto targets restore the saved autogain setting.
 - P25, DMR, and NXDN trunk targets stay parked while their trunking state machine is following an active call
@@ -262,6 +271,16 @@ to keep global/default modulation handling.
 
 Leave the field empty to inherit the global/default gain. Use `0` or `auto` for device automatic gain, or an integer
 from `1` to `49` for manual RTL-family gain in dB.
+
+`row N keys_hex_csv path is too long or invalid` (and `_dec_`)
+
+The key path is resolved relative to the target CSV. Use a path that fits in 1024 bytes and, for a relative
+reference, keep the key file next to (or below) the target CSV.
+
+`failed to import keys for trunk scan target '<id>' from '<file>'`
+
+The key file could not be opened or parsed. Key files use the `-K` (hex) and `-k` (decimal) formats described
+in [csv-formats.md](csv-formats.md); check the header row and the delimiter.
 
 `N trunk scan target(s) have no enabled <NAME> decoder (first: '<id>'); use <flags> to decode them`
 

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -329,6 +329,14 @@ RadioReference import:
   systems row is hidden until the imports directory resolves, and the application-key row is hidden in a
   build with a baked-in key. See `docs/radioreference-import.md`.
 
+### Keys
+
+A `-Y` channel-map row or a `--trunk-scan` target can carry its own key files (`keys_hex_csv`/`keys_dec_csv`
+columns; see `docs/csv-formats.md`). While the row or target is parked its keys replace the global keyring;
+leaving it restores the globals. The Import keys CSV rows edit the globals underneath a parked row, so a
+runtime import survives the next hop. The single-key rows (Basic privacy, Hytera, scrambler, RC4/DES, AES)
+disarm the keyring, so a parked keyed row overrides them again on its next hop.
+
 ## DSP Status
 
 The DSP status panel shows RTL DSP loop state when RTL input support is available. CQPSK mode reports FLL band-edge,

--- a/examples/conventional_scan_keyed.csv
+++ b/examples/conventional_scan_keyed.csv
@@ -1,0 +1,4 @@
+channel,frequency_hz,name,keys_hex_csv,keys_dec_csv
+1,462562500,System A,multi_key_hex.csv,
+2,462587500,System B,,multi_key.csv
+3,462612500,Shared,,

--- a/examples/trunk_scan_targets.csv
+++ b/examples/trunk_scan_targets.csv
@@ -1,7 +1,7 @@
-id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain
+id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain,keys_hex_csv
 county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learned from control-channel data,auto,
 city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel using examples/dmr_t3_chan.csv,auto,
-plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,
+plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,,example_aes_keys.csv
 site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel; channel map optional when the site broadcasts DFA,auto,
 field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,
 field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz) conventional channel,gfsk,

--- a/include/dsd-neo/core/csv_import.h
+++ b/include/dsd-neo/core/csv_import.h
@@ -13,6 +13,7 @@
 #ifndef DSD_NEO_INCLUDE_DSD_NEO_CORE_CSV_IMPORT_H_H
 #define DSD_NEO_INCLUDE_DSD_NEO_CORE_CSV_IMPORT_H_H
 
+#include <dsd-neo/core/csv_validate.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 
@@ -25,6 +26,8 @@ int csvGroupImportPath(const char* group_file_path, dsd_state* state);
 int csvChanImport(const dsd_opts* opts, dsd_state* state);
 int csvKeyImportDec(const dsd_opts* opts, dsd_state* state);
 int csvKeyImportHex(const dsd_opts* opts, dsd_state* state);
+int csvKeyImportDecPath(const char* path, int show_keys, dsd_state* state, dsd_csv_validation* stats);
+int csvKeyImportHexPath(const char* path, int show_keys, dsd_state* state, dsd_csv_validation* stats);
 int csvVertexKsImport(dsd_state* state, const char* path);
 int csvDmrTgKeyImport(dsd_state* state, const char* path);
 

--- a/include/dsd-neo/core/key_set.h
+++ b/include/dsd-neo/core/key_set.h
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Sparse per-row keyring copy plus the scan key swap state machine.
+ *
+ * A `dsd_key_set` is a sparse copy of the live keyring (`rkey_array` /
+ * `rkey_array_loaded`) with the `keyloader` flag and the scalar key block it
+ * was captured with. Row sets carry a zeroed scalar block so installing them
+ * clears stale `-b`/`-1` scalars; the lazily captured baseline carries the
+ * live scalars so leaving a keyed row restores them.
+ *
+ * Only core headers plus `runtime/log.h`; engine and app_control call down
+ * into it, so no hook table.
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_CORE_KEY_SET_H_H
+#define DSD_NEO_INCLUDE_DSD_NEO_CORE_KEY_SET_H_H
+
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state_fwd.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint32_t index;
+    uint64_t value;
+    uint8_t loaded;
+} dsd_key_set_entry;
+
+/**
+ * The scalar key slots that per-call activation and the keyloader-gated resets
+ * write beside the keyring. Mirrors the `dsd_state` field types exactly so the
+ * block moves with one copy.
+ */
+typedef struct {
+    unsigned long long K;
+    unsigned long long K1;
+    unsigned long long K2;
+    unsigned long long K3;
+    unsigned long long K4;
+    unsigned long long R;
+    unsigned long long RR;
+    unsigned long long H;
+    uint8_t hytera_key_segments;
+    unsigned long long A1[2];
+    unsigned long long A2[2];
+    unsigned long long A3[2];
+    unsigned long long A4[2];
+    int aes_key_loaded[2];
+    uint8_t aes_key_segments[2];
+} dsd_key_scalars;
+
+typedef struct {
+    dsd_key_set_entry* entries; /* heap, NULL when empty */
+    size_t count;
+    uint8_t present; /* a key file was named on this row/target */
+    int keyloader;   /* state->keyloader to install with the entries */
+    /* Captured for the baseline; zeroed on row sets. */
+    dsd_key_scalars scalars;
+} dsd_key_set;
+
+/**
+ * Release a set's entries and zero the struct. Inline so translation units
+ * that compile `dsd_state_trunk_lcn.c` directly (several tests) can free
+ * without linking `key_set.c`. Wipes entry contents before free.
+ */
+static inline void
+dsd_key_set_free(dsd_key_set* ks) {
+    if (ks == NULL) {
+        return;
+    }
+    if (ks->entries != NULL) {
+        DSD_MEMSET(ks->entries, 0, ks->count * sizeof(*ks->entries));
+        free(ks->entries);
+    }
+    DSD_MEMSET(ks, 0, sizeof(*ks));
+}
+
+/**
+ * Capture the live keyring plus scalar block into @p out (frees prior).
+ * Returns 0 on success, -1 on a bad argument or allocation failure; on
+ * failure @p out is left empty.
+ */
+int dsd_key_set_capture(dsd_key_set* out, const dsd_state* state);
+
+/**
+ * Install @p ks onto the live state: zero both keyring arrays, write entries,
+ * set `keyloader`, then write the scalar block. The zeroing lives here rather
+ * than relying on the keyloader-gated resets, which is what makes trunk-scan
+ * switches safe outside `noCarrier`.
+ */
+void dsd_key_set_install(dsd_state* state, const dsd_key_set* ks);
+
+/**
+ * Deep copy @p src into @p dst (frees prior @p dst entries). Returns 0 on
+ * success, -1 on a bad argument or allocation failure; on failure @p dst is
+ * left as it was.
+ */
+int dsd_key_set_copy(dsd_key_set* dst, const dsd_key_set* src);
+
+/** Non-zero when two sets hold the same entries and keyloader flag. */
+int dsd_key_set_equal(const dsd_key_set* a, const dsd_key_set* b);
+
+/**
+ * Load hex then dec key files into @p out via a throwaway state. Either path
+ * may be NULL/empty. Sets `present = 1`, `keyloader = 1`. Returns 0 on
+ * success, -1 on any importer failure with @p out untouched.
+ */
+int dsd_key_set_load_csv(dsd_key_set* out, const char* hex_path, const char* dec_path, int show_keys);
+
+/**
+ * Enter the scan swap: capture the baseline from live state when no set is
+ * active, copy @p row_set into the active slot, install it. Returns 1 when
+ * the installed set identity changed, 0 when it was already installed or the
+ * swap could not be made (allocation failure leaves the live keyring as it
+ * was, so a later leave never installs an empty baseline).
+ */
+int dsd_scan_keys_enter(dsd_state* state, const dsd_key_set* row_set);
+
+/** Leave the scan swap: reinstall the baseline, free baseline and active. */
+void dsd_scan_keys_leave(dsd_state* state);
+
+/** Install the baseline without dropping it; runtime key commands edit globals. */
+void dsd_scan_keys_suspend(dsd_state* state);
+
+/** Re-capture the baseline from live state, reinstall the active set. */
+void dsd_scan_keys_resume(dsd_state* state);
+
+/**
+ * `-Y` helper: look up the row's set; present sets enter, absent sets leave.
+ * Bumps the encrypted-lockout key epoch when the installed set changed
+ * (global ledger under `-Y`; trunk scan never bumps). Returns the bump flag.
+ */
+int dsd_scan_row_keys_apply(dsd_state* state, int row);
+
+/**
+ * Warn once that a channel map's per-row keys are stored but will never be
+ * applied, because row keys ride the `-Y` scanner only. No-op when the map
+ * carries no row keys or @p scanner_mode is on.
+ */
+void dsd_scan_row_keys_warn_if_unused(const dsd_state* state, int scanner_mode);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_CORE_KEY_SET_H_H */

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -26,6 +26,7 @@
 
 #include <dsd-neo/core/dibit.h>
 #include <dsd-neo/core/enc_lockout.h>
+#include <dsd-neo/core/key_set.h>
 
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_status_symbol.h>
@@ -502,6 +503,18 @@ struct dsd_state {
      * UI_SNAPSHOT_COPY_RANGE, for the same reason as the two stores above. */
     uint8_t* trunk_lcn_avoid;
     size_t trunk_lcn_avoid_capacity;
+    /* Sparse per-row key set per scan-list row, indexed like trunk_lcn_name. NULL until a
+     * channel-map CSV opts in with a `keys_hex_csv`/`keys_dec_csv` header column. Read it
+     * through dsd_state_trunk_lcn_keys_get(). Never inside a UI_SNAPSHOT_COPY_RANGE, for the
+     * same reason as the stores above -- and additionally because key material is never
+     * deep-copied into the snapshot. */
+    dsd_key_set* trunk_lcn_keys;
+    size_t trunk_lcn_keys_capacity;
+    /* Scan key swap state: the lazily captured global keys plus the active row set copy.
+     * Sits in the same uncopied gap as the stores above. */
+    dsd_key_set scan_keys_baseline;
+    dsd_key_set scan_keys_active;
+    uint8_t scan_keys_active_set;
     // DMR Tier III: simple provenance/trust for learned LCN->freq mappings
     // 0=unset, 1=learned (unconfirmed), 2=trusted (confirmed on-current-site CC)
     uint8_t dmr_lcn_trust[0x1000];
@@ -1758,9 +1771,9 @@ dsd_state_trunk_lcn_slot_const(const dsd_state* state, int i) {
 int dsd_state_trunk_lcn_reserve(dsd_state* state, size_t count_needed);
 
 /**
- * Free the scan-list heap tail, the per-row name store and the per-row avoid
- * store, and zero their pointers/capacities. The embedded DSD_TRUNK_LCN_EMBEDDED slots are part of
- * dsd_state and need no release.
+ * Free the scan-list heap tail, the per-row name, avoid and key stores, and the
+ * scan key swap state, and zero their pointers/capacities. The embedded
+ * DSD_TRUNK_LCN_EMBEDDED slots are part of dsd_state and need no release.
  */
 void dsd_state_trunk_lcn_free(dsd_state* state);
 
@@ -1785,7 +1798,6 @@ void dsd_state_trunk_lcn_name_free(dsd_state* state);
  * a NULL state.
  */
 int dsd_state_trunk_lcn_name_set(dsd_state* state, size_t index, const char* name);
-
 /**
  * Name of scan-list row @p index, or "" when the row is unnamed, the store is
  * shorter than @p index, or no name column was ever imported. Never NULL.
@@ -1801,6 +1813,29 @@ int dsd_state_trunk_lcn_avoid_reserve(dsd_state* state, size_t count);
 
 /** Free the per-row avoid store and zero its pointer/capacity. lcn_avoid_count is not touched. */
 void dsd_state_trunk_lcn_avoid_free(dsd_state* state);
+
+/**
+ * Ensure key-store indices 0..count-1 are addressable: grows by doubling and
+ * zero-fills the new entries. Returns 0 on success, -1 on allocation failure
+ * (state left valid, existing sets preserved).
+ */
+int dsd_state_trunk_lcn_keys_reserve(dsd_state* state, size_t count);
+
+/** Free the per-row key store and zero its pointer/capacity. */
+void dsd_state_trunk_lcn_keys_free(dsd_state* state);
+
+/**
+ * Move @p ks into the store at @p index, freeing any previous entry there.
+ * Takes ownership of the entries pointer; the caller must not free it after a
+ * successful call. Returns 0 on success, -1 on allocation failure or NULL state.
+ */
+int dsd_state_trunk_lcn_keys_set(dsd_state* state, size_t index, dsd_key_set* ks);
+
+/** Key set of scan-list row @p index, or NULL when the row carries no keys. */
+const dsd_key_set* dsd_state_trunk_lcn_keys_get(const dsd_state* state, size_t index);
+
+/** Non-zero when any row in the store carries a key set. */
+int dsd_state_trunk_lcn_keys_present(const dsd_state* state);
 
 /**
  * Flag scan-list row @p index as avoided (@p avoided != 0) or put it back. Setting a

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -64,6 +64,10 @@ typedef struct {
     dsd_trunk_scan_target_type type;
     uint32_t frequency_hz;
     char chan_csv[1024];
+    /* Per-target key files, resolved relative to the targets CSV at parse time.
+     * Loaded into the target's key set at init; empty means the global keys. */
+    char keys_hex_csv[1024];
+    char keys_dec_csv[1024];
     int dwell_ms;
     int activity_hold_ms;
     dsd_trunk_scan_modulation modulation;

--- a/src/app_control/actions/actions_trunk.c
+++ b/src/app_control/actions/actions_trunk.c
@@ -16,6 +16,7 @@
 #include "../command_dispatch.h"
 
 #include "dsd-neo/app_control/commands.h"
+#include "dsd-neo/core/key_set.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -55,6 +56,8 @@ ui_handle_trunk_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_comma
         // Scanner mode is the other automatic owner of the tuner, and
         // ui_handle_scanner_toggle clears trunking for the same reason: whichever
         // one was asked for last is the one driving, not both at once.
+        // Leaving -Y hands the foreground keyring back to the globals.
+        dsd_scan_keys_leave(state);
         opts->scanner_mode = 0;
     }
     return 1;
@@ -63,9 +66,12 @@ ui_handle_trunk_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_comma
 static int
 ui_handle_scanner_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     (void)c;
+    const int was_scanner = opts->scanner_mode ? 1 : 0;
     opts->scanner_mode = opts->scanner_mode ? 0 : 1;
     opts->trunk_enable = 0;
-    (void)state;
+    if (was_scanner) {
+        dsd_scan_keys_leave(state);
+    }
     return 1;
 }
 

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -58,6 +58,7 @@
 #include "command_dispatch.h"
 #include "commands_internal.h"
 #include "dsd-neo/core/dibit.h"
+#include "dsd-neo/core/key_set.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -1523,7 +1524,11 @@ ui_cmd_handle_import_keys_dec(dsd_opts* opts, dsd_state* state, const struct dsd
     if (state && c->n > 0) {
         char path[1024] = {0};
         if (ui_cmd_copy_payload_string(c, path, sizeof path)) {
+            // A parked keyed row holds the foreground keyring: edit the globals
+            // underneath it so the import survives the next hop.
+            dsd_scan_keys_suspend(state);
             int rc = svc_import_keys_dec(opts, state, path);
+            dsd_scan_keys_resume(state);
             result = ui_cmd_apply_status_from_service_rc(rc);
             if (rc == 0) {
                 dsd_enc_lockout_bump_key_epoch(state);
@@ -1542,7 +1547,9 @@ ui_cmd_handle_import_keys_hex(dsd_opts* opts, dsd_state* state, const struct dsd
     if (state && c->n > 0) {
         char path[1024] = {0};
         if (ui_cmd_copy_payload_string(c, path, sizeof path)) {
+            dsd_scan_keys_suspend(state);
             int rc = svc_import_keys_hex(opts, state, path);
+            dsd_scan_keys_resume(state);
             result = ui_cmd_apply_status_from_service_rc(rc);
             if (rc == 0) {
                 dsd_enc_lockout_bump_key_epoch(state);
@@ -1591,7 +1598,9 @@ ui_cmd_handle_import_keys_clear(dsd_opts* opts, dsd_state* state, const struct d
     if (!state) {
         return UI_CMD_APPLY_COMPLETED;
     }
+    dsd_scan_keys_suspend(state);
     const int rc = svc_clear_keys(opts, state);
+    dsd_scan_keys_resume(state);
     if (rc == 0) {
         // The lockout ledger is keyed on the key epoch, so targets skipped for
         // want of a key have to be reconsidered against the empty keyring the
@@ -1905,6 +1914,7 @@ apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
     reset_call_tracking(opts, state, 0);
     LOG_INFO("Channel Cycle: tuning to %.06lf MHz\n", (double)freq / 1000000);
     state->lcn_freq_roll = next + 1;
+    dsd_scan_row_keys_apply(state, next);
     mark_cc_sync(state, 1);
     return UI_CMD_APPLY_COMPLETED;
 }
@@ -3008,6 +3018,8 @@ apply_tuner_release(dsd_opts* opts, dsd_state* state) {
     }
     opts->trunk_enable = 0;
     opts->scanner_mode = 0;
+    // Leaving -Y hands the foreground keyring back to the globals.
+    dsd_scan_keys_leave(state);
     reset_call_tracking(opts, state, 1);
     ui_set_toast(state, 3, "Automatic tuning stopped");
     return UI_CMD_APPLY_COMPLETED;
@@ -3249,7 +3261,10 @@ rr_apply_simulcast(dsd_opts* opts, dsd_state* state, const dsd_app_rr_apply_payl
    opts->trunk_cli_seen is CLI provenance and is deliberately not touched -- the
    in-session action handlers do not touch it either. */
 static void
-rr_apply_tuner_owner(dsd_opts* opts, const dsd_app_rr_apply_payload* p) {
+rr_apply_tuner_owner(dsd_opts* opts, dsd_state* state, const dsd_app_rr_apply_payload* p) {
+    if (!p) {
+        return;
+    }
     if (p->trunking) {
         opts->trunk_enable = 1;
         opts->scanner_mode = 0;
@@ -3259,6 +3274,9 @@ rr_apply_tuner_owner(dsd_opts* opts, const dsd_app_rr_apply_payload* p) {
     } else {
         opts->trunk_enable = 0;
         opts->scanner_mode = 0;
+    }
+    if (!p->scanner) {
+        dsd_scan_keys_leave(state);
     }
 }
 
@@ -3364,7 +3382,7 @@ apply_rr_import(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* 
     rr_apply_edacs_variants(state, &p, mode);
     rr_apply_simulcast(opts, state, &p);
     opts->p25_prefer_candidates = p.p25_prefer_candidates ? (uint8_t)1 : (uint8_t)0;
-    rr_apply_tuner_owner(opts, &p);
+    rr_apply_tuner_owner(opts, state, &p);
     const int files_rc = rr_apply_files(opts, state, &p);
     /* Unconditional, and after every write to state->rf_mod: svc_publish_symbol_profile()
        reads it, so the simulcast override needs a second publish, and a re-apply

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/keyring.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>
@@ -29,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "dsd-neo/core/dibit.h"
+#include "dsd-neo/core/key_set.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -367,6 +369,13 @@ chan_map_adopt(dsd_state* dst, dsd_state* src) {
     dst->trunk_lcn_name_capacity = src->trunk_lcn_name_capacity;
     src->trunk_lcn_name = NULL;
     src->trunk_lcn_name_capacity = 0;
+    // The per-row key store moves with the map the same way: the next hop
+    // re-applies from the new store, so no leave is needed here.
+    dsd_state_trunk_lcn_keys_free(dst);
+    dst->trunk_lcn_keys = src->trunk_lcn_keys;
+    dst->trunk_lcn_keys_capacity = src->trunk_lcn_keys_capacity;
+    src->trunk_lcn_keys = NULL;
+    src->trunk_lcn_keys_capacity = 0;
     dst->lcn_freq_count = src_count;
     dst->lcn_freq_roll = 0;
     // Session avoids and the scan hold index rows that no longer exist.
@@ -410,6 +419,9 @@ svc_import_channel_map(dsd_opts* opts, dsd_state* state, const char* path) {
     if (import_rc == 0 && mapped_any) {
         adopt_rc = chan_map_adopt(state, imported);
     }
+    if (import_rc == 0 && mapped_any && adopt_rc == 0) {
+        dsd_scan_row_keys_warn_if_unused(state, opts->scanner_mode);
+    }
     dsd_state_ext_free_all(imported);
     dsd_state_trunk_lcn_free(imported);
     free(imported);
@@ -431,7 +443,9 @@ svc_clear_channel_map(dsd_opts* opts, dsd_state* state) {
     DSD_MEMSET(state->trunk_chan_map_used, 0, sizeof state->trunk_chan_map_used);
     state->trunk_chan_map_used_count = 0;
     DSD_MEMSET(state->trunk_lcn_freq, 0, sizeof state->trunk_lcn_freq);
-    // Releases the per-row name and avoid stores along with the scan-list heap tail.
+    // Releases the per-row name, avoid and key stores along with the scan-list heap tail.
+    // Clearing the map leaves -Y: hand the foreground keyring back to the globals first.
+    dsd_scan_keys_leave(state);
     dsd_state_trunk_lcn_free(state);
     state->lcn_freq_count = 0;
     state->lcn_freq_roll = 0;

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -8,7 +8,6 @@
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/file_io.h>
-#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/keyring.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>

--- a/src/app_control/ui_snapshot.c
+++ b/src/app_control/ui_snapshot.c
@@ -133,6 +133,12 @@ _Static_assert(offsetof(dsd_state, trunk_lcn_avoid) >= UI_SNAPSHOT_FIELD_END(tru
                "trunk_lcn_avoid must sit after the dibit_buf..trunk_lcn_freq copy range");
 _Static_assert(UI_SNAPSHOT_FIELD_END(trunk_lcn_avoid_capacity) <= offsetof(dsd_state, audio_out_idx),
                "trunk_lcn_avoid must sit before the audio_out_idx..lastsample copy range");
+/* The per-row key store is a fourth heap allocation with the same hazard, and the scan
+ * key swap state beside it is deliberately never deep-copied (key material). */
+_Static_assert(offsetof(dsd_state, trunk_lcn_keys) >= UI_SNAPSHOT_FIELD_END(trunk_lcn_freq),
+               "trunk_lcn_keys must sit after the dibit_buf..trunk_lcn_freq copy range");
+_Static_assert(UI_SNAPSHOT_FIELD_END(scan_keys_active_set) <= offsetof(dsd_state, audio_out_idx),
+               "trunk_lcn_keys..scan_keys_active_set must sit before the audio_out_idx..lastsample copy range");
 /* The trunk-scan publication and the scan hold/avoid scalars are plain inline bytes, so
  * unlike the stores above they want to be inside a copy range -- left out of one they
  * would silently never reach the UI. */

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(
         util/bit_packing.c
         util/dsd_init.c
         util/dsd_state_trunk_lcn.c
+        util/key_set.c
         util/channel_label.c
         util/enc_lockout.c
         util/dsd_events.c

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -3,6 +3,7 @@
 #include <dsd-neo/core/bit_packing.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/csv_validate.h>
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/keyring.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/parse.h>
@@ -824,16 +825,86 @@ csv_key_import_dec_apply_field(dsd_state* state, int field_count, const char* fi
     }
 }
 
+/*
+ * The channel map's columns past the frequency have always been free-text notes
+ * -- two shipped examples put commas in theirs -- so column 3 is a channel name
+ * only when the header line says `name`. The per-row key columns opt in the
+ * same way, by header name at any field index >= 2; a duplicated key header
+ * rejects the file.
+ */
+typedef struct {
+    int has_name;
+    int keys_hex_idx;
+    int keys_dec_idx;
+} chan_header_cols;
+
+static const char*
+chan_key_cell(char** fields, size_t field_count, int idx) {
+    if (idx < 0 || (size_t)idx >= field_count || !fields[idx]) {
+        return NULL;
+    }
+    return trim_ws(fields[idx]);
+}
+
+static int
+chan_resolve_key_cell(const char* base_path, const char* cell, char* out, size_t out_sz, int row_number) {
+    if (!cell || cell[0] == '\0') {
+        return 0;
+    }
+    if (dsd_path_resolve_relative_to_file(base_path, cell, out, out_sz) != 0) {
+        char row_text[32] = "?";
+        (void)DSD_SNPRINTF(row_text, sizeof(row_text), "%d", row_number);
+        LOG_ERROR("channel map file '%s' row %s: key path is too long or invalid\n", base_path, row_text);
+        return -1;
+    }
+    return 0;
+}
+
+static int
+chan_parse_header(char* header_line, chan_header_cols* out) {
+    char* fields[16];
+    out->has_name = 0;
+    out->keys_hex_idx = -1;
+    out->keys_dec_idx = -1;
+    const size_t field_count = csv_split_preserve_empty(header_line, fields, sizeof(fields) / sizeof(fields[0]));
+    if (field_count >= 3 && csv_ascii_casecmp(trim_ws(fields[2]), "name") == 0) {
+        out->has_name = 1;
+    }
+    for (size_t i = 2; i < field_count; i++) {
+        const char* name = trim_ws(fields[i]);
+        if (csv_ascii_casecmp(name, "keys_hex_csv") == 0) {
+            if (out->keys_hex_idx >= 0) {
+                LOG_ERROR("channel map header duplicates 'keys_hex_csv'\n");
+                return -1;
+            }
+            out->keys_hex_idx = (int)i;
+        } else if (csv_ascii_casecmp(name, "keys_dec_csv") == 0) {
+            if (out->keys_dec_idx >= 0) {
+                LOG_ERROR("channel map header duplicates 'keys_dec_csv'\n");
+                return -1;
+            }
+            out->keys_dec_idx = (int)i;
+        }
+    }
+    return 0;
+}
+
 /**
  * @brief Parse one channel row into @p state.
  *
  * Empty fields are preserved rather than collapsed, so `1,,851000000` reads as a
  * blank frequency and is skipped instead of promoting column 3 into its place.
  *
- * @return 1 when a frequency loaded, -1 on allocation failure.
+ * When the header opted into per-row keys, a non-blank key cell on a row that
+ * took a slot resolves its path against the map file and loads it into the
+ * row's key set. Key paths cannot contain commas: the splitter does no quote
+ * handling. A load failure fails the whole import, like a bad `-K`.
+ *
+ * @return 1 when a frequency loaded, -1 on allocation failure or key load failure.
  */
 static int
-chan_import_row(dsd_state* state, char* buffer, int has_name_column, int* out_field_count, long int* out_chan_number) {
+chan_import_row(dsd_state* state, char* buffer, const chan_header_cols* cols, const char* base_path, int row_number,
+                int show_keys, int* out_field_count, long int* out_chan_number) {
     char* fields[16];
     int freq_parsed = 0;
     long int chan_number = -1;
@@ -847,10 +918,37 @@ chan_import_row(dsd_state* state, char* buffer, int has_name_column, int* out_fi
             return -1;
         }
     }
-    if (has_name_column && field_count >= 3 && state->lcn_freq_count > lcn_before) {
+    if (cols->has_name && field_count >= 3 && state->lcn_freq_count > lcn_before) {
         if (dsd_state_trunk_lcn_name_set(state, (size_t)lcn_before, fields[2]) != 0) {
             LOG_ERROR("channel map import out of memory\n");
             return -1;
+        }
+    }
+    if ((cols->keys_hex_idx >= 0 || cols->keys_dec_idx >= 0) && state->lcn_freq_count > lcn_before) {
+        const char* hex_cell = chan_key_cell(fields, field_count, cols->keys_hex_idx);
+        const char* dec_cell = chan_key_cell(fields, field_count, cols->keys_dec_idx);
+        if ((hex_cell && hex_cell[0] != '\0') || (dec_cell && dec_cell[0] != '\0')) {
+            char hex_path[CSV_IMPORT_PATH_MAX] = "";
+            char dec_path[CSV_IMPORT_PATH_MAX] = "";
+            if (chan_resolve_key_cell(base_path, hex_cell, hex_path, sizeof(hex_path), row_number) != 0
+                || chan_resolve_key_cell(base_path, dec_cell, dec_path, sizeof(dec_path), row_number) != 0) {
+                return -1;
+            }
+            dsd_key_set ks;
+            DSD_MEMSET(&ks, 0, sizeof(ks));
+            if (dsd_key_set_load_csv(&ks, hex_cell && hex_cell[0] != '\0' ? hex_path : NULL,
+                                     dec_cell && dec_cell[0] != '\0' ? dec_path : NULL, show_keys)
+                != 0) {
+                char row_text[32] = "?";
+                (void)DSD_SNPRINTF(row_text, sizeof(row_text), "%d", row_number);
+                LOG_ERROR("channel map file '%s' row %s: failed to load row key file\n", base_path, row_text);
+                return -1;
+            }
+            if (dsd_state_trunk_lcn_keys_set(state, (size_t)lcn_before, &ks) != 0) {
+                dsd_key_set_free(&ks);
+                LOG_ERROR("channel map import out of memory\n");
+                return -1;
+            }
         }
     }
     *out_field_count = (int)field_count;
@@ -858,24 +956,9 @@ chan_import_row(dsd_state* state, char* buffer, int has_name_column, int* out_fi
     return freq_parsed;
 }
 
-/*
- * The channel map's columns past the frequency have always been free-text notes
- * -- two shipped examples put commas in theirs -- so column 3 is a channel name
- * only when the header line says `name`.
- */
-static int
-chan_header_has_name_column(char* header_line) {
-    char* fields[16];
-    const size_t field_count = csv_split_preserve_empty(header_line, fields, sizeof(fields) / sizeof(fields[0]));
-    if (field_count < 3) {
-        return 0;
-    }
-    return csv_ascii_casecmp(trim_ws(fields[2]), "name") == 0 ? 1 : 0;
-}
-
 /* stats may be NULL; when set, counts data rows so a dry run can report them. */
 static int
-chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validation* stats) {
+chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validation* stats, int show_keys) {
     if (!chan_file_path || chan_file_path[0] == '\0' || !state) {
         return -1;
     }
@@ -888,7 +971,10 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
         return -1;
     }
     int row_count = 0;
-    int has_name_column = 0;
+    chan_header_cols cols;
+    DSD_MEMSET(&cols, 0, sizeof(cols));
+    cols.keys_hex_idx = -1;
+    cols.keys_dec_idx = -1;
 
     while (fgets(buffer, BSIZE, fp)) {
         int field_count = 0;
@@ -896,13 +982,17 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
         row_count++;
         if (row_count == 1) {
             // Split in place: the header is not needed again, and the next fgets refills the buffer.
-            has_name_column = chan_header_has_name_column(buffer);
+            if (chan_parse_header(buffer, &cols) != 0) {
+                fclose(fp);
+                return -1;
+            }
             continue; //don't want labels
         }
         if (csv_line_is_blank(buffer)) {
             continue;
         }
-        const int freq_parsed = chan_import_row(state, buffer, has_name_column, &field_count, &chan_number);
+        const int freq_parsed =
+            chan_import_row(state, buffer, &cols, filename, row_count, show_keys, &field_count, &chan_number);
         if (freq_parsed < 0) {
             fclose(fp);
             return -1;
@@ -930,13 +1020,19 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
     return 0;
 }
 
+/* Dry-run entry for the validator: counts rows and never reveals key values. */
+static int
+chan_validate_run(const char* chan_file_path, dsd_state* state, dsd_csv_validation* stats) {
+    return chan_import_stats(chan_file_path, state, stats, 0);
+}
+
 int
 csvChanImport(const dsd_opts* opts, dsd_state* state) //channel map import
 {
     if (!opts || !state) {
         return -1;
     }
-    return chan_import_stats(opts->chan_in_file, state, NULL);
+    return chan_import_stats(opts->chan_in_file, state, NULL, opts->show_keys);
 }
 
 //Decimal Variant of Key Import
@@ -1010,6 +1106,11 @@ csvKeyImportDec(const dsd_opts* opts, dsd_state* state) //multi-key support
         return -1;
     }
     return key_import_dec_stats(opts->show_keys, opts->key_in_file, state, NULL);
+}
+
+int
+csvKeyImportDecPath(const char* path, int show_keys, dsd_state* state, dsd_csv_validation* stats) {
+    return key_import_dec_stats(show_keys, path, state, stats);
 }
 
 static int
@@ -1261,6 +1362,11 @@ csvKeyImportHex(const dsd_opts* opts, dsd_state* state) //key import for hex key
     return key_import_hex_stats(opts->show_keys, opts->key_in_file, state, NULL);
 }
 
+int
+csvKeyImportHexPath(const char* path, int show_keys, dsd_state* state, dsd_csv_validation* stats) {
+    return key_import_hex_stats(show_keys, path, state, stats);
+}
+
 typedef int (*csv_validate_run_fn)(const char* path, dsd_state* state, dsd_csv_validation* out);
 
 /*
@@ -1313,7 +1419,7 @@ dsd_csv_validate_group_file(const char* path, dsd_csv_validation* out) {
 
 int
 dsd_csv_validate_chan_file(const char* path, dsd_csv_validation* out) {
-    return csv_validate_into_throwaway(path, out, chan_import_stats);
+    return csv_validate_into_throwaway(path, out, chan_validate_run);
 }
 
 int

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -890,6 +890,47 @@ chan_parse_header(char* header_line, chan_header_cols* out) {
 }
 
 /**
+ * @brief Load the key files named by a row's key cells into that row's key set.
+ *
+ * Paths resolve against the map file, so a map and its key files relocate as a
+ * unit. Key paths cannot contain commas: the splitter does no quote handling.
+ *
+ * @return 0 when the row named no key file or its keys loaded, -1 on an unusable
+ *         path, a load failure or allocation failure.
+ */
+static int
+chan_import_row_keys(dsd_state* state, char** fields, size_t field_count, const chan_header_cols* cols,
+                     const char* base_path, int row_number, int show_keys, size_t slot) {
+    const char* hex_cell = chan_key_cell(fields, field_count, cols->keys_hex_idx);
+    const char* dec_cell = chan_key_cell(fields, field_count, cols->keys_dec_idx);
+    const int have_hex = (hex_cell != NULL && hex_cell[0] != '\0');
+    const int have_dec = (dec_cell != NULL && dec_cell[0] != '\0');
+    if (!have_hex && !have_dec) {
+        return 0;
+    }
+    char hex_path[CSV_IMPORT_PATH_MAX] = "";
+    char dec_path[CSV_IMPORT_PATH_MAX] = "";
+    if (chan_resolve_key_cell(base_path, hex_cell, hex_path, sizeof(hex_path), row_number) != 0
+        || chan_resolve_key_cell(base_path, dec_cell, dec_path, sizeof(dec_path), row_number) != 0) {
+        return -1;
+    }
+    dsd_key_set ks;
+    DSD_MEMSET(&ks, 0, sizeof(ks));
+    if (dsd_key_set_load_csv(&ks, have_hex ? hex_path : NULL, have_dec ? dec_path : NULL, show_keys) != 0) {
+        char row_text[32] = "?";
+        (void)DSD_SNPRINTF(row_text, sizeof(row_text), "%d", row_number);
+        LOG_ERROR("channel map file '%s' row %s: failed to load row key file\n", base_path, row_text);
+        return -1;
+    }
+    if (dsd_state_trunk_lcn_keys_set(state, slot, &ks) != 0) {
+        dsd_key_set_free(&ks);
+        LOG_ERROR("channel map import out of memory\n");
+        return -1;
+    }
+    return 0;
+}
+
+/**
  * @brief Parse one channel row into @p state.
  *
  * Empty fields are preserved rather than collapsed, so `1,,851000000` reads as a
@@ -925,35 +966,38 @@ chan_import_row(dsd_state* state, char* buffer, const chan_header_cols* cols, co
         }
     }
     if ((cols->keys_hex_idx >= 0 || cols->keys_dec_idx >= 0) && state->lcn_freq_count > lcn_before) {
-        const char* hex_cell = chan_key_cell(fields, field_count, cols->keys_hex_idx);
-        const char* dec_cell = chan_key_cell(fields, field_count, cols->keys_dec_idx);
-        if ((hex_cell && hex_cell[0] != '\0') || (dec_cell && dec_cell[0] != '\0')) {
-            char hex_path[CSV_IMPORT_PATH_MAX] = "";
-            char dec_path[CSV_IMPORT_PATH_MAX] = "";
-            if (chan_resolve_key_cell(base_path, hex_cell, hex_path, sizeof(hex_path), row_number) != 0
-                || chan_resolve_key_cell(base_path, dec_cell, dec_path, sizeof(dec_path), row_number) != 0) {
-                return -1;
-            }
-            dsd_key_set ks;
-            DSD_MEMSET(&ks, 0, sizeof(ks));
-            if (dsd_key_set_load_csv(&ks, hex_cell && hex_cell[0] != '\0' ? hex_path : NULL,
-                                     dec_cell && dec_cell[0] != '\0' ? dec_path : NULL, show_keys)
-                != 0) {
-                char row_text[32] = "?";
-                (void)DSD_SNPRINTF(row_text, sizeof(row_text), "%d", row_number);
-                LOG_ERROR("channel map file '%s' row %s: failed to load row key file\n", base_path, row_text);
-                return -1;
-            }
-            if (dsd_state_trunk_lcn_keys_set(state, (size_t)lcn_before, &ks) != 0) {
-                dsd_key_set_free(&ks);
-                LOG_ERROR("channel map import out of memory\n");
-                return -1;
-            }
+        if (chan_import_row_keys(state, fields, field_count, cols, base_path, row_number, show_keys, (size_t)lcn_before)
+            != 0) {
+            return -1;
         }
     }
     *out_field_count = (int)field_count;
     *out_chan_number = chan_number;
     return freq_parsed;
+}
+
+/*
+ * Report one parsed channel row: a dry run only wants the counters, so it never
+ * echoes rows through the process-global logger for an import that never happened.
+ */
+static void
+chan_import_row_report(const dsd_state* state, dsd_csv_validation* stats, const char* filename, int row_count,
+                       int freq_parsed, int field_count, long int chan_number) {
+    if (stats) {
+        stats->total++;
+        stats->accepted += (freq_parsed ? 1U : 0U);
+        return;
+    }
+    if (!freq_parsed) {
+        // Say so rather than echoing the map slot, which still holds
+        // whatever was there before this row failed to land.
+        LOG_WARN("WARNING: Channel map file '%s' row %d has no usable frequency; skipping.\n", filename, row_count);
+        return;
+    }
+    if (field_count >= 2 && chan_number >= 0 && chan_number < 0xFFFF) {
+        LOG_INFO("Channel [%05ld] [%09ld]", chan_number, state->trunk_chan_map[chan_number]);
+    }
+    LOG_INFO("\n");
 }
 
 /* stats may be NULL; when set, counts data rows so a dry run can report them. */
@@ -997,24 +1041,7 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
             fclose(fp);
             return -1;
         }
-        if (stats) {
-            // A dry run exists to produce the three counters; echoing every row
-            // through the process-global logger would put thousands of records
-            // on the caller's thread for an import that never happened.
-            stats->total++;
-            stats->accepted += (freq_parsed ? 1U : 0U);
-            continue;
-        }
-        if (!freq_parsed) {
-            // Say so rather than echoing the map slot, which still holds
-            // whatever was there before this row failed to land.
-            LOG_WARN("WARNING: Channel map file '%s' row %d has no usable frequency; skipping.\n", filename, row_count);
-            continue;
-        }
-        if (field_count >= 2 && chan_number >= 0 && chan_number < 0xFFFF) {
-            LOG_INFO("Channel [%05ld] [%09ld]", chan_number, state->trunk_chan_map[chan_number]);
-        }
-        LOG_INFO("\n");
+        chan_import_row_report(state, stats, filename, row_count, freq_parsed, field_count, chan_number);
     }
     fclose(fp);
     return 0;

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -12,6 +12,7 @@
  * without dragging in the full initState/freeState dependency chain.
  */
 
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <stdint.h>
@@ -225,6 +226,86 @@ dsd_state_trunk_lcn_avoid_free(dsd_state* state) {
     state->trunk_lcn_avoid_capacity = 0;
 }
 
+int
+dsd_state_trunk_lcn_keys_reserve(dsd_state* state, size_t count) {
+    if (!state) {
+        return -1;
+    }
+    if (count <= state->trunk_lcn_keys_capacity) {
+        return 0;
+    }
+    size_t capacity = state->trunk_lcn_keys_capacity > 0 ? state->trunk_lcn_keys_capacity : 16;
+    while (capacity < count) {
+        if (capacity > SIZE_MAX / 2) {
+            capacity = count;
+            break;
+        }
+        capacity *= 2;
+    }
+    if (capacity > SIZE_MAX / sizeof(dsd_key_set)) {
+        return -1;
+    }
+    dsd_key_set* keys = (dsd_key_set*)realloc(state->trunk_lcn_keys, capacity * sizeof(*keys));
+    if (!keys) {
+        return -1;
+    }
+    DSD_MEMSET(keys + state->trunk_lcn_keys_capacity, 0, (capacity - state->trunk_lcn_keys_capacity) * sizeof(*keys));
+    state->trunk_lcn_keys = keys;
+    state->trunk_lcn_keys_capacity = capacity;
+    return 0;
+}
+
+void
+dsd_state_trunk_lcn_keys_free(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    for (size_t i = 0; i < state->trunk_lcn_keys_capacity; i++) {
+        dsd_key_set_free(&state->trunk_lcn_keys[i]);
+    }
+    free(state->trunk_lcn_keys);
+    state->trunk_lcn_keys = NULL;
+    state->trunk_lcn_keys_capacity = 0;
+}
+
+int
+dsd_state_trunk_lcn_keys_set(dsd_state* state, size_t index, dsd_key_set* ks) {
+    if (!state || !ks || index == SIZE_MAX) {
+        return -1;
+    }
+    if (dsd_state_trunk_lcn_keys_reserve(state, index + 1) != 0) {
+        return -1;
+    }
+    dsd_key_set_free(&state->trunk_lcn_keys[index]);
+    state->trunk_lcn_keys[index] = *ks;
+    DSD_MEMSET(ks, 0, sizeof(*ks));
+    return 0;
+}
+
+const dsd_key_set*
+dsd_state_trunk_lcn_keys_get(const dsd_state* state, size_t index) {
+    if (!state || !state->trunk_lcn_keys || index >= state->trunk_lcn_keys_capacity) {
+        return NULL;
+    }
+    if (state->trunk_lcn_keys[index].present == 0) {
+        return NULL;
+    }
+    return &state->trunk_lcn_keys[index];
+}
+
+int
+dsd_state_trunk_lcn_keys_present(const dsd_state* state) {
+    if (!state || !state->trunk_lcn_keys) {
+        return 0;
+    }
+    for (size_t i = 0; i < state->trunk_lcn_keys_capacity; i++) {
+        if (state->trunk_lcn_keys[i].present != 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /* Rows the list and the store both reach: the count the status line reports and the
  * clear helper returns. Flags past a shrunk list stay in the store but stop counting. */
 static size_t
@@ -327,6 +408,10 @@ dsd_state_trunk_lcn_free(dsd_state* state) {
     state->trunk_lcn_freq_ext_capacity = 0;
     dsd_state_trunk_lcn_name_free(state);
     dsd_state_trunk_lcn_avoid_free(state);
+    dsd_state_trunk_lcn_keys_free(state);
+    dsd_key_set_free(&state->scan_keys_baseline);
+    dsd_key_set_free(&state->scan_keys_active);
+    state->scan_keys_active_set = 0;
 }
 
 int

--- a/src/core/util/key_set.c
+++ b/src/core/util/key_set.c
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/key_set.h>
+
+#include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/csv_validate.h>
+#include <dsd-neo/core/enc_lockout.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/runtime/log.h>
+
+#include <stdlib.h>
+
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static size_t
+key_set_capacity(void) {
+    return sizeof(((dsd_state*)0)->rkey_array) / sizeof(((dsd_state*)0)->rkey_array[0]);
+}
+
+static void
+key_scalars_capture(dsd_key_scalars* out, const dsd_state* state) {
+    out->K = state->K;
+    out->K1 = state->K1;
+    out->K2 = state->K2;
+    out->K3 = state->K3;
+    out->K4 = state->K4;
+    out->R = state->R;
+    out->RR = state->RR;
+    out->H = state->H;
+    out->hytera_key_segments = state->hytera_key_segments;
+    DSD_MEMCPY(out->A1, state->A1, sizeof(out->A1));
+    DSD_MEMCPY(out->A2, state->A2, sizeof(out->A2));
+    DSD_MEMCPY(out->A3, state->A3, sizeof(out->A3));
+    DSD_MEMCPY(out->A4, state->A4, sizeof(out->A4));
+    DSD_MEMCPY(out->aes_key_loaded, state->aes_key_loaded, sizeof(out->aes_key_loaded));
+    DSD_MEMCPY(out->aes_key_segments, state->aes_key_segments, sizeof(out->aes_key_segments));
+}
+
+static void
+key_scalars_install(dsd_state* state, const dsd_key_scalars* in) {
+    state->K = in->K;
+    state->K1 = in->K1;
+    state->K2 = in->K2;
+    state->K3 = in->K3;
+    state->K4 = in->K4;
+    state->R = in->R;
+    state->RR = in->RR;
+    state->H = in->H;
+    state->hytera_key_segments = in->hytera_key_segments;
+    DSD_MEMCPY(state->A1, in->A1, sizeof(state->A1));
+    DSD_MEMCPY(state->A2, in->A2, sizeof(state->A2));
+    DSD_MEMCPY(state->A3, in->A3, sizeof(state->A3));
+    DSD_MEMCPY(state->A4, in->A4, sizeof(state->A4));
+    DSD_MEMCPY(state->aes_key_loaded, in->aes_key_loaded, sizeof(state->aes_key_loaded));
+    DSD_MEMCPY(state->aes_key_segments, in->aes_key_segments, sizeof(state->aes_key_segments));
+}
+
+int
+dsd_key_set_capture(dsd_key_set* out, const dsd_state* state) {
+    if (out == NULL || state == NULL) {
+        return -1;
+    }
+    const size_t capacity = key_set_capacity();
+    size_t count = 0;
+    for (size_t i = 0; i < capacity; i++) {
+        if (state->rkey_array_loaded[i] != 0U || state->rkey_array[i] != 0ULL) {
+            count++;
+        }
+    }
+    dsd_key_set_entry* entries = NULL;
+    if (count > 0) {
+        entries = (dsd_key_set_entry*)calloc(count, sizeof(*entries));
+        if (entries == NULL) {
+            dsd_key_set_free(out);
+            return -1;
+        }
+        size_t at = 0;
+        for (size_t i = 0; i < capacity; i++) {
+            if (state->rkey_array_loaded[i] != 0U || state->rkey_array[i] != 0ULL) {
+                entries[at].index = (uint32_t)i;
+                entries[at].value = state->rkey_array[i];
+                entries[at].loaded = state->rkey_array_loaded[i] != 0U ? (uint8_t)1 : (uint8_t)0;
+                at++;
+            }
+        }
+    }
+    dsd_key_set_free(out);
+    out->entries = entries;
+    out->count = count;
+    out->present = 0;
+    out->keyloader = state->keyloader;
+    key_scalars_capture(&out->scalars, state);
+    return 0;
+}
+
+void
+dsd_key_set_install(dsd_state* state, const dsd_key_set* ks) {
+    if (state == NULL || ks == NULL) {
+        return;
+    }
+    const size_t capacity = key_set_capacity();
+    DSD_MEMSET(state->rkey_array, 0, sizeof(state->rkey_array));
+    DSD_MEMSET(state->rkey_array_loaded, 0, sizeof(state->rkey_array_loaded));
+    /* A NULL entry table always means an empty set; count is authoritative only with a table. */
+    const size_t count = (ks->entries != NULL) ? ks->count : 0U;
+    for (size_t i = 0; i < count; i++) {
+        const size_t idx = (size_t)ks->entries[i].index;
+        if (idx >= capacity) {
+            continue;
+        }
+        state->rkey_array[idx] = ks->entries[i].value;
+        state->rkey_array_loaded[idx] = ks->entries[i].loaded != 0U ? (unsigned char)1 : (unsigned char)0;
+    }
+    state->keyloader = ks->keyloader;
+    key_scalars_install(state, &ks->scalars);
+}
+
+int
+dsd_key_set_copy(dsd_key_set* dst, const dsd_key_set* src) {
+    if (dst == NULL || src == NULL) {
+        return -1;
+    }
+    if (dst == src) {
+        return 0;
+    }
+    dsd_key_set_entry* entries = NULL;
+    if (src->count > 0) {
+        if (src->entries == NULL) {
+            return -1;
+        }
+        entries = (dsd_key_set_entry*)calloc(src->count, sizeof(*entries));
+        if (entries == NULL) {
+            return -1;
+        }
+        DSD_MEMCPY(entries, src->entries, src->count * sizeof(*entries));
+    }
+    dsd_key_set_free(dst);
+    dst->entries = entries;
+    dst->count = src->count;
+    dst->present = src->present;
+    dst->keyloader = src->keyloader;
+    dst->scalars = src->scalars;
+    return 0;
+}
+
+int
+dsd_key_set_equal(const dsd_key_set* a, const dsd_key_set* b) {
+    if (a == NULL || b == NULL) {
+        return 0;
+    }
+    if (a == b) {
+        return 1;
+    }
+    if (a->present != b->present || a->keyloader != b->keyloader || a->count != b->count) {
+        return 0;
+    }
+    for (size_t i = 0; i < a->count; i++) {
+        if (a->entries[i].index != b->entries[i].index || a->entries[i].value != b->entries[i].value
+            || a->entries[i].loaded != b->entries[i].loaded) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static int
+key_set_path_empty(const char* path) {
+    return path == NULL || path[0] == '\0';
+}
+
+static void
+key_set_log_summary(const char* kind, const char* path, const dsd_csv_validation* stats) {
+    /* Counts are pre-formatted so no numeric conversion shares a log line with a key word. */
+    char count_text[64] = "0 of 0";
+    if (stats != NULL) {
+        (void)DSD_SNPRINTF(count_text, sizeof(count_text), "%u of %u", stats->accepted, stats->total);
+    }
+    LOG_INFO("NOTICE: Loaded %s entries (%s file) from '%s'.\n", count_text, kind, path);
+}
+
+/* The throwaway state held key material: wipe the keyring before the memory goes back. */
+static void
+key_set_free_throwaway(dsd_state* tmp) {
+    DSD_MEMSET(tmp->rkey_array, 0, sizeof(tmp->rkey_array));
+    DSD_MEMSET(tmp->rkey_array_loaded, 0, sizeof(tmp->rkey_array_loaded));
+    dsd_state_ext_free_all(tmp);
+    free(tmp);
+}
+
+int
+dsd_key_set_load_csv(dsd_key_set* out, const char* hex_path, const char* dec_path, int show_keys) {
+    if (out == NULL || (key_set_path_empty(hex_path) && key_set_path_empty(dec_path))) {
+        return -1;
+    }
+    dsd_state* tmp = (dsd_state*)calloc(1, sizeof(*tmp));
+    if (tmp == NULL) {
+        return -1;
+    }
+    if (!key_set_path_empty(hex_path)) {
+        dsd_csv_validation stats;
+        DSD_MEMSET(&stats, 0, sizeof(stats));
+        if (csvKeyImportHexPath(hex_path, show_keys, tmp, &stats) != 0) {
+            key_set_free_throwaway(tmp);
+            return -1;
+        }
+        key_set_log_summary("hex", hex_path, &stats);
+    }
+    if (!key_set_path_empty(dec_path)) {
+        dsd_csv_validation stats;
+        DSD_MEMSET(&stats, 0, sizeof(stats));
+        if (csvKeyImportDecPath(dec_path, show_keys, tmp, &stats) != 0) {
+            key_set_free_throwaway(tmp);
+            return -1;
+        }
+        key_set_log_summary("dec", dec_path, &stats);
+    }
+    dsd_key_set loaded;
+    DSD_MEMSET(&loaded, 0, sizeof(loaded));
+    const int capture_rc = dsd_key_set_capture(&loaded, tmp);
+    key_set_free_throwaway(tmp);
+    if (capture_rc != 0) {
+        return -1;
+    }
+    loaded.present = 1;
+    loaded.keyloader = 1;
+    DSD_MEMSET(&loaded.scalars, 0, sizeof(loaded.scalars));
+    dsd_key_set_free(out);
+    *out = loaded;
+    return 0;
+}
+
+int
+dsd_scan_keys_enter(dsd_state* state, const dsd_key_set* row_set) {
+    if (state == NULL || row_set == NULL) {
+        return 0;
+    }
+    if (state->scan_keys_active_set == 0) {
+        /* Both copies have to exist before anything touches the live keyring: a failed
+         * baseline capture would otherwise let a later leave install an empty set over
+         * the operator's globals. */
+        if (dsd_key_set_capture(&state->scan_keys_baseline, state) != 0) {
+            return 0;
+        }
+        if (dsd_key_set_copy(&state->scan_keys_active, row_set) != 0) {
+            dsd_key_set_free(&state->scan_keys_baseline);
+            return 0;
+        }
+        dsd_key_set_install(state, &state->scan_keys_active);
+        state->scan_keys_active_set = 1;
+        return 1;
+    }
+    if (dsd_key_set_equal(&state->scan_keys_active, row_set)) {
+        return 0;
+    }
+    if (dsd_key_set_copy(&state->scan_keys_active, row_set) != 0) {
+        return 0;
+    }
+    dsd_key_set_install(state, &state->scan_keys_active);
+    return 1;
+}
+
+void
+dsd_scan_keys_leave(dsd_state* state) {
+    if (state == NULL || state->scan_keys_active_set == 0) {
+        return;
+    }
+    dsd_key_set_install(state, &state->scan_keys_baseline);
+    dsd_key_set_free(&state->scan_keys_baseline);
+    dsd_key_set_free(&state->scan_keys_active);
+    state->scan_keys_active_set = 0;
+}
+
+void
+dsd_scan_keys_suspend(dsd_state* state) {
+    if (state == NULL || state->scan_keys_active_set == 0) {
+        return;
+    }
+    dsd_key_set_install(state, &state->scan_keys_baseline);
+}
+
+void
+dsd_scan_keys_resume(dsd_state* state) {
+    if (state == NULL || state->scan_keys_active_set == 0) {
+        return;
+    }
+    /* A failed re-capture keeps the previous baseline rather than an empty one. */
+    dsd_key_set fresh;
+    DSD_MEMSET(&fresh, 0, sizeof(fresh));
+    if (dsd_key_set_capture(&fresh, state) == 0) {
+        dsd_key_set_free(&state->scan_keys_baseline);
+        state->scan_keys_baseline = fresh;
+    }
+    dsd_key_set_install(state, &state->scan_keys_active);
+}
+
+int
+dsd_scan_row_keys_apply(dsd_state* state, int row) {
+    if (state == NULL || row < 0) {
+        return 0;
+    }
+    const dsd_key_set* row_set = dsd_state_trunk_lcn_keys_get(state, (size_t)row);
+    if (row_set != NULL && row_set->present != 0) {
+        const int changed = dsd_scan_keys_enter(state, row_set);
+        if (changed != 0) {
+            dsd_enc_lockout_bump_key_epoch(state);
+        }
+        return changed;
+    }
+    if (state->scan_keys_active_set != 0) {
+        dsd_scan_keys_leave(state);
+        dsd_enc_lockout_bump_key_epoch(state);
+        return 1;
+    }
+    return 0;
+}
+
+void
+dsd_scan_row_keys_warn_if_unused(const dsd_state* state, int scanner_mode) {
+    if (scanner_mode == 1 || !dsd_state_trunk_lcn_keys_present(state)) {
+        return;
+    }
+    LOG_WARN("WARNING: Channel map row keys apply only with -Y scanner mode; ignoring per-row keys.\n");
+}

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -68,6 +68,7 @@
 #include <string.h>
 #include <time.h>
 #include "dsd-neo/core/dibit.h"
+#include "dsd-neo/core/key_set.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_ext.h"
@@ -320,6 +321,7 @@ import_global_channel_map_if_needed(dsd_opts* opts, dsd_state* state) {
             return -1;
         }
         LOG_INFO("NOTICE: Imported channel map from %s\n", opts->chan_in_file);
+        dsd_scan_row_keys_warn_if_unused(state, opts->scanner_mode);
     }
     return 0;
 }
@@ -1353,6 +1355,9 @@ no_carrier_step_scanner_mode_if_needed(const dsd_opts* opts, dsd_state* state, t
         }
     }
     state->lcn_freq_roll++;
+    if (freq != 0) {
+        dsd_scan_row_keys_apply(state, state->lcn_freq_roll - 1);
+    }
     state->last_cc_sync_time = now;
     state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
     // A zero entry parks on the current frequency rather than retuning, so it is not a hop.

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1299,6 +1299,36 @@ no_carrier_tune_rtl_if_needed(const dsd_opts* opts, dsd_state* state, uint32_t r
 }
 #endif
 
+// Puts every configured front end on freq for one scan step. moved is set once a leg has physically
+// retuned the receiver, so a later leg failing still reports the move the caller can no longer take
+// back. Returns 0 when every leg is on frequency, -1 when the step was abandoned.
+static int
+no_carrier_step_retune(const dsd_opts* opts, dsd_state* state, long int freq, int* moved) {
+#ifndef USE_RADIO
+    UNUSED(state);
+#endif
+    *moved = 0;
+    if (opts->use_rigctl != 1 && opts->audio_in_type != AUDIO_IN_RTL) {
+        return -1;
+    }
+    if (opts->use_rigctl == 1) {
+        if (no_carrier_tune_rigctl_if_needed(opts, freq) != DSD_TRUNK_TUNE_RESULT_OK) {
+            return -1;
+        }
+        *moved = 1;
+    }
+    if (opts->audio_in_type == AUDIO_IN_RTL) {
+#ifdef USE_RADIO
+        if (no_carrier_tune_rtl_if_needed(opts, state, (uint32_t)freq) != DSD_TRUNK_TUNE_RESULT_OK) {
+            return -1;
+        }
+#else
+        return -1;
+#endif
+    }
+    return 0;
+}
+
 // Returns non-zero when the scanner actually moved to another frequency, so the caller can end any
 // call still open as an explicit release rather than a sync loss.
 static int
@@ -1334,25 +1364,8 @@ no_carrier_step_scanner_mode_if_needed(const dsd_opts* opts, dsd_state* state, t
     // still has to report as a hop or the finalizer ends the call as sync loss and leaves it
     // reacquirable by whatever decodes next -- on a different frequency.
     int moved = 0;
-    if (freq != 0) {
-        if (opts->use_rigctl != 1 && opts->audio_in_type != AUDIO_IN_RTL) {
-            return 0;
-        }
-        if (opts->use_rigctl == 1) {
-            if (no_carrier_tune_rigctl_if_needed(opts, freq) != DSD_TRUNK_TUNE_RESULT_OK) {
-                return 0;
-            }
-            moved = 1;
-        }
-        if (opts->audio_in_type == AUDIO_IN_RTL) {
-#ifdef USE_RADIO
-            if (no_carrier_tune_rtl_if_needed(opts, state, (uint32_t)freq) != DSD_TRUNK_TUNE_RESULT_OK) {
-                return moved;
-            }
-#else
-            return moved;
-#endif
-        }
+    if (freq != 0 && no_carrier_step_retune(opts, state, freq, &moved) != 0) {
+        return moved;
     }
     state->lcn_freq_roll++;
     if (freq != 0) {

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <time.h>
 #include "dsd-neo/core/enc_lockout.h"
+#include "dsd-neo/core/key_set.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -193,6 +194,9 @@ typedef struct {
 typedef struct {
     dsd_trunk_scan_target target;
     dsd_trunk_scan_snapshot snapshot;
+    /* Static per-target key configuration, loaded at init. Not part of the
+     * snapshot: the switch applies it through the scan key swap instead. */
+    dsd_key_set keys;
     p25_sm_ctx_t p25_ctx;
     dmr_sm_ctx_t dmr_ctx;
     double parked_since_m;
@@ -499,6 +503,8 @@ typedef struct {
     int default_hold_ms;
     int modulation_idx;
     int rtl_gain_idx;
+    int keys_hex_idx;
+    int keys_dec_idx;
     unsigned int row;
     char* err;
     size_t err_sz;
@@ -650,6 +656,8 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
 
     const char* modulation_s = scan_optional_field(fields, field_count, parse->modulation_idx);
     const char* rtl_gain_s = scan_optional_field(fields, field_count, parse->rtl_gain_idx);
+    const char* keys_hex_s = scan_optional_field(fields, field_count, parse->keys_hex_idx);
+    const char* keys_dec_s = scan_optional_field(fields, field_count, parse->keys_dec_idx);
 
     dsd_trunk_scan_target target;
     DSD_MEMSET(&target, 0, sizeof(target));
@@ -675,6 +683,20 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
             scan_set_error(parse->err, parse->err_sz, "row %u chan_csv path is too long or invalid", parse->row);
             return -1;
         }
+    }
+    if (keys_hex_s[0] != '\0'
+        && dsd_path_resolve_relative_to_file(parse->resolved_path, keys_hex_s, target.keys_hex_csv,
+                                             sizeof target.keys_hex_csv)
+               != 0) {
+        scan_set_error(parse->err, parse->err_sz, "row %u keys_hex_csv path is too long or invalid", parse->row);
+        return -1;
+    }
+    if (keys_dec_s[0] != '\0'
+        && dsd_path_resolve_relative_to_file(parse->resolved_path, keys_dec_s, target.keys_dec_csv,
+                                             sizeof target.keys_dec_csv)
+               != 0) {
+        scan_set_error(parse->err, parse->err_sz, "row %u keys_dec_csv path is too long or invalid", parse->row);
+        return -1;
     }
     if (scan_parse_ms_field(dwell_s, parse->default_dwell_ms, &target.dwell_ms) != 0) {
         scan_set_error(parse->err, parse->err_sz, "row %u has invalid dwell_ms '%s'", parse->row, dwell_s);
@@ -732,6 +754,8 @@ scan_read_target_csv_header(FILE* fp, char* line, size_t line_sz, dsd_trunk_scan
 
     parse->modulation_idx = -1;
     parse->rtl_gain_idx = -1;
+    parse->keys_hex_idx = -1;
+    parse->keys_dec_idx = -1;
     for (size_t i = DSD_TRUNK_SCAN_REQUIRED_CSV_FIELDS; i < field_count; i++) {
         const char* name = scan_unquote(fields[i]);
         if (strcmp(name, "modulation") == 0) {
@@ -746,6 +770,18 @@ scan_read_target_csv_header(FILE* fp, char* line, size_t line_sz, dsd_trunk_scan
                 return -1;
             }
             parse->rtl_gain_idx = (int)i;
+        } else if (strcmp(name, "keys_hex_csv") == 0) {
+            if (parse->keys_hex_idx >= 0) {
+                scan_set_error(parse->err, parse->err_sz, "trunk scan target CSV header duplicates 'keys_hex_csv'");
+                return -1;
+            }
+            parse->keys_hex_idx = (int)i;
+        } else if (strcmp(name, "keys_dec_csv") == 0) {
+            if (parse->keys_dec_idx >= 0) {
+                scan_set_error(parse->err, parse->err_sz, "trunk scan target CSV header duplicates 'keys_dec_csv'");
+                return -1;
+            }
+            parse->keys_dec_idx = (int)i;
         }
     }
     return 0;
@@ -1875,6 +1911,9 @@ trunk_scan_import_target_chan_csv(const dsd_opts* opts, dsd_state* state, const 
      * snapshot carries the positional scan list and not the names, so a kept name would end
      * up over the next target's list. Drop them before that can happen. */
     dsd_state_trunk_lcn_name_free(state);
+    /* Per-row key columns are likewise discarded: keys arrive per trunk-scan target, not
+     * per chan_csv row, and a kept set would install on the wrong target's hop. */
+    dsd_state_trunk_lcn_keys_free(state);
     free(tmp_opts);
     if (import_rc != 0) {
         scan_set_error(err, err_sz, "failed to import chan_csv '%s' for trunk scan target '%s'", target->chan_csv,
@@ -1903,6 +1942,18 @@ trunk_scan_build_target_runtime(dsd_trunk_scan_coord* coord, dsd_opts* opts, dsd
         trunk_scan_seed_target_state(state, &rt->target, now_m);
         if (trunk_scan_import_target_chan_csv(opts, state, &rt->target, err, err_sz) != 0) {
             return -1;
+        }
+        if (rt->target.keys_hex_csv[0] != '\0' || rt->target.keys_dec_csv[0] != '\0') {
+            const char* key_src =
+                rt->target.keys_hex_csv[0] != '\0' ? rt->target.keys_hex_csv : rt->target.keys_dec_csv;
+            if (dsd_key_set_load_csv(&rt->keys, rt->target.keys_hex_csv[0] != '\0' ? rt->target.keys_hex_csv : NULL,
+                                     rt->target.keys_dec_csv[0] != '\0' ? rt->target.keys_dec_csv : NULL,
+                                     opts->show_keys)
+                != 0) {
+                scan_set_error(err, err_sz, "failed to import keys for trunk scan target '%s' from '%s'", rt->target.id,
+                               key_src);
+                return -1;
+            }
         }
         p25_sm_init_ctx(&rt->p25_ctx, opts, state);
         dmr_sm_init_ctx(&rt->dmr_ctx, opts, state);
@@ -1968,6 +2019,24 @@ trunk_scan_retune_active(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_target
     return dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, cc_sps, out_request_id);
 }
 
+/*
+ * Per-target keys ride the scan key swap: a keyed target installs its set, an
+ * unkeyed one hands the foreground keyring back to the globals. Trunk scan
+ * never bumps the lockout key epoch -- every target carries its own lockout
+ * ledger snapshot, so no global invalidation is owed on a switch.
+ */
+static void
+trunk_scan_apply_target_keys(dsd_state* state, const dsd_trunk_scan_target_runtime* rt) {
+    if (!state || !rt) {
+        return;
+    }
+    if (rt->keys.present) {
+        (void)dsd_scan_keys_enter(state, &rt->keys);
+    } else {
+        dsd_scan_keys_leave(state);
+    }
+}
+
 static int
 trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord, size_t next, int save_current) {
     if (!coord || next >= coord->count) {
@@ -1984,6 +2053,7 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
     trunk_scan_restore_target_snapshot(coord, state, rt);
     trunk_scan_apply_target_opts(opts, coord, &rt->target);
+    trunk_scan_apply_target_keys(state, rt);
     trunk_scan_apply_target_demod(opts, state, &rt->target);
     trunk_scan_sync_active_sm_mode(state, rt);
 
@@ -2079,6 +2149,7 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
     trunk_scan_publish_active_target(state, coord);
     trunk_scan_restore_snapshot(state, original_snapshot);
     trunk_scan_apply_target_opts(opts, coord, &coord->targets[coord->active].target);
+    trunk_scan_apply_target_keys(state, &coord->targets[coord->active]);
     trunk_scan_apply_target_demod(opts, state, &coord->targets[coord->active].target);
     trunk_scan_sync_active_sm_mode(state, &coord->targets[coord->active]);
 }
@@ -2551,6 +2622,7 @@ trunk_scan_coord_free(dsd_trunk_scan_coord* coord) {
         free(coord->targets[i].snapshot.trunk_lcn_freq_ext);
         free(coord->targets[i].snapshot.chan_map_chan);
         free(coord->targets[i].snapshot.chan_map_freq);
+        dsd_key_set_free(&coord->targets[i].keys);
     }
     free(coord->scratch_snapshot.trunk_lcn_freq_ext);
     free(coord->scratch_snapshot.chan_map_chan);
@@ -2636,7 +2708,9 @@ trunk_scan_coord_create(const dsd_trunk_scan_target_list* list, const dsd_opts* 
  * captured, release the coordinator and its snapshots, and drop the target
  * list's owned storage. */
 static void
-trunk_scan_init_release(dsd_opts* opts, dsd_trunk_scan_coord* coord, dsd_trunk_scan_target_list* list) {
+trunk_scan_init_release(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord,
+                        dsd_trunk_scan_target_list* list) {
+    dsd_scan_keys_leave(state);
     trunk_scan_restore_saved_opts(opts, coord);
     trunk_scan_coord_free(coord);
     dsd_trunk_scan_target_list_reset(list);
@@ -2665,12 +2739,12 @@ dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t e
     }
 
     if (trunk_scan_build_target_runtime(coord, opts, state, &list, err, err_sz) != 0) {
-        trunk_scan_init_release(opts, coord, &list);
+        trunk_scan_init_release(opts, state, coord, &list);
         return -1;
     }
 
     if (dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_TRUNK_SCAN, coord, trunk_scan_free) != 0) {
-        trunk_scan_init_release(opts, coord, &list);
+        trunk_scan_init_release(opts, state, coord, &list);
         scan_set_error(err, err_sz, "failed to attach trunk scan coordinator");
         return -1;
     }
@@ -2710,6 +2784,7 @@ dsd_engine_trunk_scan_shutdown(dsd_opts* opts, dsd_state* state) {
         return;
     }
     trunk_scan_log_nxdn_diag_summaries(coord, state);
+    dsd_scan_keys_leave(state);
     trunk_scan_restore_saved_opts(opts, coord);
     trunk_scan_uninstall_runtime_hooks(coord);
     trunk_scan_clear_published_target(state);

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -641,6 +641,41 @@ scan_target_list_reserve(dsd_trunk_scan_target_list* list, size_t needed) {
     return 0;
 }
 
+/*
+ * Resolve the row's file references -- the trunking channel map and the per-row key CSVs -- against
+ * the directory holding the target CSV itself, so a target list stays relocatable as a unit.
+ */
+static int
+scan_parse_target_paths(dsd_trunk_scan_target* target, const dsd_trunk_scan_row_parse* parse, const char* chan_csv,
+                        const char* keys_hex_s, const char* keys_dec_s) {
+    if (chan_csv[0] != '\0') {
+        if (trunk_scan_type_is_conventional(target->type)) {
+            scan_set_error(parse->err, parse->err_sz, "row %u sets chan_csv for a conventional target", parse->row);
+            return -1;
+        }
+        if (dsd_path_resolve_relative_to_file(parse->resolved_path, chan_csv, target->chan_csv, sizeof target->chan_csv)
+            != 0) {
+            scan_set_error(parse->err, parse->err_sz, "row %u chan_csv path is too long or invalid", parse->row);
+            return -1;
+        }
+    }
+    if (keys_hex_s[0] != '\0'
+        && dsd_path_resolve_relative_to_file(parse->resolved_path, keys_hex_s, target->keys_hex_csv,
+                                             sizeof target->keys_hex_csv)
+               != 0) {
+        scan_set_error(parse->err, parse->err_sz, "row %u keys_hex_csv path is too long or invalid", parse->row);
+        return -1;
+    }
+    if (keys_dec_s[0] != '\0'
+        && dsd_path_resolve_relative_to_file(parse->resolved_path, keys_dec_s, target->keys_dec_csv,
+                                             sizeof target->keys_dec_csv)
+               != 0) {
+        scan_set_error(parse->err, parse->err_sz, "row %u keys_dec_csv path is too long or invalid", parse->row);
+        return -1;
+    }
+    return 0;
+}
+
 static int
 scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_trunk_scan_row_parse* parse) {
     char* fields[DSD_TRUNK_SCAN_MAX_CSV_FIELDS] = {0};
@@ -673,29 +708,7 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
         return -1;
     }
 
-    if (chan_csv[0] != '\0') {
-        if (trunk_scan_type_is_conventional(target.type)) {
-            scan_set_error(parse->err, parse->err_sz, "row %u sets chan_csv for a conventional target", parse->row);
-            return -1;
-        }
-        if (dsd_path_resolve_relative_to_file(parse->resolved_path, chan_csv, target.chan_csv, sizeof target.chan_csv)
-            != 0) {
-            scan_set_error(parse->err, parse->err_sz, "row %u chan_csv path is too long or invalid", parse->row);
-            return -1;
-        }
-    }
-    if (keys_hex_s[0] != '\0'
-        && dsd_path_resolve_relative_to_file(parse->resolved_path, keys_hex_s, target.keys_hex_csv,
-                                             sizeof target.keys_hex_csv)
-               != 0) {
-        scan_set_error(parse->err, parse->err_sz, "row %u keys_hex_csv path is too long or invalid", parse->row);
-        return -1;
-    }
-    if (keys_dec_s[0] != '\0'
-        && dsd_path_resolve_relative_to_file(parse->resolved_path, keys_dec_s, target.keys_dec_csv,
-                                             sizeof target.keys_dec_csv)
-               != 0) {
-        scan_set_error(parse->err, parse->err_sz, "row %u keys_dec_csv path is too long or invalid", parse->row);
+    if (scan_parse_target_paths(&target, parse, chan_csv, keys_hex_s, keys_dec_s) != 0) {
         return -1;
     }
     if (scan_parse_ms_field(dwell_s, parse->default_dwell_ms, &target.dwell_ms) != 0) {

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -6,6 +6,7 @@
 #include <ctype.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
@@ -2648,8 +2649,13 @@ dsd_parse_short_opts(int argc, char** argv, dsd_opts* opts, dsd_state* state, in
     // Checked after getopt completes: --dmr-tg-key-csv is imported in the long-option pass, before
     // -k/-K arm the keyring here, so the ordering has to be resolved once both have run. The map
     // only picks which key id to use, so without a keyring it is a silent no-op.
-    if (state->dmr_tg_key_map_count > 0 && state->keyloader != 1) {
+    if (state->dmr_tg_key_map_count > 0 && state->keyloader != 1 && !dsd_state_trunk_lcn_keys_present(state)) {
         LOG_WARN("WARNING: --dmr-tg-key-csv has no effect without an imported key CSV (-K/-k).\n");
+    }
+    // Row keys ride the -Y scanner: a plain -C trunking map stores them but never applies them. Checked here
+    // rather than at the `-C` flag so a later `-Y` on the same command line counts.
+    if (opts->chan_in_file[0] != '\0') {
+        dsd_scan_row_keys_warn_if_unused(state, opts->scanner_mode);
     }
     // Set after getopt completes so -r file ordering is independent of later options.
     if (opts->playfiles == 1) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1622,6 +1622,8 @@ add_executable(
     ${PROJECT_SOURCE_DIR}/src/app_control/actions/actions_logging.c
     ${PROJECT_SOURCE_DIR}/src/app_control/symbol_profile.c
     ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/key_set.c
     ${PROJECT_SOURCE_DIR}/src/runtime/decode_mode.c
     ${PROJECT_SOURCE_DIR}/src/runtime/trunk_scan_hooks.c
 )
@@ -1665,6 +1667,9 @@ add_executable(
     # chan_map_adopt()/svc_clear_channel_map() own the scan-list heap tail and the
     # per-row name store beside it.
     ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
+    # Adopt/clear move and release the per-row key store; the swap consults the lockout epoch.
+    ${PROJECT_SOURCE_DIR}/src/core/util/key_set.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
 )
 target_include_directories(
     dsd-neo_test_ui_menu_services
@@ -3689,6 +3694,17 @@ target_link_libraries(
 )
 add_test(NAME CORE_CSV_IMPORT COMMAND dsd-neo_test_core_csv_import)
 
+add_executable(dsd-neo_test_core_key_set core/test_core_key_set.c)
+target_include_directories(
+    dsd-neo_test_core_key_set
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_core_key_set
+    PRIVATE dsd-neo_core dsd-neo_proto_dmr
+)
+add_test(NAME CORE_KEY_SET COMMAND dsd-neo_test_core_key_set)
+
 add_executable(dsd-neo_test_core_csv_validate core/test_core_csv_validate.c)
 target_include_directories(
     dsd-neo_test_core_csv_validate
@@ -4407,6 +4423,7 @@ add_executable(
     ${PROJECT_SOURCE_DIR}/src/engine/trunk_scan.c
     ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
     ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/key_set.c
     ${PROJECT_SOURCE_DIR}/src/protocol/nxdn/nxdn_trunk_diag.c
 )
 target_include_directories(

--- a/tests/core/test_core_csv_import.c
+++ b/tests/core/test_core_csv_import.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/keyring.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
@@ -1380,6 +1381,305 @@ test_dmr_tg_key_import_missing_file(void) {
     return failed;
 }
 
+/* Per-row key columns opt in by header name, in either order, with or without
+ * `name`: a non-blank cell loads into the row's slot-indexed key set, a blank
+ * cell stores nothing, and a row that took no slot stores nothing. The live
+ * keyring is untouched; the sets install on the `-Y` hop. */
+/* A key cell resolves against the map file's directory, not the working directory:
+ * the map sits in its own directory and names its key file through a subdirectory. */
+static int
+test_channel_import_row_key_relative_subdir(void) {
+    int failed = 0;
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    dsd_state* scratch = (dsd_state*)calloc(1, sizeof(*scratch));
+    char dir_tmpl[] = "dsd-neo-test-rowkey-dir-XXXXXX";
+    char sub_dir[256];
+    char key_path[256];
+    char map_path[256];
+    int fd = -1;
+
+    if (!opts || !state || !scratch) {
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    /* mkstemp reserves a unique name; reuse it for the directory. */
+    fd = dsd_mkstemp(dir_tmpl);
+    if (fd < 0) {
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    (void)dsd_close(fd);
+    (void)remove(dir_tmpl);
+    (void)DSD_SNPRINTF(sub_dir, sizeof(sub_dir), "%s/sub", dir_tmpl);
+    (void)DSD_SNPRINTF(key_path, sizeof(key_path), "%s/keys.csv", sub_dir);
+    (void)DSD_SNPRINTF(map_path, sizeof(map_path), "%s/map.csv", dir_tmpl);
+    if (dsd_mkdir(dir_tmpl, 0700) != 0 || dsd_mkdir(sub_dir, 0700) != 0
+        || write_text_file(key_path, "key id(hex),key value (hex)\n0010,AAAAAAAAAAAAAAAA\n") != 0
+        || write_text_file(map_path, "channel,frequency_hz,keys_hex_csv\n"
+                                     "1,851000000,sub/keys.csv\n")
+               != 0) {
+        (void)remove(key_path);
+        (void)remove(map_path);
+        (void)remove(sub_dir);
+        (void)remove(dir_tmpl);
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+
+    DSD_SNPRINTF(opts->chan_in_file, sizeof(opts->chan_in_file), "%s", map_path);
+    if (csvChanImport(opts, state) != 0) {
+        DSD_FPRINTF(stderr, "relative-subdir row-key import returned error\n");
+        failed = 1;
+    }
+    const dsd_key_set* row0 = dsd_state_trunk_lcn_keys_get(state, 0);
+    if (!row0 || row0->present == 0) {
+        DSD_FPRINTF(stderr, "relative-subdir row stored no key set\n");
+        failed = 1;
+    } else {
+        dsd_key_set_install(scratch, row0);
+        if (scratch->rkey_array[0x10] != 0xAAAAAAAAAAAAAAAAULL || scratch->rkey_array_loaded[0x10] != 1U) {
+            DSD_FPRINTF(stderr, "relative-subdir row missed its key entry\n");
+            failed = 1;
+        }
+    }
+
+    (void)remove(key_path);
+    (void)remove(map_path);
+    (void)remove(sub_dir);
+    (void)remove(dir_tmpl);
+    free(opts);
+    free_test_state(state);
+    free_test_state(scratch);
+    return failed;
+}
+
+static int
+test_channel_import_row_key_columns(void) {
+    int failed = 0;
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    dsd_state* scratch = (dsd_state*)calloc(1, sizeof(*scratch));
+    char hex_tmpl[] = "dsd-neo-test-rowkey-hex-XXXXXX";
+    char dec_tmpl[] = "dsd-neo-test-rowkey-dec-XXXXXX";
+    char map_tmpl[] = "dsd-neo-test-rowkey-map-XXXXXX";
+    char body[4096];
+    int fd = -1;
+
+    if (!opts || !state || !scratch) {
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    fd = dsd_mkstemp(hex_tmpl);
+    if (fd < 0) {
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    (void)dsd_close(fd);
+    fd = dsd_mkstemp(dec_tmpl);
+    if (fd < 0) {
+        (void)remove(hex_tmpl);
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    (void)dsd_close(fd);
+    fd = dsd_mkstemp(map_tmpl);
+    if (fd < 0) {
+        (void)remove(hex_tmpl);
+        (void)remove(dec_tmpl);
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    (void)dsd_close(fd);
+    if (write_text_file(hex_tmpl,
+                        "key id(hex),key value (hex)\n0010,AAAAAAAAAAAAAAAA,0,CCCCCCCCCCCCCCCC,DDDDDDDDDDDDDDDD\n")
+            != 0
+        || write_text_file(dec_tmpl, "key id or tg id (dec),key number or value (dec)\n20,12345\n") != 0) {
+        (void)remove(hex_tmpl);
+        (void)remove(dec_tmpl);
+        (void)remove(map_tmpl);
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+
+    body[0] = '\0';
+    (void)DSD_SNPRINTF(body + strlen(body), sizeof(body) - strlen(body),
+                       "channel,frequency_hz,name,keys_hex_csv,keys_dec_csv\n"
+                       "1,851000000,Dispatch,%s,%s\n"
+                       "2,851012500,Ops,,\n"
+                       "bad,851025000,NoSlot,%s,%s\n"
+                       "3,851025000,Fire,,%s\n",
+                       hex_tmpl, dec_tmpl, hex_tmpl, dec_tmpl, dec_tmpl);
+    if (write_text_file(map_tmpl, body) != 0) {
+        (void)remove(hex_tmpl);
+        (void)remove(dec_tmpl);
+        (void)remove(map_tmpl);
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    DSD_SNPRINTF(opts->chan_in_file, sizeof(opts->chan_in_file), "%s", map_tmpl);
+    if (csvChanImport(opts, state) != 0) {
+        DSD_FPRINTF(stderr, "row-key channel import returned error\n");
+        failed = 1;
+    }
+    if (state->lcn_freq_count != 3) {
+        DSD_FPRINTF(stderr, "row-key slot count wrong: %d\n", state->lcn_freq_count);
+        failed = 1;
+    }
+    if (!dsd_state_trunk_lcn_keys_present(state)) {
+        DSD_FPRINTF(stderr, "row-key store reports empty after a keyed import\n");
+        failed = 1;
+    }
+    {
+        const dsd_key_set* row0 = dsd_state_trunk_lcn_keys_get(state, 0);
+        if (!row0 || row0->present == 0) {
+            DSD_FPRINTF(stderr, "row 1 stored no key set\n");
+            failed = 1;
+        } else {
+            dsd_key_set_install(scratch, row0);
+            if (scratch->rkey_array[0x10] != 0xAAAAAAAAAAAAAAAAULL || scratch->rkey_array_loaded[0x10] != 1U) {
+                DSD_FPRINTF(stderr, "row 1 missed the hex base segment\n");
+                failed = 1;
+            }
+            if (scratch->rkey_array[0x10 + 0x101] != 0ULL || scratch->rkey_array_loaded[0x10 + 0x101] != 1U) {
+                DSD_FPRINTF(stderr, "row 1 missed the hex zero segment\n");
+                failed = 1;
+            }
+            if (scratch->rkey_array[20] != 12345ULL || scratch->rkey_array_loaded[20] != 1U) {
+                DSD_FPRINTF(stderr, "row 1 missed the dec entry\n");
+                failed = 1;
+            }
+            if (scratch->keyloader != 1) {
+                DSD_FPRINTF(stderr, "row 1 did not arm keyloader\n");
+                failed = 1;
+            }
+        }
+    }
+    if (dsd_state_trunk_lcn_keys_get(state, 1) != NULL) {
+        DSD_FPRINTF(stderr, "blank key cells stored a set on row 2\n");
+        failed = 1;
+    }
+    // 'bad,...' took no slot, so index 1 belongs to row 2 and index 2 to row 3.
+    {
+        const dsd_key_set* row3 = dsd_state_trunk_lcn_keys_get(state, 2);
+        if (!row3 || row3->present == 0) {
+            DSD_FPRINTF(stderr, "row 3 stored no key set\n");
+            failed = 1;
+        } else {
+            DSD_MEMSET(scratch->rkey_array, 0, sizeof(scratch->rkey_array));
+            DSD_MEMSET(scratch->rkey_array_loaded, 0, sizeof(scratch->rkey_array_loaded));
+            dsd_key_set_install(scratch, row3);
+            if (scratch->rkey_array[20] != 12345ULL) {
+                DSD_FPRINTF(stderr, "row 3 missed the dec-only entry\n");
+                failed = 1;
+            }
+            if (scratch->rkey_array[0x10] != 0ULL) {
+                DSD_FPRINTF(stderr, "dec-only row 3 carries hex material\n");
+                failed = 1;
+            }
+        }
+    }
+    if (state->rkey_array[0x10] != 0ULL || state->rkey_array[20] != 0ULL) {
+        DSD_FPRINTF(stderr, "row-key import leaked into the live keyring\n");
+        failed = 1;
+    }
+    if (strcmp(dsd_state_trunk_lcn_name_get(state, 0), "Dispatch") != 0) {
+        DSD_FPRINTF(stderr, "name column broke beside key columns: '%s'\n", dsd_state_trunk_lcn_name_get(state, 0));
+        failed = 1;
+    }
+
+    // Reversed column order without `name` opts in the same way.
+    dsd_state_ext_free_all(state);
+    dsd_state_trunk_lcn_free(state);
+    DSD_MEMSET(state, 0, sizeof(*state));
+    body[0] = '\0';
+    (void)DSD_SNPRINTF(body + strlen(body), sizeof(body) - strlen(body),
+                       "channel,frequency_hz,keys_dec_csv,keys_hex_csv\n"
+                       "1,851000000,%s,%s\n",
+                       dec_tmpl, hex_tmpl);
+    if (write_text_file(map_tmpl, body) != 0) {
+        (void)remove(hex_tmpl);
+        (void)remove(dec_tmpl);
+        (void)remove(map_tmpl);
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    if (csvChanImport(opts, state) != 0 || dsd_state_trunk_lcn_keys_get(state, 0) == NULL) {
+        DSD_FPRINTF(stderr, "reversed key columns did not opt in\n");
+        failed = 1;
+    }
+
+    // An unloadable key path fails the whole import, like a bad `-K`.
+    dsd_state_ext_free_all(state);
+    dsd_state_trunk_lcn_free(state);
+    DSD_MEMSET(state, 0, sizeof(*state));
+    body[0] = '\0';
+    (void)DSD_SNPRINTF(body + strlen(body), sizeof(body) - strlen(body),
+                       "channel,frequency_hz,keys_hex_csv\n"
+                       "1,851000000,dsd-neo-test-missing-dir/missing.csv\n");
+    if (write_text_file(map_tmpl, body) != 0) {
+        (void)remove(hex_tmpl);
+        (void)remove(dec_tmpl);
+        (void)remove(map_tmpl);
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    if (csvChanImport(opts, state) == 0) {
+        DSD_FPRINTF(stderr, "row-key import accepted an unloadable path\n");
+        failed = 1;
+    }
+
+    // A duplicated key header rejects the file.
+    dsd_state_ext_free_all(state);
+    dsd_state_trunk_lcn_free(state);
+    DSD_MEMSET(state, 0, sizeof(*state));
+    if (write_text_file(map_tmpl, "channel,frequency_hz,keys_hex_csv,keys_dec_csv,keys_hex_csv\n"
+                                  "1,851000000,,,\n")
+        != 0) {
+        (void)remove(hex_tmpl);
+        (void)remove(dec_tmpl);
+        (void)remove(map_tmpl);
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    if (csvChanImport(opts, state) == 0) {
+        DSD_FPRINTF(stderr, "row-key import accepted a duplicated key header\n");
+        failed = 1;
+    }
+
+    (void)remove(hex_tmpl);
+    (void)remove(dec_tmpl);
+    (void)remove(map_tmpl);
+    free(opts);
+    free_test_state(state);
+    free_test_state(scratch);
+    return failed;
+}
+
 int
 main(void) {
     if (test_group_import_missing_file() != 0) {
@@ -1427,6 +1727,12 @@ main(void) {
         return 1;
     }
     if (test_channel_import_name_column_sanitizes_names() != 0) {
+        return 1;
+    }
+    if (test_channel_import_row_key_columns() != 0) {
+        return 1;
+    }
+    if (test_channel_import_row_key_relative_subdir() != 0) {
         return 1;
     }
     if (test_group_import_range_after_many_exact_rows() != 0) {

--- a/tests/core/test_core_csv_validate.c
+++ b/tests/core/test_core_csv_validate.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/protocol/nxdn/nxdn_lfsr.h>
 #include <stdio.h>
+#include <string.h>
 #include "dsd-neo/core/safe_api.h"
 
 void
@@ -355,6 +356,62 @@ test_chan_empty_frequency_field_is_skipped(void) {
     return failed;
 }
 
+/* Key columns ride along without moving the counters: a keyed row still stands
+ * or falls on its frequency, and validation opens the key files, so an
+ * unloadable key path fails validation the way it fails the import. */
+static int
+test_chan_counts_with_key_columns(void) {
+    char key_tmpl[] = "dsd-neo-test-validate-rowkey-XXXXXX";
+    char tmpl[] = "dsd-neo-test-validate-chan-keys-XXXXXX";
+    char body[1024];
+    if (write_temp_csv(key_tmpl, "key id(hex),key value (hex)\n0010,AAAAAAAAAAAAAAAA\n") != 0) {
+        return 1;
+    }
+    body[0] = '\0';
+    (void)DSD_SNPRINTF(body + strlen(body), sizeof(body) - strlen(body),
+                       "channel,frequency_hz,keys_hex_csv\n"
+                       "1,851000000,%s\n"
+                       "2,notafreq,%s\n"
+                       "3,852000000,\n",
+                       key_tmpl, key_tmpl);
+    if (write_temp_csv(tmpl, body) != 0) {
+        (void)remove(key_tmpl);
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_chan_file(tmpl, &v) != 0) {
+        DSD_FPRINTF(stderr, "chan validate failed on a keyed file\n");
+        failed = 1;
+    }
+    if (v.accepted != 2U || v.skipped != 1U || v.total != 3U) {
+        DSD_FPRINTF(stderr, "chan key-column counts wrong: accepted=%u skipped=%u total=%u\n", v.accepted, v.skipped,
+                    v.total);
+        failed = 1;
+    }
+    (void)remove(key_tmpl);
+    (void)remove(tmpl);
+    return failed;
+}
+
+static int
+test_chan_key_column_bad_path_fails(void) {
+    char tmpl[] = "dsd-neo-test-validate-chan-badkey-XXXXXX";
+    if (write_temp_csv(tmpl, "channel,frequency_hz,keys_hex_csv\n"
+                             "1,851000000,dsd-neo-test-validate-missing-dir/missing.csv\n")
+        != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_chan_file(tmpl, &v) == 0) {
+        DSD_FPRINTF(stderr, "chan validate accepted an unloadable key path\n");
+        failed = 1;
+    }
+    (void)remove(tmpl);
+    return failed;
+}
+
 int
 main(void) {
     if (test_missing_file_fails() != 0) {
@@ -379,6 +436,12 @@ main(void) {
         return 1;
     }
     if (test_chan_empty_frequency_field_is_skipped() != 0) {
+        return 1;
+    }
+    if (test_chan_counts_with_key_columns() != 0) {
+        return 1;
+    }
+    if (test_chan_key_column_bad_path_fails() != 0) {
         return 1;
     }
     if (test_key_dec_counts_mixed_rows() != 0) {

--- a/tests/core/test_core_key_set.c
+++ b/tests/core/test_core_key_set.c
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/core/key_set.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/platform/posix_compat.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+
+static void
+free_test_state(dsd_state* state) {
+    if (state) {
+        dsd_state_ext_free_all(state);
+        dsd_state_trunk_lcn_free(state);
+    }
+    free(state);
+}
+
+static int
+write_text_file(const char* path, const char* text) {
+    FILE* fp = dsd_fopen_private(path, "w");
+    if (!fp) {
+        return -1;
+    }
+    DSD_FPRINTF(fp, "%s", text);
+    fclose(fp);
+    return 0;
+}
+
+/* Capture keeps loaded-but-zero and AES segment cells plus the scalar block;
+ * install clears prior entries, sets keyloader, and zeroes/restores scalars. */
+static int
+test_capture_install_roundtrip(void) {
+    // dsd_state is a multi-megabyte struct; avoid Windows' default ~1MB stack.
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!state) {
+        return 1;
+    }
+    int failed = 0;
+
+    state->rkey_array[5] = 0xABCDEULL;
+    state->rkey_array_loaded[5] = 1U;
+    state->rkey_array[7] = 0ULL;
+    state->rkey_array_loaded[7] = 1U;
+    state->rkey_array[0x10] = 0xAAAAAAAAAAAAAAAAULL;
+    state->rkey_array_loaded[0x10] = 1U;
+    state->rkey_array[0x10 + 0x101] = 0ULL;
+    state->rkey_array_loaded[0x10 + 0x101] = 1U;
+    state->rkey_array[0x10 + 0x201] = 0xCCCCCCCCCCCCCCCCULL;
+    state->rkey_array_loaded[0x10 + 0x201] = 1U;
+    state->keyloader = 1;
+    state->K = 11ULL;
+    state->K1 = 12ULL;
+    state->R = 13ULL;
+    state->RR = 14ULL;
+    state->H = 15ULL;
+    state->hytera_key_segments = 3U;
+    state->A1[0] = 21ULL;
+    state->aes_key_loaded[1] = 1;
+    state->aes_key_segments[0] = 4U;
+
+    dsd_key_set ks;
+    DSD_MEMSET(&ks, 0, sizeof(ks));
+    dsd_key_set_capture(&ks, state);
+    if (ks.present != 0 || ks.keyloader != 1 || ks.count != 5) {
+        DSD_FPRINTF(stderr, "capture header mismatch (present=%u keyloader=%d count=%zu)\n", ks.present, ks.keyloader,
+                    ks.count);
+        failed = 1;
+    }
+    if (ks.scalars.K != 11ULL || ks.scalars.K1 != 12ULL || ks.scalars.R != 13ULL || ks.scalars.RR != 14ULL
+        || ks.scalars.H != 15ULL || ks.scalars.hytera_key_segments != 3U || ks.scalars.A1[0] != 21ULL
+        || ks.scalars.aes_key_loaded[1] != 1 || ks.scalars.aes_key_segments[0] != 4U) {
+        DSD_FPRINTF(stderr, "capture scalar block mismatch\n");
+        failed = 1;
+    }
+
+    /* Mutate the live state, then install: prior entries must clear. */
+    DSD_MEMSET(state->rkey_array, 0xAA, sizeof(state->rkey_array));
+    DSD_MEMSET(state->rkey_array_loaded, 0xAA, sizeof(state->rkey_array_loaded));
+    state->keyloader = 0;
+    state->K = 0ULL;
+    state->A1[0] = 0ULL;
+    dsd_key_set_install(state, &ks);
+    if (state->rkey_array[5] != 0xABCDEULL || state->rkey_array_loaded[5] != 1U) {
+        DSD_FPRINTF(stderr, "install did not restore slot 5\n");
+        failed = 1;
+    }
+    if (state->rkey_array[7] != 0ULL || state->rkey_array_loaded[7] != 1U) {
+        DSD_FPRINTF(stderr, "install dropped the loaded-but-zero cell\n");
+        failed = 1;
+    }
+    if (state->rkey_array[6] != 0ULL || state->rkey_array_loaded[6] != 0U) {
+        DSD_FPRINTF(stderr, "install did not clear a prior entry\n");
+        failed = 1;
+    }
+    if (state->keyloader != 1 || state->K != 11ULL || state->A1[0] != 21ULL) {
+        DSD_FPRINTF(stderr, "install did not restore keyloader/scalars\n");
+        failed = 1;
+    }
+
+    /* Installing an empty set zeroes the keyring and the scalar block. */
+    dsd_key_set empty;
+    DSD_MEMSET(&empty, 0, sizeof(empty));
+    dsd_key_set_install(state, &empty);
+    if (state->rkey_array[5] != 0ULL || state->rkey_array_loaded[5] != 0U || state->keyloader != 0 || state->K != 0ULL
+        || state->A1[0] != 0ULL) {
+        DSD_FPRINTF(stderr, "install of an empty set did not clear\n");
+        failed = 1;
+    }
+
+    /* Copy preserves the set; equal only matches identical sets. */
+    dsd_key_set copy;
+    DSD_MEMSET(&copy, 0, sizeof(copy));
+    dsd_key_set_copy(&copy, &ks);
+    if (!dsd_key_set_equal(&copy, &ks)) {
+        DSD_FPRINTF(stderr, "copy/equal mismatch\n");
+        failed = 1;
+    }
+    copy.entries[0].value ^= 1ULL;
+    if (dsd_key_set_equal(&copy, &ks)) {
+        DSD_FPRINTF(stderr, "equal missed a value change\n");
+        failed = 1;
+    }
+
+    dsd_key_set_free(&copy);
+    dsd_key_set_free(&ks);
+    free_test_state(state);
+    return failed;
+}
+
+/* Hex+dec load from real files; missing file fails with out untouched. */
+static int
+test_load_hex_dec(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!state) {
+        return 1;
+    }
+    int failed = 0;
+
+    char hex_tmpl[] = "dsd-neo-test-rowkey-hex-XXXXXX";
+    int hex_fd = dsd_mkstemp(hex_tmpl);
+    if (hex_fd < 0) {
+        free_test_state(state);
+        return 1;
+    }
+    (void)dsd_close(hex_fd);
+    char dec_tmpl[] = "dsd-neo-test-rowkey-dec-XXXXXX";
+    int dec_fd = dsd_mkstemp(dec_tmpl);
+    if (dec_fd < 0) {
+        (void)remove(hex_tmpl);
+        free_test_state(state);
+        return 1;
+    }
+    (void)dsd_close(dec_fd);
+    if (write_text_file(hex_tmpl,
+                        "key id(hex),key value (hex)\n0010,AAAAAAAAAAAAAAAA,0,CCCCCCCCCCCCCCCC,DDDDDDDDDDDDDDDD\n")
+            != 0
+        || write_text_file(dec_tmpl, "key id or tg id (dec),key number or value (dec)\n20,12345\n") != 0) {
+        (void)remove(hex_tmpl);
+        (void)remove(dec_tmpl);
+        free_test_state(state);
+        return 1;
+    }
+
+    dsd_key_set ks;
+    DSD_MEMSET(&ks, 0, sizeof(ks));
+    if (dsd_key_set_load_csv(&ks, hex_tmpl, dec_tmpl, 0) != 0) {
+        DSD_FPRINTF(stderr, "load_csv failed on valid files\n");
+        failed = 1;
+    } else {
+        if (ks.present != 1 || ks.keyloader != 1) {
+            DSD_FPRINTF(stderr, "load_csv header mismatch\n");
+            failed = 1;
+        }
+        dsd_key_set_install(state, &ks);
+        if (state->rkey_array[0x10] != 0xAAAAAAAAAAAAAAAAULL || state->rkey_array_loaded[0x10] != 1U) {
+            DSD_FPRINTF(stderr, "load_csv missed the hex base segment\n");
+            failed = 1;
+        }
+        if (state->rkey_array[0x10 + 0x101] != 0ULL || state->rkey_array_loaded[0x10 + 0x101] != 1U) {
+            DSD_FPRINTF(stderr, "load_csv missed the hex zero segment\n");
+            failed = 1;
+        }
+        if (state->rkey_array[20] != 12345ULL || state->rkey_array_loaded[20] != 1U) {
+            DSD_FPRINTF(stderr, "load_csv missed the dec entry\n");
+            failed = 1;
+        }
+        if (state->keyloader != 1 || state->K != 0ULL) {
+            DSD_FPRINTF(stderr, "row set must arm keyloader with a zeroed scalar block\n");
+            failed = 1;
+        }
+    }
+
+    /* Missing file: -1 with out untouched. */
+    const size_t keep_count = ks.count;
+    const uint64_t keep_first = ks.count > 0 ? ks.entries[0].value : 0ULL;
+    if (dsd_key_set_load_csv(&ks, "dsd-neo-test-missing-dir/missing.csv", NULL, 0) == 0) {
+        DSD_FPRINTF(stderr, "load_csv succeeded on a missing file\n");
+        failed = 1;
+    }
+    if (ks.count != keep_count || (ks.count > 0 && ks.entries[0].value != keep_first)) {
+        DSD_FPRINTF(stderr, "load_csv touched out on failure\n");
+        failed = 1;
+    }
+    if (dsd_key_set_load_csv(&ks, NULL, NULL, 0) == 0) {
+        DSD_FPRINTF(stderr, "load_csv succeeded with no paths\n");
+        failed = 1;
+    }
+
+    dsd_key_set_free(&ks);
+    (void)remove(hex_tmpl);
+    (void)remove(dec_tmpl);
+    free_test_state(state);
+    return failed;
+}
+
+/* Enter/leave/suspend/resume, including a keyloader=0 baseline with -b-style K. */
+static int
+test_enter_leave_suspend_resume(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!state) {
+        return 1;
+    }
+    int failed = 0;
+
+    state->keyloader = 0;
+    state->K = 0xBEEFULL;
+    state->rkey_array[3] = 111ULL;
+    state->rkey_array_loaded[3] = 1U;
+
+    dsd_key_set row;
+    DSD_MEMSET(&row, 0, sizeof(row));
+    row.entries = (dsd_key_set_entry*)calloc(1, sizeof(*row.entries));
+    if (!row.entries) {
+        free_test_state(state);
+        return 1;
+    }
+    row.count = 1;
+    row.present = 1;
+    row.keyloader = 1;
+    row.entries[0].index = 9U;
+    row.entries[0].value = 999ULL;
+    row.entries[0].loaded = 1U;
+
+    if (dsd_scan_keys_enter(state, &row) != 1) {
+        DSD_FPRINTF(stderr, "first enter must report a change\n");
+        failed = 1;
+    }
+    if (state->rkey_array[9] != 999ULL || state->rkey_array[3] != 0ULL || state->K != 0ULL || state->keyloader != 1) {
+        DSD_FPRINTF(stderr, "enter did not install the row set\n");
+        failed = 1;
+    }
+    if (dsd_scan_keys_enter(state, &row) != 0) {
+        DSD_FPRINTF(stderr, "repeat enter must report no change\n");
+        failed = 1;
+    }
+
+    dsd_scan_keys_suspend(state);
+    if (state->rkey_array[3] != 111ULL || state->K != 0xBEEFULL || state->keyloader != 0
+        || state->rkey_array[9] != 0ULL) {
+        DSD_FPRINTF(stderr, "suspend did not restore the baseline\n");
+        failed = 1;
+    }
+    /* Runtime key edit while suspended lands in the globals. */
+    state->rkey_array[5] = 555ULL;
+    state->rkey_array_loaded[5] = 1U;
+    dsd_scan_keys_resume(state);
+    if (state->rkey_array[9] != 999ULL || state->rkey_array[5] != 0ULL) {
+        DSD_FPRINTF(stderr, "resume did not reinstall the row set\n");
+        failed = 1;
+    }
+
+    dsd_scan_keys_leave(state);
+    if (state->rkey_array[5] != 555ULL || state->rkey_array[3] != 111ULL || state->K != 0xBEEFULL
+        || state->keyloader != 0 || state->scan_keys_active_set != 0) {
+        DSD_FPRINTF(stderr, "leave did not restore the edited baseline\n");
+        failed = 1;
+    }
+    dsd_scan_keys_leave(state);
+
+    dsd_key_set_free(&row);
+    free_test_state(state);
+    return failed;
+}
+
+/* Row apply bumps the lockout epoch only when the installed set changes. */
+static int
+test_row_apply_epoch(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!state) {
+        return 1;
+    }
+    int failed = 0;
+
+    dsd_key_set row;
+    DSD_MEMSET(&row, 0, sizeof(row));
+    row.entries = (dsd_key_set_entry*)calloc(1, sizeof(*row.entries));
+    if (!row.entries) {
+        free_test_state(state);
+        return 1;
+    }
+    row.count = 1;
+    row.present = 1;
+    row.keyloader = 1;
+    row.entries[0].index = 9U;
+    row.entries[0].value = 999ULL;
+    row.entries[0].loaded = 1U;
+    if (dsd_state_trunk_lcn_keys_set(state, 0, &row) != 0) {
+        free_test_state(state);
+        return 1;
+    }
+
+    const uint64_t epoch0 = state->enc_lockout_key_epoch;
+    if (dsd_scan_row_keys_apply(state, 0) != 1 || state->enc_lockout_key_epoch != epoch0 + 1U) {
+        DSD_FPRINTF(stderr, "keyed apply must install and bump the epoch\n");
+        failed = 1;
+    }
+    if (state->rkey_array[9] != 999ULL) {
+        DSD_FPRINTF(stderr, "keyed apply did not install entries\n");
+        failed = 1;
+    }
+    if (dsd_scan_row_keys_apply(state, 0) != 0 || state->enc_lockout_key_epoch != epoch0 + 1U) {
+        DSD_FPRINTF(stderr, "repeat apply must not bump the epoch\n");
+        failed = 1;
+    }
+    if (dsd_scan_row_keys_apply(state, 1) != 1 || state->enc_lockout_key_epoch != epoch0 + 2U) {
+        DSD_FPRINTF(stderr, "unkeyed apply must restore and bump the epoch\n");
+        failed = 1;
+    }
+    if (state->rkey_array[9] != 0ULL) {
+        DSD_FPRINTF(stderr, "unkeyed apply did not restore the baseline\n");
+        failed = 1;
+    }
+    if (dsd_scan_row_keys_apply(state, 1) != 0 || state->enc_lockout_key_epoch != epoch0 + 2U) {
+        DSD_FPRINTF(stderr, "repeat unkeyed apply must not bump the epoch\n");
+        failed = 1;
+    }
+    if (dsd_scan_row_keys_apply(state, -1) != 0) {
+        DSD_FPRINTF(stderr, "negative row must be a no-op\n");
+        failed = 1;
+    }
+
+    free_test_state(state);
+    return failed;
+}
+
+int
+main(void) {
+    if (test_capture_install_roundtrip() != 0) {
+        return 1;
+    }
+    if (test_load_hex_dec() != 0) {
+        return 1;
+    }
+    if (test_enter_leave_suspend_resume() != 0) {
+        return 1;
+    }
+    if (test_row_apply_epoch() != 0) {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/init.h>
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
@@ -1674,6 +1675,85 @@ main(void) {
 
     rc |= expect_true("rtl-fsk-long-nosync-gap-reacquires-once", g_rtl_fsk_reacquire_requests == 1);
     rc |= expect_true("rtl-fsk-long-nosync-gap-records-request", state->rtl_fsk_reacquire_last_request_m > 0.0);
+#endif
+
+#if defined(DSD_NEO_TEST_RTL_WRAP) && DSD_NEO_TEST_RTL_WRAP
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    // Per-row keys under -Y. A hop onto a keyed row installs its set, a hop
+    // back onto an unkeyed row restores the globals, a zero-frequency row
+    // parks in place keeping the previous set, and a failed tune leg swaps
+    // nothing.
+    opts->scanner_mode = 1;
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_hangtime = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->trunk_lcn_freq[0] = 940012500;
+    state->trunk_lcn_freq[1] = 941012500;
+    state->trunk_lcn_freq[2] = 0;
+    state->lcn_freq_count = 3;
+    state->lcn_freq_roll = 0;
+    state->last_cc_sync_time = time(NULL) - 11;
+    state->keyloader = 0;
+    state->K = 0xBEEFULL;
+    state->rkey_array[3] = 111ULL;
+    state->rkey_array_loaded[3] = 1U;
+    {
+        dsd_key_set ks;
+        DSD_MEMSET(&ks, 0, sizeof(ks));
+        ks.entries = (dsd_key_set_entry*)calloc(1U, sizeof(*ks.entries));
+        if (ks.entries == NULL) {
+            free_test_runtime(opts, state);
+            return 1;
+        }
+        ks.count = 1U;
+        ks.present = 1;
+        ks.keyloader = 1;
+        ks.entries[0].index = 9U;
+        ks.entries[0].value = 999ULL;
+        ks.entries[0].loaded = 1U;
+        if (dsd_state_trunk_lcn_keys_set(state, 0U, &ks) != 0) {
+            free_test_runtime(opts, state);
+            return 1;
+        }
+    }
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_tune_calls = 0;
+
+    noCarrier(opts, state);
+    rc |= expect_true("rowkey-hop-installs", state->rkey_array[9] == 999ULL && state->keyloader == 1 && state->K == 0ULL
+                                                 && state->lcn_freq_roll == 1);
+
+    state->last_cc_sync_time = time(NULL) - 11;
+    noCarrier(opts, state);
+    rc |= expect_true("rowkey-hop-restores", state->rkey_array[9] == 0ULL && state->keyloader == 0
+                                                 && state->K == 0xBEEFULL && state->rkey_array[3] == 111ULL
+                                                 && state->lcn_freq_roll == 2);
+
+    // Re-park on the keyed row, then step onto the zero-frequency row: it parks
+    // in place, so the installed set stays.
+    state->lcn_freq_roll = 0;
+    state->last_cc_sync_time = time(NULL) - 11;
+    noCarrier(opts, state);
+    rc |= expect_true("rowkey-rehop-installs", state->rkey_array[9] == 999ULL && state->scan_keys_active_set == 1);
+    state->lcn_freq_roll = 2;
+    state->last_cc_sync_time = time(NULL) - 11;
+    noCarrier(opts, state);
+    rc |= expect_true("rowkey-zero-row-keeps-set",
+                      state->rkey_array[9] == 999ULL && state->scan_keys_active_set == 1 && state->lcn_freq_roll == 3);
+
+    // A failed tune leg leaves the receiver (and the installed set) where it was.
+    state->lcn_freq_roll = 1;
+    state->last_cc_sync_time = time(NULL) - 11;
+    g_rtl_tune_result = RTL_STREAM_TUNE_FAILED;
+    noCarrier(opts, state);
+    rc |= expect_true("rowkey-failed-tune-keeps-roll", state->lcn_freq_roll == 1);
+    rc |=
+        expect_true("rowkey-failed-tune-keeps-set", state->rkey_array[9] == 999ULL && state->scan_keys_active_set == 1);
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
 #endif
 
     dsd_rtl_stream_metrics_hooks_set(NULL);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -6,6 +6,7 @@
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/enc_lockout.h>
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
@@ -32,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include "dsd-neo/core/csv_validate.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -220,7 +222,17 @@ csvChanImport(const dsd_opts* opts, dsd_state* state) {
         if (name_text) {
             *name_text++ = '\0';
         }
-        char* tail = name_text ? name_text : freq_text;
+        /* A fourth column seeds a per-row key set, the way the real importer
+         * loads key cells: enough to prove the store was allocated, which is
+         * what the trunk-scan import then has to release. */
+        char* key_text = NULL;
+        if (name_text) {
+            key_text = strchr(name_text, ',');
+            if (key_text) {
+                *key_text++ = '\0';
+            }
+        }
+        char* tail = key_text ? key_text : (name_text ? name_text : freq_text);
         while (*tail && *tail != '\r' && *tail != '\n') {
             tail++;
         }
@@ -233,10 +245,58 @@ csvChanImport(const dsd_opts* opts, dsd_state* state) {
             if (name_text && name_text[0] != '\0') {
                 (void)dsd_state_trunk_lcn_name_set(state, 0U, name_text);
             }
+            if (key_text && key_text[0] != '\0') {
+                dsd_key_set ks;
+                DSD_MEMSET(&ks, 0, sizeof(ks));
+                ks.entries = (dsd_key_set_entry*)calloc(1U, sizeof(*ks.entries));
+                if (ks.entries != NULL) {
+                    ks.count = 1U;
+                    ks.present = 1;
+                    ks.keyloader = 1;
+                    ks.entries[0].index = 9U;
+                    ks.entries[0].value = 777ULL;
+                    ks.entries[0].loaded = 1U;
+                    (void)dsd_state_trunk_lcn_keys_set(state, 0U, &ks);
+                }
+            }
         }
     }
     (void)fclose(fp);
     return g_csv_import_result;
+}
+
+/*
+ * Per-target key stubs: a readable key file seeds one keyring slot, the way the
+ * real importer loads rows, so the coordinator's install/restore is observable.
+ * dsd_key_set_load_csv() runs these against its throwaway state and captures.
+ */
+static int
+seed_scan_key_slot(dsd_state* state, const char* path) {
+    if (!state || !path || path[0] == '\0') {
+        return -1;
+    }
+    FILE* fp = fopen(path, "rb");
+    if (!fp) {
+        return -1;
+    }
+    (void)fclose(fp);
+    state->rkey_array[9] = 999ULL;
+    state->rkey_array_loaded[9] = 1U;
+    return 0;
+}
+
+int
+csvKeyImportHexPath(const char* path, int show_keys, dsd_state* state, dsd_csv_validation* stats) {
+    (void)show_keys;
+    (void)stats;
+    return seed_scan_key_slot(state, path);
+}
+
+int
+csvKeyImportDecPath(const char* path, int show_keys, dsd_state* state, dsd_csv_validation* stats) {
+    (void)show_keys;
+    (void)stats;
+    return seed_scan_key_slot(state, path);
 }
 
 int
@@ -5475,6 +5535,310 @@ test_scan_shutdown_clears_hold_and_avoid_publication(void) {
 }
 
 static int
+test_parser_accepts_target_key_columns(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] =
+        "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,keys_hex_csv,keys_dec_csv\n";
+    if (write_targets_file_with_header(dir, header,
+                                       "a,p25-trunk,851000000,,250,,primary,hexkeys.csv,deckeys.csv\n"
+                                       "b,dmr-trunk,452000000,,250,,tier iii,,\n"
+                                       "c,nxdn-conventional,461000000,,250,,conv,hexkeys.csv,\n"
+                                       "d,nxdn-trunk,461037500,,250,,type-c,,deckeys.csv\n"
+                                       "e,dmr-conventional,461112500,,250,,plant,hexkeys.csv,deckeys.csv\n"
+                                       "f,nxdn48-conventional,461556250,,250,,narrow,hexkeys.csv,\n",
+                                       target_path, sizeof target_path)
+        != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.trunk_scan_idle_dwell_ms = 3000;
+    opts.trunk_scan_activity_hold_ms = 1200;
+    dsd_trunk_scan_target_list list;
+    DSD_MEMSET(&list, 0, sizeof list);
+    char err[256] = {0};
+    int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
+
+    int test_rc = 0;
+    char want_hex[DSD_TEST_PATH_MAX] = {0};
+    char want_dec[DSD_TEST_PATH_MAX] = {0};
+    if (rc != 0 || list.count != 6 || dsd_test_path_join(want_hex, sizeof want_hex, dir, "hexkeys.csv") != 0
+        || dsd_test_path_join(want_dec, sizeof want_dec, dir, "deckeys.csv") != 0) {
+        DSD_FPRINTF(stderr, "target keys parser rc=%d count=%zu err=%s\n", rc, list.count, err);
+        test_rc = 1;
+    }
+    if (test_rc == 0) {
+        if (strcmp(list.targets[0].keys_hex_csv, want_hex) != 0
+            || strcmp(list.targets[0].keys_dec_csv, want_dec) != 0) {
+            DSD_FPRINTF(stderr, "keyed target paths mismatch hex='%s' dec='%s'\n", list.targets[0].keys_hex_csv,
+                        list.targets[0].keys_dec_csv);
+            test_rc = 1;
+        }
+        if (list.targets[1].keys_hex_csv[0] != '\0' || list.targets[1].keys_dec_csv[0] != '\0') {
+            DSD_FPRINTF(stderr, "unkeyed target carries key paths\n");
+            test_rc = 1;
+        }
+        // No type gating: every target type may carry keys, conventional ones included.
+        if (strcmp(list.targets[2].keys_hex_csv, want_hex) != 0 || list.targets[2].keys_dec_csv[0] != '\0') {
+            DSD_FPRINTF(stderr, "conventional target key paths mismatch\n");
+            test_rc = 1;
+        }
+        if (list.targets[3].keys_hex_csv[0] != '\0' || strcmp(list.targets[3].keys_dec_csv, want_dec) != 0) {
+            DSD_FPRINTF(stderr, "nxdn-trunk target key paths mismatch\n");
+            test_rc = 1;
+        }
+        if (strcmp(list.targets[4].keys_hex_csv, want_hex) != 0
+            || strcmp(list.targets[4].keys_dec_csv, want_dec) != 0) {
+            DSD_FPRINTF(stderr, "dmr-conventional target key paths mismatch\n");
+            test_rc = 1;
+        }
+        if (strcmp(list.targets[5].keys_hex_csv, want_hex) != 0 || list.targets[5].keys_dec_csv[0] != '\0') {
+            DSD_FPRINTF(stderr, "nxdn48-conventional target key paths mismatch\n");
+            test_rc = 1;
+        }
+    }
+
+    dsd_trunk_scan_target_list_reset(&list);
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_parser_rejects_duplicate_target_key_columns(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] =
+        "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,keys_hex_csv,keys_dec_csv,keys_hex_csv\n";
+    if (write_targets_file_with_header(dir, header,
+                                       "a,p25-trunk,851000000,,250,,dup,hexkeys.csv,deckeys.csv,hexkeys.csv\n",
+                                       target_path, sizeof target_path)
+        != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.trunk_scan_idle_dwell_ms = 3000;
+    opts.trunk_scan_activity_hold_ms = 1200;
+    dsd_trunk_scan_target_list list;
+    DSD_MEMSET(&list, 0, sizeof list);
+    char err[256] = {0};
+    int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
+    int test_rc = 0;
+    if (rc == 0) {
+        DSD_FPRINTF(stderr, "duplicate key header accepted\n");
+        test_rc = 1;
+    }
+    if (list.count != 0) {
+        DSD_FPRINTF(stderr, "duplicate key header left %zu targets\n", list.count);
+        test_rc = 1;
+    }
+
+    dsd_trunk_scan_target_list_reset(&list);
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_target_keys_install_and_restore_across_switches(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char hex_path[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(hex_path, sizeof hex_path, dir, "hexkeys.csv") != 0
+        || write_text_file(hex_path, "key id(hex),key value (hex)\n0010,AAAAAAAAAAAAAAAA\n") != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,keys_hex_csv\n";
+    if (write_targets_file_with_header(dir, header,
+                                       "a,p25-trunk,851000000,,250,,keyed,hexkeys.csv\n"
+                                       "b,dmr-conventional,461000000,,250,,plain,\n",
+                                       target_path, sizeof target_path)
+        != 0) {
+        (void)remove(hex_path);
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    state.keyloader = 0;
+    state.K = 0xBEEFULL;
+    state.rkey_array[3] = 111ULL;
+    state.rkey_array_loaded[3] = 1U;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0 || state.rkey_array[9] != 999ULL
+        || state.rkey_array_loaded[9] != 1U || state.keyloader != 1 || state.K != 0ULL) {
+        DSD_FPRINTF(stderr, "keyed target init mismatch rc=%d active=%zu loaded=%u keyloader=%d err=%s\n", rc,
+                    dsd_engine_trunk_scan_active_index(&state), state.rkey_array_loaded[9], state.keyloader, err);
+        test_rc = 1;
+    }
+    const uint64_t epoch0 = state.enc_lockout_key_epoch;
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || state.rkey_array[9] != 0ULL || state.keyloader != 0
+        || state.K != 0xBEEFULL || state.rkey_array[3] != 111ULL || state.enc_lockout_key_epoch != epoch0) {
+        DSD_FPRINTF(stderr, "unkeyed target did not restore globals active=%zu\n",
+                    dsd_engine_trunk_scan_active_index(&state));
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || state.rkey_array[9] != 999ULL || state.keyloader != 1
+        || state.enc_lockout_key_epoch != epoch0) {
+        DSD_FPRINTF(stderr, "keyed target did not reinstall active=%zu\n", dsd_engine_trunk_scan_active_index(&state));
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    if (state.rkey_array[9] != 0ULL || state.keyloader != 0 || state.K != 0xBEEFULL || state.rkey_array[3] != 111ULL) {
+        DSD_FPRINTF(stderr, "shutdown did not restore globals\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_clear_now();
+    (void)remove(hex_path);
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_target_chan_csv_keys_are_discarded(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char hex_path[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(hex_path, sizeof hex_path, dir, "hexkeys.csv") != 0
+        || write_text_file(hex_path, "key id(hex),key value (hex)\n0010,AAAAAAAAAAAAAAAA\n") != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    char chan_path[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(chan_path, sizeof chan_path, dir, "chan.csv") != 0
+        || write_text_file(chan_path, "channel,frequency,name,keys_hex_csv\n1,851012500,Dispatch,hexkeys.csv\n") != 0) {
+        (void)remove(hex_path);
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    if (write_targets_file(dir, "a,p25-trunk,851000000,chan.csv,250,,\n", target_path, sizeof target_path) != 0) {
+        (void)remove(hex_path);
+        cleanup_paths(dir, NULL, chan_path);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "chan_csv keys scan init failed err=%s\n", err);
+        test_rc = 1;
+    }
+    if (state.trunk_lcn_keys != NULL || dsd_state_trunk_lcn_keys_get(&state, 0U) != NULL) {
+        DSD_FPRINTF(stderr, "trunk scan kept a chan_csv key store\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    (void)remove(hex_path);
+    cleanup_paths(dir, target_path, chan_path);
+    return test_rc;
+}
+
+static int
+test_target_keys_survive_failed_alternate_retune(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char hex_path[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(hex_path, sizeof hex_path, dir, "hexkeys.csv") != 0
+        || write_text_file(hex_path, "key id(hex),key value (hex)\n0010,AAAAAAAAAAAAAAAA\n") != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,keys_hex_csv\n";
+    if (write_targets_file_with_header(dir, header,
+                                       "a,p25-trunk,851000000,,250,,keyed,hexkeys.csv\n"
+                                       "b,p25-trunk,852000000,,250,,plain,\n",
+                                       target_path, sizeof target_path)
+        != 0) {
+        (void)remove(hex_path);
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0 || state.rkey_array[9] != 999ULL) {
+        DSD_FPRINTF(stderr, "keyed fallback scan init failed rc=%d active=%zu err=%s\n", rc,
+                    dsd_engine_trunk_scan_active_index(&state), err);
+        test_rc = 1;
+    }
+    const uint64_t epoch0 = state.enc_lockout_key_epoch;
+
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_cc_request = failing_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || state.rkey_array[9] != 999ULL || state.keyloader != 1
+        || state.enc_lockout_key_epoch != epoch0) {
+        DSD_FPRINTF(stderr, "failed alternate retune did not re-park the original keys active=%zu\n",
+                    dsd_engine_trunk_scan_active_index(&state));
+        test_rc = 1;
+    }
+
+    DSD_MEMSET(&hooks, 0, sizeof hooks);
+    dsd_trunk_tuning_hooks_set(hooks);
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    if (state.rkey_array[9] != 0ULL || state.keyloader != 0) {
+        DSD_FPRINTF(stderr, "fallback shutdown did not restore globals\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_clear_now();
+    (void)remove(hex_path);
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
 run_with_default_tune_hook(int (*test_fn)(void)) {
     dsd_trunk_tuning_hooks hooks = {0};
     hooks.tune_to_cc_request = counting_tune_to_cc;
@@ -5496,6 +5860,8 @@ main(void) {
     rc |= run_with_default_tune_hook(test_parser_valid_mixed_targets_and_relative_chan_csv);
     rc |= run_with_default_tune_hook(test_parser_accepts_quoted_chan_csv_with_comma);
     rc |= run_with_default_tune_hook(test_parser_accepts_optional_modulation_and_gain_columns);
+    rc |= run_with_default_tune_hook(test_parser_accepts_target_key_columns);
+    rc |= run_with_default_tune_hook(test_parser_rejects_duplicate_target_key_columns);
     rc |= run_with_default_tune_hook(test_parser_accepts_nxdn_targets);
     rc |= run_with_default_tune_hook(test_parser_rejects_invalid_inputs);
     rc |= run_with_default_tune_hook(test_parser_accepts_100_targets);
@@ -5504,6 +5870,9 @@ main(void) {
     rc |= run_with_default_tune_hook(test_target_chan_csv_names_are_discarded);
     rc |= run_with_default_tune_hook(test_coordinator_rotation_past_32_targets);
     rc |= run_with_default_tune_hook(test_coordinator_preserves_long_lcn_list_across_rotation);
+    rc |= run_with_default_tune_hook(test_target_keys_install_and_restore_across_switches);
+    rc |= run_with_default_tune_hook(test_target_chan_csv_keys_are_discarded);
+    rc |= run_with_default_tune_hook(test_target_keys_survive_failed_alternate_retune);
     rc |= run_with_default_tune_hook(test_coordinator_preserves_large_chan_map_across_rotation);
     rc |= test_targets_csv_rejects_rows_past_the_memory_budget();
     rc |= run_with_default_tune_hook(test_call_identity_state_isolated_per_target);

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -71,6 +71,8 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
         # dsd_import.c owns the scan-list heap tail through these.
         ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
+        # A channel-map row's key cells load through the key-set helpers.
+        ${PROJECT_SOURCE_DIR}/src/core/util/key_set.c
         ${PROJECT_SOURCE_DIR}/src/core/util/talkgroup_policy.c
         # csvDmrTgKeyImport() clears the live map through keyring_dmr_tg_map_reset().
         ${PROJECT_SOURCE_DIR}/src/core/vocoder/keyring.c

--- a/tests/ui/test_ui_cmd_actions.c
+++ b/tests/ui/test_ui_cmd_actions.c
@@ -20,9 +20,39 @@
 #include "command_dispatch.h"
 #include "services.h"
 
+#include "dsd-neo/core/csv_validate.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+
+#include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/runtime/log.h>
+
+void
+dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
+    (void)level;
+    (void)format;
+}
+
+/* The scan key swap links here through actions_trunk.c; this suite never loads
+ * per-row key files, so the path wrappers stay refused. */
+int
+csvKeyImportHexPath(const char* path, int show_keys, dsd_state* state, dsd_csv_validation* stats) {
+    (void)path;
+    (void)show_keys;
+    (void)state;
+    (void)stats;
+    return -1;
+}
+
+int
+csvKeyImportDecPath(const char* path, int show_keys, dsd_state* state, dsd_csv_validation* stats) {
+    (void)path;
+    (void)show_keys;
+    (void)state;
+    (void)stats;
+    return -1;
+}
 
 static int g_open_audio_calls;
 static int g_close_audio_calls;

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/core/enc_lockout.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/init.h>
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
@@ -23,6 +24,7 @@
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "../../src/app_control/commands_internal.h"
@@ -1861,6 +1863,90 @@ test_scan_hold_avoid_commands(void) {
     return rc;
 }
 
+#ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
+/*
+ * Per-row keys through the command queue: a channel cycle onto a keyed row
+ * installs its set, a runtime key import while parked lands in the globals
+ * and survives the next leave, and scanner toggle off restores the baseline.
+ */
+static int
+test_scan_row_keys_commands(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    const char* hex_csv = "ui_cmd_queue_rowkey_hex.csv";
+    static const unsigned char hex_data[] = "key id(hex),key value (hex)\n0007,0000000000001234\n";
+
+    init_test_context(&opts, &state);
+    remove(hex_csv);
+    rc |= expect_int("rowkey hex file written", write_file_bytes(hex_csv, hex_data, sizeof(hex_data) - 1U), 0);
+
+    state.lcn_freq_count = 2;
+    state.lcn_freq_roll = 1;
+    state.trunk_lcn_freq[0] = 857000000L;
+    state.trunk_lcn_freq[1] = 858000000L;
+    state.keyloader = 0;
+    state.K = 0xBEEFULL;
+    {
+        dsd_key_set ks;
+        DSD_MEMSET(&ks, 0, sizeof(ks));
+        ks.entries = (dsd_key_set_entry*)calloc(1U, sizeof(*ks.entries));
+        if (ks.entries == NULL) {
+            remove(hex_csv);
+            freeState(&state);
+            return 1;
+        }
+        ks.count = 1U;
+        ks.present = 1;
+        ks.keyloader = 1;
+        ks.entries[0].index = 9U;
+        ks.entries[0].value = 999ULL;
+        ks.entries[0].loaded = 1U;
+        if (dsd_state_trunk_lcn_keys_set(&state, 1U, &ks) != 0) {
+            remove(hex_csv);
+            freeState(&state);
+            return 1;
+        }
+    }
+
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    rc |= expect_int("keyed cycle queued", dsd_app_command_action(DSD_APP_CMD_CHANNEL_CYCLE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("keyed cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_true("keyed cycle tunes the keyed row", g_io_control_tune_freq == 858000000L);
+    rc |= expect_u64("keyed cycle installs the row set", state.rkey_array[9], 999ULL);
+    rc |= expect_int("keyed cycle arms keyloader", state.keyloader, 1);
+
+    // A runtime import while parked edits the globals underneath the row set.
+    post_string(DSD_APP_CMD_IMPORT_KEYS_HEX, hex_csv);
+    rc |= expect_int("parked key import drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_u64("parked import keeps the row set live", state.rkey_array[9], 999ULL);
+    dsd_scan_keys_leave(&state);
+    rc |= expect_u64("parked import survives the leave", state.rkey_array[7], 0x1234ULL);
+    rc |= expect_int("parked import arms the baseline", state.keyloader, 1);
+    rc |= expect_u64("leave drops the row slot", state.rkey_array[9], 0ULL);
+
+    // Scanner toggle off hands the foreground keyring back to the globals.
+    rc |= expect_int("repark installs again", dsd_scan_keys_enter(&state, dsd_state_trunk_lcn_keys_get(&state, 1U)), 1);
+    opts.scanner_mode = 1;
+    rc |= expect_int("scanner toggle queued", dsd_app_command_action(DSD_APP_CMD_SCANNER_TOGGLE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("scanner toggle drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("scanner toggle leaves scanner mode", opts.scanner_mode, 0);
+    rc |= expect_int("scanner toggle leaves the swap", (int)state.scan_keys_active_set, 0);
+    rc |= expect_u64("scanner toggle restores the imported slot", state.rkey_array[7], 0x1234ULL);
+    rc |= expect_u64("scanner toggle drops the row slot", state.rkey_array[9], 0ULL);
+
+    remove(hex_csv);
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
+    freeState(&state);
+    return rc;
+}
+#endif
+
 int
 main(void) {
     int rc = 0;
@@ -1881,6 +1967,7 @@ main(void) {
 #endif
     rc |= test_tuner_release();
     rc |= test_scan_hold_avoid_commands();
+    rc |= test_scan_row_keys_commands();
 #endif
     if (rc == 0) {
         printf("DSD_APP_CMD_QUEUE: OK\n");

--- a/tests/ui/test_ui_menu_services.c
+++ b/tests/ui/test_ui_menu_services.c
@@ -10,8 +10,10 @@
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/csv_validate.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/file_io.h>
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
@@ -29,6 +31,7 @@
 #include <sndfile.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "services.h"
 
@@ -150,6 +153,9 @@ static uint32_t g_chan_import_chan[4];
 static long int g_chan_import_freq[4];
 /* Per-row names, NULL for a row the file leaves unnamed. */
 static const char* g_chan_import_name[4];
+/* Per-row key seed: set entries load a one-slot key set into the row. */
+static int g_chan_import_has_key[4];
+static unsigned long long g_chan_import_key[4];
 /* A name stored with no row to go with it, so the refused-adopt path can be driven with a
  * name store live in the throwaway import state: the service still owes exactly one free of
  * it and no change to the live map. */
@@ -172,6 +178,20 @@ csvChanImport(const dsd_opts* opts, dsd_state* state) {
         if (g_chan_import_name[i] != NULL) {
             (void)dsd_state_trunk_lcn_name_set(state, row, g_chan_import_name[i]);
         }
+        if (g_chan_import_has_key[i]) {
+            dsd_key_set ks;
+            DSD_MEMSET(&ks, 0, sizeof(ks));
+            ks.entries = (dsd_key_set_entry*)calloc(1U, sizeof(*ks.entries));
+            if (ks.entries != NULL) {
+                ks.count = 1U;
+                ks.present = 1;
+                ks.keyloader = 1;
+                ks.entries[0].index = 9U;
+                ks.entries[0].value = g_chan_import_key[i];
+                ks.entries[0].loaded = 1U;
+                (void)dsd_state_trunk_lcn_keys_set(state, row, &ks);
+            }
+        }
     }
     return 0;
 }
@@ -189,6 +209,24 @@ int
 csvKeyImportHex(const dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
+    return g_key_import_result;
+}
+
+int
+csvKeyImportHexPath(const char* path, int show_keys, dsd_state* state, dsd_csv_validation* stats) {
+    (void)path;
+    (void)show_keys;
+    (void)state;
+    (void)stats;
+    return g_key_import_result;
+}
+
+int
+csvKeyImportDecPath(const char* path, int show_keys, dsd_state* state, dsd_csv_validation* stats) {
+    (void)path;
+    (void)show_keys;
+    (void)state;
+    (void)stats;
     return g_key_import_result;
 }
 
@@ -988,6 +1026,60 @@ test_clear_services_unload_what_the_importers_loaded(void) {
     return rc;
 }
 
+/*
+ * Adopt moves the per-row key store with the map; a keyless reimport drops it.
+ * Clearing the map leaves -Y, so it restores the globals the parked row set
+ * shadowed first.
+ */
+static int
+test_channel_map_keys_adopt_and_clear(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    g_chan_import_result = 0;
+    g_chan_import_count = 1;
+    g_chan_import_chan[0] = 101;
+    g_chan_import_freq[0] = 851000000L;
+    g_chan_import_name[0] = NULL;
+    g_chan_import_has_key[0] = 1;
+    g_chan_import_key[0] = 0xBEEFULL;
+    rc |= expect_int("keyed map import ok", svc_import_channel_map(&opts, &state, "a.csv"), 0);
+    rc |= expect_int("adopt keeps the row key set", (int)(dsd_state_trunk_lcn_keys_get(&state, 0U) != NULL), 1);
+    rc |= expect_int("adopt reports a keyed store", dsd_state_trunk_lcn_keys_present(&state), 1);
+
+    g_chan_import_has_key[0] = 0;
+    rc |= expect_int("keyless reimport ok", svc_import_channel_map(&opts, &state, "b.csv"), 0);
+    rc |= expect_int("keyless reimport drops the key store", (int)(state.trunk_lcn_keys == NULL), 1);
+    rc |= expect_int("keyless reimport reads back empty", (int)(dsd_state_trunk_lcn_keys_get(&state, 0U) == NULL), 1);
+
+    // Park on a keyed row, then clear: the live keyring must show the globals again.
+    g_chan_import_has_key[0] = 1;
+    rc |= expect_int("keyed map reimport ok", svc_import_channel_map(&opts, &state, "c.csv"), 0);
+    state.keyloader = 0;
+    state.K = 0xBEEFULL;
+    state.rkey_array[3] = 111ULL;
+    state.rkey_array_loaded[3] = 1U;
+    rc |= expect_int("parking on the keyed row installs it",
+                     dsd_scan_keys_enter(&state, dsd_state_trunk_lcn_keys_get(&state, 0U)), 1);
+    rc |= expect_ull("parked row key live", state.rkey_array[9], 0xBEEFULL);
+    rc |= expect_int("clear ok", svc_clear_channel_map(&opts, &state), 0);
+    rc |= expect_int("clear leaves the swap", (int)state.scan_keys_active_set, 0);
+    rc |= expect_int("clear restores keyloader", state.keyloader, 0);
+    rc |= expect_ull("clear restores scalar K", state.K, 0xBEEFULL);
+    rc |= expect_ull("clear restores the global slot", state.rkey_array[3], 111ULL);
+    rc |= expect_ull("clear drops the row slot", state.rkey_array[9], 0ULL);
+    rc |= expect_int("clear releases the key store", (int)(state.trunk_lcn_keys == NULL), 1);
+
+    g_chan_import_result = -1;
+    g_chan_import_has_key[0] = 0;
+    g_chan_import_key[0] = 0ULL;
+    dsd_state_trunk_lcn_free(&state);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -1001,6 +1093,7 @@ main(void) {
 #endif
     rc |= test_file_network_and_import_failure_contracts();
     rc |= test_channel_map_reimport_replaces_previous_map();
+    rc |= test_channel_map_keys_adopt_and_clear();
     rc |= test_key_import_arms_keyloader();
     rc |= test_clear_services_unload_what_the_importers_loaded();
     return rc ? 1 : 0;


### PR DESCRIPTION
## Summary

- Closes #382. Each scan row can now name its own key file(s): optional `keys_hex_csv` and `keys_dec_csv` columns in the `-Y` channel map (header opt-in by name, like `name`) and in the trunk-scan target CSV (optional column by header name, like `modulation`/`rtl_gain`). Paths resolve relative to the list file and load through the existing `-K`/`-k` importers into a sparse per-row key set at import time, so a hop never touches disk.
- New core unit `core/key_set.h`: sparse keyring copy plus the scalar key block (`K`, `K1..K4`, `H`, `R`, `RR`, `A1..A4`, AES slot state) and a swap state machine. Stepping onto a keyed row lazily captures the live keys as a baseline and installs the row's set; stepping onto an unkeyed row, leaving `-Y`, clearing the map, or trunk-scan shutdown reinstalls the baseline. Install zeroes the scalar block itself rather than relying on the keyloader-gated no-carrier reset, so trunk-scan switches are safe outside `noCarrier`.
- Runtime key import/clear from the TUI suspends the swap, edits the globals, and resumes, so an import survives the next hop. The single-key `KEY_*` commands are deliberately not wrapped (documented).
- Under `-Y` the encrypted-lockout key epoch bumps only when the installed set changes; trunk scan never bumps it because every target carries its own ledger snapshot.
- Channel-map keys apply only under `-Y`: discarded under a trunk-scan target's `chan_csv` (as names already are), warned about once under plain `-C` trunking. A bad key path fails the list import, consistent with `-C` and `chan_csv` today.
- Trunk scan: two path fields on the target, a heap-owned key set on the runtime (not the snapshot), applied at every park including the advance fallback that re-parks on the original target.
- Docs: `csv-formats.md`, `trunk-scan.md`, `cli.md`, `ui-terminal.md`, `code_map.md`; new `examples/conventional_scan_keyed.csv` and a keyed row in `examples/trunk_scan_targets.csv`. Qt/Android picker imports are documented as unsupported for keyed lists, since the picker copies files and relative key paths would not resolve.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. (Solo maintainer; two-axis review plus a dedicated edge-case pass on keyloader semantics, mid-call swaps and lockout-epoch interaction.)
- [x] High-risk areas touched are marked: **parser / crypto (key material handling)**.
- [x] Outside review was requested when available, or unavailability is documented. (Not available.)
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. (None added.)
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [ ] `tools/preflight_ci.sh` (run separately by the maintainer)
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes (n/a)
- [ ] `tools/osv_scan.sh` for dependency input changes (n/a)
- [x] `tools/check_secret_redaction.sh` (plus `tools/check_arch_rules.sh`, `tools/semgrep.sh --strict`)
- [x] Radio-off configure (`-DDSD_ENABLE_RTLSDR=OFF -DDSD_REQUIRE_RTLSDR=OFF -DDSD_ENABLE_SOAPYSDR=OFF -DDSD_REQUIRE_SOAPYSDR=OFF`) builds and passes ctest.

Tests: `CORE_KEY_SET` (new), `CORE_CSV_IMPORT`, `CORE_CSV_VALIDATE`, `ENGINE_TRUNK_SCAN`, `ENGINE_NO_CARRIER_RESET`, `UI_CMD_QUEUE`, `UI_CMD_ACTIONS`, `UI_MENU_SERVICES`.

## Risk

- Security/dependency impact: key material now also lives in per-row heap sets; they sit outside every UI snapshot copy range (static-asserted), are wiped before free, and only file paths and pre-formatted counts are logged. No new dependencies.
- CLI/UI behavior impact: new optional CSV columns; existing lists are unchanged. A `-C` map with key columns under plain trunking logs one warning. A TUI single-key command while a keyed row is parked is overridden on the next hop (documented).
- Compatibility or packaging impact: none for existing files. Qt/Android picker imports of keyed lists are unsupported and documented.

## Notes for the reviewer

- The `-C` "keys ignored" warning is emitted from `args.c` post-parse as well as the engine and menu-service import paths, because the CLI imports `-C` during argv parsing (before a later `-Y` is seen) and the engine path only imports when the CLI did not. One shared core helper carries the string.
- Deliberately skipped (YAGNI): path-keyed caching of a key file named by many rows, and a UI marker that a row is keyed.
