### PR TITLE
fix(core): stamp every -J event-log line with the row's timestamp (#469)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -208,10 +208,22 @@ Windows console runs:
   those captures are migrated or their support window ends. Neither stored format carries the NXDN symbol rate, so NXDN
   capture replay requires `-fi` or `-fn` instead of `-fa`.
 - `-d <dir>` Save raw MBE vocoder frames in this folder
-- `-J <file>` Append event log output. While scanning a `-Y` list or rotating `--trunk-scan` targets, each
-  line names the channel it was heard on in brackets between the timestamp and the protocol token
-  (`2026-04-30 09:12:04 [Fire Dispatch] P25p1 TGT: ...`); lines from a receiver that is not scanning a named
-  channel are unchanged.
+- `-J <file>` Append event log output. Every line starts with a `YYYY-MM-DD HH:MM:SS` stamp, so the file
+  filters, sorts and splits by time with ordinary line tools. An event's detail lines (`Text:` for a decoded
+  text message, `Talker Alias:`, `GPS:`, `DSD-neo:` for a decoder notice) follow its line and repeat that
+  event's own stamp rather than reading the clock again; a voice transmission reacquired after a sync loss
+  appends a `Reacquired:` continuation carrying the stamp of the row it extends. While scanning a `-Y` list
+  or rotating `--trunk-scan` targets, each line names the channel it was heard on in brackets between the
+  timestamp and the protocol token; lines from a receiver that is not scanning a named channel are unchanged.
+
+  ```text
+  2026-04-30 09:12:04 [Fire Dispatch] P25p1 TGT: 00050061; SRC: 00001234;
+  2026-04-30 09:12:04 Talker Alias: ENGINE 12
+  2026-04-30 09:12:11 TMS SRC: 1234; DST: 42; Slot 1;
+  2026-04-30 09:12:11 Text: MEET AT THE NORTH GATE
+  2026-04-30 09:12:20 DMR TGT: 00000100; SRC: 00000000; Slot 1;
+  2026-04-30 09:12:20 Reacquired: DMR TGT: 00000100; SRC: 00004321; Slot 1;
+  ```
 - `--frame-log <file>` Append frame-level one-line timestamped traces
 - `--p25-sm-log <file>` Append P25 state-machine health and frequency-decision traces. Grant traces identify initial
   assignments versus updates; post-call stale-update handling reports guard, validation-probe, and activity outcomes.

--- a/src/core/util/dsd_events.c
+++ b/src/core/util/dsd_events.c
@@ -188,13 +188,119 @@ typedef struct {
     uint8_t internal;
 } watchdog_event_merge_added;
 
