### PR TITLE
fix(dmr): decode Motorola TMS text as UTF-16LE from the real text offset (#466)

### DIFF
--- a/include/dsd-neo/protocol/dmr/dmr_utf8_text.h
+++ b/include/dsd-neo/protocol/dmr/dmr_utf8_text.h
@@ -22,13 +22,19 @@ extern "C" {
 void utf8_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input);
 
 /**
- * @brief Print @p len octets of UTF-16BE text to stderr, with the ASCII subset copied into
- *        the slot's event text when @p wr is 1.
+ * @brief Print @p len octets of UTF-16BE text (ETSI TS 102 361-3 text messaging) to stderr, with
+ *        the printable characters copied as UTF-8 into the slot's event text when @p wr is 1.
  *
  * Surrogate pairs are rendered as one character and unpaired halves as U+FFFD; a trailing odd
- * octet is ignored.
+ * octet is ignored. Control characters print as markers and stay out of the event text.
  */
 void utf16_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input);
+
+/**
+ * @brief The same for little-endian units, the UCS-2 LE that Motorola TMS carries (MOTOTRBO Text
+ *        Messaging ADK Guide: "The MOTOTRBO radio only supports the UCS2-LE encoding schema").
+ */
+void utf16le_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input);
 
 #ifdef __cplusplus
 }

--- a/src/protocol/dmr/dmr_pdu.c
+++ b/src/protocol/dmr/dmr_pdu.c
@@ -59,19 +59,32 @@ convert_hex_to_dec(uint16_t input) {
 
 static void
 utf16_text_emit_scalar(uint32_t scalar) {
-    if (!dsd_unicode_scalar_is_control(scalar) && scalar != 0x040DU) { // If not a linebreak or terminal commmands
+    if (!dsd_unicode_scalar_is_control(scalar)) { // If not a linebreak or terminal commmands
         dsd_unicode_fput_scalar(scalar, stderr);
     } else if (scalar == 0U) { // If padding (0 could also indicate end of text terminator?)
         DSD_FPRINTF(stderr, "_");
-    } else if (scalar == 0x040DU) { //Ѝ or 0x040D may be ETLF
-        DSD_FPRINTF(stderr, " / ");
     } else {
         DSD_FPRINTF(stderr, "-");
     }
 }
 
-void
-utf16_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input) {
+// The event text is rendered as UTF-8 by the ncurses UI, the Qt model and the event log, so the
+// scalar goes in encoded rather than truncated to its low octet (issue #466). Control characters,
+// padding included, stay out: the log prints one line per event.
+static void
+utf16_text_collect_scalar(dsd_state* state, uint8_t slot, uint32_t scalar) {
+    if (dsd_unicode_scalar_is_control(scalar)) {
+        return;
+    }
+    char utf8[DSD_UTF8_MAX_BYTES + 1];
+    if (dsd_utf8_encode_scalar(scalar, utf8, sizeof utf8) > 0U) {
+        dsd_append(state->event_history_s[slot].Event_History_Items[0].text_message,
+                   sizeof state->event_history_s[slot].Event_History_Items[0].text_message, utf8);
+    }
+}
+
+static void
+utf16_text_render(dsd_state* state, uint8_t wr, int little_endian, uint16_t len, const uint8_t* input) {
     uint8_t slot = state->currentslot;
     // Only opened when wr says so, and closed under the same condition a loop
     // later. A zeroed guard makes the close a no-op instead of a read of an
@@ -83,37 +96,32 @@ utf16_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input) 
                      sizeof(state->event_history_s[slot].Event_History_Items[0].text_message), "%s",
                      ""); //full text string
     }
