### PR TITLE
feat(core): add direct per-row scan keys (#382)

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -51,6 +51,9 @@ copy first. There are two copy paths, with different lifetimes:
   (`chan.csv` → `chan (2).csv`); updates stage a temp file and rename over the
   target so a half-copied CSV is never observable.
 
+Embedded `single_key_dec`/`single_key_hex` values in a channel map travel with that copied file and therefore work on
+Android. Referenced `keys_dec_csv`/`keys_hex_csv` companion files are not copied or path-rewritten automatically.
+
 Both are reached through `DecoderHost` virtuals (`importContentUri` /
 `importDocument`); the desktop default of `importDocument` implements the same
 semantics under `QStandardPaths::AppDataLocation`, which is what

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -468,7 +468,8 @@ Notes
     them learned over the air.
   - Optional per-target `modulation` and `rtl_gain` columns can override demod hints and RTL-family tuner gain for the
     active target. Optional `keys_hex_csv`/`keys_dec_csv` columns load a per-target key set, while
-    `single_key_dec`/`single_key_hex` embed `-b`/`-H` equivalents; leaving the target restores the global keys.
+    `single_key_dec`/`single_key_hex` embed `-b`/`-H` equivalents; a target cannot mix direct and file key sources.
+    Leaving the target restores the global keys.
   - Idle dwell: `--trunk-scan-dwell-ms <250..600000>` (default `3000`).
   - Conventional DMR/NXDN activity hold (both NXDN rates): `--trunk-scan-activity-hold-ms <250..600000>`
     (default `1200`).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -448,9 +448,10 @@ Notes
 - Conventional scan mode: `-Y` (not trunking; scans for sync on enabled decoders). For NXDN the hold is refreshed
   only by frames whose content passed a CRC, so an open squelch on an empty channel no longer parks the scan.
   A channel map with a `name` column (see `docs/csv-formats.md`) names the row being listened to in the Scan Mode
-  row, in Call Info, and on the event history rows recorded while it is tuned. A map with `keys_hex_csv`/`keys_dec_csv`
-  columns loads a per-row key set instead of the global keyring while that row is tuned; leaving `-Y` (scanner
-  toggle, trunk set, tuner release) hands the foreground keyring back to the global keys.
+  row, in Call Info, and on the event history rows recorded while it is tuned. A map can load a per-row key set from
+  `keys_hex_csv`/`keys_dec_csv`, or embed `-b`/`-H` equivalents in `single_key_dec`/`single_key_hex`; leaving `-Y`
+  (scanner toggle, trunk set, tuner release) hands the foreground keyring back to the global keys. A row may not mix
+  direct and file sources.
   While scanning, the terminal's Trunking menu and hotkeys hold the scan on the channel on air (`Y`), avoid it for the
   rest of the session (`b`), step to the next channel (`L`, skipping avoided rows) and clear all avoids; see
   `docs/ui-terminal.md`.
@@ -466,8 +467,8 @@ Notes
     are rejected in this mode. Targets that are sites of one P25 system (same WACN/SYS) share the band plan one of
     them learned over the air.
   - Optional per-target `modulation` and `rtl_gain` columns can override demod hints and RTL-family tuner gain for the
-    active target. Optional `keys_hex_csv`/`keys_dec_csv` columns load a per-target key set while the target is
-    parked; leaving the target restores the global keys.
+    active target. Optional `keys_hex_csv`/`keys_dec_csv` columns load a per-target key set, while
+    `single_key_dec`/`single_key_hex` embed `-b`/`-H` equivalents; leaving the target restores the global keys.
   - Idle dwell: `--trunk-scan-dwell-ms <250..600000>` (default `3000`).
   - Conventional DMR/NXDN activity hold (both NXDN rates): `--trunk-scan-activity-hold-ms <250..600000>`
     (default `1200`).

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -91,7 +91,7 @@ The one deliberate crossing is by provenance: when the parked target's WACN/SYS 
 snapshot holds a P25 IDEN entry learned on that same WACN/SYS, the coordinator copies it into an empty slot at
 trust 1 (`trunk_scan_share_peer_idens()`), and `dsd_engine_p25_bandplan_export()` in
 `src/engine/p25_bandplan_export.c` merges every target's tables into one band-plan CSV. The keyring is not snapshotted: each target instead carries a static
-`dsd_key_set` (`keys_hex_csv`/`keys_dec_csv` columns) that the switch installs through the scan key swap in
+`dsd_key_set` (key-file or direct-key columns) that the switch installs through the scan key swap in
 `<dsd-neo/core/key_set.h>`, restoring the globals on unkeyed targets and at shutdown without touching the key epoch.
 
 Tests: `tests/engine/test_engine_trunk_scan.c` (`ENGINE_TRUNK_SCAN`) and
@@ -128,8 +128,8 @@ Tests: `tests/engine/test_engine_trunk_scan.c` (`ENGINE_TRUNK_SCAN`) and
   frontend words it as a target or a channel and never names both at once. Those names come from a channel-map CSV
   that opts in with a `name` header column and live in a heap store beside the scan list, reached through
   `dsd_state_trunk_lcn_name_get()`/`_set()`/`_reserve()`/`_free()` in `src/core/util/dsd_state_trunk_lcn.c` and
-  released by `dsd_state_trunk_lcn_free()`. Per-row key sets (`keys_hex_csv`/`keys_dec_csv` columns, `-Y` only) live
-  in a sibling store with the same shape (`dsd_state_trunk_lcn_keys_*`), swapped by `dsd_scan_keys_enter()`/
+  released by `dsd_state_trunk_lcn_free()`. Per-row key sets (key-file or direct-key columns, `-Y` only) live in a
+  sibling store with the same shape (`dsd_state_trunk_lcn_keys_*`), swapped by `dsd_scan_keys_enter()`/
   `dsd_scan_keys_leave()` in `src/core/util/key_set.c`, and are likewise never deep-copied into the UI snapshot.
 - API note: text arriving as UTF-16 code units (DMR UDT/SMS, talker aliases) is decoded with
   `<dsd-neo/core/utf16.h>` and printed one scalar value at a time through `dsd_unicode_fput_scalar()` in

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -11,8 +11,8 @@ If you want known-good starting points, see `examples/` in the repository.
 - Fields are split on literal commas (`,`). Quoting/escaping is **not supported**.
   - Do not include commas inside a field.
 - Avoid blank lines and comment-only lines (they may be parsed as data).
-- Extra columns after the required ones are ignored, except where a format names an optional column by header (the
-  channel map's `name`). Use the rest for notes/labels.
+- Extra columns after the required ones are ignored, except where a format names an optional column by header (such as
+  a channel map's `name` or key columns). Use the rest for notes/labels.
 - Imported text fields are copied into fixed-size runtime buffers. Keep short fields concise; long `mode` and `name`
   values are truncated in runtime display/policy state.
 
@@ -98,18 +98,26 @@ Notes:
   stores no name either.
 - A row skipped for an unusable frequency keeps its name in the file's numbering but is never shown, because the
   scanner parks on the frequency it is already on rather than tuning such a row.
-- Two more optional columns carry per-row keys for the `-Y` scanner: `keys_hex_csv` (loaded like `-K`) and
+- Two optional columns carry per-row key files for the `-Y` scanner: `keys_hex_csv` (loaded like `-K`) and
   `keys_dec_csv` (loaded like `-k`). They opt in by header name at any column position past the frequency (like
   `name`, matched case-insensitively); a duplicated key header rejects the file. A row may fill both columns;
   they load into one per-row key set.
 - Each key cell names a key file path, resolved relative to the channel map. Blank cells store nothing, and a row
   whose channel number does not parse takes no slot and stores nothing. Paths cannot contain commas: the splitter
   does no quote handling.
+- `single_key_dec` embeds the `-b` Motorola Basic Privacy key number directly in a row. It accepts unsigned decimal
+  `0..255`. `single_key_hex` embeds the `-H` key: an optional leading `0x`, embedded ASCII whitespace, and exactly
+  10, 32, or 64 hexadecimal digits are accepted. Both direct columns may be filled together. They are also matched
+  case-insensitively at any position past the frequency.
+- A row must choose one source family: any nonblank `single_key_dec`/`single_key_hex` value together with a nonblank
+  `keys_dec_csv`/`keys_hex_csv` path rejects the import. Blank direct cells are absent; an explicit decimal `0` or an
+  all-zero hex key is present and clears the corresponding global keys while that row is active.
 - Row keys take effect only under `-Y`: hopping onto a keyed row installs its set, hopping back onto an unkeyed
   row restores the global keys. Under plain trunking `-C` they are stored but never applied (one warning); under
   trunk-scan per-target `chan_csv` they are discarded, like `name`.
-- Validation opens the key files, so an unloadable key path fails validation. The Qt/Android picker flow (which
-  copies files) does not support per-row key files.
+- Validation opens key files and validates direct values, so an unloadable path or malformed direct key fails the
+  import. Diagnostics name the field but never repeat a direct key value. The Qt/Android picker flow supports direct
+  values because they are embedded in the copied channel map; it does not copy companion per-row key files.
 - Where a name shows: the end of the `-Y` conventional scanner's **Scan Mode** row, a `Channel:` line at the top of
   the Call Info panel, and as a prefix on the event history rows recorded while that channel is tuned. Encrypted
   traffic that reports no talkgroup still says which channel it was heard on. While a `--trunk-scan` target is on
@@ -144,13 +152,13 @@ channel,frequency_hz,name
 2,462587500,GMRS 2
 ```
 
-Example with per-row keys (`examples/conventional_scan_keyed.csv`):
+Example with file-backed and direct per-row keys (`examples/conventional_scan_keyed.csv`):
 
 ```csv
-channel,frequency_hz,name,keys_hex_csv,keys_dec_csv
-1,462562500,System A,multi_key_hex.csv,
-2,462587500,System B,,multi_key.csv
-3,462612500,Shared,,
+channel,frequency_hz,name,keys_hex_csv,keys_dec_csv,single_key_dec,single_key_hex
+1,462562500,System A,multi_key_hex.csv,,,
+2,462587500,System B,,multi_key.csv,,
+3,462612500,Shared,,,1,0000001F00
 ```
 
 ## Trunk Scan Target CSV (`--trunk-scan <file>` / `[trunk_scan] targets_csv`)
@@ -185,6 +193,8 @@ Columns:
 | `rtl_gain` | No | Per-target RTL-family tuner gain. Empty uses the global/default gain. `0` or `auto` requests device automatic gain. `1..49` requests manual dB gain. Ignored for non-RTL retuning paths. |
 | `keys_hex_csv` | No | Per-target hex key file (`-K` format), resolved relative to this CSV. A row may fill both key columns; they load into one per-target key set. Empty uses the global keys. |
 | `keys_dec_csv` | No | Per-target decimal key file (`-k` format), resolved relative to this CSV. Empty uses the global keys. |
+| `single_key_dec` | No | Embedded `-b` Motorola Basic Privacy key number (`0..255`). Explicit `0` is present and overrides the global key. May be combined with `single_key_hex`, but not either key-file column. |
+| `single_key_hex` | No | Embedded `-H` key: optional `0x`, whitespace ignored, exactly 10, 32, or 64 hex digits. May be combined with `single_key_dec`, but not either key-file column. |
 | `p25_bandplan_csv` | No | Per-target [P25 band plan CSV](#p25-band-plan-csv---p25-bandplan-file--trunking-p25_bandplan_csv) for a `p25-trunk` target, resolved relative to this CSV. The rows are parked in the target's snapshot, so one exported multi-system file can be named on every P25 row: each target seeds only the rows that carry its own WACN/SYS (and rows that carry none). |
 
 Validation notes:
@@ -194,6 +204,8 @@ Validation notes:
   parsing, with an error naming the budget.
 - Duplicate IDs and duplicate `(type, frequency_hz)` rows are rejected. `nxdn-conventional` and
   `nxdn48-conventional` are distinct types, so one frequency may appear once as each.
+- Optional column names are exact-case in this format. Duplicate direct-key headers, malformed direct values, and
+  rows that mix a direct value with a key-file path are rejected without echoing the key value.
 - `chan_csv` and `p25_bandplan_csv` on conventional (`dmr-conventional`/`nxdn-conventional`/`nxdn48-conventional`)
   rows are rejected; a duplicated `p25_bandplan_csv` header is rejected, and a band plan that fails to load fails
   the whole import.

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -103,15 +103,17 @@ Notes:
   `name`, matched case-insensitively); a duplicated key header rejects the file. A row may fill both columns;
   they load into one per-row key set.
 - Each key cell names a key file path, resolved relative to the channel map. Blank cells store nothing, and a row
-  whose channel number does not parse takes no slot and stores nothing. Paths cannot contain commas: the splitter
-  does no quote handling.
+  whose channel number does not parse takes no slot and stores nothing. A file-only key path on such a row is not
+  opened. Paths cannot contain commas: the splitter does no quote handling.
 - `single_key_dec` embeds the `-b` Motorola Basic Privacy key number directly in a row. It accepts unsigned decimal
   `0..255`. `single_key_hex` embeds the `-H` key: an optional leading `0x`, embedded ASCII whitespace, and exactly
   10, 32, or 64 hexadecimal digits are accepted. Both direct columns may be filled together. They are also matched
   case-insensitively at any position past the frequency.
 - A row must choose one source family: any nonblank `single_key_dec`/`single_key_hex` value together with a nonblank
-  `keys_dec_csv`/`keys_hex_csv` path rejects the import. Blank direct cells are absent; an explicit decimal `0` or an
-  all-zero hex key is present and clears the corresponding global keys while that row is active.
+  `keys_dec_csv`/`keys_hex_csv` path rejects the import. This source conflict and direct-key syntax are validated even
+  when the channel number does not parse, although that row still takes no slot. Blank direct cells are absent; an
+  explicit decimal `0` or an all-zero hex key is present. A direct-key row installs a complete replacement key set,
+  so scalar key families not supplied by that row and all file-backed keyring entries are cleared while it is active.
 - Row keys take effect only under `-Y`: hopping onto a keyed row installs its set, hopping back onto an unkeyed
   row restores the global keys. Under plain trunking `-C` they are stored but never applied (one warning); under
   trunk-scan per-target `chan_csv` they are discarded, like `name`.

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -312,8 +312,12 @@ in [csv-formats.md](csv-formats.md); check the header row and the delimiter.
 `row N has invalid single_key_dec value` (or `single_key_hex`)
 
 Use unsigned decimal `0..255` for `single_key_dec`, or 10, 32, or 64 hex digits for `single_key_hex`. Direct key
-values are intentionally omitted from error messages. Remove any `keys_hex_csv`/`keys_dec_csv` value from the same
-row: direct and file key sources cannot be mixed.
+values are intentionally omitted from error messages.
+
+`row N combines direct keys with keys_hex_csv/keys_dec_csv`
+
+Remove either the `single_key_dec`/`single_key_hex` values or the key-file paths from that row. Direct and file key
+sources cannot be mixed for one target.
 
 `N trunk scan target(s) have no enabled <NAME> decoder (first: '<id>'); use <flags> to decode them`
 

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -58,6 +58,8 @@ Column behavior:
 | `rtl_gain` | No | RTL-family tuner gain for this target. Empty uses the global/default gain. `0` or `auto` requests device automatic gain. `1..49` requests manual dB gain. |
 | `keys_hex_csv` | No | Per-target hex key file (`-K` format), resolved relative to the target CSV. Parking the target installs its set; leaving it restores the global keys. A row may fill both key columns; they load into one set. Empty uses the global keys. |
 | `keys_dec_csv` | No | Per-target decimal key file (`-k` format), resolved relative to the target CSV. Empty uses the global keys. |
+| `single_key_dec` | No | Embedded `-b` Motorola Basic Privacy key number (`0..255`). Explicit `0` is an active override. It may be combined with `single_key_hex`, but not either key-file column. |
+| `single_key_hex` | No | Embedded `-H` key. It accepts an optional `0x`, ignores ASCII whitespace, and requires exactly 10, 32, or 64 hex digits. It may be combined with `single_key_dec`, but not either key-file column. |
 | `p25_bandplan_csv` | No | P25 band plan CSV for a `p25-trunk` target (format in [csv-formats.md](csv-formats.md)), resolved relative to the target CSV. Its rows are parked in the target's snapshot, so an exported multi-system plan can be named on every P25 row and each target keeps only the rows that carry its WACN/SYS (plus rows that carry none). |
 
 Targets that turn out to be sites of the same P25 system (same WACN/SYS) share what one of them learned over the
@@ -70,8 +72,8 @@ WACN/SYS into one file.
 A target's `chan_csv` may carry the optional `name` column described in [csv-formats.md](csv-formats.md), and it
 parses, but trunk scan discards the names. Each target's channel map is parked in a per-target snapshot that carries
 the frequencies positionally and no names, so a name kept from one target would sit beside the next target's list.
-Per-row `keys_hex_csv`/`keys_dec_csv` columns in a `chan_csv` are discarded the same way: keys arrive per
-trunk-scan target, not per channel-map row, and a kept set would install on the wrong target's hop.
+Per-row key-file and direct-key columns in a `chan_csv` are discarded the same way: keys arrive per trunk-scan
+target, not per channel-map row, and a kept set would install on the wrong target's hop.
 Under `--trunk-scan` the channel being heard is labelled by the target `id` instead.
 
 Target list limits and validation:
@@ -87,8 +89,8 @@ Target list limits and validation:
   values above `LONG_MAX`.
 - Duplicate `id` values are rejected.
 - Duplicate `(type, frequency_hz)` pairs are rejected.
-- A duplicated `keys_hex_csv` or `keys_dec_csv` header is rejected, and an unloadable key path fails the
-  whole import the way a bad `-K`/`-k` does.
+- A duplicated key header is rejected. An unloadable key path fails the whole import like a bad `-K`/`-k`; a malformed
+  direct key or a row mixing direct and file sources also fails, without repeating direct key material in the error.
 - `chan_csv` is only valid for `p25-trunk`, `dmr-trunk`, and `nxdn-trunk` targets; `p25_bandplan_csv` is refused
   on conventional targets, a duplicated `p25_bandplan_csv` header is rejected, and a band plan that fails to load
   fails the whole import. A global `--p25-bandplan`/`[trunking] p25_bandplan_csv` is rejected in this mode like
@@ -306,6 +308,12 @@ reference, keep the key file next to (or below) the target CSV.
 
 The key file could not be opened or parsed. Key files use the `-K` (hex) and `-k` (decimal) formats described
 in [csv-formats.md](csv-formats.md); check the header row and the delimiter.
+
+`row N has invalid single_key_dec value` (or `single_key_hex`)
+
+Use unsigned decimal `0..255` for `single_key_dec`, or 10, 32, or 64 hex digits for `single_key_hex`. Direct key
+values are intentionally omitted from error messages. Remove any `keys_hex_csv`/`keys_dec_csv` value from the same
+row: direct and file key sources cannot be mixed.
 
 `N trunk scan target(s) have no enabled <NAME> decoder (first: '<id>'); use <flags> to decode them`
 

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -346,10 +346,10 @@ RadioReference import:
 ### Keys
 
 A `-Y` channel-map row or a `--trunk-scan` target can carry key files (`keys_hex_csv`/`keys_dec_csv`) or embedded
-Basic Privacy/Hytera values (`single_key_dec`/`single_key_hex`; see `docs/csv-formats.md`). While the row or target
-is parked its keys replace the globals; leaving restores them. The Import keys CSV rows edit the globals underneath
-a parked row, so a runtime import survives the next hop. The single-key menu rows disarm the keyring, so a parked
-keyed row overrides them again on its next hop.
+Basic Privacy, Hytera, or AES values (`single_key_dec`/`single_key_hex`; see `docs/csv-formats.md`). While the row or
+target is parked its keys replace the globals; leaving restores them. The Import keys CSV rows edit the globals
+underneath a parked row, so a runtime import survives the next hop. The single-key menu rows disarm the keyring, so
+a parked keyed row overrides them again on its next hop.
 
 ## DSP Status
 

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -345,11 +345,11 @@ RadioReference import:
 
 ### Keys
 
-A `-Y` channel-map row or a `--trunk-scan` target can carry its own key files (`keys_hex_csv`/`keys_dec_csv`
-columns; see `docs/csv-formats.md`). While the row or target is parked its keys replace the global keyring;
-leaving it restores the globals. The Import keys CSV rows edit the globals underneath a parked row, so a
-runtime import survives the next hop. The single-key rows (Basic privacy, Hytera, scrambler, RC4/DES, AES)
-disarm the keyring, so a parked keyed row overrides them again on its next hop.
+A `-Y` channel-map row or a `--trunk-scan` target can carry key files (`keys_hex_csv`/`keys_dec_csv`) or embedded
+Basic Privacy/Hytera values (`single_key_dec`/`single_key_hex`; see `docs/csv-formats.md`). While the row or target
+is parked its keys replace the globals; leaving restores them. The Import keys CSV rows edit the globals underneath
+a parked row, so a runtime import survives the next hop. The single-key menu rows disarm the keyring, so a parked
+keyed row overrides them again on its next hop.
 
 ## DSP Status
 

--- a/examples/conventional_scan_keyed.csv
+++ b/examples/conventional_scan_keyed.csv
@@ -1,4 +1,4 @@
-channel,frequency_hz,name,keys_hex_csv,keys_dec_csv
-1,462562500,System A,multi_key_hex.csv,
-2,462587500,System B,,multi_key.csv
-3,462612500,Shared,,
+channel,frequency_hz,name,keys_hex_csv,keys_dec_csv,single_key_dec,single_key_hex
+1,462562500,System A,multi_key_hex.csv,,,
+2,462587500,System B,,multi_key.csv,,
+3,462612500,Shared,,,1,0000001F00

--- a/examples/trunk_scan_targets.csv
+++ b/examples/trunk_scan_targets.csv
@@ -1,7 +1,7 @@
-id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain,keys_hex_csv
-county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learned from control-channel data,auto,
-city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel using examples/dmr_t3_chan.csv,auto,
-plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,,example_aes_keys.csv
-site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel; channel map optional when the site broadcasts DFA,auto,
-field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,
-field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz) conventional channel,gfsk,
+id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain,keys_hex_csv,single_key_dec,single_key_hex
+county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learned from control-channel data,auto,,example_aes_keys.csv,,
+city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel using examples/dmr_t3_chan.csv,auto,,,,
+plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,,,1,0000001F00
+site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel; channel map optional when the site broadcasts DFA,auto,,,,
+field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,,,,
+field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz) conventional channel,gfsk,,,,

--- a/include/dsd-neo/core/key_set.h
+++ b/include/dsd-neo/core/key_set.h
@@ -9,8 +9,9 @@
  *
  * A `dsd_key_set` is a sparse copy of the live keyring (`rkey_array` /
  * `rkey_array_loaded`) with the `keyloader` flag and the scalar key block it
- * was captured with. Row sets carry a zeroed scalar block so installing them
- * clears stale `-b`/`-1` scalars; the lazily captured baseline carries the
+ * was captured with. File-backed row sets carry a zeroed scalar block so
+ * installing them clears stale direct scalars; embedded direct-key sets carry
+ * their parsed `-b`/`-H` equivalents. The lazily captured baseline carries the
  * live scalars so leaving a keyed row restores them.
  *
  * Only core headers plus `runtime/log.h`; engine and app_control call down
@@ -57,14 +58,15 @@ typedef struct {
     unsigned long long A4[2];
     int aes_key_loaded[2];
     uint8_t aes_key_segments[2];
+    uint8_t aes_key[32];
 } dsd_key_scalars;
 
 typedef struct {
     dsd_key_set_entry* entries; /* heap, NULL when empty */
     size_t count;
-    uint8_t present; /* a key file was named on this row/target */
+    uint8_t present; /* a key source was supplied on this row/target */
     int keyloader;   /* state->keyloader to install with the entries */
-    /* Captured for the baseline; zeroed on row sets. */
+    /* Captured for the baseline or parsed directly; zeroed for file-backed sets. */
     dsd_key_scalars scalars;
 } dsd_key_set;
 
@@ -79,11 +81,18 @@ dsd_key_set_free(dsd_key_set* ks) {
         return;
     }
     if (ks->entries != NULL) {
-        DSD_MEMSET(ks->entries, 0, ks->count * sizeof(*ks->entries));
+        DSD_SECURE_ZERO(ks->entries, ks->count * sizeof(*ks->entries));
         free(ks->entries);
     }
-    DSD_MEMSET(ks, 0, sizeof(*ks));
+    DSD_SECURE_ZERO(ks, sizeof(*ks));
 }
+
+typedef enum {
+    DSD_KEY_DIRECT_OK = 0,
+    DSD_KEY_DIRECT_INVALID_ARGUMENT = -1,
+    DSD_KEY_DIRECT_INVALID_DEC = -2,
+    DSD_KEY_DIRECT_INVALID_HEX = -3,
+} dsd_key_direct_result;
 
 /**
  * Capture the live keyring plus scalar block into @p out (frees prior).
@@ -107,7 +116,7 @@ void dsd_key_set_install(dsd_state* state, const dsd_key_set* ks);
  */
 int dsd_key_set_copy(dsd_key_set* dst, const dsd_key_set* src);
 
-/** Non-zero when two sets hold the same entries and keyloader flag. */
+/** Non-zero when two sets hold the same metadata, scalar block, and entries. */
 int dsd_key_set_equal(const dsd_key_set* a, const dsd_key_set* b);
 
 /**
@@ -116,6 +125,19 @@ int dsd_key_set_equal(const dsd_key_set* a, const dsd_key_set* b);
  * success, -1 on any importer failure with @p out untouched.
  */
 int dsd_key_set_load_csv(dsd_key_set* out, const char* hex_path, const char* dec_path, int show_keys);
+
+/**
+ * Parse direct `-H`/`-b` equivalents into a scalar-only set. Either value may
+ * be NULL or ASCII-whitespace-only, but at least one must be present. Hex input
+ * accepts an optional leading `0x`, ignores embedded ASCII whitespace, and
+ * requires exactly 10, 32, or 64 digits. Decimal input is an unsigned value in
+ * `[0, 255]`. Both inputs may be supplied together.
+ *
+ * On success the set has `present = 1` and `keyloader = 0`. On failure @p out
+ * is untouched and the result identifies the invalid field without exposing
+ * its value to callers' diagnostics.
+ */
+dsd_key_direct_result dsd_key_set_load_direct(dsd_key_set* out, const char* single_hex, const char* single_dec);
 
 /**
  * Enter the scan swap: capture the baseline from live state when no set is

--- a/include/dsd-neo/core/safe_api.h
+++ b/include/dsd-neo/core/safe_api.h
@@ -163,6 +163,36 @@ dsd_safe_memset_impl(void* dst, size_t dst_size, int value, size_t count) {
 #endif
 }
 
+/**
+ * @brief Compiler-resistant zeroing for buffers that held secret material.
+ *
+ * Volatile stores keep the wipe observable even when the buffer is released or
+ * leaves scope immediately afterward. This is intentionally separate from
+ * DSD_MEMSET, whose ordinary memset semantics permit dead-store elimination.
+ */
+static inline void*
+dsd_safe_secure_zero_impl(void* dst, size_t dst_size, size_t count) {
+    if (dst == NULL) {
+        return NULL;
+    }
+    if (count == 0U) {
+        return dst;
+    }
+    if (!dsd_safe_count_fits(dst_size, count)) {
+        return NULL;
+    }
+#if defined(__cplusplus)
+    volatile unsigned char* bytes = static_cast<volatile unsigned char*>(dst);
+#else
+    volatile unsigned char* bytes = (volatile unsigned char*)dst;
+#endif
+    while (count > 0U) {
+        *bytes++ = 0U;
+        count--;
+    }
+    return dst;
+}
+
 static inline int dsd_safe_vfprintf(FILE* stream, const char* fmt, va_list ap) DSD_NEO_PRINTF_FORMAT(2, 0);
 
 static inline int
@@ -258,6 +288,7 @@ dsd_safe_sscanf(const char* src, const char* fmt, ...) {
 #define DSD_MEMCPY(dst, src, count)           dsd_safe_memcpy_impl((dst), DSD_NEO_OBJECT_SIZE(dst), (src), (count))
 #define DSD_MEMMOVE(dst, src, count)          dsd_safe_memmove_impl((dst), DSD_NEO_OBJECT_SIZE(dst), (src), (count))
 #define DSD_MEMSET(dst, value, count)         dsd_safe_memset_impl((dst), DSD_NEO_OBJECT_SIZE(dst), (value), (count))
+#define DSD_SECURE_ZERO(dst, count)           dsd_safe_secure_zero_impl((dst), DSD_NEO_OBJECT_SIZE(dst), (count))
 #define DSD_FPRINTF(stream, ...)              dsd_safe_fprintf((stream), __VA_ARGS__)
 #define DSD_SNPRINTF(dst, dst_size, ...)      dsd_safe_snprintf((dst), (dst_size), __VA_ARGS__)
 #define DSD_SSCANF(src, ...)                  dsd_safe_sscanf((src), __VA_ARGS__)

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -530,10 +530,11 @@ struct dsd_state {
     uint8_t* trunk_lcn_avoid;
     size_t trunk_lcn_avoid_capacity;
     /* Sparse per-row key set per scan-list row, indexed like trunk_lcn_name. NULL until a
-     * channel-map CSV opts in with a `keys_hex_csv`/`keys_dec_csv` header column. Read it
-     * through dsd_state_trunk_lcn_keys_get(). Never inside a UI_SNAPSHOT_COPY_RANGE, for the
-     * same reason as the stores above -- and additionally because key material is never
-     * deep-copied into the snapshot. */
+     * channel-map CSV opts in with a key-file or direct-key header column. Read it through
+     * dsd_state_trunk_lcn_keys_get(); returned pointers are decoder-thread-only and invalidated
+     * by later store growth. Never inside a UI_SNAPSHOT_COPY_RANGE, for the same reason as the
+     * stores above -- and additionally because key material is never deep-copied into the
+     * snapshot. */
     dsd_key_set* trunk_lcn_keys;
     size_t trunk_lcn_keys_capacity;
     /* Scan key swap state: the lazily captured global keys plus the active row set copy.
@@ -1899,7 +1900,10 @@ void dsd_state_trunk_lcn_keys_free(dsd_state* state);
  */
 int dsd_state_trunk_lcn_keys_set(dsd_state* state, size_t index, dsd_key_set* ks);
 
-/** Key set of scan-list row @p index, or NULL when the row carries no keys. */
+/**
+ * Key set of scan-list row @p index, or NULL when the row carries no keys.
+ * Decoder thread only; the pointer is invalidated by subsequent key-store growth.
+ */
 const dsd_key_set* dsd_state_trunk_lcn_keys_get(const dsd_state* state, size_t index);
 
 /** Non-zero when any row in the store carries a key set. */

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -11,6 +11,7 @@
 #ifndef DSD_NEO_INCLUDE_DSD_NEO_ENGINE_TRUNK_SCAN_H_
 #define DSD_NEO_INCLUDE_DSD_NEO_ENGINE_TRUNK_SCAN_H_
 
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <stddef.h>
@@ -70,6 +71,10 @@ typedef struct {
      * Loaded into the target's key set at init; empty means the global keys. */
     char keys_hex_csv[1024];
     char keys_dec_csv[1024];
+    /* Parsed direct `-H`/`-b` equivalents. Kept as fixed metadata so raw key
+     * text never survives parsing or reaches a diagnostic. */
+    dsd_key_scalars single_key_scalars;
+    uint8_t single_keys_present;
     /* Per-target P25 band plan CSV (trunk targets only), resolved relative to the targets CSV at
      * parse time and loaded into the target's own band-plan store at init; empty means none. */
     char p25_bandplan_csv[1024];

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "../util/key_set_internal.h"
 #include "csv_parse_internal.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -766,7 +767,12 @@ chan_import_direct_keys(dsd_key_set* ks, const char* single_hex_cell, const char
     const dsd_key_direct_result direct_rc = dsd_key_set_load_direct(ks, single_hex_cell, single_dec_cell);
     if (direct_rc != DSD_KEY_DIRECT_OK) {
         char row_text[32] = "?";
-        const char* field = direct_rc == DSD_KEY_DIRECT_INVALID_DEC ? "single_key_dec" : "single_key_hex";
+        const char* field = "single_key_dec/single_key_hex";
+        if (direct_rc == DSD_KEY_DIRECT_INVALID_DEC) {
+            field = "single_key_dec";
+        } else if (direct_rc == DSD_KEY_DIRECT_INVALID_HEX) {
+            field = "single_key_hex";
+        }
         (void)DSD_SNPRINTF(row_text, sizeof(row_text), "%d", row_number);
         LOG_ERROR("channel map file '%s' row %s: invalid %s value\n", base_path, row_text, field);
         return -1;
@@ -798,7 +804,7 @@ chan_import_key_files(dsd_key_set* ks, const char* hex_cell, const char* dec_cel
 
 static int
 chan_import_row_keys(dsd_state* state, char** fields, size_t field_count, const chan_header_cols* cols,
-                     const char* base_path, int row_number, int show_keys, size_t slot) {
+                     const char* base_path, int row_number, int show_keys, int store, size_t slot) {
     const char* hex_cell = chan_key_cell(fields, field_count, cols->keys_hex_idx);
     const char* dec_cell = chan_key_cell(fields, field_count, cols->keys_dec_idx);
     const char* single_hex_cell = chan_key_cell(fields, field_count, cols->single_key_hex_idx);
@@ -816,10 +822,21 @@ chan_import_row_keys(dsd_state* state, char** fields, size_t field_count, const 
         return -1;
     }
 
+    /* A row whose channel number is invalid owns no scan-list slot. Its direct
+     * cells still need syntax validation, but a file-only row keeps the legacy
+     * behavior of not opening a key path that could never be activated. */
+    if (!store && !have_direct) {
+        return 0;
+    }
+
     dsd_key_set ks;
     DSD_MEMSET(&ks, 0, sizeof(ks));
     if (have_direct && chan_import_direct_keys(&ks, single_hex_cell, single_dec_cell, base_path, row_number) != 0) {
         return -1;
+    }
+    if (!store) {
+        dsd_key_set_free(&ks);
+        return 0;
     }
     if (have_files && chan_import_key_files(&ks, hex_cell, dec_cell, base_path, row_number, show_keys) != 0) {
         return -1;
@@ -839,9 +856,11 @@ chan_import_row_keys(dsd_state* state, char** fields, size_t field_count, const 
  * blank frequency and is skipped instead of promoting column 3 into its place.
  *
  * When the header opts into per-row keys, a row that took a slot stores either
- * its direct scalar values or a key file resolved against the map. Key paths
- * cannot contain commas: the splitter does no quote handling. Invalid direct
- * input or a key-file load failure rejects the whole import.
+ * its direct scalar values or a key file resolved against the map. Direct cells
+ * are still validated on a row that took no slot, while file-only paths on such
+ * a row are not opened. Key paths cannot contain commas: the splitter does no
+ * quote handling. Invalid direct input or a key-file load failure rejects the
+ * whole import.
  *
  * @return 1 when a frequency loaded, -1 on allocation failure or key load failure.
  */
@@ -867,10 +886,11 @@ chan_import_row(dsd_state* state, char* buffer, const chan_header_cols* cols, co
             return -1;
         }
     }
-    if ((cols->keys_hex_idx >= 0 || cols->keys_dec_idx >= 0 || cols->single_key_hex_idx >= 0
-         || cols->single_key_dec_idx >= 0)
-        && state->lcn_freq_count > lcn_before) {
-        if (chan_import_row_keys(state, fields, field_count, cols, base_path, row_number, show_keys, (size_t)lcn_before)
+    const int row_has_slot = state->lcn_freq_count > lcn_before;
+    if (cols->keys_hex_idx >= 0 || cols->keys_dec_idx >= 0 || cols->single_key_hex_idx >= 0
+        || cols->single_key_dec_idx >= 0) {
+        const size_t slot = row_has_slot ? (size_t)lcn_before : 0U;
+        if (chan_import_row_keys(state, fields, field_count, cols, base_path, row_number, show_keys, row_has_slot, slot)
             != 0) {
             return -1;
         }
@@ -925,6 +945,7 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
     cols.keys_dec_idx = -1;
     cols.single_key_hex_idx = -1;
     cols.single_key_dec_idx = -1;
+    int rc = 0;
 
     while (fgets(buffer, BSIZE, fp)) {
         int field_count = 0;
@@ -933,8 +954,8 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
         if (row_count == 1) {
             // Split in place: the header is not needed again, and the next fgets refills the buffer.
             if (chan_parse_header(buffer, &cols) != 0) {
-                fclose(fp);
-                return -1;
+                rc = -1;
+                break;
             }
             continue; //don't want labels
         }
@@ -944,13 +965,14 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
         const int freq_parsed =
             chan_import_row(state, buffer, &cols, filename, row_count, show_keys, &field_count, &chan_number);
         if (freq_parsed < 0) {
-            fclose(fp);
-            return -1;
+            rc = -1;
+            break;
         }
         chan_import_row_report(state, stats, filename, row_count, freq_parsed, field_count, chan_number);
     }
+    DSD_SECURE_ZERO(buffer, sizeof(buffer));
     fclose(fp);
-    return 0;
+    return rc;
 }
 
 /* Dry-run entry for the validator: counts rows and never reveals key values. */
@@ -1028,6 +1050,7 @@ key_import_dec_stats(int show_keys, const char* key_file_path, dsd_state* state,
         }
         LOG_INFO("\n");
     }
+    DSD_SECURE_ZERO(buffer, sizeof(buffer));
     fclose(fp);
     return 0;
 }
@@ -1282,6 +1305,7 @@ key_import_hex_stats(int show_keys, const char* key_file_path, dsd_state* state,
 
         LOG_INFO("\n");
     }
+    DSD_SECURE_ZERO(buffer, sizeof(buffer));
     fclose(fp);
     return 0;
 }
@@ -1323,6 +1347,7 @@ csv_validate_into_throwaway(const char* path, dsd_csv_validation* out, csv_valid
         dsd_state_ext_free_all(state);
     }
     dsd_state_trunk_lcn_free(state);
+    dsd_key_state_secure_wipe(state);
     free(state);
 
     if (rc != 0) {

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -674,6 +674,8 @@ typedef struct {
     int has_name;
     int keys_hex_idx;
     int keys_dec_idx;
+    int single_key_hex_idx;
+    int single_key_dec_idx;
 } chan_header_cols;
 
 static const char*
@@ -682,6 +684,11 @@ chan_key_cell(char** fields, size_t field_count, int idx) {
         return NULL;
     }
     return trim_ws(fields[idx]);
+}
+
+static int
+chan_key_cell_present(const char* cell) {
+    return cell != NULL && cell[0] != '\0';
 }
 
 static int
@@ -704,6 +711,8 @@ chan_parse_header(char* header_line, chan_header_cols* out) {
     out->has_name = 0;
     out->keys_hex_idx = -1;
     out->keys_dec_idx = -1;
+    out->single_key_hex_idx = -1;
+    out->single_key_dec_idx = -1;
     const size_t field_count = csv_split_preserve_empty(header_line, fields, sizeof(fields) / sizeof(fields[0]));
     if (field_count >= 3 && csv_ascii_casecmp(trim_ws(fields[2]), "name") == 0) {
         out->has_name = 1;
@@ -722,42 +731,97 @@ chan_parse_header(char* header_line, chan_header_cols* out) {
                 return -1;
             }
             out->keys_dec_idx = (int)i;
+        } else if (csv_ascii_casecmp(name, "single_key_hex") == 0) {
+            if (out->single_key_hex_idx >= 0) {
+                LOG_ERROR("channel map header duplicates 'single_key_hex'\n");
+                return -1;
+            }
+            out->single_key_hex_idx = (int)i;
+        } else if (csv_ascii_casecmp(name, "single_key_dec") == 0) {
+            if (out->single_key_dec_idx >= 0) {
+                LOG_ERROR("channel map header duplicates 'single_key_dec'\n");
+                return -1;
+            }
+            out->single_key_dec_idx = (int)i;
         }
     }
     return 0;
 }
 
 /**
- * @brief Load the key files named by a row's key cells into that row's key set.
+ * @brief Load the key source named by a row into that row's key set.
  *
  * Paths resolve against the map file, so a map and its key files relocate as a
  * unit. Key paths cannot contain commas: the splitter does no quote handling.
  *
- * @return 0 when the row named no key file or its keys loaded, -1 on an unusable
- *         path, a load failure or allocation failure.
+ * A row may use the two file columns or the two direct scalar columns, but not
+ * both source families. Direct values never appear in a diagnostic.
+ *
+ * @return 0 when the row named no key source or its keys loaded, -1 on invalid
+ *         input, an unusable path, a load failure or allocation failure.
  */
+static int
+chan_import_direct_keys(dsd_key_set* ks, const char* single_hex_cell, const char* single_dec_cell,
+                        const char* base_path, int row_number) {
+    const dsd_key_direct_result direct_rc = dsd_key_set_load_direct(ks, single_hex_cell, single_dec_cell);
+    if (direct_rc != DSD_KEY_DIRECT_OK) {
+        char row_text[32] = "?";
+        const char* field = direct_rc == DSD_KEY_DIRECT_INVALID_DEC ? "single_key_dec" : "single_key_hex";
+        (void)DSD_SNPRINTF(row_text, sizeof(row_text), "%d", row_number);
+        LOG_ERROR("channel map file '%s' row %s: invalid %s value\n", base_path, row_text, field);
+        return -1;
+    }
+    return 0;
+}
+
+static int
+chan_import_key_files(dsd_key_set* ks, const char* hex_cell, const char* dec_cell, const char* base_path,
+                      int row_number, int show_keys) {
+    char hex_path[CSV_IMPORT_PATH_MAX] = "";
+    char dec_path[CSV_IMPORT_PATH_MAX] = "";
+    if (chan_resolve_key_cell(base_path, hex_cell, hex_path, sizeof(hex_path), row_number) != 0) {
+        return -1;
+    }
+    if (chan_resolve_key_cell(base_path, dec_cell, dec_path, sizeof(dec_path), row_number) != 0) {
+        return -1;
+    }
+    const int have_hex = chan_key_cell_present(hex_cell);
+    const int have_dec = chan_key_cell_present(dec_cell);
+    if (dsd_key_set_load_csv(ks, have_hex ? hex_path : NULL, have_dec ? dec_path : NULL, show_keys) == 0) {
+        return 0;
+    }
+    char row_text[32] = "?";
+    (void)DSD_SNPRINTF(row_text, sizeof(row_text), "%d", row_number);
+    LOG_ERROR("channel map file '%s' row %s: failed to load row key file\n", base_path, row_text);
+    return -1;
+}
+
 static int
 chan_import_row_keys(dsd_state* state, char** fields, size_t field_count, const chan_header_cols* cols,
                      const char* base_path, int row_number, int show_keys, size_t slot) {
     const char* hex_cell = chan_key_cell(fields, field_count, cols->keys_hex_idx);
     const char* dec_cell = chan_key_cell(fields, field_count, cols->keys_dec_idx);
-    const int have_hex = (hex_cell != NULL && hex_cell[0] != '\0');
-    const int have_dec = (dec_cell != NULL && dec_cell[0] != '\0');
-    if (!have_hex && !have_dec) {
+    const char* single_hex_cell = chan_key_cell(fields, field_count, cols->single_key_hex_idx);
+    const char* single_dec_cell = chan_key_cell(fields, field_count, cols->single_key_dec_idx);
+    const int have_files = chan_key_cell_present(hex_cell) || chan_key_cell_present(dec_cell);
+    const int have_direct = chan_key_cell_present(single_hex_cell) || chan_key_cell_present(single_dec_cell);
+    if (!have_files && !have_direct) {
         return 0;
     }
-    char hex_path[CSV_IMPORT_PATH_MAX] = "";
-    char dec_path[CSV_IMPORT_PATH_MAX] = "";
-    if (chan_resolve_key_cell(base_path, hex_cell, hex_path, sizeof(hex_path), row_number) != 0
-        || chan_resolve_key_cell(base_path, dec_cell, dec_path, sizeof(dec_path), row_number) != 0) {
-        return -1;
-    }
-    dsd_key_set ks;
-    DSD_MEMSET(&ks, 0, sizeof(ks));
-    if (dsd_key_set_load_csv(&ks, have_hex ? hex_path : NULL, have_dec ? dec_path : NULL, show_keys) != 0) {
+    if (have_files && have_direct) {
         char row_text[32] = "?";
         (void)DSD_SNPRINTF(row_text, sizeof(row_text), "%d", row_number);
-        LOG_ERROR("channel map file '%s' row %s: failed to load row key file\n", base_path, row_text);
+        LOG_ERROR("channel map file '%s' row %s: direct keys cannot be combined with key CSV files\n", base_path,
+                  row_text);
+        return -1;
+    }
+
+    dsd_key_set ks;
+    DSD_MEMSET(&ks, 0, sizeof(ks));
+    if (have_direct && chan_import_direct_keys(&ks, single_hex_cell, single_dec_cell, base_path, row_number) != 0) {
+        return -1;
+    }
+    if (have_files && chan_import_key_files(&ks, hex_cell, dec_cell, base_path, row_number, show_keys) != 0) {
         return -1;
     }
     if (dsd_state_trunk_lcn_keys_set(state, slot, &ks) != 0) {
@@ -774,10 +838,10 @@ chan_import_row_keys(dsd_state* state, char** fields, size_t field_count, const 
  * Empty fields are preserved rather than collapsed, so `1,,851000000` reads as a
  * blank frequency and is skipped instead of promoting column 3 into its place.
  *
- * When the header opted into per-row keys, a non-blank key cell on a row that
- * took a slot resolves its path against the map file and loads it into the
- * row's key set. Key paths cannot contain commas: the splitter does no quote
- * handling. A load failure fails the whole import, like a bad `-K`.
+ * When the header opts into per-row keys, a row that took a slot stores either
+ * its direct scalar values or a key file resolved against the map. Key paths
+ * cannot contain commas: the splitter does no quote handling. Invalid direct
+ * input or a key-file load failure rejects the whole import.
  *
  * @return 1 when a frequency loaded, -1 on allocation failure or key load failure.
  */
@@ -803,7 +867,9 @@ chan_import_row(dsd_state* state, char* buffer, const chan_header_cols* cols, co
             return -1;
         }
     }
-    if ((cols->keys_hex_idx >= 0 || cols->keys_dec_idx >= 0) && state->lcn_freq_count > lcn_before) {
+    if ((cols->keys_hex_idx >= 0 || cols->keys_dec_idx >= 0 || cols->single_key_hex_idx >= 0
+         || cols->single_key_dec_idx >= 0)
+        && state->lcn_freq_count > lcn_before) {
         if (chan_import_row_keys(state, fields, field_count, cols, base_path, row_number, show_keys, (size_t)lcn_before)
             != 0) {
             return -1;
@@ -857,6 +923,8 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
     DSD_MEMSET(&cols, 0, sizeof(cols));
     cols.keys_hex_idx = -1;
     cols.keys_dec_idx = -1;
+    cols.single_key_hex_idx = -1;
+    cols.single_key_dec_idx = -1;
 
     while (fgets(buffer, BSIZE, fp)) {
         int field_count = 0;

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -245,11 +245,21 @@ dsd_state_trunk_lcn_keys_reserve(dsd_state* state, size_t count) {
     if (capacity > SIZE_MAX / sizeof(dsd_key_set)) {
         return -1;
     }
-    dsd_key_set* keys = (dsd_key_set*)realloc(state->trunk_lcn_keys, capacity * sizeof(*keys));
+    dsd_key_set* keys = (dsd_key_set*)calloc(capacity, sizeof(*keys));
     if (!keys) {
         return -1;
     }
-    DSD_MEMSET(keys + state->trunk_lcn_keys_capacity, 0, (capacity - state->trunk_lcn_keys_capacity) * sizeof(*keys));
+    /* Structural move: each entry pointer keeps its single owner in the new
+     * array. Deep-freeing the old structs would invalidate the moved sets. The
+     * decoder thread owns imports/growth, so no reader can observe the brief
+     * unpublished copy or retain a pointer across this call. */
+    dsd_key_set* const old_keys = state->trunk_lcn_keys;
+    const size_t old_capacity = state->trunk_lcn_keys_capacity;
+    if (old_keys != NULL && old_capacity > 0U) {
+        DSD_MEMCPY(keys, old_keys, old_capacity * sizeof(*keys));
+        DSD_SECURE_ZERO(old_keys, old_capacity * sizeof(*old_keys));
+        free(old_keys);
+    }
     state->trunk_lcn_keys = keys;
     state->trunk_lcn_keys_capacity = capacity;
     return 0;
@@ -263,6 +273,7 @@ dsd_state_trunk_lcn_keys_free(dsd_state* state) {
     for (size_t i = 0; i < state->trunk_lcn_keys_capacity; i++) {
         dsd_key_set_free(&state->trunk_lcn_keys[i]);
     }
+    DSD_SECURE_ZERO(state->trunk_lcn_keys, state->trunk_lcn_keys_capacity * sizeof(*state->trunk_lcn_keys));
     free(state->trunk_lcn_keys);
     state->trunk_lcn_keys = NULL;
     state->trunk_lcn_keys_capacity = 0;
@@ -278,7 +289,7 @@ dsd_state_trunk_lcn_keys_set(dsd_state* state, size_t index, dsd_key_set* ks) {
     }
     dsd_key_set_free(&state->trunk_lcn_keys[index]);
     state->trunk_lcn_keys[index] = *ks;
-    DSD_MEMSET(ks, 0, sizeof(*ks));
+    DSD_SECURE_ZERO(ks, sizeof(*ks));
     return 0;
 }
 

--- a/src/core/util/key_set.c
+++ b/src/core/util/key_set.c
@@ -17,10 +17,33 @@
 
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "key_set_internal.h"
 
 static size_t
 key_set_capacity(void) {
     return sizeof(((dsd_state*)0)->rkey_array) / sizeof(((dsd_state*)0)->rkey_array[0]);
+}
+
+void
+dsd_key_state_secure_wipe(dsd_state* state) {
+    if (state == NULL) {
+        return;
+    }
+    DSD_SECURE_ZERO(state->rkey_array, sizeof(state->rkey_array));
+    DSD_SECURE_ZERO(state->rkey_array_loaded, sizeof(state->rkey_array_loaded));
+    DSD_SECURE_ZERO(state->aes_key, sizeof(state->aes_key));
+    DSD_SECURE_ZERO(&state->K, sizeof(state->K));
+    DSD_SECURE_ZERO(&state->K1, sizeof(state->K1));
+    DSD_SECURE_ZERO(&state->K2, sizeof(state->K2));
+    DSD_SECURE_ZERO(&state->K3, sizeof(state->K3));
+    DSD_SECURE_ZERO(&state->K4, sizeof(state->K4));
+    DSD_SECURE_ZERO(&state->R, sizeof(state->R));
+    DSD_SECURE_ZERO(&state->RR, sizeof(state->RR));
+    DSD_SECURE_ZERO(&state->H, sizeof(state->H));
+    DSD_SECURE_ZERO(state->A1, sizeof(state->A1));
+    DSD_SECURE_ZERO(state->A2, sizeof(state->A2));
+    DSD_SECURE_ZERO(state->A3, sizeof(state->A3));
+    DSD_SECURE_ZERO(state->A4, sizeof(state->A4));
 }
 
 static void
@@ -323,7 +346,7 @@ key_set_parse_direct_hex(const char* text, dsd_key_scalars* scalars) {
     const size_t segment_count = nhex == 10U ? 1U : nhex / 16U;
     const size_t first_width = nhex == 10U ? 10U : 16U;
     for (size_t i = 0U; i < segment_count; i++) {
-        const size_t offset = (nhex == 10U) ? 0U : i * 16U;
+        const size_t offset = i * 16U;
         const size_t width = (i == 0U) ? first_width : 16U;
         if (dsd_parse_hex_u64_n(hex + offset, width, &segments[i]) != 0) {
             DSD_SECURE_ZERO(segments, sizeof(segments));
@@ -393,21 +416,7 @@ key_set_log_summary(const char* kind, const char* path, const dsd_csv_validation
 static void
 key_set_free_throwaway(dsd_state* tmp) {
     dsd_state_ext_free_all(tmp);
-    DSD_SECURE_ZERO(tmp->rkey_array, sizeof(tmp->rkey_array));
-    DSD_SECURE_ZERO(tmp->rkey_array_loaded, sizeof(tmp->rkey_array_loaded));
-    DSD_SECURE_ZERO(tmp->aes_key, sizeof(tmp->aes_key));
-    DSD_SECURE_ZERO(&tmp->K, sizeof(tmp->K));
-    DSD_SECURE_ZERO(&tmp->K1, sizeof(tmp->K1));
-    DSD_SECURE_ZERO(&tmp->K2, sizeof(tmp->K2));
-    DSD_SECURE_ZERO(&tmp->K3, sizeof(tmp->K3));
-    DSD_SECURE_ZERO(&tmp->K4, sizeof(tmp->K4));
-    DSD_SECURE_ZERO(&tmp->R, sizeof(tmp->R));
-    DSD_SECURE_ZERO(&tmp->RR, sizeof(tmp->RR));
-    DSD_SECURE_ZERO(&tmp->H, sizeof(tmp->H));
-    DSD_SECURE_ZERO(tmp->A1, sizeof(tmp->A1));
-    DSD_SECURE_ZERO(tmp->A2, sizeof(tmp->A2));
-    DSD_SECURE_ZERO(tmp->A3, sizeof(tmp->A3));
-    DSD_SECURE_ZERO(tmp->A4, sizeof(tmp->A4));
+    dsd_key_state_secure_wipe(tmp);
     free(tmp);
 }
 

--- a/src/core/util/key_set.c
+++ b/src/core/util/key_set.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/csv_validate.h>
 #include <dsd-neo/core/enc_lockout.h>
+#include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/runtime/log.h>
@@ -39,6 +40,7 @@ key_scalars_capture(dsd_key_scalars* out, const dsd_state* state) {
     DSD_MEMCPY(out->A4, state->A4, sizeof(out->A4));
     DSD_MEMCPY(out->aes_key_loaded, state->aes_key_loaded, sizeof(out->aes_key_loaded));
     DSD_MEMCPY(out->aes_key_segments, state->aes_key_segments, sizeof(out->aes_key_segments));
+    DSD_MEMCPY(out->aes_key, state->aes_key, sizeof(out->aes_key));
 }
 
 static void
@@ -58,6 +60,7 @@ key_scalars_install(dsd_state* state, const dsd_key_scalars* in) {
     DSD_MEMCPY(state->A4, in->A4, sizeof(state->A4));
     DSD_MEMCPY(state->aes_key_loaded, in->aes_key_loaded, sizeof(state->aes_key_loaded));
     DSD_MEMCPY(state->aes_key_segments, in->aes_key_segments, sizeof(state->aes_key_segments));
+    DSD_MEMCPY(state->aes_key, in->aes_key, sizeof(state->aes_key));
 }
 
 int
@@ -148,6 +151,37 @@ dsd_key_set_copy(dsd_key_set* dst, const dsd_key_set* src) {
     return 0;
 }
 
+static int
+key_scalar_words_equal(const dsd_key_scalars* a, const dsd_key_scalars* b) {
+    return a->K == b->K && a->K1 == b->K1 && a->K2 == b->K2 && a->K3 == b->K3 && a->K4 == b->K4 && a->R == b->R
+           && a->RR == b->RR && a->H == b->H && a->hytera_key_segments == b->hytera_key_segments;
+}
+
+static int
+key_scalar_slot_equal(const dsd_key_scalars* a, const dsd_key_scalars* b, size_t slot) {
+    return a->A1[slot] == b->A1[slot] && a->A2[slot] == b->A2[slot] && a->A3[slot] == b->A3[slot]
+           && a->A4[slot] == b->A4[slot] && a->aes_key_loaded[slot] == b->aes_key_loaded[slot]
+           && a->aes_key_segments[slot] == b->aes_key_segments[slot];
+}
+
+static int
+key_scalars_equal(const dsd_key_scalars* a, const dsd_key_scalars* b) {
+    if (!key_scalar_words_equal(a, b)) {
+        return 0;
+    }
+    for (size_t i = 0; i < 2U; i++) {
+        if (!key_scalar_slot_equal(a, b, i)) {
+            return 0;
+        }
+    }
+    for (size_t i = 0; i < sizeof(a->aes_key); i++) {
+        if (a->aes_key[i] != b->aes_key[i]) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 int
 dsd_key_set_equal(const dsd_key_set* a, const dsd_key_set* b) {
     if (a == NULL || b == NULL) {
@@ -156,7 +190,11 @@ dsd_key_set_equal(const dsd_key_set* a, const dsd_key_set* b) {
     if (a == b) {
         return 1;
     }
-    if (a->present != b->present || a->keyloader != b->keyloader || a->count != b->count) {
+    if (a->present != b->present || a->keyloader != b->keyloader || a->count != b->count
+        || !key_scalars_equal(&a->scalars, &b->scalars)) {
+        return 0;
+    }
+    if (a->count > 0U && (a->entries == NULL || b->entries == NULL)) {
         return 0;
     }
     for (size_t i = 0; i < a->count; i++) {
@@ -173,6 +211,174 @@ key_set_path_empty(const char* path) {
     return path == NULL || path[0] == '\0';
 }
 
+static int
+key_set_is_ascii_space(unsigned char c) {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+static int
+key_set_text_present(const char* text) {
+    if (text == NULL) {
+        return 0;
+    }
+    while (*text != '\0') {
+        if (!key_set_is_ascii_space((unsigned char)*text)) {
+            return 1;
+        }
+        text++;
+    }
+    return 0;
+}
+
+static int
+key_set_parse_direct_dec(const char* text, unsigned long long* out) {
+    const unsigned char* p = (const unsigned char*)text;
+    while (*p != '\0' && key_set_is_ascii_space(*p)) {
+        p++;
+    }
+    if (*p < (unsigned char)'0' || *p > (unsigned char)'9') {
+        return -1;
+    }
+    unsigned int value = 0U;
+    while (*p >= (unsigned char)'0' && *p <= (unsigned char)'9') {
+        const unsigned int digit = (unsigned int)(*p - (unsigned char)'0');
+        if (value > (255U - digit) / 10U) {
+            return -1;
+        }
+        value = (value * 10U) + digit;
+        p++;
+    }
+    while (*p != '\0' && key_set_is_ascii_space(*p)) {
+        p++;
+    }
+    if (*p != '\0') {
+        return -1;
+    }
+    *out = (unsigned long long)value;
+    return 0;
+}
+
+static int
+key_set_collect_direct_hex(const char* text, char out[65], size_t* out_len) {
+    const unsigned char* p = (const unsigned char*)text;
+    while (*p != '\0' && key_set_is_ascii_space(*p)) {
+        p++;
+    }
+    if (p[0] == (unsigned char)'0' && (p[1] == (unsigned char)'x' || p[1] == (unsigned char)'X')) {
+        p += 2;
+    }
+    size_t count = 0U;
+    while (*p != '\0') {
+        if (key_set_is_ascii_space(*p)) {
+            p++;
+            continue;
+        }
+        if (dsd_hex_nibble_value(*p) < 0 || count >= 64U) {
+            DSD_SECURE_ZERO(out, 65U);
+            return -1;
+        }
+        out[count++] = (char)*p++;
+    }
+    out[count] = '\0';
+    *out_len = count;
+    return 0;
+}
+
+static void
+key_set_direct_store_segment(dsd_key_scalars* scalars, size_t segment, uint64_t value) {
+    unsigned long long* const slots[4] = {scalars->A1, scalars->A2, scalars->A3, scalars->A4};
+    slots[segment][0] = value;
+    slots[segment][1] = value;
+    for (size_t i = 0U; i < 8U; i++) {
+        scalars->aes_key[(segment * 8U) + i] = (uint8_t)((value >> (56U - (i * 8U))) & 0xFFU);
+    }
+}
+
+static int
+key_set_direct_hex_width_valid(size_t nhex) {
+    return nhex == 10U || nhex == 32U || nhex == 64U;
+}
+
+static int
+key_set_direct_segments_nonzero(const uint64_t segments[4], size_t count) {
+    for (size_t i = 0U; i < count; i++) {
+        if (segments[i] != 0U) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+key_set_parse_direct_hex(const char* text, dsd_key_scalars* scalars) {
+    char hex[65];
+    DSD_MEMSET(hex, 0, sizeof(hex));
+    size_t nhex = 0U;
+    if (key_set_collect_direct_hex(text, hex, &nhex) != 0 || !key_set_direct_hex_width_valid(nhex)) {
+        DSD_SECURE_ZERO(hex, sizeof(hex));
+        return -1;
+    }
+
+    uint64_t segments[4] = {0U, 0U, 0U, 0U};
+    const size_t segment_count = nhex == 10U ? 1U : nhex / 16U;
+    const size_t first_width = nhex == 10U ? 10U : 16U;
+    for (size_t i = 0U; i < segment_count; i++) {
+        const size_t offset = (nhex == 10U) ? 0U : i * 16U;
+        const size_t width = (i == 0U) ? first_width : 16U;
+        if (dsd_parse_hex_u64_n(hex + offset, width, &segments[i]) != 0) {
+            DSD_SECURE_ZERO(segments, sizeof(segments));
+            DSD_SECURE_ZERO(hex, sizeof(hex));
+            return -1;
+        }
+    }
+
+    scalars->H = segments[0];
+    scalars->K1 = segments[0];
+    scalars->K2 = segments[1];
+    scalars->K3 = segments[2];
+    scalars->K4 = segments[3];
+    const int any_nonzero = key_set_direct_segments_nonzero(segments, segment_count);
+    scalars->hytera_key_segments = any_nonzero ? (uint8_t)segment_count : 0U;
+    if (segment_count > 1U) {
+        for (size_t i = 0U; i < segment_count; i++) {
+            key_set_direct_store_segment(scalars, i, segments[i]);
+        }
+        scalars->aes_key_loaded[0] = scalars->aes_key_loaded[1] = any_nonzero;
+        scalars->aes_key_segments[0] = scalars->aes_key_segments[1] = (uint8_t)segment_count;
+    }
+
+    DSD_SECURE_ZERO(segments, sizeof(segments));
+    DSD_SECURE_ZERO(hex, sizeof(hex));
+    return 0;
+}
+
+dsd_key_direct_result
+dsd_key_set_load_direct(dsd_key_set* out, const char* single_hex, const char* single_dec) {
+    const int have_hex = key_set_text_present(single_hex);
+    const int have_dec = key_set_text_present(single_dec);
+    if (out == NULL || (!have_hex && !have_dec)) {
+        return DSD_KEY_DIRECT_INVALID_ARGUMENT;
+    }
+
+    dsd_key_set loaded;
+    DSD_MEMSET(&loaded, 0, sizeof(loaded));
+    loaded.present = 1U;
+    loaded.keyloader = 0;
+    if (have_dec && key_set_parse_direct_dec(single_dec, &loaded.scalars.K) != 0) {
+        dsd_key_set_free(&loaded);
+        return DSD_KEY_DIRECT_INVALID_DEC;
+    }
+    if (have_hex && key_set_parse_direct_hex(single_hex, &loaded.scalars) != 0) {
+        dsd_key_set_free(&loaded);
+        return DSD_KEY_DIRECT_INVALID_HEX;
+    }
+
+    dsd_key_set_free(out);
+    *out = loaded;
+    DSD_SECURE_ZERO(&loaded, sizeof(loaded));
+    return DSD_KEY_DIRECT_OK;
+}
+
 static void
 key_set_log_summary(const char* kind, const char* path, const dsd_csv_validation* stats) {
     /* Counts are pre-formatted so no numeric conversion shares a log line with a key word. */
@@ -186,9 +392,22 @@ key_set_log_summary(const char* kind, const char* path, const dsd_csv_validation
 /* The throwaway state held key material: wipe the keyring before the memory goes back. */
 static void
 key_set_free_throwaway(dsd_state* tmp) {
-    DSD_MEMSET(tmp->rkey_array, 0, sizeof(tmp->rkey_array));
-    DSD_MEMSET(tmp->rkey_array_loaded, 0, sizeof(tmp->rkey_array_loaded));
     dsd_state_ext_free_all(tmp);
+    DSD_SECURE_ZERO(tmp->rkey_array, sizeof(tmp->rkey_array));
+    DSD_SECURE_ZERO(tmp->rkey_array_loaded, sizeof(tmp->rkey_array_loaded));
+    DSD_SECURE_ZERO(tmp->aes_key, sizeof(tmp->aes_key));
+    DSD_SECURE_ZERO(&tmp->K, sizeof(tmp->K));
+    DSD_SECURE_ZERO(&tmp->K1, sizeof(tmp->K1));
+    DSD_SECURE_ZERO(&tmp->K2, sizeof(tmp->K2));
+    DSD_SECURE_ZERO(&tmp->K3, sizeof(tmp->K3));
+    DSD_SECURE_ZERO(&tmp->K4, sizeof(tmp->K4));
+    DSD_SECURE_ZERO(&tmp->R, sizeof(tmp->R));
+    DSD_SECURE_ZERO(&tmp->RR, sizeof(tmp->RR));
+    DSD_SECURE_ZERO(&tmp->H, sizeof(tmp->H));
+    DSD_SECURE_ZERO(tmp->A1, sizeof(tmp->A1));
+    DSD_SECURE_ZERO(tmp->A2, sizeof(tmp->A2));
+    DSD_SECURE_ZERO(tmp->A3, sizeof(tmp->A3));
+    DSD_SECURE_ZERO(tmp->A4, sizeof(tmp->A4));
     free(tmp);
 }
 
@@ -231,6 +450,7 @@ dsd_key_set_load_csv(dsd_key_set* out, const char* hex_path, const char* dec_pat
     DSD_MEMSET(&loaded.scalars, 0, sizeof(loaded.scalars));
     dsd_key_set_free(out);
     *out = loaded;
+    DSD_SECURE_ZERO(&loaded, sizeof(loaded));
     return 0;
 }
 
@@ -294,6 +514,7 @@ dsd_scan_keys_resume(dsd_state* state) {
     if (dsd_key_set_capture(&fresh, state) == 0) {
         dsd_key_set_free(&state->scan_keys_baseline);
         state->scan_keys_baseline = fresh;
+        DSD_SECURE_ZERO(&fresh, sizeof(fresh));
     }
     dsd_key_set_install(state, &state->scan_keys_active);
 }

--- a/src/core/util/key_set_internal.h
+++ b/src/core/util/key_set_internal.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_SRC_CORE_UTIL_KEY_SET_INTERNAL_H_
+#define DSD_NEO_SRC_CORE_UTIL_KEY_SET_INTERNAL_H_
+
+#include <dsd-neo/core/state_fwd.h>
+
+/* Compiler-resistant wipe of the inline key material held by a state. */
+void dsd_key_state_secure_wipe(dsd_state* state);
+
+#endif /* DSD_NEO_SRC_CORE_UTIL_KEY_SET_INTERNAL_H_ */

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2130,6 +2130,7 @@ no_carrier_unload_keys_if_needed(dsd_state* state) {
     DSD_MEMSET(state->A4, 0, sizeof(state->A4));
     DSD_MEMSET(state->aes_key_loaded, 0, sizeof(state->aes_key_loaded));
     DSD_MEMSET(state->aes_key_segments, 0, sizeof(state->aes_key_segments));
+    DSD_SECURE_ZERO(state->aes_key, sizeof(state->aes_key));
     state->H = 0;
 }
 

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -515,6 +515,8 @@ typedef struct {
     int rtl_gain_idx;
     int keys_hex_idx;
     int keys_dec_idx;
+    int single_key_hex_idx;
+    int single_key_dec_idx;
     int p25_bandplan_idx;
     unsigned int row;
     char* err;
@@ -643,9 +645,20 @@ scan_target_list_reserve(dsd_trunk_scan_target_list* list, size_t needed) {
     if (capacity > SIZE_MAX / sizeof(dsd_trunk_scan_target)) {
         return -1;
     }
-    dsd_trunk_scan_target* targets = (dsd_trunk_scan_target*)realloc(list->targets, capacity * sizeof *targets);
+    dsd_trunk_scan_target* targets = (dsd_trunk_scan_target*)calloc(capacity, sizeof *targets);
     if (!targets) {
         return -1;
+    }
+    /* Targets contain only fixed-size inline data. Move the populated structs,
+     * wipe the now-duplicate key metadata, and publish the new allocation last. */
+    dsd_trunk_scan_target* const old_targets = list->targets;
+    const size_t old_capacity = list->capacity;
+    if (old_targets != NULL && list->count > 0U) {
+        DSD_MEMCPY(targets, old_targets, list->count * sizeof(*targets));
+    }
+    if (old_targets != NULL) {
+        DSD_SECURE_ZERO(old_targets, old_capacity * sizeof(*old_targets));
+        free(old_targets);
     }
     list->targets = targets;
     list->capacity = capacity;
@@ -702,6 +715,41 @@ scan_parse_target_paths(dsd_trunk_scan_target* target, const dsd_trunk_scan_row_
 }
 
 static int
+scan_validate_target_key_sources(const dsd_trunk_scan_row_parse* parse, const char* keys_hex_s, const char* keys_dec_s,
+                                 const char* single_hex_s, const char* single_dec_s) {
+    const int have_files = keys_hex_s[0] != '\0' || keys_dec_s[0] != '\0';
+    const int have_direct = single_hex_s[0] != '\0' || single_dec_s[0] != '\0';
+    if (have_files && have_direct) {
+        scan_set_error(parse->err, parse->err_sz, "row %u combines direct keys with keys_hex_csv/keys_dec_csv",
+                       parse->row);
+        return -1;
+    }
+    return 0;
+}
+
+static int
+scan_parse_target_direct_keys(dsd_trunk_scan_target* target, const dsd_trunk_scan_row_parse* parse,
+                              const char* single_hex_s, const char* single_dec_s) {
+    if (single_hex_s[0] == '\0' && single_dec_s[0] == '\0') {
+        return 0;
+    }
+
+    dsd_key_set direct;
+    DSD_MEMSET(&direct, 0, sizeof(direct));
+    const dsd_key_direct_result rc = dsd_key_set_load_direct(&direct, single_hex_s[0] != '\0' ? single_hex_s : NULL,
+                                                             single_dec_s[0] != '\0' ? single_dec_s : NULL);
+    if (rc != DSD_KEY_DIRECT_OK) {
+        const char* field = rc == DSD_KEY_DIRECT_INVALID_DEC ? "single_key_dec" : "single_key_hex";
+        scan_set_error(parse->err, parse->err_sz, "row %u has invalid %s value", parse->row, field);
+        return -1;
+    }
+    target->single_key_scalars = direct.scalars;
+    target->single_keys_present = 1U;
+    dsd_key_set_free(&direct);
+    return 0;
+}
+
+static int
 scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_trunk_scan_row_parse* parse) {
     char* fields[DSD_TRUNK_SCAN_MAX_CSV_FIELDS] = {0};
     size_t field_count = 0;
@@ -718,6 +766,8 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
     const char* rtl_gain_s = scan_optional_field(fields, field_count, parse->rtl_gain_idx);
     const char* keys_hex_s = scan_optional_field(fields, field_count, parse->keys_hex_idx);
     const char* keys_dec_s = scan_optional_field(fields, field_count, parse->keys_dec_idx);
+    const char* single_hex_s = scan_optional_field(fields, field_count, parse->single_key_hex_idx);
+    const char* single_dec_s = scan_optional_field(fields, field_count, parse->single_key_dec_idx);
     const char* p25_bandplan_s = scan_optional_field(fields, field_count, parse->p25_bandplan_idx);
 
     dsd_trunk_scan_target target;
@@ -734,7 +784,8 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
         return -1;
     }
 
-    if (scan_parse_target_paths(&target, parse, chan_csv, keys_hex_s, keys_dec_s, p25_bandplan_s) != 0) {
+    if (scan_validate_target_key_sources(parse, keys_hex_s, keys_dec_s, single_hex_s, single_dec_s) != 0
+        || scan_parse_target_paths(&target, parse, chan_csv, keys_hex_s, keys_dec_s, p25_bandplan_s) != 0) {
         return -1;
     }
     if (scan_parse_ms_field(dwell_s, parse->default_dwell_ms, &target.dwell_ms) != 0) {
@@ -758,7 +809,13 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
         scan_set_error(parse->err, parse->err_sz, "out of memory loading trunk scan targets");
         return -1;
     }
+    /* Parse secrets after every fallible non-secret row check. Once accepted,
+     * the list owns the only surviving copy. */
+    if (scan_parse_target_direct_keys(&target, parse, single_hex_s, single_dec_s) != 0) {
+        return -1;
+    }
     parsed->targets[parsed->count++] = target;
+    DSD_SECURE_ZERO(&target, sizeof(target));
     return 0;
 }
 
@@ -771,6 +828,7 @@ scan_match_optional_header(dsd_trunk_scan_row_parse* parse, const char* name, si
     } cols[] = {
         {"modulation", &parse->modulation_idx},         {"rtl_gain", &parse->rtl_gain_idx},
         {"keys_hex_csv", &parse->keys_hex_idx},         {"keys_dec_csv", &parse->keys_dec_idx},
+        {"single_key_hex", &parse->single_key_hex_idx}, {"single_key_dec", &parse->single_key_dec_idx},
         {"p25_bandplan_csv", &parse->p25_bandplan_idx},
     };
 
@@ -821,6 +879,8 @@ scan_read_target_csv_header(FILE* fp, char* line, size_t line_sz, dsd_trunk_scan
     parse->rtl_gain_idx = -1;
     parse->keys_hex_idx = -1;
     parse->keys_dec_idx = -1;
+    parse->single_key_hex_idx = -1;
+    parse->single_key_dec_idx = -1;
     parse->p25_bandplan_idx = -1;
     for (size_t i = DSD_TRUNK_SCAN_REQUIRED_CSV_FIELDS; i < field_count; i++) {
         if (scan_match_optional_header(parse, scan_unquote(fields[i]), i) != 0) {
@@ -895,6 +955,11 @@ dsd_trunk_scan_load_targets_csv(const char* path, const dsd_opts* opts, dsd_trun
     parse.err_sz = err_sz;
     parse.modulation_idx = -1;
     parse.rtl_gain_idx = -1;
+    parse.keys_hex_idx = -1;
+    parse.keys_dec_idx = -1;
+    parse.single_key_hex_idx = -1;
+    parse.single_key_dec_idx = -1;
+    parse.p25_bandplan_idx = -1;
 
     if (scan_read_target_csv_header(fp, line, sizeof line, &parse) != 0) {
         fclose(fp);
@@ -913,6 +978,7 @@ dsd_trunk_scan_load_targets_csv(const char* path, const dsd_opts* opts, dsd_trun
         return -1;
     }
     *out = parsed;
+    DSD_SECURE_ZERO(&parsed, sizeof(parsed));
     return 0;
 }
 
@@ -921,10 +987,11 @@ dsd_trunk_scan_target_list_reset(dsd_trunk_scan_target_list* list) {
     if (!list) {
         return;
     }
-    free(list->targets);
-    list->targets = NULL;
-    list->count = 0;
-    list->capacity = 0;
+    if (list->targets != NULL) {
+        DSD_SECURE_ZERO(list->targets, list->capacity * sizeof(*list->targets));
+        free(list->targets);
+    }
+    DSD_SECURE_ZERO(list, sizeof(*list));
 }
 
 static int
@@ -1694,6 +1761,24 @@ trunk_scan_get_const(const dsd_state* state) {
     return (const dsd_trunk_scan_coord*)dsd_state_ext_get_const(state, DSD_STATE_EXT_ENGINE_TRUNK_SCAN);
 }
 
+#if defined(DSD_TRUNK_SCAN_TEST_CLOCK)
+int
+trunk_scan_test_target_embedded_keys_cleared(const dsd_state* state, size_t index) {
+    const dsd_trunk_scan_coord* coord = trunk_scan_get_const(state);
+    if (coord == NULL || index >= coord->count) {
+        return 0;
+    }
+    dsd_key_set probe;
+    dsd_key_set empty;
+    DSD_MEMSET(&probe, 0, sizeof(probe));
+    DSD_MEMSET(&empty, 0, sizeof(empty));
+    probe.scalars = coord->targets[index].target.single_key_scalars;
+    const int cleared = coord->targets[index].target.single_keys_present == 0U && dsd_key_set_equal(&probe, &empty);
+    DSD_SECURE_ZERO(&probe, sizeof(probe));
+    return cleared;
+}
+#endif
+
 static int
 trunk_scan_target_is_p25(const dsd_trunk_scan_target* target) {
     return target && target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK;
@@ -1998,6 +2083,19 @@ trunk_scan_build_target_runtime(dsd_trunk_scan_coord* coord, dsd_opts* opts, dsd
     for (size_t i = 0; i < build_count; i++) {
         dsd_trunk_scan_target_runtime* rt = &coord->targets[i];
         rt->target = list->targets[i];
+        const int have_key_files = rt->target.keys_hex_csv[0] != '\0' || rt->target.keys_dec_csv[0] != '\0';
+        if (rt->target.single_keys_present != 0U && have_key_files) {
+            scan_set_error(err, err_sz, "trunk scan target '%s' combines direct keys with key CSV files",
+                           rt->target.id);
+            return -1;
+        }
+        if (rt->target.single_keys_present != 0U) {
+            rt->keys.present = 1U;
+            rt->keys.keyloader = 0;
+            rt->keys.scalars = rt->target.single_key_scalars;
+            DSD_SECURE_ZERO(&rt->target.single_key_scalars, sizeof(rt->target.single_key_scalars));
+            rt->target.single_keys_present = 0U;
+        }
         trunk_scan_restore_snapshot(state, empty_snapshot);
         trunk_scan_apply_target_opts(opts, coord, &rt->target);
         trunk_scan_apply_target_demod(opts, state, &rt->target);
@@ -2008,7 +2106,7 @@ trunk_scan_build_target_runtime(dsd_trunk_scan_coord* coord, dsd_opts* opts, dsd
         if (trunk_scan_import_target_p25_bandplan(state, &rt->target, err, err_sz) != 0) {
             return -1;
         }
-        if (rt->target.keys_hex_csv[0] != '\0' || rt->target.keys_dec_csv[0] != '\0') {
+        if (have_key_files) {
             const char* key_src =
                 rt->target.keys_hex_csv[0] != '\0' ? rt->target.keys_hex_csv : rt->target.keys_dec_csv;
             if (dsd_key_set_load_csv(&rt->keys, rt->target.keys_hex_csv[0] != '\0' ? rt->target.keys_hex_csv : NULL,
@@ -2806,7 +2904,11 @@ trunk_scan_coord_free(dsd_trunk_scan_coord* coord) {
     free(coord->scratch_snapshot.trunk_lcn_freq_ext);
     free(coord->scratch_snapshot.chan_map_chan);
     free(coord->scratch_snapshot.chan_map_freq);
-    free(coord->targets);
+    if (coord->targets != NULL) {
+        DSD_SECURE_ZERO(coord->targets, coord->count * sizeof(*coord->targets));
+        free(coord->targets);
+    }
+    DSD_SECURE_ZERO(coord, sizeof(*coord));
     free(coord);
 }
 

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -657,7 +657,10 @@ scan_target_list_reserve(dsd_trunk_scan_target_list* list, size_t needed) {
         DSD_MEMCPY(targets, old_targets, list->count * sizeof(*targets));
     }
     if (old_targets != NULL) {
-        DSD_SECURE_ZERO(old_targets, old_capacity * sizeof(*old_targets));
+        const size_t wipe_count = list->count < old_capacity ? list->count : old_capacity;
+        for (size_t i = 0U; i < wipe_count; i++) {
+            DSD_SECURE_ZERO(&old_targets[i].single_key_scalars, sizeof(old_targets[i].single_key_scalars));
+        }
         free(old_targets);
     }
     list->targets = targets;
@@ -739,7 +742,12 @@ scan_parse_target_direct_keys(dsd_trunk_scan_target* target, const dsd_trunk_sca
     const dsd_key_direct_result rc = dsd_key_set_load_direct(&direct, single_hex_s[0] != '\0' ? single_hex_s : NULL,
                                                              single_dec_s[0] != '\0' ? single_dec_s : NULL);
     if (rc != DSD_KEY_DIRECT_OK) {
-        const char* field = rc == DSD_KEY_DIRECT_INVALID_DEC ? "single_key_dec" : "single_key_hex";
+        const char* field = "single_key_dec/single_key_hex";
+        if (rc == DSD_KEY_DIRECT_INVALID_DEC) {
+            field = "single_key_dec";
+        } else if (rc == DSD_KEY_DIRECT_INVALID_HEX) {
+            field = "single_key_hex";
+        }
         scan_set_error(parse->err, parse->err_sz, "row %u has invalid %s value", parse->row, field);
         return -1;
     }
@@ -815,7 +823,7 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
         return -1;
     }
     parsed->targets[parsed->count++] = target;
-    DSD_SECURE_ZERO(&target, sizeof(target));
+    DSD_SECURE_ZERO(&target.single_key_scalars, sizeof(target.single_key_scalars));
     return 0;
 }
 
@@ -953,20 +961,15 @@ dsd_trunk_scan_load_targets_csv(const char* path, const dsd_opts* opts, dsd_trun
         scan_default_ms(opts ? opts->trunk_scan_activity_hold_ms : 0, DSD_TRUNK_SCAN_ACTIVITY_HOLD_DEFAULT_MS);
     parse.err = err;
     parse.err_sz = err_sz;
-    parse.modulation_idx = -1;
-    parse.rtl_gain_idx = -1;
-    parse.keys_hex_idx = -1;
-    parse.keys_dec_idx = -1;
-    parse.single_key_hex_idx = -1;
-    parse.single_key_dec_idx = -1;
-    parse.p25_bandplan_idx = -1;
 
     if (scan_read_target_csv_header(fp, line, sizeof line, &parse) != 0) {
+        DSD_SECURE_ZERO(line, sizeof(line));
         fclose(fp);
         return -1;
     }
 
     int rows_rc = scan_load_target_csv_rows(fp, line, sizeof line, &parsed, &parse);
+    DSD_SECURE_ZERO(line, sizeof(line));
     fclose(fp);
     if (rows_rc != 0) {
         dsd_trunk_scan_target_list_reset(&parsed);
@@ -978,7 +981,9 @@ dsd_trunk_scan_load_targets_csv(const char* path, const dsd_opts* opts, dsd_trun
         return -1;
     }
     *out = parsed;
-    DSD_SECURE_ZERO(&parsed, sizeof(parsed));
+    parsed.targets = NULL;
+    parsed.count = 0U;
+    parsed.capacity = 0U;
     return 0;
 }
 
@@ -988,10 +993,15 @@ dsd_trunk_scan_target_list_reset(dsd_trunk_scan_target_list* list) {
         return;
     }
     if (list->targets != NULL) {
-        DSD_SECURE_ZERO(list->targets, list->capacity * sizeof(*list->targets));
+        const size_t wipe_count = list->count < list->capacity ? list->count : list->capacity;
+        for (size_t i = 0U; i < wipe_count; i++) {
+            DSD_SECURE_ZERO(&list->targets[i].single_key_scalars, sizeof(list->targets[i].single_key_scalars));
+        }
         free(list->targets);
     }
-    DSD_SECURE_ZERO(list, sizeof(*list));
+    list->targets = NULL;
+    list->count = 0U;
+    list->capacity = 0U;
 }
 
 static int
@@ -2900,15 +2910,15 @@ trunk_scan_coord_free(dsd_trunk_scan_coord* coord) {
         free(coord->targets[i].snapshot.chan_map_chan);
         free(coord->targets[i].snapshot.chan_map_freq);
         dsd_key_set_free(&coord->targets[i].keys);
+        DSD_SECURE_ZERO(&coord->targets[i].target.single_key_scalars,
+                        sizeof(coord->targets[i].target.single_key_scalars));
     }
     free(coord->scratch_snapshot.trunk_lcn_freq_ext);
     free(coord->scratch_snapshot.chan_map_chan);
     free(coord->scratch_snapshot.chan_map_freq);
     if (coord->targets != NULL) {
-        DSD_SECURE_ZERO(coord->targets, coord->count * sizeof(*coord->targets));
         free(coord->targets);
     }
-    DSD_SECURE_ZERO(coord, sizeof(*coord));
     free(coord);
 }
 

--- a/src/engine/trunk_scan_internal.h
+++ b/src/engine/trunk_scan_internal.h
@@ -7,9 +7,13 @@
 #ifndef DSD_NEO_SRC_ENGINE_TRUNK_SCAN_INTERNAL_H_
 #define DSD_NEO_SRC_ENGINE_TRUNK_SCAN_INTERNAL_H_
 
+#include <dsd-neo/core/state_fwd.h>
+#include <stddef.h>
+
 #if defined(DSD_TRUNK_SCAN_TEST_CLOCK)
 void trunk_scan_test_set_now(double now_m);
 void trunk_scan_test_clear_now(void);
+int trunk_scan_test_target_embedded_keys_cleared(const dsd_state* state, size_t index);
 #endif
 
 #endif /* DSD_NEO_SRC_ENGINE_TRUNK_SCAN_INTERNAL_H_ */

--- a/tests/core/test_core_csv_import.c
+++ b/tests/core/test_core_csv_import.c
@@ -1681,6 +1681,121 @@ test_channel_import_row_key_columns(void) {
 }
 
 static int
+test_channel_import_direct_key_columns(void) {
+    int failed = 0;
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    dsd_state* scratch = (dsd_state*)calloc(1, sizeof(*scratch));
+    char map_tmpl[] = "dsd-neo-test-direct-rowkey-map-XXXXXX";
+    if (!opts || !state || !scratch) {
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    int fd = dsd_mkstemp(map_tmpl);
+    if (fd < 0) {
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    (void)dsd_close(fd);
+
+    static const char valid_map[] = "channel,frequency_hz,name,SINGLE_KEY_HEX,single_key_DEC\n"
+                                    "1,851000000,Dispatch,00112233445566778899AABBCCDDEEFF,7\n"
+                                    "2,851012500,Ops,,\n"
+                                    "bad,851025000,NoSlot,0123456789,99\n"
+                                    "3,851025000,Clear,,0\n";
+    if (write_text_file(map_tmpl, valid_map) != 0) {
+        (void)remove(map_tmpl);
+        free(opts);
+        free_test_state(state);
+        free_test_state(scratch);
+        return 1;
+    }
+    DSD_SNPRINTF(opts->chan_in_file, sizeof(opts->chan_in_file), "%s", map_tmpl);
+    state->K = 88ULL;
+    state->aes_key[0] = 0xAAU;
+    if (csvChanImport(opts, state) != 0 || state->lcn_freq_count != 3) {
+        DSD_FPRINTF(stderr, "direct row-key channel import failed\n");
+        failed = 1;
+    }
+    const dsd_key_set* row0 = dsd_state_trunk_lcn_keys_get(state, 0U);
+    if (row0 == NULL || row0->keyloader != 0 || row0->scalars.K != 7ULL || row0->scalars.K1 != 0x0011223344556677ULL
+        || row0->scalars.K2 != 0x8899AABBCCDDEEFFULL || row0->scalars.aes_key[15] != 0xFFU) {
+        DSD_FPRINTF(stderr, "direct row-key values did not land in slot 0\n");
+        failed = 1;
+    } else {
+        dsd_key_set_install(scratch, row0);
+        if (scratch->K != 7ULL || scratch->K1 != 0x0011223344556677ULL || scratch->keyloader != 0
+            || scratch->aes_key[15] != 0xFFU) {
+            DSD_FPRINTF(stderr, "direct row-key set did not install\n");
+            failed = 1;
+        }
+    }
+    if (dsd_state_trunk_lcn_keys_get(state, 1U) != NULL) {
+        DSD_FPRINTF(stderr, "blank direct cells stored a key set\n");
+        failed = 1;
+    }
+    const dsd_key_set* row2 = dsd_state_trunk_lcn_keys_get(state, 2U);
+    if (row2 == NULL || row2->present != 1U || row2->scalars.K != 0ULL) {
+        DSD_FPRINTF(stderr, "explicit zero direct key did not override globals\n");
+        failed = 1;
+    }
+    if (state->K != 88ULL || state->aes_key[0] != 0xAAU) {
+        DSD_FPRINTF(stderr, "direct row-key import leaked into live key state\n");
+        failed = 1;
+    }
+
+    dsd_state_trunk_lcn_free(state);
+    DSD_MEMSET(state, 0, sizeof(*state));
+    if (write_text_file(map_tmpl, "channel,frequency_hz,keys_hex_csv,single_key_dec\n"
+                                  "1,851000000,keys.csv,1\n")
+            != 0
+        || csvChanImport(opts, state) == 0) {
+        DSD_FPRINTF(stderr, "direct/file row-key conflict was accepted\n");
+        failed = 1;
+    }
+
+    dsd_state_trunk_lcn_free(state);
+    DSD_MEMSET(state, 0, sizeof(*state));
+    if (write_text_file(map_tmpl, "channel,frequency_hz,single_key_hex,single_key_hex\n"
+                                  "1,851000000,0123456789,0123456789\n")
+            != 0
+        || csvChanImport(opts, state) == 0) {
+        DSD_FPRINTF(stderr, "duplicate direct row-key header was accepted\n");
+        failed = 1;
+    }
+
+    dsd_state_trunk_lcn_free(state);
+    DSD_MEMSET(state, 0, sizeof(*state));
+    if (write_text_file(map_tmpl, "channel,frequency_hz,single_key_dec\n"
+                                  "1,851000000,256\n")
+            != 0
+        || csvChanImport(opts, state) == 0) {
+        DSD_FPRINTF(stderr, "invalid direct decimal row key was accepted\n");
+        failed = 1;
+    }
+
+    dsd_state_trunk_lcn_free(state);
+    DSD_MEMSET(state, 0, sizeof(*state));
+    if (write_text_file(map_tmpl, "channel,frequency_hz,single_key_hex\n"
+                                  "1,851000000,not-a-key\n")
+            != 0
+        || csvChanImport(opts, state) == 0) {
+        DSD_FPRINTF(stderr, "invalid direct hexadecimal row key was accepted\n");
+        failed = 1;
+    }
+
+    (void)remove(map_tmpl);
+    free(opts);
+    free_test_state(state);
+    free_test_state(scratch);
+    return failed;
+}
+
+static int
 test_channel_import_accepts_hex_and_iden_chan_keys(void) {
     int failed = 0;
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
@@ -2073,6 +2188,9 @@ main(void) {
         return 1;
     }
     if (test_channel_import_row_key_columns() != 0) {
+        return 1;
+    }
+    if (test_channel_import_direct_key_columns() != 0) {
         return 1;
     }
     if (test_channel_import_row_key_relative_subdir() != 0) {

--- a/tests/core/test_core_csv_validate.c
+++ b/tests/core/test_core_csv_validate.c
@@ -417,6 +417,8 @@ test_chan_direct_key_columns_validate(void) {
     char valid_tmpl[] = "dsd-neo-test-validate-chan-direct-XXXXXX";
     char conflict_tmpl[] = "dsd-neo-test-validate-chan-direct-mix-XXXXXX";
     char invalid_tmpl[] = "dsd-neo-test-validate-chan-direct-bad-XXXXXX";
+    char skipped_conflict_tmpl[] = "dsd-neo-test-validate-chan-direct-skip-mix-XXXXXX";
+    char skipped_invalid_tmpl[] = "dsd-neo-test-validate-chan-direct-skip-bad-XXXXXX";
     if (write_temp_csv(valid_tmpl, "channel,frequency_hz,single_key_dec,single_key_hex\n"
                                    "1,851000000,1,0123456789\n"
                                    "2,notafreq,2,00112233445566778899AABBCCDDEEFF\n"
@@ -445,9 +447,25 @@ test_chan_direct_key_columns_validate(void) {
         DSD_FPRINTF(stderr, "chan validation accepted an invalid direct key\n");
         failed = 1;
     }
+    if (write_temp_csv(skipped_invalid_tmpl, "channel,frequency_hz,single_key_hex\n"
+                                             "bad,851000000,invalid-secret-value\n")
+            != 0
+        || dsd_csv_validate_chan_file(skipped_invalid_tmpl, &v) == 0) {
+        DSD_FPRINTF(stderr, "chan validation skipped an invalid direct key on a no-slot row\n");
+        failed = 1;
+    }
+    if (write_temp_csv(skipped_conflict_tmpl, "channel,frequency_hz,keys_hex_csv,single_key_dec\n"
+                                              "bad,851000000,keys.csv,1\n")
+            != 0
+        || dsd_csv_validate_chan_file(skipped_conflict_tmpl, &v) == 0) {
+        DSD_FPRINTF(stderr, "chan validation skipped mixed key sources on a no-slot row\n");
+        failed = 1;
+    }
     (void)remove(valid_tmpl);
     (void)remove(conflict_tmpl);
     (void)remove(invalid_tmpl);
+    (void)remove(skipped_conflict_tmpl);
+    (void)remove(skipped_invalid_tmpl);
     return failed;
 }
 

--- a/tests/core/test_core_csv_validate.c
+++ b/tests/core/test_core_csv_validate.c
@@ -413,6 +413,45 @@ test_chan_key_column_bad_path_fails(void) {
 }
 
 static int
+test_chan_direct_key_columns_validate(void) {
+    char valid_tmpl[] = "dsd-neo-test-validate-chan-direct-XXXXXX";
+    char conflict_tmpl[] = "dsd-neo-test-validate-chan-direct-mix-XXXXXX";
+    char invalid_tmpl[] = "dsd-neo-test-validate-chan-direct-bad-XXXXXX";
+    if (write_temp_csv(valid_tmpl, "channel,frequency_hz,single_key_dec,single_key_hex\n"
+                                   "1,851000000,1,0123456789\n"
+                                   "2,notafreq,2,00112233445566778899AABBCCDDEEFF\n"
+                                   "3,852000000,0,\n")
+        != 0) {
+        return 1;
+    }
+    dsd_csv_validation v = {0U, 0U, 0U};
+    int failed = 0;
+    if (dsd_csv_validate_chan_file(valid_tmpl, &v) != 0 || v.accepted != 2U || v.skipped != 1U || v.total != 3U) {
+        DSD_FPRINTF(stderr, "chan direct-key validation mismatch: accepted=%u skipped=%u total=%u\n", v.accepted,
+                    v.skipped, v.total);
+        failed = 1;
+    }
+    if (write_temp_csv(conflict_tmpl, "channel,frequency_hz,keys_hex_csv,single_key_dec\n"
+                                      "1,851000000,keys.csv,1\n")
+            != 0
+        || dsd_csv_validate_chan_file(conflict_tmpl, &v) == 0) {
+        DSD_FPRINTF(stderr, "chan validation accepted mixed direct/file key sources\n");
+        failed = 1;
+    }
+    if (write_temp_csv(invalid_tmpl, "channel,frequency_hz,single_key_hex\n"
+                                     "1,851000000,invalid-secret-value\n")
+            != 0
+        || dsd_csv_validate_chan_file(invalid_tmpl, &v) == 0) {
+        DSD_FPRINTF(stderr, "chan validation accepted an invalid direct key\n");
+        failed = 1;
+    }
+    (void)remove(valid_tmpl);
+    (void)remove(conflict_tmpl);
+    (void)remove(invalid_tmpl);
+    return failed;
+}
+
+static int
 test_p25_bandplan_counts_mixed_rows(void) {
     char tmpl[] = "dsd-neo-test-validate-bandplan-XXXXXX";
     if (write_temp_csv(tmpl, "iden,base_hz,spacing_hz,type,tx_offset_hz,bandwidth_hz,wacn,sysid\n"
@@ -503,6 +542,9 @@ main(void) {
         return 1;
     }
     if (test_chan_key_column_bad_path_fails() != 0) {
+        return 1;
+    }
+    if (test_chan_direct_key_columns_validate() != 0) {
         return 1;
     }
     if (test_key_dec_counts_mixed_rows() != 0) {

--- a/tests/core/test_core_dmr_voice_alg_gate.c
+++ b/tests/core/test_core_dmr_voice_alg_gate.c
@@ -5,8 +5,12 @@
 
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/key_material.h>
+#include <dsd-neo/core/key_set.h>
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
@@ -75,6 +79,27 @@ main(void) {
     state.K1 = 0x0123456789ULL;
     rc |= expect_eq("missing-alg-hbp-key-slot0", dsd_dmr_missing_alg_key_can_decrypt(&state, 0), 1);
     rc |= expect_eq("missing-alg-hbp-key-slot1", dsd_dmr_missing_alg_key_can_decrypt(&state, 1), 1);
+
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    if (opts == NULL) {
+        return 1;
+    }
+    opts->dmr_mute_encL = 1;
+    opts->dmr_mute_encR = 1;
+    dsd_key_set direct;
+    DSD_MEMSET(&direct, 0, sizeof(direct));
+    if (dsd_key_set_load_direct(&direct, "0123456789", "7") != DSD_KEY_DIRECT_OK) {
+        rc = 1;
+    } else {
+        DSD_MEMSET(&state, 0, sizeof(state));
+        dsd_key_set_install(&state, &direct);
+        rc |= expect_eq("direct-bp-missing-alg-decryptable", dsd_dmr_missing_alg_key_can_decrypt(&state, 0), 1);
+        rc |= expect_eq("direct-hbp-missing-alg-decryptable", dsd_dmr_missing_alg_key_can_decrypt(&state, 1), 1);
+        rc |= expect_eq("direct-key-keeps-left-mute-preference", opts->dmr_mute_encL, 1);
+        rc |= expect_eq("direct-key-keeps-right-mute-preference", opts->dmr_mute_encR, 1);
+    }
+    dsd_key_set_free(&direct);
+    free(opts);
 
     DSD_MEMSET(&state, 0, sizeof(state));
     state.M = 0x24;

--- a/tests/core/test_core_dmr_voice_alg_gate.c
+++ b/tests/core/test_core_dmr_voice_alg_gate.c
@@ -6,11 +6,8 @@
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/key_material.h>
 #include <dsd-neo/core/key_set.h>
-#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
@@ -80,12 +77,6 @@ main(void) {
     rc |= expect_eq("missing-alg-hbp-key-slot0", dsd_dmr_missing_alg_key_can_decrypt(&state, 0), 1);
     rc |= expect_eq("missing-alg-hbp-key-slot1", dsd_dmr_missing_alg_key_can_decrypt(&state, 1), 1);
 
-    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
-    if (opts == NULL) {
-        return 1;
-    }
-    opts->dmr_mute_encL = 1;
-    opts->dmr_mute_encR = 1;
     dsd_key_set direct;
     DSD_MEMSET(&direct, 0, sizeof(direct));
     if (dsd_key_set_load_direct(&direct, "0123456789", "7") != DSD_KEY_DIRECT_OK) {
@@ -95,11 +86,8 @@ main(void) {
         dsd_key_set_install(&state, &direct);
         rc |= expect_eq("direct-bp-missing-alg-decryptable", dsd_dmr_missing_alg_key_can_decrypt(&state, 0), 1);
         rc |= expect_eq("direct-hbp-missing-alg-decryptable", dsd_dmr_missing_alg_key_can_decrypt(&state, 1), 1);
-        rc |= expect_eq("direct-key-keeps-left-mute-preference", opts->dmr_mute_encL, 1);
-        rc |= expect_eq("direct-key-keeps-right-mute-preference", opts->dmr_mute_encR, 1);
     }
     dsd_key_set_free(&direct);
-    free(opts);
 
     DSD_MEMSET(&state, 0, sizeof(state));
     state.M = 0x24;

--- a/tests/core/test_core_key_set.c
+++ b/tests/core/test_core_key_set.c
@@ -65,6 +65,8 @@ test_capture_install_roundtrip(void) {
     state->A1[0] = 21ULL;
     state->aes_key_loaded[1] = 1;
     state->aes_key_segments[0] = 4U;
+    state->aes_key[0] = 0xABU;
+    state->aes_key[31] = 0xCDU;
 
     dsd_key_set ks;
     DSD_MEMSET(&ks, 0, sizeof(ks));
@@ -76,7 +78,8 @@ test_capture_install_roundtrip(void) {
     }
     if (ks.scalars.K != 11ULL || ks.scalars.K1 != 12ULL || ks.scalars.R != 13ULL || ks.scalars.RR != 14ULL
         || ks.scalars.H != 15ULL || ks.scalars.hytera_key_segments != 3U || ks.scalars.A1[0] != 21ULL
-        || ks.scalars.aes_key_loaded[1] != 1 || ks.scalars.aes_key_segments[0] != 4U) {
+        || ks.scalars.aes_key_loaded[1] != 1 || ks.scalars.aes_key_segments[0] != 4U || ks.scalars.aes_key[0] != 0xABU
+        || ks.scalars.aes_key[31] != 0xCDU) {
         DSD_FPRINTF(stderr, "capture scalar block mismatch\n");
         failed = 1;
     }
@@ -87,6 +90,7 @@ test_capture_install_roundtrip(void) {
     state->keyloader = 0;
     state->K = 0ULL;
     state->A1[0] = 0ULL;
+    DSD_MEMSET(state->aes_key, 0, sizeof(state->aes_key));
     dsd_key_set_install(state, &ks);
     if (state->rkey_array[5] != 0xABCDEULL || state->rkey_array_loaded[5] != 1U) {
         DSD_FPRINTF(stderr, "install did not restore slot 5\n");
@@ -100,7 +104,8 @@ test_capture_install_roundtrip(void) {
         DSD_FPRINTF(stderr, "install did not clear a prior entry\n");
         failed = 1;
     }
-    if (state->keyloader != 1 || state->K != 11ULL || state->A1[0] != 21ULL) {
+    if (state->keyloader != 1 || state->K != 11ULL || state->A1[0] != 21ULL || state->aes_key[0] != 0xABU
+        || state->aes_key[31] != 0xCDU) {
         DSD_FPRINTF(stderr, "install did not restore keyloader/scalars\n");
         failed = 1;
     }
@@ -128,9 +133,154 @@ test_capture_install_roundtrip(void) {
         DSD_FPRINTF(stderr, "equal missed a value change\n");
         failed = 1;
     }
+    copy.entries[0].value ^= 1ULL;
+    copy.scalars.aes_key[31] ^= 1U;
+    if (dsd_key_set_equal(&copy, &ks)) {
+        DSD_FPRINTF(stderr, "equal missed an AES byte change\n");
+        failed = 1;
+    }
 
     dsd_key_set_free(&copy);
     dsd_key_set_free(&ks);
+    free_test_state(state);
+    return failed;
+}
+
+static int
+test_load_direct(void) {
+    int failed = 0;
+    dsd_key_set direct;
+    DSD_MEMSET(&direct, 0, sizeof(direct));
+
+    if (dsd_key_set_load_direct(&direct, NULL, " 255 \t") != DSD_KEY_DIRECT_OK || direct.present != 1U
+        || direct.keyloader != 0 || direct.count != 0U || direct.scalars.K != 255ULL) {
+        DSD_FPRINTF(stderr, "direct decimal parse mismatch\n");
+        failed = 1;
+    }
+
+    if (dsd_key_set_load_direct(&direct, " 0x01 23 45 67 89 ", NULL) != DSD_KEY_DIRECT_OK
+        || direct.scalars.H != 0x0123456789ULL || direct.scalars.K1 != 0x0123456789ULL || direct.scalars.K2 != 0ULL
+        || direct.scalars.hytera_key_segments != 1U || direct.scalars.aes_key_loaded[0] != 0
+        || direct.scalars.aes_key_segments[0] != 0U) {
+        DSD_FPRINTF(stderr, "direct 40-bit hex parse mismatch\n");
+        failed = 1;
+    }
+
+    if (dsd_key_set_load_direct(&direct, "00112233445566778899AABBCCDDEEFF", "7") != DSD_KEY_DIRECT_OK
+        || direct.scalars.K != 7ULL || direct.scalars.K1 != 0x0011223344556677ULL
+        || direct.scalars.K2 != 0x8899AABBCCDDEEFFULL || direct.scalars.hytera_key_segments != 2U
+        || direct.scalars.A1[0] != direct.scalars.K1 || direct.scalars.A1[1] != direct.scalars.K1
+        || direct.scalars.A2[0] != direct.scalars.K2 || direct.scalars.aes_key_loaded[0] != 1
+        || direct.scalars.aes_key_loaded[1] != 1 || direct.scalars.aes_key_segments[0] != 2U
+        || direct.scalars.aes_key[0] != 0x00U || direct.scalars.aes_key[15] != 0xFFU
+        || direct.scalars.aes_key[16] != 0U) {
+        DSD_FPRINTF(stderr, "direct combined AES-128/decimal parse mismatch\n");
+        failed = 1;
+    }
+
+    if (dsd_key_set_load_direct(&direct, "00112233445566778899AABBCCDDEEFF102132435465768798A9BACBDCEDFE0F", NULL)
+            != DSD_KEY_DIRECT_OK
+        || direct.scalars.K3 != 0x1021324354657687ULL || direct.scalars.K4 != 0x98A9BACBDCEDFE0FULL
+        || direct.scalars.hytera_key_segments != 4U || direct.scalars.aes_key_segments[1] != 4U
+        || direct.scalars.aes_key[16] != 0x10U || direct.scalars.aes_key[31] != 0x0FU) {
+        DSD_FPRINTF(stderr, "direct AES-256 parse mismatch\n");
+        failed = 1;
+    }
+
+    if (dsd_key_set_load_direct(&direct, "00000000000000000000000000000000", "0") != DSD_KEY_DIRECT_OK
+        || direct.present != 1U || direct.scalars.K != 0ULL || direct.scalars.hytera_key_segments != 0U
+        || direct.scalars.aes_key_loaded[0] != 0 || direct.scalars.aes_key_segments[0] != 2U) {
+        DSD_FPRINTF(stderr, "explicit zero direct key mismatch\n");
+        failed = 1;
+    }
+
+    dsd_key_set before;
+    DSD_MEMSET(&before, 0, sizeof(before));
+    if (dsd_key_set_copy(&before, &direct) != 0) {
+        failed = 1;
+    }
+    static const char* const bad_dec[] = {"-1", "+1", "256", "999999999999999999999", "1 2"};
+    for (size_t i = 0U; i < sizeof(bad_dec) / sizeof(bad_dec[0]); i++) {
+        if (dsd_key_set_load_direct(&direct, NULL, bad_dec[i]) != DSD_KEY_DIRECT_INVALID_DEC
+            || !dsd_key_set_equal(&direct, &before)) {
+            DSD_FPRINTF(stderr, "invalid direct decimal was accepted or mutated output at %zu\n", i);
+            failed = 1;
+        }
+    }
+    static const char* const bad_hex[] = {"123", "00112233445566778899AABBCCDDEEFG", "0x", "-0123456789"};
+    for (size_t i = 0U; i < sizeof(bad_hex) / sizeof(bad_hex[0]); i++) {
+        if (dsd_key_set_load_direct(&direct, bad_hex[i], NULL) != DSD_KEY_DIRECT_INVALID_HEX
+            || !dsd_key_set_equal(&direct, &before)) {
+            DSD_FPRINTF(stderr, "invalid direct hex was accepted or mutated output at %zu\n", i);
+            failed = 1;
+        }
+    }
+    if (dsd_key_set_load_direct(&direct, " \t ", NULL) != DSD_KEY_DIRECT_INVALID_ARGUMENT
+        || !dsd_key_set_equal(&direct, &before)
+        || dsd_key_set_load_direct(NULL, NULL, "1") != DSD_KEY_DIRECT_INVALID_ARGUMENT) {
+        DSD_FPRINTF(stderr, "direct invalid-argument handling mismatch\n");
+        failed = 1;
+    }
+
+    dsd_key_set other;
+    DSD_MEMSET(&other, 0, sizeof(other));
+    if (dsd_key_set_load_direct(&other, NULL, "1") != DSD_KEY_DIRECT_OK) {
+        failed = 1;
+    } else {
+        before.scalars.K = 2ULL;
+        if (dsd_key_set_equal(&before, &other)) {
+            DSD_FPRINTF(stderr, "scalar-only direct sets compared equal\n");
+            failed = 1;
+        }
+    }
+
+    unsigned char secret[8];
+    DSD_MEMSET(secret, 0xA5, sizeof(secret));
+    (void)DSD_SECURE_ZERO(secret, sizeof(secret));
+    for (size_t i = 0U; i < sizeof(secret); i++) {
+        if (secret[i] != 0U) {
+            DSD_FPRINTF(stderr, "secure zero left byte %zu\n", i);
+            failed = 1;
+            break;
+        }
+    }
+
+    dsd_key_set_free(&other);
+    dsd_key_set_free(&before);
+    dsd_key_set_free(&direct);
+    return failed;
+}
+
+static int
+test_direct_key_store_growth(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (state == NULL) {
+        return 1;
+    }
+    int failed = 0;
+    for (size_t i = 0U; i < 20U; i++) {
+        char value[8];
+        (void)DSD_SNPRINTF(value, sizeof(value), "%zu", i);
+        dsd_key_set direct;
+        DSD_MEMSET(&direct, 0, sizeof(direct));
+        if (dsd_key_set_load_direct(&direct, NULL, value) != DSD_KEY_DIRECT_OK
+            || dsd_state_trunk_lcn_keys_set(state, i, &direct) != 0) {
+            dsd_key_set_free(&direct);
+            failed = 1;
+            break;
+        }
+    }
+    if (state->trunk_lcn_keys_capacity < 20U) {
+        DSD_FPRINTF(stderr, "direct key store did not grow\n");
+        failed = 1;
+    }
+    for (size_t i = 0U; i < 20U && !failed; i++) {
+        const dsd_key_set* direct = dsd_state_trunk_lcn_keys_get(state, i);
+        if (direct == NULL || direct->scalars.K != (unsigned long long)i || direct->present != 1U) {
+            DSD_FPRINTF(stderr, "direct key store lost row %zu across growth\n", i);
+            failed = 1;
+        }
+    }
     free_test_state(state);
     return failed;
 }
@@ -342,6 +492,32 @@ test_row_apply_epoch(void) {
         DSD_FPRINTF(stderr, "repeat unkeyed apply must not bump the epoch\n");
         failed = 1;
     }
+
+    dsd_key_set direct_one;
+    dsd_key_set direct_two;
+    DSD_MEMSET(&direct_one, 0, sizeof(direct_one));
+    DSD_MEMSET(&direct_two, 0, sizeof(direct_two));
+    if (dsd_key_set_load_direct(&direct_one, NULL, "1") != DSD_KEY_DIRECT_OK
+        || dsd_key_set_load_direct(&direct_two, NULL, "2") != DSD_KEY_DIRECT_OK
+        || dsd_state_trunk_lcn_keys_set(state, 2U, &direct_one) != 0
+        || dsd_state_trunk_lcn_keys_set(state, 3U, &direct_two) != 0) {
+        dsd_key_set_free(&direct_one);
+        dsd_key_set_free(&direct_two);
+        free_test_state(state);
+        return 1;
+    }
+    if (dsd_scan_row_keys_apply(state, 2) != 1 || state->K != 1ULL || state->enc_lockout_key_epoch != epoch0 + 3U) {
+        DSD_FPRINTF(stderr, "first direct row did not install and bump the epoch\n");
+        failed = 1;
+    }
+    if (dsd_scan_row_keys_apply(state, 3) != 1 || state->K != 2ULL || state->enc_lockout_key_epoch != epoch0 + 4U) {
+        DSD_FPRINTF(stderr, "distinct scalar-only row did not install and bump the epoch\n");
+        failed = 1;
+    }
+    if (dsd_scan_row_keys_apply(state, 3) != 0 || state->enc_lockout_key_epoch != epoch0 + 4U) {
+        DSD_FPRINTF(stderr, "repeat direct row changed the epoch\n");
+        failed = 1;
+    }
     if (dsd_scan_row_keys_apply(state, -1) != 0) {
         DSD_FPRINTF(stderr, "negative row must be a no-op\n");
         failed = 1;
@@ -357,6 +533,12 @@ main(void) {
         return 1;
     }
     if (test_load_hex_dec() != 0) {
+        return 1;
+    }
+    if (test_load_direct() != 0) {
+        return 1;
+    }
+    if (test_direct_key_store_growth() != 0) {
         return 1;
     }
     if (test_enter_leave_suspend_resume() != 0) {

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -1759,6 +1759,51 @@ main(void) {
                                                             && cc->candidates[1] == 852012500L);
     rc |= expect_true("trunk-scan-still-resets-p25-metrics", state->p25_p1_fec_ok == 0);
 
+    free_test_runtime(opts, state);
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+
+    // Key-file sets arm keyloader and are transmission-scoped. Their canonical
+    // AES bytes must be erased with the scalar aliases on carrier loss.
+    state->keyloader = 1;
+    state->K = 7ULL;
+    state->K1 = state->H = 0x0011223344556677ULL;
+    state->A1[0] = state->A1[1] = state->K1;
+    state->aes_key_loaded[0] = state->aes_key_loaded[1] = 1;
+    state->aes_key_segments[0] = state->aes_key_segments[1] = 2U;
+    DSD_MEMSET(state->aes_key, 0xA5, sizeof(state->aes_key));
+    noCarrier(opts, state);
+    int aes_cleared = 1;
+    for (size_t i = 0U; i < sizeof(state->aes_key); i++) {
+        if (state->aes_key[i] != 0U) {
+            aes_cleared = 0;
+            break;
+        }
+    }
+    rc |= expect_true("keyloader-carrier-reset-clears-aes-bytes", aes_cleared && state->K == 0ULL && state->K1 == 0ULL
+                                                                      && state->H == 0ULL
+                                                                      && state->aes_key_loaded[0] == 0);
+
+    // Embedded direct keys deliberately use keyloader=0, matching -b/-H:
+    // noCarrier preserves them and must not alter the operator's mute policy.
+    dsd_key_set direct;
+    DSD_MEMSET(&direct, 0, sizeof(direct));
+    if (dsd_key_set_load_direct(&direct, "00112233445566778899AABBCCDDEEFF", "7") != DSD_KEY_DIRECT_OK) {
+        free_test_runtime(opts, state);
+        return 1;
+    }
+    dsd_key_set_install(state, &direct);
+    dsd_key_set_free(&direct);
+    opts->dmr_mute_encL = 1;
+    opts->dmr_mute_encR = 1;
+    noCarrier(opts, state);
+    rc |= expect_true("direct-key-carrier-reset-persists", state->keyloader == 0 && state->K == 7ULL
+                                                               && state->K1 == 0x0011223344556677ULL
+                                                               && state->aes_key[15] == 0xFFU);
+    rc |= expect_true("direct-key-carrier-reset-preserves-mute-policy",
+                      opts->dmr_mute_encL == 1 && opts->dmr_mute_encR == 1);
+
 #ifdef USE_RADIO
     // Radio builds also exercise the RTL/FSK reacquisition counters. A recovered
     // sync must close the current gap and refresh the last-sync timer without

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -754,14 +754,15 @@ test_parser_accepts_100_targets(void) {
     body[0] = '\0';
     for (int i = 0; i < 100; i++) {
         char row[128];
-        DSD_SNPRINTF(row, sizeof row, "id%d,dmr-conventional,%u,,,,\n", i, 461000000U + (unsigned)i);
+        DSD_SNPRINTF(row, sizeof row, "id%d,dmr-conventional,%u,,,,,%u\n", i, 461000000U + (unsigned)i, (unsigned)i);
         if (append_text(body, sizeof body, row) != 0) {
             cleanup_paths(dir, NULL, NULL);
             return 1;
         }
     }
     char target_path[DSD_TEST_PATH_MAX];
-    if (write_targets_file(dir, body, target_path, sizeof target_path) != 0) {
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,single_key_dec\n";
+    if (write_targets_file_with_header(dir, header, body, target_path, sizeof target_path) != 0) {
         cleanup_paths(dir, NULL, NULL);
         return 1;
     }
@@ -777,7 +778,9 @@ test_parser_accepts_100_targets(void) {
     int test_rc = 0;
     if (rc != 0 || list.count != 100 || list.targets == NULL || strcmp(list.targets[99].id, "id99") != 0
         || list.targets[99].frequency_hz != 461000099U || list.targets[99].dwell_ms != 3000
-        || list.targets[99].activity_hold_ms != 1200) {
+        || list.targets[99].activity_hold_ms != 1200 || list.targets[0].single_keys_present != 1U
+        || list.targets[0].single_key_scalars.K != 0ULL || list.targets[99].single_keys_present != 1U
+        || list.targets[99].single_key_scalars.K != 99ULL) {
         DSD_FPRINTF(stderr, "parser 100 targets rc=%d count=%zu err=%s\n", rc, list.count, err);
         test_rc = 1;
     }
@@ -5977,6 +5980,101 @@ test_parser_accepts_target_key_columns(void) {
 }
 
 static int
+test_parser_accepts_direct_target_key_columns(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] =
+        "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,single_key_dec,single_key_hex\n";
+    if (write_targets_file_with_header(dir, header,
+                                       "a,p25-trunk,851000000,,250,,primary,7,00112233445566778899AABBCCDDEEFF\n"
+                                       "b,dmr-trunk,452000000,,250,,plain,,\n"
+                                       "c,nxdn-conventional,461000000,,250,,zero,0,0000000000\n",
+                                       target_path, sizeof target_path)
+        != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    dsd_trunk_scan_target_list list;
+    DSD_MEMSET(&list, 0, sizeof list);
+    char err[256] = {0};
+    const int load_rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
+    int test_rc = 0;
+    if (load_rc != 0 || list.count != 3U) {
+        DSD_FPRINTF(stderr, "direct target parser rc=%d count=%zu err=%s\n", load_rc, list.count, err);
+        test_rc = 1;
+    } else {
+        if (list.targets[0].single_keys_present != 1U || list.targets[0].single_key_scalars.K != 7ULL
+            || list.targets[0].single_key_scalars.K1 != 0x0011223344556677ULL
+            || list.targets[0].single_key_scalars.K2 != 0x8899AABBCCDDEEFFULL
+            || list.targets[0].single_key_scalars.aes_key[15] != 0xFFU) {
+            DSD_FPRINTF(stderr, "direct target parser lost combined key fields\n");
+            test_rc = 1;
+        }
+        if (list.targets[1].single_keys_present != 0U) {
+            DSD_FPRINTF(stderr, "blank direct target fields stored a key set\n");
+            test_rc = 1;
+        }
+        if (list.targets[2].single_keys_present != 1U || list.targets[2].single_key_scalars.K != 0ULL
+            || list.targets[2].single_key_scalars.K1 != 0ULL) {
+            DSD_FPRINTF(stderr, "explicit zero direct target key was not preserved\n");
+            test_rc = 1;
+        }
+    }
+
+    dsd_trunk_scan_target_list_reset(&list);
+
+    static const char duplicate_header[] =
+        "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,single_key_dec,single_key_dec\n";
+    if (write_targets_file_with_header(dir, duplicate_header, "a,p25-trunk,851000000,,250,,dup,1,2\n", target_path,
+                                       sizeof target_path)
+            != 0
+        || dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err) == 0) {
+        DSD_FPRINTF(stderr, "duplicate direct target key header was accepted\n");
+        test_rc = 1;
+        dsd_trunk_scan_target_list_reset(&list);
+    }
+
+    static const char conflict_header[] =
+        "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,keys_hex_csv,single_key_dec\n";
+    static const char conflict_value[] = "241";
+    if (write_targets_file_with_header(dir, conflict_header, "a,p25-trunk,851000000,,250,,mixed,private-keys.csv,241\n",
+                                       target_path, sizeof target_path)
+            != 0
+        || dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err) == 0) {
+        DSD_FPRINTF(stderr, "mixed direct/file target key sources were accepted\n");
+        test_rc = 1;
+        dsd_trunk_scan_target_list_reset(&list);
+    } else if (strstr(err, conflict_value) != NULL || strstr(err, "private-keys.csv") != NULL) {
+        DSD_FPRINTF(stderr, "mixed target key diagnostic exposed a supplied value\n");
+        test_rc = 1;
+    }
+
+    static const char invalid_header[] =
+        "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,single_key_hex\n";
+    static const char invalid_value[] = "private-invalid-key";
+    if (write_targets_file_with_header(dir, invalid_header, "a,p25-trunk,851000000,,250,,invalid,private-invalid-key\n",
+                                       target_path, sizeof target_path)
+            != 0
+        || dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err) == 0) {
+        DSD_FPRINTF(stderr, "invalid direct target key was accepted\n");
+        test_rc = 1;
+        dsd_trunk_scan_target_list_reset(&list);
+    } else if (strstr(err, invalid_value) != NULL || strstr(err, "single_key_hex") == NULL) {
+        DSD_FPRINTF(stderr, "invalid direct target diagnostic was unsafe or imprecise: %s\n", err);
+        test_rc = 1;
+    }
+
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
 test_parser_rejects_duplicate_target_key_columns(void) {
     char dir[DSD_TEST_PATH_MAX];
     if (make_temp_dir(dir, sizeof dir) != 0) {
@@ -6086,6 +6184,98 @@ test_target_keys_install_and_restore_across_switches(void) {
 
     trunk_scan_test_clear_now();
     (void)remove(hex_path);
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_direct_target_keys_install_and_restore_across_switches(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] =
+        "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,single_key_dec,single_key_hex\n";
+    if (write_targets_file_with_header(dir, header,
+                                       "a,dmr-conventional,461000000,,250,,first,7,00112233445566778899AABBCCDDEEFF\n"
+                                       "b,dmr-conventional,461000001,,250,,global,,\n"
+                                       "c,dmr-conventional,461000002,,250,,second,9,0123456789\n",
+                                       target_path, sizeof target_path)
+        != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.dmr_mute_encL = 1;
+    opts.dmr_mute_encR = 1;
+    state.K = 0xBEEFULL;
+    state.K1 = 0x1111111111111111ULL;
+    state.H = state.K1;
+    state.aes_key[0] = 0xCCU;
+    state.rkey_array[3] = 111ULL;
+    state.rkey_array_loaded[3] = 1U;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    const int init_rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (init_rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0U || state.K != 7ULL
+        || state.K1 != 0x0011223344556677ULL || state.K2 != 0x8899AABBCCDDEEFFULL || state.keyloader != 0
+        || state.aes_key[15] != 0xFFU || state.rkey_array[3] != 0ULL) {
+        DSD_FPRINTF(stderr, "direct target init mismatch rc=%d active=%zu err=%s\n", init_rc,
+                    dsd_engine_trunk_scan_active_index(&state), err);
+        test_rc = 1;
+    }
+    if (opts.dmr_mute_encL != 1 || opts.dmr_mute_encR != 1) {
+        DSD_FPRINTF(stderr, "direct target changed encrypted-audio mute preferences\n");
+        test_rc = 1;
+    }
+    for (size_t i = 0U; i < 3U; i++) {
+        if (!trunk_scan_test_target_embedded_keys_cleared(&state, i)) {
+            DSD_FPRINTF(stderr, "runtime target %zu retained embedded direct key metadata\n", i);
+            test_rc = 1;
+        }
+    }
+    const uint64_t epoch0 = state.enc_lockout_key_epoch;
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1U || state.K != 0xBEEFULL || state.K1 != 0x1111111111111111ULL
+        || state.aes_key[0] != 0xCCU || state.rkey_array[3] != 111ULL || state.enc_lockout_key_epoch != epoch0) {
+        DSD_FPRINTF(stderr, "unkeyed target did not restore direct-key baseline\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 2U || state.K != 9ULL || state.K1 != 0x0123456789ULL
+        || state.H != 0x0123456789ULL || state.aes_key[0] != 0U || state.aes_key_segments[0] != 0U
+        || state.enc_lockout_key_epoch != epoch0) {
+        DSD_FPRINTF(stderr, "second direct target did not install distinct scalar keys\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.78);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0U || state.K != 7ULL || state.K1 != 0x0011223344556677ULL
+        || state.enc_lockout_key_epoch != epoch0) {
+        DSD_FPRINTF(stderr, "first direct target did not reinstall\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    if (state.K != 0xBEEFULL || state.K1 != 0x1111111111111111ULL || state.aes_key[0] != 0xCCU
+        || state.rkey_array[3] != 111ULL || opts.dmr_mute_encL != 1 || opts.dmr_mute_encR != 1) {
+        DSD_FPRINTF(stderr, "direct target shutdown did not restore global key state\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_clear_now();
     cleanup_paths(dir, target_path, NULL);
     return test_rc;
 }
@@ -6665,6 +6855,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_parser_accepts_quoted_chan_csv_with_comma);
     rc |= run_with_default_tune_hook(test_parser_accepts_optional_modulation_and_gain_columns);
     rc |= run_with_default_tune_hook(test_parser_accepts_target_key_columns);
+    rc |= run_with_default_tune_hook(test_parser_accepts_direct_target_key_columns);
     rc |= run_with_default_tune_hook(test_parser_rejects_duplicate_target_key_columns);
     rc |= run_with_default_tune_hook(test_parser_accepts_nxdn_targets);
     rc |= run_with_default_tune_hook(test_parser_rejects_invalid_inputs);
@@ -6675,6 +6866,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_coordinator_rotation_past_32_targets);
     rc |= run_with_default_tune_hook(test_coordinator_preserves_long_lcn_list_across_rotation);
     rc |= run_with_default_tune_hook(test_target_keys_install_and_restore_across_switches);
+    rc |= run_with_default_tune_hook(test_direct_target_keys_install_and_restore_across_switches);
     rc |= run_with_default_tune_hook(test_target_chan_csv_keys_are_discarded);
     rc |= run_with_default_tune_hook(test_target_keys_survive_failed_alternate_retune);
     rc |= run_with_default_tune_hook(test_coordinator_preserves_large_chan_map_across_rotation);

--- a/tests/fuzz/corpus/core_csv_import/README.md
+++ b/tests/fuzz/corpus/core_csv_import/README.md
@@ -6,7 +6,8 @@ The first byte selects which importer the fuzz harness exercises, then the remai
 file and parsed as that CSV format:
 
 - `selector % 7 == 0`: group list (`csvGroupImportPath`) -- seeded by `group.csv`, `malformed.csv` (`F`)
-- `selector % 7 == 1`: channel map (`csvChanImport`) -- seeded by `channel.csv` (`G`)
+- `selector % 7 == 1`: channel map (`csvChanImport`) -- seeded by `channel.csv`, `channel_direct.csv`, and
+  `channel_direct_conflict.csv` (`G`)
 - `selector % 7 == 2`: decimal key list (`csvKeyImportDec`) -- seeded by `key_dec.csv` (`H`)
 - `selector % 7 == 3`: hex key list (`csvKeyImportHex`) -- seeded by `key_hex.csv` (`I`)
 - `selector % 7 == 4`: Vertex keystream map (`csvVertexKsImport`) -- seeded by `vertex.csv` (`J`)

--- a/tests/fuzz/corpus/core_csv_import/channel_direct.csv
+++ b/tests/fuzz/corpus/core_csv_import/channel_direct.csv
@@ -1,0 +1,3 @@
+Gchannel,frequency_hz,single_key_dec,single_key_hex
+1,851000000,1,0000001F00
+2,851012500,0,00112233445566778899AABBCCDDEEFF

--- a/tests/fuzz/corpus/core_csv_import/channel_direct_conflict.csv
+++ b/tests/fuzz/corpus/core_csv_import/channel_direct_conflict.csv
@@ -1,0 +1,2 @@
+Gchannel,frequency_hz,keys_hex_csv,single_key_dec
+1,851000000,keys.csv,1


### PR DESCRIPTION
## Summary

- Follow up on the direct-key behavior requested in [this PR #464 comment](https://github.com/arancormonk/dsd-neo/pull/464#issuecomment-5538898850).
- Add optional `single_key_dec` (`-b`) and `single_key_hex` (`-H`) columns to `-Y` channel maps and trunk-scan target CSVs.
- Parse direct keys at import time, preserve explicit zero overrides, allow decimal and hex values together, and reject rows that mix direct values with key-file sources.
- Preserve the global key baseline and encrypted-audio mute preferences across scan hops; capture the full AES byte key and securely wipe secret-bearing temporary and heap storage.
- Update operator documentation, examples, regression tests, and the channel-import fuzz corpus.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human. Maintainer review is requested on this PR.
- [x] Risky or broad changes have a second reviewer, or the solo-maintainer exception and extra guardrails are documented. The plan received independent Claude and OMP reviews, and the implementation received the full quality-preflight pass.
- [x] High-risk areas touched are marked: security and parser.
- [x] Outside review was requested when available: Claude and OMP reviewed the implementation plan before work was finalized.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny. Key lifecycle, decryption gating, carrier reset, scan switching, and redaction have focused coverage.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. No suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — 604/604 passed
- [x] `tools/preflight_ci.sh`
- [x] `tools/quality_preflight.sh` — scan-build, strict lint/security checks, and fuzz smoke passed
- [ ] `tools/cmake_format_check.sh` — not applicable; no CMake changes
- [ ] `tools/zizmor.sh` — not applicable; no workflow changes
- [ ] `tools/osv_scan.sh` — not required; no dependency inputs changed (also covered by quality preflight)
- [x] `tools/check_secret_redaction.sh`, `tools/check_workflow_git_pins.sh`, `tools/check_workflow_download_pins.sh`, and `tools/check_vcpkg_overlay_pins.sh`
- [x] Radio-disabled build and test suite — 560/560 passed
- [x] Focused ASan/UBSan tests passed

## Risk

- Security/dependency impact: Direct keys remain in the operator-owned CSV by design. Runtime diagnostics never echo their values, and parsed copies are compiler-resistant-wiped when released. No dependency changes.
- CLI/UI behavior impact: Additive optional CSV columns only. A keyed row or target temporarily replaces global key state; leaving it restores the baseline without changing mute preferences.
- Compatibility or packaging impact: Existing key-file columns and CSVs remain compatible. No packaging changes.
