### PR TITLE
fix(tools): run GCC's analyzer instead of skipping it (#474)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -597,10 +597,12 @@ lane_iwyu() {
 
 # shellcheck disable=SC2329 # Started through runner_spawn.
 lane_fanalyzer() {
-  if command -v gcc > /dev/null 2>&1 && command -v g++ > /dev/null 2>&1; then
+  # gcc alone: the analyzer covers C only, so the script no longer calls g++, and
+  # a host that builds C++ with clang should not lose the analysis over it.
+  if command -v gcc > /dev/null 2>&1; then
     run_check "GCC fanalyzer strict (${tu_count} TU(s), ${jobs_fanalyzer} worker(s))" tools/gcc_fanalyzer.sh --strict --jobs "$jobs_fanalyzer" -- "${analysis_tus[@]}"
   else
-    mark_missing_tool "gcc/g++" "GCC fanalyzer analysis"
+    mark_missing_tool "gcc" "GCC fanalyzer analysis"
   fi
 }
 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,8 @@ Quick examples
   - `tools/clang_tidy.sh` (promotes broad bugprone/performance/portability findings; targeted TUs supported).
   - `tools/cppcheck.sh` (use `--strict` for broader checks).
   - `tools/iwyu.sh` (include hygiene via include-what-you-use; excludes `src/third_party`).
-  - `tools/gcc_fanalyzer.sh` (GCC `-fanalyzer` path-sensitive diagnostics; excludes `src/third_party`).
+  - `tools/gcc_fanalyzer.sh` (GCC `-fanalyzer` path-sensitive diagnostics; C translation units only, excludes
+    `src/third_party`).
   - `tools/scan_build.sh` (Clang Static Analyzer via `scan-build`, heavier full-build pass; excludes `src/third_party`; supports repeatable `--cmake-arg` passthrough).
   - `tools/semgrep.sh` (additional SAST and project guardrail rules; use `--strict` to fail on findings; excludes `src/third_party`).
   - `tools/shell_lint.sh` (ShellCheck plus `shfmt -d` for shell scripts and hooks).

--- a/docs/code-quality-guardrails.md
+++ b/docs/code-quality-guardrails.md
@@ -55,6 +55,27 @@ to the verdict, and a change to any local check should use them rather than prin
   `runner_note_missing` instead). Either one makes the run report what it did not cover rather than "all checks passed",
   and is fatal under `DSD_HOOK_FAIL_ON_MISSING_TOOLS=1`, which `tools/quality_preflight.sh` sets.
 
+`tools/gcc_fanalyzer.sh` compiles each C translation unit with `-S -o /dev/null -fanalyzer`. Assembling is the point:
+`-fanalyzer` is an interprocedural pass that never runs under `-fsyntax-only`, which the script passed for as long as it
+existed, so the pre-push lane and the CI leg both reported a clean run over an empty analysis.
+`tests/tools/test_gcc_fanalyzer.sh` seeds a double free and fails if the script stops reporting or counting it.
+
+Two scope decisions keep that check worth reading:
+
+- **C only.** GCC's manual says the analyzer "is only suitable for use on C code in this release"; on C++ it walks
+  exception-unwind edges out of `extern "C"` callees that cannot throw and reports leaks no execution reaches. C++ units
+  are skipped, and the count is printed.
+- **`-Wanalyzer-null-dereference` is off.** `dsd_safe_memset_impl()` and its neighbours in `core/safe_api.h` compare
+  their destination against NULL, which teaches the analyzer that the caller's own pointer parameter may be NULL; every
+  `DSD_MEMSET(p, 0, sizeof *p)` followed by `p->field` then reads as a null dereference. That is how the project zeroes
+  a struct, so the class covered 91 reports and no reachable path.
+
+Every other analyzer diagnostic is fatal. Where the analyzer's model rather than the code is what fails, the suppression
+is a `#pragma GCC diagnostic ignored` guarded by `#if defined(__GNUC__) && !defined(__clang__)` at the site with its
+reason: the stderr and stdin capture helpers in tests, where `dup2()` returns a descriptor the process already owns and
+must not close, and `config_profile_free_context()`, where the analyzer loses the tie between `pctx->n` and the count
+that filled the array.
+
 The repository intentionally blocks or flags patterns that are easy to reintroduce during large edits:
 
 - Use the project safe API wrappers instead of raw C memory/string/formatting APIs in project-owned code.