-    // The octets are UTF-16BE. Pairs are combined and unpaired halves shown as U+FFFD before
-    // anything reaches stderr, so the C runtime never sees a code unit it cannot encode
-    // (issue #358).
+    // Pairs are combined and unpaired halves shown as U+FFFD before anything reaches stderr, so
+    // the C runtime never sees a code unit it cannot encode (issue #358).
     dsd_utf16_decoder decoder;
     uint32_t scalars[DSD_UTF16_MAX_SCALARS_PER_UNIT];
     dsd_utf16_decoder_reset(&decoder);
     for (uint16_t i = 0; (uint16_t)(i + 1U) < len; i += 2) {
-        uint16_t ch16 = (uint16_t)input[i + 0];
-        ch16 <<= 8;
-        ch16 |= (uint16_t)input[i + 1];
+        uint16_t ch16;
+        if (little_endian) {
+            ch16 = (uint16_t)((uint16_t)input[i + 1] << 8 | (uint16_t)input[i + 0]);
+        } else {
+            ch16 = (uint16_t)((uint16_t)input[i + 0] << 8 | (uint16_t)input[i + 1]);
+        }
 
         size_t n = dsd_utf16_decoder_push(&decoder, ch16, scalars, DSD_UTF16_MAX_SCALARS_PER_UNIT);
         for (size_t k = 0; k < n; k++) {
             utf16_text_emit_scalar(scalars[k]);
-        }
-
-        //convert to ascii range (will break eastern langauge, but can't do much about that right now)
-        char c[2];
-        c[0] = (char)input[i + 1];
-        c[1] = 0;
-
-        //short version (disabled)
-
-        //this is the long version, complete message for logging purposes
-        if (wr == 1 && input[i] == 0 && input[i + 1] < 0x7F && input[i + 1] >= 0x20) {
-            dsd_append(state->event_history_s[slot].Event_History_Items[0].text_message,
-                       sizeof state->event_history_s[slot].Event_History_Items[0].text_message, c);
+            if (wr == 1) {
+                utf16_text_collect_scalar(state, slot, scalars[k]);
+            }
         }
     }
     if (dsd_utf16_decoder_finish(&decoder, scalars, 1U) > 0U) {
         utf16_text_emit_scalar(scalars[0]);
+        if (wr == 1) {
+            utf16_text_collect_scalar(state, slot, scalars[0]);
+        }
     }
 
     //add elipses to indicate this is possibly truncated
@@ -123,6 +131,16 @@ utf16_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input) 
         dsd_event_history_mark_dirty(&state->event_history_s[slot]);
         dsd_event_history_transaction_end(&transaction);
     }
+}
+
+void
+utf16_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input) {
+    utf16_text_render(state, wr, 0, len, input);
+}
+
+void
+utf16le_to_text(dsd_state* state, uint8_t wr, uint16_t len, const uint8_t* input) {
+    utf16_text_render(state, wr, 1, len, input);
 }
 
 void
@@ -572,85 +590,80 @@ decode_ip_pdu_tms_truncated(dsd_state* state, uint8_t slot, uint32_t src24, uint
     return -1;
 }
 
