### PR TITLE
fix(core): forward-declare p25_bandplan_row in csv_import.h, sample header includers per tree (#471)

### DIFF
--- a/include/dsd-neo/core/csv_import.h
+++ b/include/dsd-neo/core/csv_import.h
@@ -17,7 +17,7 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 
-typedef struct p25_bandplan_row p25_bandplan_row_t;
+struct p25_bandplan_row;
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,7 +48,7 @@ int csvP25BandplanImport(const dsd_opts* opts, dsd_state* state);
  * import format, through a private temp file and atomic replace. Refuses an
  * empty list. Returns 0 on success, -1 otherwise.
  */
-int csvP25BandplanExportRows(const char* path, const p25_bandplan_row_t* rows, int count);
+int csvP25BandplanExportRows(const char* path, const struct p25_bandplan_row* rows, int count);
 
 #ifdef __cplusplus
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,13 @@ if(NOT WIN32)
                 ${PROJECT_SOURCE_DIR}/tests/tools/test_ci_arch_toolchain_pull_retry.sh
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         )
+        add_test(
+            NAME TOOLS_CI_CHANGED_FILES_HEADER_EXPANSION
+            COMMAND
+                ${DSD_NEO_BASH_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/tests/tools/test_ci_changed_files_header_expansion.sh
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        )
     endif()
 endif()
 

--- a/tests/tools/test_ci_changed_files_header_expansion.sh
+++ b/tests/tools/test_ci_changed_files_header_expansion.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+#
+# tools/ci_changed_files.sh expands a changed header to the translation units
+# that include it, capped per language. The cap used to be one alphabetical cut
+# across the whole repository, so a header with more than five src/ includers
+# never reached a tests/ TU on a pull request; an IWYU verdict that only renders
+# from a tests/ includer then failed the full-tree push run on main after #471
+# merged. The cap now applies per top-level tree, so every tree that includes the
+# header is represented. This builds a throwaway repository in which src/ alone
+# overflows the cap and checks the tests/ includer still lands in analysis_tus.
+set -euo pipefail
+
+if ! command -v rg > /dev/null 2>&1; then
+  echo "SKIP: rg not found; header include expansion needs it" >&2
+  exit 0
+fi
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+SCRIPT="$ROOT_DIR/tools/ci_changed_files.sh"
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+cd "$WORK"
+git init -q .
+git config user.email test@example.invalid
+git config user.name test
+git config commit.gpgsign false
+
+mkdir -p include/dsd-neo/core src/core tests/core apps/cli
+printf 'struct row;\n' > include/dsd-neo/core/widget.h
+for n in a b c d e f g; do
+  printf '#include <dsd-neo/core/widget.h>\n' > "src/core/$n.c"
+done
+printf '#include <dsd-neo/core/widget.h>\n' > src/core/z.cpp
+printf '#include <dsd-neo/core/widget.h>\n' > tests/core/test_widget.c
+printf '#include <dsd-neo/core/widget.h>\n' > apps/cli/main.c
+printf 'int unrelated;\n' > src/core/unrelated.c
+git add -A
+git commit -q -m base
+base=$(git rev-parse HEAD)
+
+printf 'struct row;\nstruct other;\n' > include/dsd-neo/core/widget.h
+git commit -q -am "touch header"
+head=$(git rev-parse HEAD)
+
+bash "$SCRIPT" --base "$base" --head "$head" --out-dir out > /dev/null 2>&1
+mapfile -t tus < out/analysis_tus.txt
+
+has() {
+  local want="$1"
+  local t=""
+  for t in "${tus[@]}"; do
+    [[ "$t" == "$want" ]] && return 0
+  done
+  return 1
+}
+
+fail=0
+# Every tree that includes the header contributes, even though src/ alone
+# overflows the per-language cap.
+has tests/core/test_widget.c || {
+  echo "FAIL: tests/ includer dropped from analysis_tus" >&2
+  fail=1
+}
+has apps/cli/main.c || {
+  echo "FAIL: apps/ includer dropped from analysis_tus" >&2
+  fail=1
+}
+has src/core/z.cpp || {
+  echo "FAIL: C++ includer dropped from analysis_tus" >&2
+  fail=1
+}
+# The cap still bounds each tree: seven src/ C includers, at most five chosen.
+src_c=0
+for t in "${tus[@]}"; do
+  [[ "$t" == src/*.c ]] && src_c=$((src_c + 1))
+done
+if [[ $src_c -ne 5 ]]; then
+  echo "FAIL: expected 5 src/ C includers under the cap, got $src_c" >&2
+  fail=1
+fi
+has src/core/unrelated.c && {
+  echo "FAIL: non-includer listed in analysis_tus" >&2
+  fail=1
+}
+
+if [[ $fail -ne 0 ]]; then
+  printf 'analysis_tus:\n%s\n' "${tus[@]}" >&2
+  exit 1
+fi
+echo "PASS: header expansion samples every tree under the per-language cap"

--- a/tools/ci_changed_files.sh
+++ b/tools/ci_changed_files.sh
@@ -116,33 +116,45 @@ escape_rg() {
   printf '%s' "$1" | sed -e 's/[][(){}.^$*+?|\\]/\\&/g'
 }
 
+# Expand a changed header to the translation units that include it directly,
+# sampled per language and per top-level tree (src, apps, tests, examples) so
+# each tree contributes up to MAX_TUS_PER_HEADER_PER_LANGUAGE files. A single
+# alphabetical cut across the whole repository let the first five src/ includers
+# fill the quota, and a verdict that only renders in a tests/ TU (IWYU judges a
+# header by the includer it is analysed from) then surfaced on main after the
+# merge (#471, the IWYU failure on main after the merge).
+HEADER_INCLUDER_ROOTS=(src apps tests examples)
+
 collect_header_includers() {
   local pattern="$1"
-  local c_file=""
-  local cxx_file=""
-  local c_matches=()
-  local cxx_matches=()
+  local root=""
+  local f=""
+  local matches=()
 
-  mapfile -t c_matches < <(
-    rg -l --glob '!src/third_party/**' \
-      -g'*.c' \
-      "$pattern" src apps tests examples 2> /dev/null |
-      sort |
-      head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
-  )
-  mapfile -t cxx_matches < <(
-    rg -l --glob '!src/third_party/**' \
-      -g'*.cc' -g'*.cpp' -g'*.cxx' \
-      "$pattern" src apps tests examples 2> /dev/null |
-      sort |
-      head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
-  )
-
-  for c_file in "${c_matches[@]}"; do
-    printf '%s\n' "$c_file"
-  done
-  for cxx_file in "${cxx_matches[@]}"; do
-    printf '%s\n' "$cxx_file"
+  for root in "${HEADER_INCLUDER_ROOTS[@]}"; do
+    if [[ ! -d "$root" ]]; then
+      continue
+    fi
+    mapfile -t matches < <(
+      rg -l --glob '!src/third_party/**' \
+        -g'*.c' \
+        "$pattern" "$root" 2> /dev/null |
+        sort |
+        head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
+    )
+    for f in "${matches[@]}"; do
+      printf '%s\n' "$f"
+    done
+    mapfile -t matches < <(
+      rg -l --glob '!src/third_party/**' \
+        -g'*.cc' -g'*.cpp' -g'*.cxx' \
+        "$pattern" "$root" 2> /dev/null |
+        sort |
+        head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
+    )
+    for f in "${matches[@]}"; do
+      printf '%s\n' "$f"
+    done
   done
 }
 


### PR DESCRIPTION
## Summary

- The main push after #471 merged failed the full-tree IWYU run (run 33808789416) while the identical tree had passed on the PR (run 33807855781). No code delta: the merge was a fast-forward of the PR head. The PR run analysed 61 TUs, the push run 822, and the one verdict lives in a TU the PR never sampled.
- `include/dsd-neo/core/csv_import.h` re-typedef'd `struct p25_bandplan_row` locally. IWYU holds the file that typedefs a struct responsible for its full definition whenever the analysed TU also sees the complete type, and `tests/ui/test_ui_cmd_actions.c` does. Replaced the typedef with the bare `struct p25_bandplan_row;` forward declaration the sibling headers already use (`engine/trunk_scan.h`, `csv_parse_internal.h`) and take `const struct p25_bandplan_row*` in the export signature, rather than pulling `state.h` into a public core header.
- Why the PR missed it: `tools/ci_changed_files.sh` expanded a changed header to the first five includers of the whole repository in sort order per language, so any header with five or more `src/` includers never sampled a `tests/` TU. The cap now applies per top-level tree (`src`, `apps`, `tests`, `examples`), so every tree that includes the header contributes up to five TUs. On #471's diff that expands to 105 TUs instead of 61; all of them pass `tools/iwyu.sh --strict` locally.
- New `TOOLS_CI_CHANGED_FILES_HEADER_EXPANSION` builds a throwaway repository in which `src/` alone overflows the cap and checks that the `tests/`, `apps/` and C++ includers still land in `analysis_tus.txt` while the cap still bounds `src/`. It fails against the previous sampler.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. (Solo maintainer; header change is a forward-declaration swap, CI change is covered by the new test.)
- [x] High-risk areas touched are marked: none (a public header's forward declaration and the PR changed-files targeting script; no workflow permissions touched).
- [x] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests. (CI targeting change has a bash regression test.)
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. (None added.)
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (601/601)
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes (not high-risk)
- [x] `tools/cmake_format_check.sh` for CMake changes
- [ ] `tools/zizmor.sh` for workflow changes (no workflow edit)
- [ ] `tools/osv_scan.sh` for dependency input changes (n/a)
- [ ] pin/redaction checks (n/a, run inside preflight)
- [x] `tools/iwyu.sh --strict -- tests/ui/test_ui_cmd_actions.c` reproduces the main failure before the change and passes after; the same over all 105 TUs the new sampler selects for #471's diff: `analyzed=89 suggested=0 fatal=0`.

## Risk

- Security/dependency impact: none.
- CLI/UI behavior impact: none; the header change is a declaration form only, every includer that names `p25_bandplan_row_t` already gets it from `state.h`.
- Compatibility or packaging impact: PR static-analysis jobs analyse more TUs when a widely included header changes (bounded at 5 per tree per language, so at most 40 per header instead of 10).