--- a/src/protocol/dpmr/dpmr_voice.c
+++ b/src/protocol/dpmr/dpmr_voice.c
@@ -513,69 +513,16 @@ dpmr_crc7(const uint8_t* input, uint32_t bit_length) {
  * "Mapping of dialled strings to the AI address space" */
 void
 dpmr_convert_air_interface_id(uint32_t ai_id, char id[8]) {
+    /* Place values from the standard's mapping table: the leading digits are
+     * decimal-spaced and the trailing ones base-11, which is what lets a dialled
+     * '*' ride in the same address space as the digits. */
+    static const uint32_t k_place_value[7] = {1464100U, 146410U, 14641U, 1331U, 121U, 11U, 1U};
     uint32_t remaining = ai_id;
-    uint32_t digit;
 
-    /* 1st digit */
-    digit = remaining / 1464100;
-    remaining = remaining % 1464100;
-    if (digit == 10) {
-        id[0] = '*';
-    } else {
-        id[0] = digit + '0';
-    }
-
-    /* 2nd digit */
-    digit = remaining / 146410;
-    remaining = remaining % 146410;
-    if (digit == 10) {
-        id[1] = '*';
-    } else {
-        id[1] = digit + '0';
-    }
-
-    /* 3rd digit */
-    digit = remaining / 14641;
-    remaining = remaining % 14641;
-    if (digit == 10) {
-        id[2] = '*';
-    } else {
-        id[2] = digit + '0';
-    }
-
-    /* 4th digit */
-    digit = remaining / 1331;
-    remaining = remaining % 1331;
-    if (digit == 10) {
-        id[3] = '*';
-    } else {
-        id[3] = digit + '0';
-    }
-
-    /* 5th digit */
-    digit = remaining / 121;
-    remaining = remaining % 121;
-    if (digit == 10) {
-        id[4] = '*';
-    } else {
-        id[4] = digit + '0';
-    }
-
-    /* 6th digit */
-    digit = remaining / 11;
-    remaining = remaining % 11;
-    if (digit == 10) {
-        id[5] = '*';
-    } else {
-        id[5] = digit + '0';
-    }
-
-    /* 7th digit */
-    digit = remaining;
-    if (digit == 10) {
-        id[6] = '*';
-    } else {
-        id[6] = digit + '0';
+    for (size_t i = 0U; i < 7U; i++) {
+        const uint32_t digit = remaining / k_place_value[i];
+        remaining = remaining % k_place_value[i];
+        id[i] = (digit == 10U) ? '*' : (char)(digit + '0');
     }
 
     /* Add the "end of string" */

--- a/src/runtime/radioreference/rr_generate.c
+++ b/src/runtime/radioreference/rr_generate.c
@@ -94,15 +94,16 @@ typedef struct {
 } rr_text;
 
 /**
- * @brief Append a string, growing the buffer by doubling.
+ * @brief Append a counted string, growing the buffer by doubling.
  *
  * A failure is sticky: later appends become no-ops and the caller checks once.
  *
- * @param text Buffer.
- * @param add  String to append.
+ * @param text    Buffer.
+ * @param add     Bytes to append.
+ * @param add_len Length of @p add, not counting the terminator.
  */
 static void
-rr_text_add(rr_text* text, const char* add) {
+rr_text_add_n(rr_text* text, const char* add, size_t add_len) {
     if (text->failed) {
         return;
     }
@@ -111,7 +112,6 @@ rr_text_add(rr_text* text, const char* add) {
         return;
     }
 
-    const size_t add_len = strlen(add);
     const size_t needed = text->len + add_len + 1U;
     if (needed > text->cap) {
         size_t next = (text->cap == 0U) ? 1024U : text->cap;
@@ -134,6 +134,24 @@ rr_text_add(rr_text* text, const char* add) {
     DSD_MEMCPY(text->data + text->len, add, add_len);
     text->len += add_len;
     text->data[text->len] = '\0';
+}
+
+/**
+ * @brief Append a NUL-terminated string.
+ *
+ * @param text Buffer.
+ * @param add  String to append.
+ */
+static void
+rr_text_add(rr_text* text, const char* add) {
+    if (text->failed) {
+        return;
+    }
+    if (add == NULL) {
+        text->failed = 1;
+        return;
+    }
+    rr_text_add_n(text, add, strlen(add));
 }
 
 /**
@@ -170,7 +188,7 @@ rr_text_chan_row(rr_text* text, long chan, long long freq_hz, const char* note) 
         text->failed = 1;
         return;
     }
-    rr_text_add(text, line);
+    rr_text_add_n(text, line, (size_t)written);
 }
 
 /**
@@ -1382,7 +1400,7 @@ rr_text_group_row(rr_text* text, const dsd_rr_talkgroup* talkgroup, const char* 
         text->failed = 1;
         return;
     }
-    rr_text_add(text, line);
+    rr_text_add_n(text, line, (size_t)written);
 }
 
 /** What a group-CSV pass did, so the warnings can be worded once at the end. */

--- a/src/ui/terminal/menu_actions.c
+++ b/src/ui/terminal/menu_actions.c
@@ -145,10 +145,12 @@ config_profile_copy_source_path(const UiCtx* c, char* path, size_t path_size) {
     return 1;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 10
 /* GCC's analyzer loses the tie between pctx->n and the count that filled
  * pctx->names, so it walks a path where the names were allocated but this loop
- * runs zero times and reports them as leaked. */
+ * runs zero times and reports them as leaked.
+ * The analyzer arrived in GCC 10; before that the option below is unknown,
+ * which -Werror turns into a build failure. */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
 #endif
@@ -166,7 +168,7 @@ config_profile_free_context(ProfileSelCtx* pctx) {
     free((void*)pctx->names);
     free(pctx);
 }
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 10
 #pragma GCC diagnostic pop
 #endif
 

--- a/src/ui/terminal/menu_actions.c
+++ b/src/ui/terminal/menu_actions.c
@@ -145,6 +145,13 @@ config_profile_copy_source_path(const UiCtx* c, char* path, size_t path_size) {
     return 1;
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
+/* GCC's analyzer loses the tie between pctx->n and the count that filled
+ * pctx->names, so it walks a path where the names were allocated but this loop
+ * runs zero times and reports them as leaked. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-malloc-leak"
+#endif
 static void
 config_profile_free_context(ProfileSelCtx* pctx) {
     if (!pctx) {
@@ -159,6 +166,9 @@ config_profile_free_context(ProfileSelCtx* pctx) {
     free((void*)pctx->names);
     free(pctx);
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 static ProfileSelCtx*
 config_profile_create_context(dsd_state* state, const char* path, const char** names, int count) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,9 +33,11 @@ target_include_directories(
 target_link_libraries(dsd-neo_test_support INTERFACE dsd-neo_platform)
 
 # Shell tools under tools/ run CI on our behalf; the ones with retry or give-up
-# logic get a bash-driven test that fakes the program they wrap. Bash only: the
-# scripts themselves are bash, so nothing is lost by skipping them where it is
-# missing.
+# logic get a bash-driven test that fakes the program they wrap, and
+# gcc_fanalyzer.sh one that drives the real compiler over a seeded defect, since
+# its failure mode was reporting a clean run over an empty analysis. Bash only:
+# the scripts themselves are bash, so nothing is lost by skipping them where it
+# is missing.
 if(NOT WIN32)
     find_program(DSD_NEO_BASH_EXECUTABLE bash)
     if(DSD_NEO_BASH_EXECUTABLE)
@@ -58,6 +60,13 @@ if(NOT WIN32)
             COMMAND
                 ${DSD_NEO_BASH_EXECUTABLE}
                 ${PROJECT_SOURCE_DIR}/tests/tools/test_check_runner.sh
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        )
+        add_test(
+            NAME TOOLS_GCC_FANALYZER
+            COMMAND
+                ${DSD_NEO_BASH_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/tests/tools/test_gcc_fanalyzer.sh
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         )
     endif()

--- a/tests/core/test_core_frame_log.c
+++ b/tests/core/test_core_frame_log.c
@@ -275,6 +275,13 @@ stderr_capture_init(stderr_capture_t* capture) {
     capture->redirected = 0;
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
+/* dup2() returns the descriptor it wrote onto - here stderr, which the process
+ * already owns and must not close - but GCC's analyzer models the return as a
+ * freshly opened descriptor and reports the redirect as a leak. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-fd-leak"
+#endif
 static int
 stderr_capture_begin(stderr_capture_t* capture, const char** failure, int* saved_errno) {
     capture->stream = tmpfile();
@@ -297,6 +304,9 @@ stderr_capture_begin(stderr_capture_t* capture, const char** failure, int* saved
     capture->redirected = 1;
     return 0;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 static int
 stderr_capture_read(stderr_capture_t* capture, char* buf, size_t buf_size, const char** failure, int* saved_errno) {

--- a/tests/core/test_core_frame_log.c
+++ b/tests/core/test_core_frame_log.c
@@ -275,10 +275,12 @@ stderr_capture_init(stderr_capture_t* capture) {
     capture->redirected = 0;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
 /* dup2() returns the descriptor it wrote onto - here stderr, which the process
  * already owns and must not close - but GCC's analyzer models the return as a
- * freshly opened descriptor and reports the redirect as a leak. */
+ * freshly opened descriptor and reports the redirect as a leak. GCC 13 is
+ * where that check got its name: an older gcc rejects the option below as
+ * unknown, which -Werror turns into a build failure. */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wanalyzer-fd-leak"
 #endif
@@ -304,7 +306,7 @@ stderr_capture_begin(stderr_capture_t* capture, const char** failure, int* saved
     capture->redirected = 1;
     return 0;
 }
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
 #pragma GCC diagnostic pop
 #endif
 

--- a/tests/core/test_core_hytera_bp_silence.c
+++ b/tests/core/test_core_hytera_bp_silence.c
@@ -57,7 +57,7 @@ test_silence_detection(const char silence[49]) {
 
     rc |= expect_eq_int("silence-detected", dmr_ambe49_is_default_silence(silence), 1);
 
-    char not_silence[49];
+    char not_silence[49] = {0};
     DSD_MEMCPY(not_silence, silence, sizeof(not_silence));
     not_silence[48] ^= 1;
     rc |= expect_eq_int("silence-rejected", dmr_ambe49_is_default_silence(not_silence), 0);
@@ -104,8 +104,8 @@ test_voice_stream_aes_keystream(void) {
 static int
 test_voice_stream_silence_skip(const char silence[49]) {
     uint8_t ks_bits[128] = {1};
-    char frame[49];
-    char original[49];
+    char frame[49] = {0};
+    char original[49] = {0};
     DSD_MEMCPY(frame, silence, sizeof(frame));
     DSD_MEMCPY(original, silence, sizeof(original));
 
@@ -153,8 +153,8 @@ test_basic_privacy_rejects_invalid_keys(void) {
 static int
 test_hytera_bp_silence_skip(const char silence[49]) {
     int rc = 0;
-    char frame[49];
-    char original[49];
+    char frame[49] = {0};
+    char original[49] = {0};
     DSD_MEMCPY(frame, silence, sizeof(frame));
     DSD_MEMCPY(original, silence, sizeof(original));
     int frame_counter = 0;

--- a/tests/protocol/nxdn/test_nxdn_crc32_bits.c
+++ b/tests/protocol/nxdn/test_nxdn_crc32_bits.c
@@ -142,7 +142,7 @@ expect_label(const char* tag, uint8_t message_type, const char* want) {
         DSD_FPRINTF(stderr, "%s: got %s want %s\n", tag, got == NULL ? "(null)" : got, want == NULL ? "(null)" : want);
         return 1;
     }
-    if (got != NULL && strcmp(got, want) != 0) {
+    if (got != NULL && want != NULL && strcmp(got, want) != 0) {
         DSD_FPRINTF(stderr, "%s: got '%s' want '%s'\n", tag, got, want);
         return 1;
     }

--- a/tests/protocol/p25/test_p25_lcw_src_zero_guard.c
+++ b/tests/protocol/p25/test_p25_lcw_src_zero_guard.c
@@ -161,10 +161,12 @@ expect_contains(const char* tag, const char* text, const char* needle) {
     return 0;
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
 /* dup2() returns the descriptor it wrote onto - one the process already owns
  * and must not close - but GCC's analyzer models the return as a freshly opened
- * descriptor and reports the redirect as a leak. */
+ * descriptor and reports the redirect as a leak. GCC 13 is
+ * where that check got its name: an older gcc rejects the option below as
+ * unknown, which -Werror turns into a build failure. */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wanalyzer-fd-leak"
 #endif
@@ -212,7 +214,7 @@ capture_lcw_output(dsd_opts* opts, dsd_state* st, uint8_t lcw[96], char* out, si
     (void)fclose(capture);
     return 0;
 }
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
 #pragma GCC diagnostic pop
 #endif
 

--- a/tests/protocol/p25/test_p25_lcw_src_zero_guard.c
+++ b/tests/protocol/p25/test_p25_lcw_src_zero_guard.c
@@ -161,6 +161,13 @@ expect_contains(const char* tag, const char* text, const char* needle) {
     return 0;
 }
 
+#if defined(__GNUC__) && !defined(__clang__)
+/* dup2() returns the descriptor it wrote onto - one the process already owns
+ * and must not close - but GCC's analyzer models the return as a freshly opened
+ * descriptor and reports the redirect as a leak. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-fd-leak"
+#endif
 static int
 capture_lcw_output(dsd_opts* opts, dsd_state* st, uint8_t lcw[96], char* out, size_t out_sz) {
     if (!out || out_sz == 0) {
@@ -205,6 +212,9 @@ capture_lcw_output(dsd_opts* opts, dsd_state* st, uint8_t lcw[96], char* out, si
     (void)fclose(capture);
     return 0;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 static void
 reset_lcw_state(dsd_state* state) {

--- a/tests/runtime/test_runtime_bootstrap_audio.c
+++ b/tests/runtime/test_runtime_bootstrap_audio.c
@@ -88,6 +88,13 @@ reset_devices(void) {
 #if !defined(_WIN32)
 typedef void (*bootstrap_audio_fn)(dsd_opts* opts);
 
+#if defined(__GNUC__) && !defined(__clang__)
+/* dup2() returns the descriptor it wrote onto - one the process already owns
+ * and must not close - but GCC's analyzer models the return as a freshly opened
+ * descriptor and reports the redirect as a leak. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wanalyzer-fd-leak"
+#endif
 static int
 with_stdin_text(const char* text, bootstrap_audio_fn fn, dsd_opts* opts) {
     int rc = 0;
@@ -150,6 +157,9 @@ with_stdin_text(const char* text, bootstrap_audio_fn fn, dsd_opts* opts) {
     fclose(f);
     return rc;
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 static int
 test_output_selection_defaults_and_clamps(void) {

--- a/tests/runtime/test_runtime_bootstrap_audio.c
+++ b/tests/runtime/test_runtime_bootstrap_audio.c
@@ -88,10 +88,12 @@ reset_devices(void) {
 #if !defined(_WIN32)
 typedef void (*bootstrap_audio_fn)(dsd_opts* opts);
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
 /* dup2() returns the descriptor it wrote onto - one the process already owns
  * and must not close - but GCC's analyzer models the return as a freshly opened
- * descriptor and reports the redirect as a leak. */
+ * descriptor and reports the redirect as a leak. GCC 13 is
+ * where that check got its name: an older gcc rejects the option below as
+ * unknown, which -Werror turns into a build failure. */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wanalyzer-fd-leak"
 #endif
@@ -157,7 +159,7 @@ with_stdin_text(const char* text, bootstrap_audio_fn fn, dsd_opts* opts) {
     fclose(f);
     return rc;
 }
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 13
 #pragma GCC diagnostic pop
 #endif
 

--- a/tests/tools/test_gcc_fanalyzer.sh
+++ b/tests/tools/test_gcc_fanalyzer.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+#
+# tools/gcc_fanalyzer.sh passed -fsyntax-only for as long as it existed. GCC's
+# analyzer is an IPA pass and never runs under that flag, so the pre-push lane
+# and the CI leg reported a clean run over an empty analysis, and the verdict
+# regex separately missed the [-Werror=analyzer-...] spelling that --strict
+# produces. Both failures are silent by nature - the script exits 0 and prints a
+# summary - so the cases here drive the real script over a throwaway compilation
+# database and check that a seeded defect is actually reported and counted.
+set -euo pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
+if ! command -v gcc > /dev/null 2>&1 || ! command -v python3 > /dev/null 2>&1; then
+  echo "SKIP: gcc or python3 not available"
+  exit 0
+fi
+if ! gcc -fanalyzer -S -o /dev/null -x c /dev/null > /dev/null 2>&1; then
+  echo "SKIP: this gcc does not support -fanalyzer"
+  exit 0
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+REPO="$WORK/repo"
+mkdir -p "$REPO/tools/lib"
+git -C "$REPO" init -q
+# The script resolves its root with git and sources the worker-sizing library
+# from there, so the throwaway repository needs its own copy.
+cp "$ROOT_DIR/tools/lib/jobs.sh" "$REPO/tools/lib/jobs.sh"
+
+failures=0
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+# A double free the analyzer reports, and nothing an ordinary -Wall -Wextra
+# -Wpedantic -Werror build would object to: --strict adds those, and a case that
+# failed on a plain warning would prove nothing about the analyzer.
+cat > "$REPO/seeded.c" << 'EOF'
+#include <stdlib.h>
+
+void seeded_double_free(void);
+
+void
+seeded_double_free(void) {
+    char* p = (char*)malloc(16);
+    if (p == NULL) {
+        return;
+    }
+    free(p);
+    free(p);
+}
+EOF
+
+cat > "$REPO/clean.c" << 'EOF'
+#include <stddef.h>
+
+void clean_add(int* out, int a, int b);
+
+void
+clean_add(int* out, int a, int b) {
+    if (out != NULL) {
+        *out = a + b;
+    }
+}
+EOF
+
+# Leaks as plainly as seeded.c does: if C++ units ever stop being skipped, this
+# case fails rather than quietly starting to analyze what GCC does not support.
+cat > "$REPO/unit.cpp" << 'EOF'
+#include <stdlib.h>
+
+void cxx_leak();
+
+void
+cxx_leak() {
+    char* p = (char*)malloc(16);
+    (void)p;
+}
+EOF
+
+cat > "$REPO/compile_commands.json" << EOF
+[
+  {"directory": "$REPO", "command": "gcc -c seeded.c -o seeded.o", "file": "seeded.c"},
+  {"directory": "$REPO", "command": "gcc -c clean.c -o clean.o", "file": "clean.c"},
+  {"directory": "$REPO", "command": "g++ -c unit.cpp -o unit.o", "file": "unit.cpp"}
+]
+EOF
+
+# run_case NAME ARGS...: run the script inside the throwaway repository, leaving
+# the exit status in rc and the output in $WORK/NAME.out.
+rc=0
+run_case() {
+  local name="$1"
+  shift
+  rc=0
+  (cd "$REPO" && "$ROOT_DIR/tools/gcc_fanalyzer.sh" "$@") > "$WORK/${name}.out" 2>&1 || rc=$?
+}
+
+# A seeded defect fails the run and is named in the output. Under -fsyntax-only
+# this case passed with an empty analysis.
+run_case seeded -- seeded.c
+if [[ $rc -eq 0 ]]; then
+  fail "a seeded double free did not fail the run"
+fi
+if ! grep -q -- "-Wanalyzer-double-free" "$WORK/seeded.out"; then
+  fail "the double free was not reported"
+fi
+if ! grep -q "analyzer_diagnostics=1" "$WORK/seeded.out"; then
+  fail "the summary did not count the diagnostic"
+  cat "$WORK/seeded.out" >&2
+fi
+
+# --strict is how the pre-push hook and CI run it, and -Werror renames every
+# diagnostic to [-Werror=analyzer-...]; the count has to survive that.
+run_case strict --strict -- seeded.c
+if [[ $rc -eq 0 ]]; then
+  fail "--strict did not fail on a seeded double free"
+fi
+if ! grep -q "analyzer_diagnostics=1" "$WORK/strict.out"; then
+  fail "--strict did not count the diagnostic"
+  cat "$WORK/strict.out" >&2
+fi
+
+# A clean unit still passes, so the cases above are not failing on the setup.
+run_case clean --strict -- clean.c
+if [[ $rc -ne 0 ]]; then
+  fail "a clean translation unit failed the run"
+  cat "$WORK/clean.out" >&2
+fi
+
+# GCC supports the analyzer on C only, so C++ units are skipped - and a skip of
+# something the caller asked for reaches the pre-push gate as a NOTE line rather
+# than passing quietly.
+run_case cxx --strict -- unit.cpp
+if [[ $rc -ne 0 ]]; then
+  fail "a C++ translation unit was not skipped"
+  cat "$WORK/cxx.out" >&2
+fi
+if ! grep -q "gcc-fanalyzer: NOTE: 1 requested C++ translation unit(s) were not analyzed" "$WORK/cxx.out"; then
+  fail "the skipped C++ unit was not noted for the gate"
+  cat "$WORK/cxx.out" >&2
+fi
+if ! grep -q "gcc-fanalyzer: NOTE: .*unit\.cpp" "$WORK/cxx.out"; then
+  fail "the note did not name the skipped unit"
+fi
+
+if [[ $failures -ne 0 ]]; then
+  echo "TOOLS_GCC_FANALYZER: $failures failure(s)" >&2
+  exit 1
+fi
+echo "TOOLS_GCC_FANALYZER: OK"

--- a/tests/tools/test_gcc_fanalyzer.sh
+++ b/tests/tools/test_gcc_fanalyzer.sh
@@ -111,7 +111,9 @@ fi
 if ! grep -q -- "-Wanalyzer-double-free" "$WORK/seeded.out"; then
   fail "the double free was not reported"
 fi
-if ! grep -q "analyzer_diagnostics=1" "$WORK/seeded.out"; then
+# A count, not exactly one: which diagnostics a given GCC reports for the same
+# defect is its business, and the check is that they were counted at all.
+if ! grep -qE "analyzer_diagnostics=[1-9]" "$WORK/seeded.out"; then
   fail "the summary did not count the diagnostic"
   cat "$WORK/seeded.out" >&2
 fi
@@ -122,7 +124,7 @@ run_case strict --strict -- seeded.c
 if [[ $rc -eq 0 ]]; then
   fail "--strict did not fail on a seeded double free"
 fi
-if ! grep -q "analyzer_diagnostics=1" "$WORK/strict.out"; then
+if ! grep -qE "analyzer_diagnostics=[1-9]" "$WORK/strict.out"; then
   fail "--strict did not count the diagnostic"
   cat "$WORK/strict.out" >&2
 fi

--- a/tools/gcc_fanalyzer.sh
+++ b/tools/gcc_fanalyzer.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Run GCC's static analyzer (-fanalyzer) using compile_commands.json.
 # - Supports targeted translation units
-# - Excludes build/ and src/third_party/
+# - Excludes build/, src/third_party/ and C++ translation units
 # - By default, fails on analyzer diagnostics or compiler errors
 
 ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
@@ -22,7 +22,8 @@ Options:
 Arguments:
   files...        Optional list of translation units to analyze (e.g., src/foo.c).
                   When omitted, analyzes all translation units in the compilation
-                  database after filtering.
+                  database after filtering. C++ units are skipped: GCC supports
+                  the analyzer on C only.
 USAGE
 }
 
@@ -72,10 +73,6 @@ done
 
 if ! command -v gcc > /dev/null 2>&1; then
   echo "gcc not found. Please install GCC." >&2
-  exit 1
-fi
-if ! command -v g++ > /dev/null 2>&1; then
-  echo "g++ not found. Please install G++." >&2
   exit 1
 fi
 if ! command -v python3 > /dev/null 2>&1; then
@@ -190,8 +187,16 @@ def score_entry(entry):
     return score
 
 
+C_SUFFIXES = {".c"}
+CXX_SUFFIXES = {".cc", ".cpp", ".cxx"}
+
+
 def is_translation_unit(path):
-    return pathlib.Path(path).suffix.lower() in {".c", ".cc", ".cpp", ".cxx"}
+    return pathlib.Path(path).suffix.lower() in (C_SUFFIXES | CXX_SUFFIXES)
+
+
+def is_c_translation_unit(path):
+    return pathlib.Path(path).suffix.lower() in C_SUFFIXES
 
 
 entries_by_rel = {}
@@ -247,6 +252,24 @@ if requested:
             print(f"  {p}")
     selected_rel = sorted(p for p in requested_tus if p in entries_by_rel)
 
+# GCC manual, -fanalyzer: "The analyzer is only suitable for use on C code in
+# this release." On C++ it walks exception-unwind edges out of extern "C"
+# callees that cannot throw, and reports leaks on paths no execution reaches.
+skipped_cxx = [p for p in selected_rel if not is_c_translation_unit(p)]
+selected_rel = [p for p in selected_rel if is_c_translation_unit(p)]
+if skipped_cxx and requested:
+    # Asked for these and did not analyze them, so it goes to the gate as a note.
+    # The names stay on the marked line: the runner drops continuation lines.
+    shown = ", ".join(skipped_cxx[:5])
+    if len(skipped_cxx) > 5:
+        shown += f", and {len(skipped_cxx) - 5} more"
+    print(
+        f"gcc-fanalyzer: NOTE: {len(skipped_cxx)} requested C++ translation unit(s) were not "
+        f"analyzed (GCC supports -fanalyzer on C only): {shown}"
+    )
+elif skipped_cxx:
+    print(f"Skipping {len(skipped_cxx)} C++ translation unit(s): GCC analyzes C only.")
+
 if not selected_rel:
     print("No translation units selected for GCC analyzer.")
     raise SystemExit(0)
@@ -266,9 +289,12 @@ print(
     f"(strict={'yes' if strict else 'no'}, jobs={jobs})..."
 )
 
-analyzer_diag = re.compile(r"\[-Wanalyzer-[^]]+\]")
-compiler_error = re.compile(r"(^|\\s)error:", re.IGNORECASE)
-compiler_warning = re.compile(r"(^|\\s)warning:", re.IGNORECASE)
+# --strict adds -Werror, so GCC spells these [-Werror=analyzer-...] instead.
+analyzer_diag = re.compile(r"\[-W(?:error=)?analyzer-[^]]+\]")
+# Anchored on the "file:line:col: error:" / "cc1: error:" prefix, so a source
+# line quoted inside an analyzer trace cannot pass for a diagnostic of its own.
+compiler_error = re.compile(r"^\S+: (?:fatal )?error:", re.MULTILINE)
+compiler_warning = re.compile(r"^\S+: warning:", re.MULTILINE)
 
 
 def transform_command(rel, entry):
@@ -281,9 +307,10 @@ def transform_command(rel, entry):
     if pathlib.Path(cmd[0]).name in {"ccache", "sccache"} and len(cmd) > 1:
         compiler_index = 1
 
+    # Only C units reach this point, so the driver is always gcc.
     suffix = pathlib.Path(rel).suffix.lower()
-    desired_compiler = "gcc" if suffix == ".c" else "g++"
-    cmd[compiler_index] = desired_compiler
+    cmd[compiler_index] = "gcc"
+
 
     filtered = []
     skip_next = False
@@ -298,7 +325,17 @@ def transform_command(rel, entry):
             continue
         filtered.append(token)
 
-    filtered.extend(["-fsyntax-only", "-fanalyzer", "-fdiagnostics-color=never"])
+    # -fanalyzer is an IPA pass and never runs under -fsyntax-only, which is how
+    # this script came to analyze nothing at all. Assembling to /dev/null keeps
+    # the run cheap and gives the pass a function body to walk.
+    filtered.extend(["-S", "-o", os.devnull, "-fanalyzer", "-fdiagnostics-color=never"])
+    # dsd_safe_memset_impl() and its neighbours in core/safe_api.h compare their
+    # destination against NULL, which teaches the analyzer that the caller's own
+    # pointer parameter may be NULL; every DSD_MEMSET(p, 0, sizeof *p) followed by
+    # p->field then reads as a null dereference. Zeroing a struct that way is the
+    # project convention, so the class costs 91 reports here and has never
+    # covered a reachable path.
+    filtered.append("-Wno-analyzer-null-dereference")
     if strict:
         strict_warnings = [
             "-Wall",

--- a/tools/shell_lint.sh
+++ b/tools/shell_lint.sh
@@ -78,7 +78,10 @@ set +e
 # separately.
 {
   echo "shellcheck files: ${#FILTERED[@]}"
-  shellcheck "${FILTERED[@]}"
+  # -x follows the `# shellcheck source=` directives. Without it a script is
+  # clean only while whatever it sources happens to be in the same file list, so
+  # changing one of these scripts alone failed the lint on SC1091.
+  shellcheck -x "${FILTERED[@]}"
 } 2>&1 | tee "$LOG_FILE"
 shellcheck_rc=${PIPESTATUS[0]}
 {


### PR DESCRIPTION
## Summary

- `tools/gcc_fanalyzer.sh` compiled with `-fsyntax-only`. GCC's analyzer is an interprocedural pass that never runs
  under that flag, so the pre-push lane and the CI `gcc-fanalyzer` leg have reported a clean run over an **empty
  analysis** for as long as they have existed — a seeded double free, leak and null dereference all pass. Assembling to
  `/dev/null` gives the pass a function body to walk: 708 C translation units, 12 s on 32 cores. Follow-up to #474,
  which found the no-op and left it out of scope.
- The verdict was wrong in the same direction. `--strict` adds `-Werror`, which renames every diagnostic to
  `[-Werror=analyzer-…]`, and the hit-count regex matched only `[-Wanalyzer-…]`; both callers pass `--strict`, so a
  failing run would have printed `analyzer_diagnostics=0` and only failed through the exit-code fallback. The
  compiler-error regex matched a literal backslash-s rather than whitespace, and is now anchored on the diagnostic
  prefix so a source line quoted inside an analyzer trace cannot pass for a diagnostic of its own.
- `tests/tools/test_gcc_fanalyzer.sh` drives the real script over a throwaway compilation database and fails if a
  seeded double free stops being reported or counted, or if a C++ unit is analyzed or skipped silently. It reports
  **six failures against the script as it stood**.

### What the analyzer actually found: no defects

Turned on, the tree produced 122 findings in 62 units. Every one is a modeling artifact, not a bug — each `src/` site
read individually, the test side sampled:

| Class | Count | Cause |
|---|---|---|
| `analyzer-null-dereference` | 91 | The project's own `DSD_MEMSET` |
| `analyzer-malloc-leak` | 17 | C++ exception-unwind paths; test-local allocations |
| uninitialized / out-of-bounds | 7 | The analyzer does not model `vsnprintf`'s writes |
| `analyzer-fd-leak` | 6 | `dup2()` save/restore in the test capture helpers |

The dominant class is structural and reduces to twenty lines: `dsd_safe_memset_impl()` compares its destination against
NULL, which teaches the analyzer that the *caller's* pointer parameter may be NULL, so every
`DSD_MEMSET(p, 0, sizeof *p)` followed by `p->field` reads as a null dereference. The same function with a plain
`__builtin_memset` reports nothing. That is how this project zeroes a struct, so the class is off, with the reason
recorded at the flag and in `docs/code-quality-guardrails.md`.

C++ units are skipped: GCC's manual says the analyzer "is only suitable for use on C code in this release", and on C++
it walks exception-unwind edges out of `extern "C"` callees that cannot throw. Skipping a unit the caller asked for
reaches the pre-push gate as a `: NOTE: ` line rather than passing quietly.

### The rest, fixed rather than suppressed

- `dpmr_convert_air_interface_id()` mapped seven digits with seven unrolled copies of the same divide-and-test — 128
  paths through a function that fills eight bytes, across which the analyzer loses the array's initialization state. A
  place-value table says the same thing in ten lines. **Checked against the old code over all 2^32 inputs: no
  difference.**
- `rr_text_chan_row()` and `rr_text_group_row()` formatted into a local buffer, validated the length `snprintf`
  returned, then handed `rr_text_add()` a pointer to measure again. Passing the validated length skips the second walk
  and stops the conjured `strlen()` from reading as a 128-byte over-read.
- `expect_label()` proved `want` non-NULL by comparing two NULL tests against each other; testing it where it is used
  says the same thing plainly. The silence-detection buffers are zeroed before the copy that fills them.
- Four sites keep a narrow `#pragma GCC diagnostic ignored` with its reason, guarded by
  `#if defined(__GNUC__) && !defined(__clang__)` because clang rejects the unknown warning name under `-Werror`: three
  stderr/stdin capture helpers where `dup2()` returns a descriptor the process already owns and must not close, and
  `config_profile_free_context()`, where the analyzer loses the tie between `pctx->n` and the count that filled it.

### Also here

`tools/shell_lint.sh` did not pass `-x`, so shellcheck followed a `# shellcheck source=` directive only while the
sourced file happened to be in the same batch. Changing `gcc_fanalyzer.sh`, `clang_tidy.sh` or `iwyu.sh` alone failed
the lane on SC1091 for a directive that was already there — which is exactly what this branch hit.

### Verification of the CI leg

The `gcc-fanalyzer` leg runs whole-tree on push to main and over the changed units on a PR. Reproduced end to end
inside the pinned `archlinux:base-devel` image the workflow uses (pinned mbelib-neo, `dev-debug` preset,
`tools/gcc_fanalyzer.sh --strict`): 708 analyzed, 0 diagnostics, exit 0. The new ctest case runs on `ubuntu-latest`
instead, so it was also run against the pinned `ubuntu:24.04` image (gcc 13.3.0) and passes; its diagnostic-count
assertion is deliberately not pinned to one number, since which diagnostics a given GCC reports for one seeded defect
is its business.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [x] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched are marked: security / workflow / release / parser / crypto / dependency / network input / none — none. Developer tooling, one protocol formatting helper proven equivalent exhaustively, and one CSV row append; no workflow changes.
- [ ] Outside review was requested when available, or unavailability is documented.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests — `tests/tools/test_gcc_fanalyzer.sh` covers the tool; the dPMR mapping is covered by the existing `DPMR_VOICE_BRIDGE` vectors plus the exhaustive 2^32 equivalence check, and the RadioReference rows by `RUNTIME_RR_*` and `UI_RR_WIZARD`.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny — the dPMR and RadioReference changes are behavior-preserving and were verified as above.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope — four site pragmas with their reason, plus one flag-level class whose cause is documented in `docs/code-quality-guardrails.md`.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — 604/604.
- [x] `tools/preflight_ci.sh` — clean.
- [x] `tools/quality_preflight.sh` for broad or high-risk changes — clean, including scan-build (142 s), gitleaks, OSV and the fuzz smoke pass.
- [x] `tools/cmake_format_check.sh` for CMake changes — clean (one test registration).
- [ ] `tools/zizmor.sh` for workflow changes — no workflow changes.
- [ ] `tools/osv_scan.sh` for dependency input changes — no dependency changes; run anyway by the quality preflight, clean.
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh` — run by the preflight, clean.

## Risk

- Security/dependency impact: none new. A guardrail that has never run starts running; `-Wanalyzer-null-dereference`
  is off by decision, with its evidence recorded, and the leak, double-free, use-after-free, fd and taint classes are
  now enforced for the first time.
- CLI/UI behavior impact: none. The dPMR identity mapping is exhaustively equivalent, the RadioReference rows are
  byte-for-byte the same, and `config_profile_free_context()` is unchanged apart from a comment and a pragma.
- Compatibility or packaging impact: none. The analyzer step costs about 12 s on 32 cores for the whole tree where it
  previously did nothing; `g++` is no longer required by the script, since it no longer analyzes C++.