+// Motorola TMS over UDP 4007, as the MOTOTRBO Text Messaging ADK Guide describes the text and as
+// Moto.Net, TRBO-NET and node-dmr-lib build the packet (sdrtrunk agrees on the encoding):
+//   0..1  length, big-endian, of every octet that follows it
+//   2     header: 0x80 extension present, 0x40 ack requested, 0x20 reserved, 0x10 system, and the
+//         message type in the low bits (0 simple text, 0x1F ack)
+//   3     address length; that many octets of address follow when non-zero
+//   then  header-extension octets while the header says so, each with bit 7 set while another
+//         follows (8F 04 on every capture seen: a sequence number and an encoding octet)
+//   then  the text, UCS-2 little-endian, an optional subject line and CR LF ahead of the body
+// The text is located from that layout rather than by backing up from the end of the header,
+// which only lined up for ASCII (issue #466).
 static int DSD_ATTR_USED
 decode_ip_pdu_parse_udp_tms_address(dsd_state* state, uint8_t slot, uint32_t src24, uint32_t dst24,
-                                    uint16_t payload_len, uint8_t* payload, int* tms_ptr) {
+                                    uint16_t payload_len, const uint8_t* payload, size_t* tms_ptr) {
+    if (*tms_ptr >= (size_t)payload_len) {
+        return decode_ip_pdu_tms_truncated(state, slot, src24, dst24);
+    }
     uint8_t tms_adl = payload[(*tms_ptr)++];
     if (tms_adl == 0) {
         return 0;
     }
-
-    (*tms_ptr)--;
-    if (tms_adl < 4U || (size_t)(*tms_ptr) + (size_t)tms_adl >= (size_t)payload_len) {
+    if (*tms_ptr + (size_t)tms_adl > (size_t)payload_len) {
         return decode_ip_pdu_tms_truncated(state, slot, src24, dst24);
     }
-    payload[*tms_ptr] = 0;
     DSD_FPRINTF(stderr, "Address Len: %d; Address: ", tms_adl);
-    utf16_to_text(state, 1, tms_adl - 4, payload + *tms_ptr);
-    payload[*tms_ptr] = tms_adl;
+    // dsd-fme found four octets past the address text on every capture it had, and no public
+    // source parses this field, so the text is still taken as adl - 4 octets: the same characters
+    // as before for ASCII, now read as the UCS-2 LE they are.
+    if (tms_adl > 4U) {
+        utf16le_to_text(state, 1, (uint16_t)(tms_adl - 4U), payload + *tms_ptr);
+    }
     *tms_ptr += tms_adl;
-    *tms_ptr += 1;
     DSD_FPRINTF(stderr, "; ");
     return 0;
 }
 
 static int DSD_ATTR_USED
 decode_ip_pdu_skip_udp_tms_extensions(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint32_t src24,
-                                      uint32_t dst24, uint16_t payload_len, const uint8_t* payload, int* tms_ptr) {
-    if ((size_t)*tms_ptr >= (size_t)payload_len) {
-        return decode_ip_pdu_tms_truncated(state, slot, src24, dst24);
-    }
-
-    uint8_t tms_more = payload[*tms_ptr] >> 7;
-    while (tms_more) {
-        if ((size_t)*tms_ptr >= (size_t)payload_len) {
+                                      uint32_t dst24, uint16_t payload_len, const uint8_t* payload, size_t* tms_ptr) {
+    uint8_t tms_more;
+    do {
+        if (*tms_ptr >= (size_t)payload_len) {
             return decode_ip_pdu_tms_truncated(state, slot, src24, dst24);
         }
-        uint8_t tms_b1 = payload[(*tms_ptr)++];
+        uint8_t tms_ext = payload[(*tms_ptr)++];
         if (opts->payload == 1) {
-            if ((size_t)*tms_ptr >= (size_t)payload_len) {
-                return decode_ip_pdu_tms_truncated(state, slot, src24, dst24);
-            }
-            uint8_t tms_b2 = payload[*tms_ptr];
-            DSD_FPRINTF(stderr, "B1: %02X; B2: %02X; ", tms_b1, tms_b2);
+            DSD_FPRINTF(stderr, "EXT: %02X; ", tms_ext);
         }
-        tms_more = tms_b1 >> 7;
-        if (tms_more) {
-            if ((size_t)*tms_ptr >= (size_t)payload_len) {
-                return decode_ip_pdu_tms_truncated(state, slot, src24, dst24);
-            }
-            (*tms_ptr)++;
-        }
-    }
+        tms_more = tms_ext & 0x80U;
+    } while (tms_more);
     return 0;
 }
 
+// The text runs from tms_ptr to the end of what the length field covers, clamped to the octets
+// the UDP payload actually holds; an odd trailing octet is dropped rather than read as a unit.
 static int DSD_ATTR_USED
 decode_ip_pdu_prepare_tms_text_span(dsd_state* state, uint8_t slot, uint32_t src24, uint32_t dst24,
-                                    uint16_t payload_len, int* tms_ptr, int* tms_len) {
-    if ((*tms_ptr % 2) == 0) {
-        (*tms_ptr)++;
-    }
-    if (*tms_len > 3) {
-        int consumed = *tms_ptr - 3;
-        if (consumed >= *tms_len) {
-            return decode_ip_pdu_tms_truncated(state, slot, src24, dst24);
-        }
-        *tms_len -= consumed;
-    }
-    *tms_ptr -= 2;
-    if (*tms_ptr < 0 || (size_t)*tms_ptr >= (size_t)payload_len) {
+                                    uint16_t payload_len, size_t tms_ptr, int tms_len, size_t* text_len) {
+    size_t consumed = tms_ptr - 2U; // octets of header after the length field
+    if (tms_ptr >= (size_t)payload_len || tms_len <= 0 || (size_t)tms_len <= consumed) {
         return decode_ip_pdu_tms_truncated(state, slot, src24, dst24);
     }
-    if ((size_t)*tms_len > ((size_t)payload_len - (size_t)*tms_ptr)) {
-        *tms_len = (int)((size_t)payload_len - (size_t)*tms_ptr);
+    size_t span = (size_t)tms_len - consumed;
+    size_t available = (size_t)payload_len - tms_ptr;
+    if (span > available) {
+        span = available;
     }
+    *text_len = span & ~(size_t)1U;
     return 0;
 }
 
 static void DSD_ATTR_USED
 decode_ip_pdu_handle_udp_tms(const dsd_opts* opts, dsd_state* state, uint8_t slot, uint32_t src24, uint32_t dst24,
-                             uint16_t payload_len, uint8_t* payload) {
+                             uint16_t payload_len, const uint8_t* payload) {
     int tms_len = 0;
     if (payload_len >= 2) {
         tms_len = (payload[0] << 8) | payload[1];
@@ -662,14 +675,17 @@ decode_ip_pdu_handle_udp_tms(const dsd_opts* opts, dsd_state* state, uint8_t slo
         return;
     }
 
-    int tms_ptr = 2;
+    size_t tms_ptr = 2;
     uint8_t tms_hdr = payload[tms_ptr++];
     uint8_t tms_ack = (tms_hdr >> 0) & 0xF;
     if (opts->payload == 1) {
         DSD_FPRINTF(stderr, "HDR: %02X; ", tms_hdr);
     }
-    if (decode_ip_pdu_parse_udp_tms_address(state, slot, src24, dst24, payload_len, payload, &tms_ptr) != 0
-        || decode_ip_pdu_skip_udp_tms_extensions(opts, state, slot, src24, dst24, payload_len, payload, &tms_ptr)
+    if (decode_ip_pdu_parse_udp_tms_address(state, slot, src24, dst24, payload_len, payload, &tms_ptr) != 0) {
+        return;
+    }
+    if ((tms_hdr & 0x80U) != 0U
+        && decode_ip_pdu_skip_udp_tms_extensions(opts, state, slot, src24, dst24, payload_len, payload, &tms_ptr)
                != 0) {
         return;
     }
@@ -681,17 +697,15 @@ decode_ip_pdu_handle_udp_tms(const dsd_opts* opts, dsd_state* state, uint8_t slo
         return;
     }
 
-    if (decode_ip_pdu_prepare_tms_text_span(state, slot, src24, dst24, payload_len, &tms_ptr, &tms_len) != 0) {
+    size_t text_len = 0;
+    if (decode_ip_pdu_prepare_tms_text_span(state, slot, src24, dst24, payload_len, tms_ptr, tms_len, &text_len) != 0) {
         return;
     }
-    uint8_t temp = payload[tms_ptr];
-    payload[tms_ptr] = 0;
     if (opts->payload == 1) {
-        DSD_FPRINTF(stderr, "Ptr: %d; Len: %d;", tms_ptr, tms_len);
+        DSD_FPRINTF(stderr, "Ptr: %u; Len: %u;", (unsigned)tms_ptr, (unsigned)text_len);
     }
     DSD_FPRINTF(stderr, "\n Text: ");
-    utf16_to_text(state, 1, tms_len, payload + tms_ptr);
-    payload[tms_ptr] = temp;
+    utf16le_to_text(state, 1, (uint16_t)text_len, payload + tms_ptr);
 }
 
 static void DSD_ATTR_USED

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7408,6 +7408,27 @@ target_link_libraries(
 )
 add_test(NAME DMR_PDU_UTF16_TEXT COMMAND dsd-neo_test_dmr_pdu_utf16_text)
 
+# DMR TMS (UDP 4007): UCS-2 LE text located from the header, event text kept as UTF-8 (#466)
+add_executable(
+    dsd-neo_test_dmr_tms_utf16le
+    protocol/dmr/test_dmr_tms_utf16le.c
+    test_support/data_event_gps_shim.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_ars.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_pdu.c
+    ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_text.c
+)
+target_include_directories(
+    dsd-neo_test_dmr_tms_utf16le
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/protocol/dmr
+)
+target_include_directories(
+    dsd-neo_test_dmr_tms_utf16le
+    SYSTEM
+    PRIVATE ${_PUBLIC_INCLUDES}
+)
+target_link_libraries(dsd-neo_test_dmr_tms_utf16le PRIVATE dsd-neo_test_support)
+add_test(NAME DMR_TMS_UTF16LE COMMAND dsd-neo_test_dmr_tms_utf16le)
+
 # DMR LRRP: IP/UDP header lengths (IHL/UDP len) must bound LRRP payload
 add_executable(
     dsd-neo_test_dmr_lrrp_ip_udp_lengths
@@ -9240,6 +9261,7 @@ set(_DSD_NEO_BIT_PACKING_TEST_TARGETS
     dsd-neo_test_dmr_lrrp_token_alignment
     dsd-neo_test_dmr_lrrp_wrapped_document
     dsd-neo_test_dmr_pdu_utf16_text
+    dsd-neo_test_dmr_tms_utf16le
     dsd-neo_test_dmr_relaxed_header_ip
     dsd-neo_test_dmr_t3_ann_wd_tscc
     dsd-neo_test_dmr_t3_cmove

--- a/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
+++ b/tests/protocol/dmr/test_dmr_lrrp_ip_udp_lengths.c
@@ -749,7 +749,9 @@ main(void) {
         rc |= expect_has_substr(st.dmr_lrrp_gps[0], "Acknowledgment;", "tms acknowledgment");
 
         reset_spies();
-        const uint8_t text_payload[] = {0x00, 0x06, 0x00, 0x00, 'O', 0x00, 'K'};
+        // Length, header (extension present), no address, extension 8F 04, then "OK" in UCS-2 LE
+        // as Motorola radios send it (#466).
+        const uint8_t text_payload[] = {0x00, 0x08, 0xA0, 0x00, 0x8F, 0x04, 'O', 0x00, 'K', 0x00};
         plen = build_ipv4_udp_payload(pkt, sizeof pkt, 4007U, text_payload, sizeof(text_payload));
         st.event_history_s[0].Event_History_Items[0].text_message[0] = '\0';
         st.dmr_lrrp_gps[0][0] = '\0';

--- a/tests/protocol/dmr/test_dmr_pdu_utf16_text.c
+++ b/tests/protocol/dmr/test_dmr_pdu_utf16_text.c
@@ -4,9 +4,11 @@
  */
 
 /*
- * utf16_to_text() renders DMR SMS/TMS text from UTF-16BE octets (issue #358 covers the same
- * %lc hazard for UDT text). Surrogate pairs must combine into one character, an unpaired half
- * must become U+FFFD, and the historical markers for padding and the 0x040D line break stay.
+ * utf16_to_text() renders ETSI text (TS 102 361-3: UTF-16BE) and utf16le_to_text() Motorola TMS
+ * text (UCS-2 LE) to stderr and into the slot's event text (issue #358 covers the same %lc hazard
+ * for UDT text). Surrogate pairs must combine into one character, an unpaired half must become
+ * U+FFFD, the historical markers for padding and control characters stay on stderr, and the event
+ * text keeps every printable character as UTF-8 rather than the ASCII subset (issue #466).
  */
 
 #include <assert.h>
@@ -83,13 +85,30 @@ dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, ch
 #pragma GCC diagnostic pop
 #endif
 
-/* UTF-16BE: U+4739, U+1F600 as a pair, a lone high surrogate, 'A', padding, then 0x040D. */
+/* UTF-16BE: U+4739, U+1F600 as a pair, a lone high surrogate, 'A', padding, then U+040D (Cyrillic
+ * capital I with grave, which an earlier misreading of Motorola framing had special-cased as a
+ * line break). */
 static const uint8_t kText[] = {0x47, 0x39, 0xD8, 0x3D, 0xDE, 0x00, 0xD8, 0x00, 0x00, 0x41, 0x00, 0x00, 0x04, 0x0D};
 
 static const char kExpected[] = "\xE4\x9C\xB9"
                                 "\xF0\x9F\x98\x80"
                                 "\xEF\xBF\xBD"
-                                "A_ / ";
+                                "A_"
+                                "\xD0\x8D";
+
+/* The same characters without the padding: the event text is UTF-8, not the ASCII subset. */
+static const char kExpectedEvent[] = "\xE4\x9C\xB9"
+                                     "\xF0\x9F\x98\x80"
+                                     "\xEF\xBF\xBD"
+                                     "A"
+                                     "\xD0\x8D";
+
+/* UCS-2 LE, as Motorola TMS sends it: CR LF (a blank subject line) then "Zażółć gęślą jaźń". */
+static const uint8_t kTextLe[] = {0x0D, 0x00, 0x0A, 0x00, 0x5A, 0x00, 0x61, 0x00, 0x7C, 0x01, 0xF3, 0x00, 0x42,
+                                  0x01, 0x07, 0x01, 0x20, 0x00, 0x67, 0x00, 0x19, 0x01, 0x5B, 0x01, 0x6C, 0x00,
+                                  0x05, 0x01, 0x20, 0x00, 0x6A, 0x00, 0x61, 0x00, 0x7A, 0x01, 0x44, 0x01};
+
+static const char kPangramUtf8[] = "Za\xC5\xBC\xC3\xB3\xC5\x82\xC4\x87 g\xC4\x99\xC5\x9Bl\xC4\x85 ja\xC5\xBA\xC5\x84";
 
 int
 main(void) {
@@ -110,8 +129,26 @@ main(void) {
         DSD_FPRINTF(stderr, "utf16_to_text printed: %s\n", buf);
         assert(0 && "UTF-16 text was not transcoded as expected");
     }
-    /* The event log keeps only the ASCII characters, as before. */
-    assert(strcmp(st.event_history_s[0].Event_History_Items[0].text_message, "A") == 0);
+    if (strcmp(st.event_history_s[0].Event_History_Items[0].text_message, kExpectedEvent) != 0) {
+        DSD_FPRINTF(stderr, "event text: %s\n", st.event_history_s[0].Event_History_Items[0].text_message);
+        assert(0 && "event text was not the UTF-8 of the printable characters");
+    }
+
+    /* Little-endian units: the control characters print as markers and stay out of the event text. */
+    char expected_le[128];
+    DSD_SNPRINTF(expected_le, sizeof expected_le, "--%s", kPangramUtf8);
+    assert(dsd_test_capture_stderr_begin(&cap, "dmr_pdu_utf16") == 0);
+    utf16le_to_text(&st, 1, (uint16_t)sizeof kTextLe, kTextLe);
+    assert(dsd_test_capture_stderr_end(&cap) == 0);
+    assert(dsd_test_capture_stderr_read(&cap, buf, sizeof buf) == 0);
+    if (strcmp(buf, expected_le) != 0) {
+        DSD_FPRINTF(stderr, "utf16le_to_text printed: %s\n", buf);
+        assert(0 && "UTF-16LE text was not transcoded as expected");
+    }
+    if (strcmp(st.event_history_s[0].Event_History_Items[0].text_message, kPangramUtf8) != 0) {
+        DSD_FPRINTF(stderr, "event text: %s\n", st.event_history_s[0].Event_History_Items[0].text_message);
+        assert(0 && "UTF-16LE event text was not the pangram");
+    }
 
     /* An odd trailing octet is ignored rather than read past. */
     assert(dsd_test_capture_stderr_begin(&cap, "dmr_pdu_utf16") == 0);

--- a/tests/protocol/dmr/test_dmr_tms_utf16le.c
+++ b/tests/protocol/dmr/test_dmr_tms_utf16le.c
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Motorola TMS (UDP 4007) carries its text as UCS-2 little-endian (MOTOTRBO Text Messaging ADK
+ * Guide: "The MOTOTRBO radio only supports the UCS2-LE encoding schema"), after a two-octet
+ * length, a header octet, an address-length octet and one or more header-extension octets whose
+ * bit 7 says another follows. Issue #466: the decoder read the units big-endian from one octet
+ * before the text, which only cancels out for ASCII, and the event-log copy kept ASCII only.
+ *
+ * The first packet is the reporter's vector: the Polish pangram behind a blank subject line
+ * (CR LF). The second carries ASCII in the same framing, the case an endianness-only change
+ * would have broken. The rest are truncated shapes that must not read past the payload.
+ */
+
+#include <assert.h>
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/time_format.h>
+#include <dsd-neo/runtime/unicode.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/safe_api.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#endif
+
+// Minimal stubs for direct link with dmr_pdu.c
+const char*
+dsd_degrees_glyph(void) {
+    return "";
+}
+
+int
+dsd_unicode_supported(void) {
+    return 1;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+lip_protocol_decoder(dsd_opts* opts, dsd_state* state, uint8_t* input) {
+    (void)opts;
+    (void)state;
+    (void)input;
+}
+
+void
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+decode_cellocator(dsd_opts* opts, dsd_state* state, uint8_t* input, int len) {
+    (void)opts;
+    (void)state;
+    (void)input;
+    (void)len;
+}
+
+int
+dsd_event_emit_data_notice(dsd_opts* opts, dsd_state* state, uint8_t slot, const dsd_call_observation* observation,
+                           const char* notice) {
+    (void)opts;
+    (void)state;
+    (void)observation->ota_source_id;
+    (void)observation->ota_target_id;
+    (void)notice;
+    (void)slot;
+    return 0;
+}
+
+int
+dsd_format_local_datetime(time_t timestamp, dsd_local_datetime_format format, char* out, size_t out_size) {
+    (void)timestamp;
+    const char* value = (format == DSD_LOCAL_DATETIME_DATE_SLASH) ? "1999/01/02" : "11:22:33";
+    DSD_SNPRINTF(out, out_size, "%s", value);
+    return 1;
+}
+
+#if defined(__GNUC__) && !defined(__cplusplus)
+#pragma GCC diagnostic pop
+#endif
+
+// Under test
+int decode_ip_pdu(dsd_opts* opts, dsd_state* state, uint16_t len, uint8_t* input);
+
+/* "Zażółć gęślą jaźń" as UTF-8. */
+static const char kPangramUtf8[] = "Za\xC5\xBC\xC3\xB3\xC5\x82\xC4\x87 g\xC4\x99\xC5\x9Bl\xC4\x85 ja\xC5\xBA\xC5\x84";
+
+/* The reporter's packet: IPv4/UDP 4007 -> 4007, TMS length 42, header A0, no address, header
+ * extension 8F 04, then CR LF and the pangram, all UCS-2 LE. */
+static const uint8_t kPangramPacket[] = {
+    0x45, 0x00, 0x00, 0x48, 0x00, 0x01, 0x00, 0x00, 0x40, 0x11, 0x00, 0x00, 0x0C, 0x00, 0x00, 0x01, 0x0D, 0x00,
+    0x00, 0x02, 0x0F, 0xA7, 0x0F, 0xA7, 0x00, 0x34, 0x00, 0x00, 0x00, 0x2A, 0xA0, 0x00, 0x8F, 0x04, 0x0D, 0x00,
+    0x0A, 0x00, 0x5A, 0x00, 0x61, 0x00, 0x7C, 0x01, 0xF3, 0x00, 0x42, 0x01, 0x07, 0x01, 0x20, 0x00, 0x67, 0x00,
+    0x19, 0x01, 0x5B, 0x01, 0x6C, 0x00, 0x05, 0x01, 0x20, 0x00, 0x6A, 0x00, 0x61, 0x00, 0x7A, 0x01, 0x44, 0x01,
+};
+
+static const char kAscii[] = "The quick brown fox";
+
+/* Builds the same IPv4/UDP/TMS framing around @p text (ASCII, widened to UCS-2 LE) preceded by
+ * the blank subject line. Returns the packet length. */
+static size_t
+build_ascii_packet(uint8_t* out, size_t out_size, const char* text) {
+    size_t text_units = strlen(text);
+    size_t tms_payload = 2U + 1U + 1U + 2U + 4U + (text_units * 2U); /* len, hdr, adl, ext, CR LF, text */
+    size_t udp_len = 8U + tms_payload;
+    size_t total = 20U + udp_len;
+    assert(total <= out_size);
+    DSD_MEMSET(out, 0, out_size);
+    DSD_MEMCPY(out, kPangramPacket, 20U);
+    out[2] = (uint8_t)(total >> 8);
+    out[3] = (uint8_t)(total & 0xFFU);
+    out[20] = 0x0F;
+    out[21] = 0xA7;
+    out[22] = 0x0F;
+    out[23] = 0xA7;
+    out[24] = (uint8_t)(udp_len >> 8);
+    out[25] = (uint8_t)(udp_len & 0xFFU);
+    size_t p = 28U;
+    size_t tms_len = tms_payload - 2U;
+    out[p++] = (uint8_t)(tms_len >> 8);
+    out[p++] = (uint8_t)(tms_len & 0xFFU);
+    out[p++] = 0xA0;
+    out[p++] = 0x00;
+    out[p++] = 0x8F;
+    out[p++] = 0x04;
+    out[p++] = 0x0D;
+    out[p++] = 0x00;
+    out[p++] = 0x0A;
+    out[p++] = 0x00;
+    for (size_t i = 0; i < text_units; i++) {
+        out[p++] = (uint8_t)text[i];
+        out[p++] = 0x00;
+    }
+    assert(p == total);
+    return total;
+}
+
+static void
+run_packet(dsd_opts* opts, dsd_state* st, const uint8_t* packet, size_t packet_len, char* buf, size_t buf_size,
+           const char* prefix) {
+    uint8_t copy[512];
+    assert(packet_len <= sizeof copy);
+    DSD_MEMCPY(copy, packet, packet_len);
+    st->event_history_s[0].Event_History_Items[0].text_message[0] = '\0';
+    st->dmr_lrrp_gps[0][0] = '\0';
+    dsd_test_capture_stderr cap;
+    assert(dsd_test_capture_stderr_begin(&cap, prefix) == 0);
+    decode_ip_pdu(opts, st, (uint16_t)packet_len, copy);
+    assert(dsd_test_capture_stderr_end(&cap) == 0);
+    assert(dsd_test_capture_stderr_read(&cap, buf, buf_size) == 0);
+}
+
+int
+main(void) {
+    static dsd_opts opts;
+    static dsd_state st;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    DSD_MEMSET(&st, 0, sizeof st);
+    st.currentslot = 0;
+    st.event_history_s = (Event_History_I*)calloc(2, sizeof(Event_History_I));
+    assert(st.event_history_s != NULL);
+
+    char buf[1024];
+    const char* text_message = st.event_history_s[0].Event_History_Items[0].text_message;
+
+    /* 1. The reporter's vector: every accented character survives, including the last one. */
+    run_packet(&opts, &st, kPangramPacket, sizeof kPangramPacket, buf, sizeof buf, "dmr_tms_le");
+    if (strcmp(text_message, kPangramUtf8) != 0) {
+        DSD_FPRINTF(stderr, "event text: '%s'\nstderr: %s\n", text_message, buf);
+        assert(0 && "TMS event-log text was not the pangram");
+    }
+    char expected_line[128];
+    DSD_SNPRINTF(expected_line, sizeof expected_line, "Text: --%s", kPangramUtf8);
+    if (strstr(buf, expected_line) == NULL) {
+        DSD_FPRINTF(stderr, "stderr: %s\n", buf);
+        assert(0 && "TMS stderr text was not the pangram");
+    }
+    assert(strstr(st.dmr_lrrp_gps[0], "TMS SRC: 1; DST: 2;") != NULL);
+
+    /* 2. ASCII in the same framing still decodes verbatim. */
+    uint8_t packet[256];
+    size_t packet_len = build_ascii_packet(packet, sizeof packet, kAscii);
+    run_packet(&opts, &st, packet, packet_len, buf, sizeof buf, "dmr_tms_le");
+    if (strcmp(text_message, kAscii) != 0) {
+        DSD_FPRINTF(stderr, "event text: '%s'\nstderr: %s\n", text_message, buf);
+        assert(0 && "ASCII TMS text changed");
+    }
+    DSD_SNPRINTF(expected_line, sizeof expected_line, "Text: --%s", kAscii);
+    assert(strstr(buf, expected_line) != NULL);
+
+    /* 3. A header-extension octet that promises another, at the end of the payload. */
+    (void)build_ascii_packet(packet, sizeof packet, kAscii);
+    size_t cut = 28U + 5U; /* keep len, hdr, adl, 8F */
+    packet[2] = (uint8_t)(cut >> 8);
+    packet[3] = (uint8_t)(cut & 0xFFU);
+    packet[24] = 0;
+    packet[25] = (uint8_t)(cut - 20U);
+    run_packet(&opts, &st, packet, cut, buf, sizeof buf, "dmr_tms_le");
+    assert(text_message[0] == '\0');
+    assert(strstr(st.dmr_lrrp_gps[0], "Truncated") != NULL);
+
+    /* 4. A TMS length larger than the UDP payload: the text is clamped, not over-read. */
+    packet_len = build_ascii_packet(packet, sizeof packet, kAscii);
+    packet[28] = 0x01;
+    packet[29] = 0x00;
+    run_packet(&opts, &st, packet, packet_len, buf, sizeof buf, "dmr_tms_le");
+    assert(strcmp(text_message, kAscii) == 0);
+
+    /* 5. An address-length octet that runs past the payload is reported, not followed. */
+    packet_len = build_ascii_packet(packet, sizeof packet, kAscii);
+    packet[31] = 0xF0;
+    run_packet(&opts, &st, packet, packet_len, buf, sizeof buf, "dmr_tms_le");
+    assert(text_message[0] == '\0');
+    assert(strstr(st.dmr_lrrp_gps[0], "Truncated") != NULL);
+
+    free(st.event_history_s);
+    DSD_FPRINTF(stderr, "DMR_TMS_UTF16LE: PASS\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #466.

- Motorola TMS (UDP 4007) text is UCS-2 little-endian (MOTOTRBO Text Messaging ADK Guide: "The MOTOTRBO radio only supports the UCS2-LE encoding schema"; sdrtrunk, Moto.Net, TRBO-NET and node-dmr-lib all read it that way). `utf16_to_text()` read the units big-endian from one octet before the text with that octet zeroed, which cancels out for ASCII only: a unit with a non-zero high octet became two wrong characters and swallowed the one after it.
- The TMS handler now walks the header layout the three encoders agree on (length, header octet, address by its length octet, header-extension octets while bit 7 says another follows) and hands the text from its real start to a new `utf16le_to_text()`, with the length taken from the TMS length field and clamped to the UDP payload. The payload is no longer modified in place.
- The event-history copy of the text was a separate filter keeping only `00 XX` pairs with printable ASCII `XX`. It now receives the decoded scalars as UTF-8 (controls skipped), the way the talker-alias path already does; the ncurses UI, Qt model and event log already render that field as UTF-8.
- The `0x040D` "line break" special case was the misaligned extension octet `04` followed by CR. It is removed, so Cyrillic U+040D in ETSI text prints as itself.
- The ETSI path is unchanged: TS 102 361-3 specifies UTF-16BE for text on port 5016 and the compressed-UDP text port. Port 5007 (VTX) has no public source and stays as it was.
- The address field (`adl > 0`) keeps the dsd-fme "length minus four" reading, now aligned and little-endian. No public source parses it, so that and any header-extension shape other than `8F 04` are the parts live traffic has not confirmed.

Tests: the reporter's packet is a regression test (`DMR_TMS_UTF16LE`), alongside ASCII in the same framing, a header extension cut short, a TMS length past the payload and an address length past the payload. `DMR_PDU_UTF16_TEXT` now checks the UTF-8 event text and an LE case. The synthetic port-4007 vector in `DMR_LRRP_IP_UDP_LENGTHS` encoded the old misalignment and now carries real framing.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: parser / network input.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope (none added).
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure`
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes
- [ ] `tools/osv_scan.sh` for dependency input changes
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes

Also run: the three affected tests under `asan-ubsan-debug`.

## Risk

- Security/dependency impact: none; the TMS parser bounds every read against the UDP payload length and no longer writes into it.
- CLI/UI behavior impact: TMS text on stderr, the event history and the event log now shows non-ASCII characters; ETSI text no longer prints U+040D as ` / `. With payload printing on, the dump shows `EXT: xx;` per header-extension octet instead of `B1:/B2:` pairs.
- Compatibility or packaging impact: none.
