### PR TITLE
fix(ui): count scan avoids as a list fact, not a verdict on the channel on air (#463)

### DIFF
--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -199,8 +199,9 @@ During scanning:
   now, and "Clear avoids" puts every avoided target back. A hold only pauses the idle dwell: the parked target's
   trunking state machine keeps following calls, and `L` still moves while held (the hold then applies to the new
   target). Avoiding the last usable target is refused, as is `L` on a single-target list. Avoids are not written back
-  to the CSV. The Trunk Scan row shows `HOLD`, `Avoided: N`, and `[avoided]` when every alternate failed to retune and
-  the receiver fell back onto a target that was avoided.
+  to the CSV. The Trunk Scan row shows `HOLD`, then `[avoided]` when every alternate failed to retune and the
+  receiver fell back onto a target that was avoided, and last `Avoids: N`, the number of targets currently out of the
+  rotation.
 - A non-empty target `modulation` value overrides global CLI/config modulation locks for that target only.
 - A target `rtl_gain` value is applied at the retune boundary. Manual per-target gain temporarily suspends supervisory
   tuner autogain; `auto` and global-auto targets restore the saved autogain setting.

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -480,11 +480,12 @@ The name comes from the optional `name` column of the channel map (see `docs/csv
 renders exactly as it always did. The name goes last because it is the one field whose length you choose: the
 frequency and speed keep their columns, and on a narrow terminal it is the name that reaches the edge.
 
-When the rotation is not moving, the row says why, ahead of the name: `HOLD` while `Y` holds the scan, and
-`Avoided: N` while `b` has taken rows out of it for the session.
+While `Y` holds the scan, `HOLD` appears ahead of the name with the other facts about the channel on air. While
+`b` has taken rows out of the rotation for the session, `Avoids: N` closes the row: it counts the rows that are
+out of the list, and says nothing about the channel you are hearing, which under `-Y` is never an avoided one.
 
 ```
-| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec HOLD Avoided: 2 Channel: Marion
+| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec HOLD Channel: Marion Avoids: 2
 ```
 
 With `--trunk-scan` the same section names the target on air and its place in the rotation:

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -864,16 +864,19 @@ ui_render_trunk_scan_status(const dsd_opts* opts, const dsd_state* state) {
         printw(" (%u/%u)", (unsigned int)state->trunk_scan_active_ordinal,
                (unsigned int)state->trunk_scan_target_count);
     }
-    // Why the rotation is not moving: an operator hold, or a receiver parked on a target the
-    // operator avoided because every alternate failed to retune.
+    // The target on air first: an operator hold, or a receiver parked on a target the operator
+    // avoided because every alternate failed to retune.
     if (state->trunk_scan_hold) {
         printw(" HOLD");
     }
     if (state->trunk_scan_active_avoided) {
         printw(" [avoided]");
     }
+    // Then the list: how many targets `b` has taken out of the rotation. A noun count, last, so
+    // it is not read as a second verdict on the parked target beside HOLD and [avoided]. Same
+    // word as the "Clear avoids" menu row and the Qt SCAN AVOIDS badge.
     if (state->trunk_scan_avoided_count != 0) {
-        printw(" Avoided: %u", (unsigned int)state->trunk_scan_avoided_count);
+        printw(" Avoids: %u", (unsigned int)state->trunk_scan_avoided_count);
     }
     printw("\n");
 }
@@ -897,10 +900,7 @@ ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* stat
         if (state->lcn_scan_hold) {
             printw(" HOLD");
         }
-        if (state->lcn_avoid_count != 0) {
-            printw(" Avoided: %u", (unsigned int)state->lcn_avoid_count);
-        }
-        // The row's name goes last: it is the one field of operator-chosen length, so the fixed
+        // The row's name follows: it is the one field of operator-chosen length, so the fixed
         // fields keep their columns and a long name is what runs off a narrow terminal. The
         // resolver applies the placeholder-row rule (a 0 Hz row is stepped over without a retune,
         // so its name would credit the wrong channel) and yields to an active --trunk-scan target,
@@ -910,6 +910,15 @@ ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* stat
             if (dsd_channel_label_current(opts, state, name, sizeof(name)) == 1) {
                 printw(" Channel: %s", name);
             }
+        }
+        // Last, the list: how many rows `b` has taken out of the rotation. Everything before it
+        // describes the channel on air, and under -Y that channel is never an avoided one (the
+        // avoid steps off the row in the same command, and the hangtime step and `L` skip avoided
+        // rows), so a participle beside HOLD read as a false verdict on the channel being heard
+        // (PR #463 feedback). A noun count after the name cannot. Same word as the "Clear avoids"
+        // menu row and the Qt SCAN AVOIDS badge.
+        if (state->lcn_avoid_count != 0) {
+            printw(" Avoids: %u", (unsigned int)state->lcn_avoid_count);
         }
         printw(" \n");
     }

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -895,8 +895,10 @@ test_scanner_status_row_rendering(void) {
     ui_render_scanner_and_reverse_status(&opts, &state);
     assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Channel: Marion \n");
 
-    /* Hold and the avoided count explain why the scan stopped moving. They sit between the
-       fixed fields and the name, so the name stays the one field that runs off the edge. */
+    /* HOLD is a state of the channel on air, so it sits with the channel's fixed fields. The
+       avoid count is a property of the list, not of this channel, so it trails the name: a
+       reader must not take "Avoided" beside HOLD as a verdict on the channel they are hearing
+       (PR #463 feedback). */
     state.lcn_scan_hold = 1;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
@@ -904,11 +906,18 @@ test_scanner_status_row_rendering(void) {
     state.lcn_avoid_count = 2;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec HOLD Avoided: 2 Channel: Marion \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec HOLD Channel: Marion Avoids: 2 \n");
     state.lcn_scan_hold = 0;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Avoided: 2 Channel: Marion \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Channel: Marion Avoids: 2 \n");
+
+    /* An unnamed row on air: the count still closes the row, after the fixed fields. */
+    reset_lcn_name_stub();
+    reset_printw_capture();
+    ui_render_scanner_and_reverse_status(&opts, &state);
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Avoids: 2 \n");
+    DSD_SNPRINTF(g_lcn_name_stub[0], sizeof(g_lcn_name_stub[0]), "Marion");
     state.lcn_avoid_count = 0;
 
     /* The last row of the list is on air once roll has caught up with the count: the bound is
@@ -968,7 +977,9 @@ test_trunk_scan_status_row_rendering(void) {
     ui_render_trunk_scan_status(&opts, &state);
     assert_capture_equals("| Trunk Scan:  Target: county-p25 (3/6)\n");
 
-    /* Hold, a parked-on-avoided fallback, and the avoided count follow the position. */
+    /* HOLD and the parked-on-avoided fallback describe the target on air and follow its
+       position; the list-wide avoid count comes last and under a different word, so the two
+       meanings of "avoided" never sit side by side. */
     state.trunk_scan_hold = 1;
     reset_printw_capture();
     ui_render_trunk_scan_status(&opts, &state);
@@ -977,15 +988,15 @@ test_trunk_scan_status_row_rendering(void) {
     state.trunk_scan_avoided_count = 2;
     reset_printw_capture();
     ui_render_trunk_scan_status(&opts, &state);
-    assert_capture_equals("| Trunk Scan:  Target: county-p25 (3/6) HOLD [avoided] Avoided: 2\n");
+    assert_capture_equals("| Trunk Scan:  Target: county-p25 (3/6) HOLD [avoided] Avoids: 2\n");
     state.trunk_scan_hold = 0;
     reset_printw_capture();
     ui_render_trunk_scan_status(&opts, &state);
-    assert_capture_equals("| Trunk Scan:  Target: county-p25 (3/6) [avoided] Avoided: 2\n");
+    assert_capture_equals("| Trunk Scan:  Target: county-p25 (3/6) [avoided] Avoids: 2\n");
     state.trunk_scan_active_avoided = 0;
     reset_printw_capture();
     ui_render_trunk_scan_status(&opts, &state);
-    assert_capture_equals("| Trunk Scan:  Target: county-p25 (3/6) Avoided: 2\n");
+    assert_capture_equals("| Trunk Scan:  Target: county-p25 (3/6) Avoids: 2\n");
     state.trunk_scan_avoided_count = 0;
 
     /* No position published yet: name the target without inventing an "n of m". */


### PR DESCRIPTION
## Summary

Follow-up to #463, from the tester feedback in https://github.com/arancormonk/dsd-neo/pull/463#issuecomment-5522897725: the Scan Mode row's `Avoided: N` read as a state of the channel being heard.

The reading was structural, not a misreading:

- Every other token on the row (frequency, dwell, `HOLD`) describes the channel on air, so a participle in that slot reads the same way, and `Avoided: 2 Channel: Marion` runs together.
- Under `-Y` the channel on air is never an avoided one: `b` steps off the row in the same command, and the hangtime step and `L` skip avoided rows. So the reading was always false.
- The Trunk Scan row printed `[avoided]` (the parked target is an avoided one) beside `Avoided: 2` (two targets are out of the list): one word, two meanings, side by side.

Both rows now print the count last and as a noun, `Avoids: N`, the word the "Clear avoids" menu row and the Qt `SCAN AVOIDS` badge already use. `HOLD` and `[avoided]` stay with the target's fixed fields.

```
| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec HOLD Channel: Marion Avoids: 2
| Trunk Scan:  Target: county-p25 (3/6) HOLD [avoided] Avoids: 2
```

Rows are byte-identical when nothing is avoided. No state, command, hook or Qt change. `docs/ui-terminal.md` and `docs/trunk-scan.md` follow, and the printer test's pinned strings are updated plus a pinned case for an unnamed row.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: none (terminal status row text only).
- [x] Outside review was requested when available, or unavailability is documented (the change answers an outside tester's report).
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. (None added; `tests/ui/test_ui_ncurses_printer_helpers.c` pins the new rows.)
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. (n/a)
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. (None added.)
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (597/597)
- [x] `tools/preflight_ci.sh` (clean)
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes (not run; text-only change)
- [ ] `tools/cmake_format_check.sh` for CMake changes (n/a)
- [ ] `tools/zizmor.sh` for workflow changes (n/a)
- [ ] `tools/osv_scan.sh` for dependency input changes (n/a)
- [ ] security-sensitive workflow/release checks (n/a)

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: two status-row strings change wording and position while avoids are active; unchanged otherwise.
- Compatibility or packaging impact: none.