+static int
+watchdog_event_char_is_digit(char c) {
+    return c >= '0' && c <= '9';
+}
+
+// Width of the "YYYY-MM-DD HH:MM:SS" prefix every builder emits, without the space that follows it.
+enum { k_watchdog_event_stamp_len = 19 };
+
+// Parse the "YYYY-MM-DD HH:MM:SS" prefix at the head of `s` (at most `cap` readable bytes) into
+// datestr (11 bytes) and timestr (9 bytes). Returns non-zero when the prefix is present and
+// well-formed. Every builder emits it, so this is the one place its shape is known: the log
+// writer and the merge re-render both recover a row's stamp through it.
+static int
+watchdog_event_parse_datetime_prefix(const char* s, size_t cap, char* datestr, char* timestr) {
+    // Separators at offsets 4, 7, 10, 13, 16; digits everywhere else.
+    static const char k_separators[k_watchdog_event_stamp_len] = {0,   0, 0, 0,   '-', 0, 0,   '-', 0, 0,
+                                                                  ' ', 0, 0, ':', 0,   0, ':', 0,   0};
+    if (s == NULL || strnlen(s, cap) < (size_t)k_watchdog_event_stamp_len) {
+        return 0;
+    }
+    for (size_t i = 0; i < (size_t)k_watchdog_event_stamp_len; i++) {
+        if (k_separators[i] != 0 ? s[i] != k_separators[i] : !watchdog_event_char_is_digit(s[i])) {
+            return 0;
+        }
+    }
+    DSD_SNPRINTF(datestr, 11U, "%s", s);
+    DSD_SNPRINTF(timestr, 9U, "%s", s + 11);
+    return 1;
+}
+
+static int watchdog_event_row_datetime(const Event_History* item, char* datestr, size_t datestr_size, char* timestr,
+                                       size_t timestr_size);
+
+static void
+watchdog_event_write_log_detail(FILE* event_log_file, const char* stamp, const char* label, const char* value,
+                                uint8_t wanted) {
+    if (wanted == 0U) {
+        return;
+    }
+    // Unstamped, the line keeps its leading space so it still reads as a continuation.
+    DSD_FPRINTF(event_log_file, "%s %s%s \n", stamp, label, value);
+}
+
+// Which detail lines this entry writes: the caller's selection, else every non-empty field.
+static watchdog_event_merge_added
+watchdog_event_log_details_wanted(const Event_History* row, const watchdog_event_merge_added* selection) {
+    if (selection != NULL) {
+        return *selection;
+    }
+    watchdog_event_merge_added wanted;
+    wanted.alias = row->alias[0] != '\0' ? 1U : 0U;
+    wanted.gps = row->gps_s[0] != '\0' ? 1U : 0U;
+    wanted.text_message = row->text_message[0] != '\0' ? 1U : 0U;
+    wanted.internal = row->internal_str[0] != '\0' ? 1U : 0U;
+    return wanted;
+}
+
+// The stamp every line of the entry carries. Returns 2 when it came from the rendered line, 1
+// when it came from the row, 0 when neither offers one (stamp is then empty).
+static int
+watchdog_event_log_entry_stamp(const char* event_string, const Event_History* row, char* stamp, size_t stamp_size) {
+    char datestr[11];
+    char timestr[9];
+    stamp[0] = '\0';
+    if (event_string != NULL
+        && watchdog_event_parse_datetime_prefix(event_string, strlen(event_string), datestr, timestr)) {
+        DSD_SNPRINTF(stamp, stamp_size, "%s %s", datestr, timestr);
+        return 2;
+    }
+    if (watchdog_event_row_datetime(row, datestr, sizeof datestr, timestr, sizeof timestr)) {
+        DSD_SNPRINTF(stamp, stamp_size, "%s %s", datestr, timestr);
+        return 1;
+    }
+    return 0;
+}
+
+static void
+watchdog_event_write_log_rendered_line(FILE* event_log_file, const char* stamp, int stamped_from_line,
+                                       const char* prefix, const char* event_string, uint8_t slot, uint8_t swrite) {
+    if (stamped_from_line && prefix != NULL) {
+        // The marker follows the stamp so the continuation line filters and sorts with the row
+        // it extends.
+        const char* rest = event_string + k_watchdog_event_stamp_len;
+        if (*rest == ' ') {
+            rest++;
+        }
+        DSD_FPRINTF(event_log_file, "%s %s%s ", stamp, prefix, rest);
+    } else if (prefix != NULL) {
+        DSD_FPRINTF(event_log_file, " %s%s ", prefix, event_string);
+    } else {
+        DSD_FPRINTF(event_log_file, "%s ", event_string);
+    }
+    if (swrite == 1) {
+        DSD_FPRINTF(event_log_file, "Slot %d; ", slot + 1);
+    }
+    DSD_FPRINTF(event_log_file, "\n");
+}
+
 // One event-log entry: the rendered line, then whichever optional detail lines apply. A row's
 // first commit and a reacquired segment's continuation are the same entry shape, so they share
 // one writer and the log format keeps a single source of truth.
 //
+// Every line the writer emits starts with the row's "YYYY-MM-DD HH:MM:SS " stamp, so the log stays
+// line-oriented: a date filter, a sort, or an awk field split treats a text message or a talker
+// alias exactly like the event it belongs to (#469). The stamp is the one on the rendered line when
+// there is one -- the detail lines describe that line, so they carry its clock rather than a fresh
+// read -- and otherwise the row's own, recovered the way a merge re-render recovers it. A row with
+// no recoverable stamp writes its lines unstamped rather than inventing a time.
+//
 // `event_string` NULL suppresses the rendered line, for a continuation that only has new detail
-// to report. `prefix` marks the entry as a continuation. `selection` limits the detail lines to
-// what the caller just learned; NULL writes every non-empty one.
+// to report. `prefix` marks the entry as a continuation and sits between the stamp and the rest of
+// the rendered line. `selection` limits the detail lines to what the caller just learned; NULL
+// writes every non-empty one.
 static void
 watchdog_event_write_log_entry(const dsd_opts* opts, uint8_t slot, uint8_t swrite, const char* prefix,
                                const char* event_string, const Event_History* row,
@@ -202,29 +308,22 @@ watchdog_event_write_log_entry(const dsd_opts* opts, uint8_t slot, uint8_t swrit
     if (opts->event_out_file[0] == '\0') {
         return;
     }
+    char stamp[k_watchdog_event_stamp_len + 1];
+    const int stamp_source = watchdog_event_log_entry_stamp(event_string, row, stamp, sizeof stamp);
+    const watchdog_event_merge_added wanted = watchdog_event_log_details_wanted(row, selection);
+
     FILE* event_log_file = dsd_fopen_private(opts->event_out_file, "a");
     if (event_log_file == NULL) {
         return;
     }
     if (event_string != NULL) {
-        DSD_FPRINTF(event_log_file, "%s%s ", prefix != NULL ? prefix : "", event_string);
-        if (swrite == 1) {
-            DSD_FPRINTF(event_log_file, "Slot %d; ", slot + 1);
-        }
-        DSD_FPRINTF(event_log_file, "\n");
+        watchdog_event_write_log_rendered_line(event_log_file, stamp, stamp_source == 2, prefix, event_string, slot,
+                                               swrite);
     }
-    if (selection != NULL ? selection->text_message != 0U : row->text_message[0] != '\0') {
-        DSD_FPRINTF(event_log_file, "%s \n", row->text_message);
-    }
-    if (selection != NULL ? selection->alias != 0U : row->alias[0] != '\0') {
-        DSD_FPRINTF(event_log_file, " Talker Alias: %s \n", row->alias);
-    }
-    if (selection != NULL ? selection->gps != 0U : row->gps_s[0] != '\0') {
-        DSD_FPRINTF(event_log_file, " GPS: %s \n", row->gps_s);
-    }
-    if (selection != NULL ? selection->internal != 0U : row->internal_str[0] != '\0') {
-        DSD_FPRINTF(event_log_file, " DSD-neo: %s \n", row->internal_str);
-    }
+    watchdog_event_write_log_detail(event_log_file, stamp, "Text: ", row->text_message, wanted.text_message);
+    watchdog_event_write_log_detail(event_log_file, stamp, "Talker Alias: ", row->alias, wanted.alias);
+    watchdog_event_write_log_detail(event_log_file, stamp, "GPS: ", row->gps_s, wanted.gps);
+    watchdog_event_write_log_detail(event_log_file, stamp, "DSD-neo: ", row->internal_str, wanted.internal);
     fflush(event_log_file);
     fclose(event_log_file);
 }
@@ -696,7 +795,7 @@ watchdog_event_log_merge_continuation(const dsd_opts* opts, uint8_t slot, uint8_
     // A re-render that produced no string, or one identical to what the row already showed, has
     // nothing new to say; the detail lines below may still.
     const char* rendered = (rendered_changed && retained->event_string[0] != '\0') ? retained->event_string : NULL;
-    watchdog_event_write_log_entry(opts, slot, swrite, " Reacquired: ", rendered, retained, added);
+    watchdog_event_write_log_entry(opts, slot, swrite, "Reacquired: ", rendered, retained, added);
 }
 
 // True when the staged row may be folded into the row already committed for this slot: the
@@ -1648,11 +1747,6 @@ watchdog_event_ctx_from_row(const dsd_call_event_render_env* env, const Event_Hi
     ctx->s_name_loaded = item->s_name[0] != '\0' ? 1U : 0U;
 }
 
-static int
-watchdog_event_char_is_digit(char c) {
-    return c >= '0' && c <= '9';
-}
-
 // Recover the "YYYY-MM-DD HH:MM:SS " prefix every builder emits, straight from the string the row
 // is already displaying, and only fall back to item->event_time when that string carries no
 // parseable prefix -- a row a protocol staged directly rather than rendering.
@@ -1667,11 +1761,6 @@ watchdog_event_char_is_digit(char c) {
 static int
 watchdog_event_row_datetime(const Event_History* item, char* datestr, size_t datestr_size, char* timestr,
                             size_t timestr_size) {
-    // "YYYY-MM-DD HH:MM:SS": separators at offsets 4, 7, 10, 13, 16; digits everywhere else.
-    static const char k_watchdog_event_datetime_separators[19] = {0,   0, 0, 0,   '-', 0, 0,   '-', 0, 0,
-                                                                  ' ', 0, 0, ':', 0,   0, ':', 0,   0};
-    const char* s = item->event_string;
-
     // Field widths of the prefix, including the terminator each is written with -- not the caller's
     // buffer capacities. The size parameters below only reject a buffer too small to hold a field;
     // widening one must not copy more of the timestamp than the field itself.
@@ -1680,20 +1769,8 @@ watchdog_event_row_datetime(const Event_History* item, char* datestr, size_t dat
     if (datestr_size < k_datestr_len || timestr_size < k_timestr_len) {
         return 0;
     }
-    if (strnlen(s, sizeof(item->event_string)) >= 19U) {
-        int parsed = 1;
-        for (size_t i = 0; i < 19U; i++) {
-            if (k_watchdog_event_datetime_separators[i] != 0 ? s[i] != k_watchdog_event_datetime_separators[i]
-                                                             : !watchdog_event_char_is_digit(s[i])) {
-                parsed = 0;
-                break;
-            }
-        }
-        if (parsed) {
-            DSD_SNPRINTF(datestr, 11U, "%s", s);
-            DSD_SNPRINTF(timestr, 9U, "%s", s + 11);
-            return 1;
-        }
+    if (watchdog_event_parse_datetime_prefix(item->event_string, sizeof(item->event_string), datestr, timestr)) {
+        return 1;
     }
 
     // No prefix to preserve. A stamp is better than nothing; a zero one would render 1970-01-01,

--- a/tests/core/test_core_call_alert_history.c
+++ b/tests/core/test_core_call_alert_history.c
@@ -355,6 +355,30 @@ expect_str_eq(const char* label, const char* got, const char* want) {
     return 0;
 }
 
+// Every line of a -J event log starts with the row's "YYYY-MM-DD HH:MM:SS" stamp (#469): the
+// detail lines and a reacquired continuation included, so line-oriented tooling never meets an
+// undated line.
+static int
+expect_every_line_stamped(const char* label, const char* buf, const char* stamp) {
+    const size_t stamp_len = strlen(stamp);
+    int lines = 0;
+    for (const char* line = buf; line != NULL && *line != '\0';) {
+        const char* end = strchr(line, '\n');
+        const size_t len = end != NULL ? (size_t)(end - line) : strlen(line);
+        if (len > 0 && (len < stamp_len || strncmp(line, stamp, stamp_len) != 0)) {
+            DSD_FPRINTF(stderr, "%s: line without stamp '%.*s'\n", label, (int)len, line);
+            return 1;
+        }
+        lines++;
+        line = end != NULL ? end + 1 : NULL;
+    }
+    if (lines == 0) {
+        DSD_FPRINTF(stderr, "%s: log is empty\n", label);
+        return 1;
+    }
+    return 0;
+}
+
 static int
 event_history_item_equal(const Event_History* lhs, const Event_History* rhs) {
     return lhs->write == rhs->write && lhs->color_pair == rhs->color_pair && lhs->severity == rhs->severity
@@ -1172,11 +1196,61 @@ test_event_log_writes_optional_metadata_lines(void) {
     buf[n] = '\0';
 
     int rc = 0;
-    rc |= expect_has_substr("event log main line", buf, "TEST EVENT; Slot 2;");
-    rc |= expect_has_substr("event log text", buf, "hello text");
-    rc |= expect_has_substr("event log alias", buf, "Talker Alias: Unit 7");
-    rc |= expect_has_substr("event log gps", buf, "GPS: 41.500000 -87.250000");
-    rc |= expect_has_substr("event log internal", buf, "DSD-neo: status detail");
+    rc |= expect_has_substr("event log main line", buf, "2026-04-30 00:00:00 TEST EVENT; Slot 2;");
+    rc |= expect_has_substr("event log text", buf, "\n2026-04-30 00:00:00 Text: hello text \n");
+    rc |= expect_has_substr("event log alias", buf, "\n2026-04-30 00:00:00 Talker Alias: Unit 7 \n");
+    rc |= expect_has_substr("event log gps", buf, "\n2026-04-30 00:00:00 GPS: 41.500000 -87.250000 \n");
+    rc |= expect_has_substr("event log internal", buf, "\n2026-04-30 00:00:00 DSD-neo: status detail \n");
+    rc |= expect_every_line_stamped("event log detail lines carry the header's stamp", buf, "2026-04-30 00:00:00 ");
+    return rc;
+}
+
+// A rendered line with no parseable prefix, on a row with no stamp of its own, has nothing to
+// stamp the detail lines with. They keep their pre-#469 shape -- a leading space and the label --
+// rather than an invented time.
+static int
+test_event_log_unstamped_row_keeps_bare_detail_lines(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    static Event_History_I event_history[2];
+    reset_fixture(&opts, &state, event_history);
+
+    char path[] = "/tmp/dsd-neo-events-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        DSD_FPRINTF(stderr, "mkstemp failed for unstamped event log test\n");
+        return 1;
+    }
+    close(fd);
+    remove(path);
+    DSD_SNPRINTF(opts.event_out_file, sizeof opts.event_out_file, "%s", path);
+
+    Event_History* row = &state.event_history_s[1].Event_History_Items[0];
+    row->event_time = 0;
+    row->event_string[0] = '\0';
+    DSD_SNPRINTF(row->text_message, sizeof row->text_message, "%s", "hello text");
+    DSD_SNPRINTF(row->alias, sizeof row->alias, "%s", "Unit 7");
+
+    char event_string[] = "TEST EVENT;";
+    write_event_to_log_file(&opts, &state, 1, 1, event_string);
+
+    FILE* f = fopen(path, "rb");
+    if (f == NULL) {
+        remove(path);
+        DSD_FPRINTF(stderr, "unstamped event log was not created\n");
+        return 1;
+    }
+    char buf[4096];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    fclose(f);
+    remove(path);
+    buf[n] = '\0';
+
+    int rc = 0;
+    rc |= expect_has_substr("unstamped main line", buf, "TEST EVENT; Slot 2;");
+    rc |= expect_has_substr("unstamped text line keeps its label", buf, "\n Text: hello text \n");
+    rc |= expect_has_substr("unstamped alias line keeps its shape", buf, "\n Talker Alias: Unit 7 \n");
+    rc |= expect_no_substr("no time is invented for an unstamped row", buf, "2026-04-30");
     return rc;
 }
 
@@ -3924,6 +3998,8 @@ test_merge_logs_continuation_only_when_render_changes(void) {
     int rc = expect_int("merged transmission commits one row", committed_history_rows(&event_history[0]), 1);
     rc |= expect_has_substr("first segment logged its own line", buf, "SRC: 00000000;");
     rc |= expect_has_substr("continuation reports the learned source", buf, " Reacquired: ");
+    rc |= expect_has_substr("continuation marker follows the row's stamp", buf, "\n2026-04-30 00:00:00 Reacquired: ");
+    rc |= expect_every_line_stamped("continuation log lines all start with the stamp", buf, "2026-04-30 00:00:00 ");
     rc |= expect_int("only the informative merge logs a continuation", reacquired_lines, 1);
     dsd_state_ext_free_all(&state);
     return rc;
@@ -4047,8 +4123,9 @@ test_merge_logs_metadata_the_segment_added(void) {
     buf[n] = '\0';
 
     int rc = expect_int("metadata-only merge commits one row", committed_history_rows(&event_history[0]), 1);
-    rc |= expect_has_substr("merged alias reaches the log", buf, " Talker Alias: UNIT 12 FIRE");
-    rc |= expect_has_substr("merged gps reaches the log", buf, " GPS: lat 3.0 lon 4.0");
+    rc |= expect_has_substr("merged alias reaches the log", buf, "\n2026-04-30 00:00:00 Talker Alias: UNIT 12 FIRE \n");
+    rc |= expect_has_substr("merged gps reaches the log", buf, "\n2026-04-30 00:00:00 GPS: lat 3.0 lon 4.0 \n");
+    rc |= expect_every_line_stamped("detail-only continuation carries the row's stamp", buf, "2026-04-30 00:00:00 ");
     rc |= expect_str_eq("merged row keeps the alias", event_history[0].Event_History_Items[1].alias, "UNIT 12 FIRE");
     dsd_state_ext_free_all(&state);
     return rc;
@@ -4822,6 +4899,7 @@ main(void) {
     rc |= test_p25_event_string_keeps_full_prefix_after_sprintf_hardening();
     rc |= test_source_less_current_event_updates_history_metadata();
     rc |= test_event_log_writes_optional_metadata_lines();
+    rc |= test_event_log_unstamped_row_keeps_bare_detail_lines();
     rc |= test_source_transition_rotates_slot_wav_files();
     rc |= test_ysf_current_sanitizes_ids_and_text_message();
     rc |= test_m17_dstar_dpmr_current_strings();


### PR DESCRIPTION
## Summary

- Fixes #469. The `-J` event log wrote one timestamped line per event and then the text-message, talker-alias, GPS and notice lines bare, so a DMR TMS/UDT text message landed with no date or time and `grep`/`awk`/`sort` treated it differently from every other record. The reacquired-segment continuation had the same defect from the other side (`" Reacquired: 2026-..."`).
- Every line the writer emits now starts with the row's `YYYY-MM-DD HH:MM:SS` stamp. Detail lines take the stamp of the rendered line they sit under (never a fresh clock read, so `--playfiles` and merges stay consistent); a detail-only continuation recovers it from the retained row through the prefix parser the merge re-render already used, now factored out and shared. A row with no recoverable stamp writes its lines in their previous unstamped shape rather than inventing a time.
- The text line gains a `Text:` label so all four detail lines are self-describing, and the `Reacquired:` marker follows the stamp.
- The writer is split into stamp / rendered-line / detail helpers to stay under the Lizard complexity limit.
- Tests pin the stamped and labelled detail lines, the detail-only continuation, the marker placement and the unstamped fallback. `docs/cli.md` documents the line format with a sample.

```
2026-09-02 20:25:11 TMS SRC: 1234; DST: 42; Slot 1;
2026-09-02 20:25:11 Text: meet at the north gate
2026-09-02 20:25:20 DMR TGT: 00000100; SRC: 00000000; Slot 1;
2026-09-02 20:25:20 Reacquired: DMR TGT: 00000100; SRC: 00004321; Slot 1;
2026-09-02 20:25:20 Talker Alias: UNIT 12 FIRE
```

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. (Not risky or broad: one static writer in `src/core/util/dsd_events.c`; nothing in the project reads the log back, and the terminal/Qt history views render from the struct, not the file.)
- [x] High-risk areas touched are marked: none.
- [x] Outside review was requested when available, or unavailability is documented. (Solo maintainer.)
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. (The shared prefix parser is the existing validation loop moved verbatim; covered by the existing merge/re-render tests plus the new writer tests.)
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. (None touched.)
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. (None added.)
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (599/599)
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes (not broad or high-risk)
- [ ] `tools/cmake_format_check.sh` for CMake changes (no CMake changes)
- [ ] `tools/zizmor.sh` for workflow changes (no workflow changes)
- [ ] `tools/osv_scan.sh` for dependency input changes (no dependency changes)
- [ ] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` for security-sensitive workflow/release changes (not applicable; the redaction check runs inside preflight)

Also replayed the real NXDN `-fi` capture with `-J` and confirmed with `grep -vc '^[0-9]\{4\}-'` that no line lacks a stamp.

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: `-J` log format only. Detail lines gain a timestamp prefix, the text line gains a `Text:` label, and the `Reacquired:` marker moves after the stamp. On-screen history is unchanged.
- Compatibility or packaging impact: any external tooling that matched the bare text line or the leading `Reacquired:` marker needs updating; no in-repo consumer exists.
