### PR TITLE
fix(engine): retain scan voice hold after terminator (#381)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -458,7 +458,9 @@ Notes
   Voice-only scan: `--scan-voice-only` steps on unless decoded voice frames hold the row. `--scan-voice-qualify-ms
   <100..600000>` (default `1000`) is the window after sync in which voice must appear or the scan moves on;
   `--scan-voice-hold-ms <100..600000>` (default `2000`) is the time to stay after the last voice frame. Encrypted
-  voice without a key holds unless the talkgroup policy blocks it; unknown identity counts as voice.
+  voice without a key holds unless the talkgroup policy blocks it; unknown identity counts as voice. The last-media
+  time survives an over-the-air terminator, so the full hold still runs when a protocol closes the call before the
+  scanner's next tick.
 - Single-tuner trunk scan mode: `--trunk-scan <targets.csv>`
   - Rotates one tuner across CSV-defined P25 trunk, DMR trunk, DMR conventional, NXDN trunk, NXDN96 conventional
     (`nxdn-conventional`) and NXDN48 conventional (`nxdn48-conventional`) targets. Full guide: `docs/trunk-scan.md`.
@@ -475,7 +477,8 @@ Notes
     (default `1200`).
   - Voice-only scan (`--scan-voice-only` with the qualify/hold flags above): conventional targets hold only from
     decoded voice, with `dwell_ms` as the qualify window and `activity_hold_ms` as the hold; trunked targets are
-    unchanged (control-only rotates after dwell) and show no `Voice:` marker on the status line.
+    unchanged (control-only rotates after dwell) and show no `Voice:` marker on the status line. A conventional
+    target shows `VOICE` while its call is active and `TAIL` after the call ends while the hold remains.
   - Cannot be combined with conventional `-Y` scan mode or IQ replay.
   - Single-tuner limitation: systems not currently parked can be missed while another target is being monitored.
 - Channel map CSV: `-C <file>` (e.g., `connect_plus_chan.csv`). The channel column takes decimal, `0x2A46` hex, or

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -46,8 +46,9 @@ Generated (do not edit/commit):
   - Single-tuner trunk scan coordinator: `src/engine/trunk_scan.c` behind
     `include/dsd-neo/engine/trunk_scan.h` (see below)
   - Voice-gated scan for -Y and trunk scan (issue #381): `src/engine/scan_voice_gate.c` behind
-    `include/dsd-neo/engine/scan_voice_gate.h` (tests: `ENGINE_SCAN_VOICE_GATE`, `ENGINE_NO_CARRIER_RESET`,
-    `ENGINE_TRUNK_SCAN`)
+    `include/dsd-neo/engine/scan_voice_gate.h`; its probe returns separate active and retained last-media clocks so
+    a protocol terminator cannot erase the scanner's tail anchor (tests: `ENGINE_SCAN_VOICE_GATE`,
+    `ENGINE_NO_CARRIER_RESET`, `ENGINE_TRUNK_SCAN`)
   - Installs runtime hook tables used by DSP/frame-sync code
     (`src/engine/frame_sync_hooks_install.c`, `include/dsd-neo/runtime/frame_sync_hooks.h`)
 - Build files: `src/engine/CMakeLists.txt`

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -135,7 +135,8 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
 - Per-target CSV values override these defaults.
 - `--scan-voice-only`: conventional targets hold only from decoded voice media (headers and data no longer hold),
   with the per-target `dwell_ms` as the qualify window in which voice must appear and `activity_hold_ms` as the
-  hold after the last voice frame; trunked targets are unchanged (control-only rotates after dwell). The
+  hold after the last voice frame, including when a terminator closes the call before the next scan tick; trunked
+  targets are unchanged (control-only rotates after dwell). The
   `--scan-voice-qualify-ms` and `--scan-voice-hold-ms` timings apply to the `-Y` conventional scan only, not to
   trunk-scan targets.
 
@@ -248,8 +249,9 @@ During scanning:
   data-call tuning, and encrypted-call tuning controls all apply to that decision, so data headers refresh the hold
   only when data-call tuning is enabled (`-e`, or `tune_data_calls` in a config file); it is off by default.
   With `--scan-voice-only`, headers alone never hold: the hold refreshes only from decoded voice media (stamped
-  with the media time, so LC-less voice holds), `dwell_ms` is the qualify window and `activity_hold_ms` the hold.
-  The terminal status line marks the parked conventional target `Voice: QUALIFY`, `VOICE` or `TAIL`. Trunked
+  with a retained media time, so LC-less and just-ended voice hold), `dwell_ms` is the qualify window and
+  `activity_hold_ms` the hold. The terminal status line marks the parked conventional target `Voice: QUALIFY`,
+  `VOICE` while a media-bearing call is active, or `TAIL` after it ends while the hold runs. Trunked
   targets are unchanged: control-only traffic rotates after dwell, and they carry no `Voice:` marker.
 - An `nxdn-trunk` target with a `chan_csv` reports channels it was granted but could not map, once per channel while
   it is parked (`NOTICE: NXDN trunking: grant: CH 12 has no frequency mapping in chan_csv (site.csv)`), and a summary

--- a/include/dsd-neo/core/call_state.h
+++ b/include/dsd-neo/core/call_state.h
@@ -170,6 +170,10 @@ typedef struct {
     double started_m;
     double updated_m;
     double ended_m;
+    /** First decoded-media update in this logical transmission (monotonic seconds), or 0. */
+    double media_started_m;
+    /** Most recent decoded-media update in this logical transmission (monotonic seconds), or 0. */
+    double media_updated_m;
     dsd_call_phase phase;
     int protocol; /**< DSD_SYNC_* value, or DSD_SYNC_NONE when unobserved. */
     dsd_call_kind kind;

--- a/include/dsd-neo/engine/scan_voice_gate.h
+++ b/include/dsd-neo/engine/scan_voice_gate.h
@@ -23,8 +23,21 @@
 extern "C" {
 #endif
 
-/** Newest policy-allowed voice media time (monotonic s), or < 0 when none. */
-double dsd_scan_voice_probe(const dsd_opts* opts, const dsd_state* state);
+/** Policy-allowed decoded voice media visible to a scanner tick. */
+typedef struct {
+    /** Newest media time on an active call with media latched, or < 0 when none. */
+    double active_media_m;
+    /** Newest media time on an active or ended call, or < 0 when none. */
+    double retained_media_m;
+} dsd_scan_voice_probe_result;
+
+/**
+ * Probe both call slots for policy-allowed decoded voice media.
+ *
+ * Both result fields are initialized to -1. Returns -1 for invalid arguments,
+ * 0 when no qualifying media exists, and 1 when retained media exists.
+ */
+int dsd_scan_voice_probe(const dsd_opts* opts, const dsd_state* state, dsd_scan_voice_probe_result* out);
 
 /** Restart the per-visit gate memory on a scan hop. */
 void dsd_scan_voice_gate_note_retune(dsd_state* state, double now_m);

--- a/include/dsd-neo/engine/scan_voice_gate.h
+++ b/include/dsd-neo/engine/scan_voice_gate.h
@@ -34,6 +34,8 @@ typedef struct {
 /**
  * Probe both call slots for policy-allowed decoded voice media.
  *
+ * The returned timestamps are raw call-state anchors and may predate the current
+ * scanner visit or hold window. Callers must apply their own freshness bound.
  * Both result fields are initialized to -1. Returns -1 for invalid arguments,
  * 0 when no qualifying media exists, and 1 when retained media exists.
  */
@@ -44,6 +46,9 @@ void dsd_scan_voice_gate_note_retune(dsd_state* state, double now_m);
 
 /** Per-frame tick while parked on a -Y row; a no-op unless scanner_mode is on. */
 void dsd_scan_voice_gate_tick(const dsd_opts* opts, dsd_state* state, int synced, double now_m);
+
+/** Non-zero when the gate has a visit anchor and owns the scanner's step timing. */
+int dsd_scan_voice_gate_owns_step(const dsd_opts* opts, const dsd_state* state);
 
 /** Non-zero when the gate says the -Y visit is over and the scan should step. */
 int dsd_scan_voice_gate_should_step(const dsd_opts* opts, const dsd_state* state, double now_m);

--- a/src/core/util/call_state.c
+++ b/src/core/util/call_state.c
@@ -507,9 +507,12 @@ call_state_seed_reacquired_snapshot(dsd_call_snapshot* snapshot, const dsd_call_
     snapshot->has_service_metadata = previous->has_service_metadata;
     snapshot->emergency = previous->emergency;
     snapshot->priority = previous->priority;
+    snapshot->media_started_m = previous->media_started_m;
+    snapshot->media_updated_m = previous->media_updated_m;
     // audio_permitted and started_m are deliberately not carried: the reacquired segment
     // re-earns audio from the next crypto update exactly as it does today, and started_m stays
-    // the reopen instant so per-segment durations remain the segment's own.
+    // the reopen instant so per-segment durations remain the segment's own. The media clocks do
+    // carry because a recoverable reopen is still part of the same logical transmission.
 }
 
 // A protocol whose end path tears down live decoder state it needs back on a heal (the DMR
@@ -711,8 +714,15 @@ dsd_call_state_update_media(dsd_state* state, uint8_t slot, int media_active, do
         dsd_call_state_ext_unlock(ext);
         return 0;
     }
+    const double now_m = call_state_observed_m(observed_m);
     snapshot->media_active = media_active ? 1U : 0U;
-    snapshot->updated_m = call_state_observed_m(observed_m);
+    snapshot->updated_m = now_m;
+    if (media_active) {
+        if (snapshot->media_started_m <= 0.0) {
+            snapshot->media_started_m = now_m;
+        }
+        snapshot->media_updated_m = now_m;
+    }
     snapshot->revision = call_state_next_nonzero(snapshot->revision);
     ext->calls.revision = call_state_next_nonzero(ext->calls.revision);
     dsd_call_state_ext_unlock(ext);

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1359,7 +1359,7 @@ no_carrier_step_retune(const dsd_opts* opts, dsd_state* state, long int freq, in
 // call still open as an explicit release rather than a sync loss.
 static int
 no_carrier_scanner_step_is_due(const dsd_opts* opts, const dsd_state* state, time_t now) {
-    if (opts->scan_voice_only == 1 && state->scan_voice_gate_sync_m >= 0.0) {
+    if (opts->scan_voice_only == 1 && (state->scan_voice_gate_sync_m >= 0.0 || state->scan_voice_gate_voice_m >= 0.0)) {
         return dsd_scan_voice_gate_should_step(opts, state, dsd_time_now_monotonic_s());
     }
     return (now - state->last_cc_sync_time) > opts->trunk_hangtime;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1359,7 +1359,7 @@ no_carrier_step_retune(const dsd_opts* opts, dsd_state* state, long int freq, in
 // call still open as an explicit release rather than a sync loss.
 static int
 no_carrier_scanner_step_is_due(const dsd_opts* opts, const dsd_state* state, time_t now) {
-    if (opts->scan_voice_only == 1 && (state->scan_voice_gate_sync_m >= 0.0 || state->scan_voice_gate_voice_m >= 0.0)) {
+    if (dsd_scan_voice_gate_owns_step(opts, state)) {
         return dsd_scan_voice_gate_should_step(opts, state, dsd_time_now_monotonic_s());
     }
     return (now - state->last_cc_sync_time) > opts->trunk_hangtime;

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -45,9 +45,12 @@ scan_voice_snapshot_is_voice(const dsd_call_snapshot* call) {
     if (call->media_started_m <= 0.0 || call->media_updated_m <= 0.0) {
         return 0;
     }
-    double span_started_m = call->started_m;
-    if (span_started_m <= 0.0 || call->media_started_m < span_started_m) {
-        span_started_m = call->media_started_m;
+    double span_started_m = call->media_started_m;
+    /* A recoverable reopen retains the logical transmission's media clocks but
+     * starts a new segment. Qualify from the later boundary so one post-gap
+     * vocoder frame cannot borrow the pre-gap media span. */
+    if (call->started_m > span_started_m) {
+        span_started_m = call->started_m;
     }
     if ((call->media_updated_m - span_started_m) < DSD_SCAN_VOICE_MIN_SPAN_S) {
         return 0;
@@ -135,9 +138,7 @@ scan_voice_gate_track_visit(dsd_state* state, double now_m) {
      * legacy hangtime rule. */
     const uint8_t hold_now = state->lcn_scan_hold ? 1U : 0U;
     if (state->scan_voice_gate_hold_seen && !hold_now) {
-        state->scan_voice_gate_arrive_m = now_m;
-        state->scan_voice_gate_sync_m = -1.0;
-        state->scan_voice_gate_voice_m = -1.0;
+        dsd_scan_voice_gate_note_retune(state, now_m);
     }
     state->scan_voice_gate_hold_seen = hold_now;
 }
@@ -177,9 +178,8 @@ dsd_scan_voice_gate_tick(const dsd_opts* opts, dsd_state* state, int synced, dou
         state->scan_voice_gate_sync_m = now_m;
     }
     dsd_scan_voice_probe_result media;
-    (void)dsd_scan_voice_probe(opts, state, &media);
-    const int retained_in_visit =
-        media.retained_media_m >= 0.0 && media.retained_media_m >= state->scan_voice_gate_arrive_m;
+    const int probe_rc = dsd_scan_voice_probe(opts, state, &media);
+    const int retained_in_visit = probe_rc > 0 && media.retained_media_m >= state->scan_voice_gate_arrive_m;
     const int active_in_visit = media.active_media_m >= 0.0 && media.active_media_m >= state->scan_voice_gate_arrive_m;
     if (retained_in_visit && media.retained_media_m > state->scan_voice_gate_voice_m) {
         state->scan_voice_gate_voice_m = media.retained_media_m;
@@ -188,8 +188,14 @@ dsd_scan_voice_gate_tick(const dsd_opts* opts, dsd_state* state, int synced, dou
 }
 
 int
+dsd_scan_voice_gate_owns_step(const dsd_opts* opts, const dsd_state* state) {
+    return scan_voice_gate_enabled(opts) && state
+           && (state->scan_voice_gate_voice_m >= 0.0 || state->scan_voice_gate_sync_m >= 0.0);
+}
+
+int
 dsd_scan_voice_gate_should_step(const dsd_opts* opts, const dsd_state* state, double now_m) {
-    if (!scan_voice_gate_enabled(opts) || !state) {
+    if (!dsd_scan_voice_gate_owns_step(opts, state)) {
         return 0;
     }
     if (state->lcn_scan_hold) {

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -36,27 +36,56 @@ scan_voice_resolve_ms(int configured, int fallback) {
 
 static int
 scan_voice_snapshot_is_voice(const dsd_call_snapshot* call) {
-    if (!call || call->phase != DSD_CALL_PHASE_ACTIVE) {
-        return 0;
-    }
-    if (!call->media_active) {
+    if (!call || (call->phase != DSD_CALL_PHASE_ACTIVE && call->phase != DSD_CALL_PHASE_ENDED)) {
         return 0;
     }
     if (call->kind == DSD_CALL_KIND_DATA) {
         return 0;
     }
-    if ((call->updated_m - call->started_m) < DSD_SCAN_VOICE_MIN_SPAN_S) {
+    if (call->media_started_m <= 0.0 || call->media_updated_m <= 0.0) {
+        return 0;
+    }
+    double span_started_m = call->started_m;
+    if (span_started_m <= 0.0 || call->media_started_m < span_started_m) {
+        span_started_m = call->media_started_m;
+    }
+    if ((call->media_updated_m - span_started_m) < DSD_SCAN_VOICE_MIN_SPAN_S) {
         return 0;
     }
     return 1;
 }
 
-double
-dsd_scan_voice_probe(const dsd_opts* opts, const dsd_state* state) {
-    if (!opts || !state) {
-        return -1.0;
+static int
+scan_voice_snapshot_policy_allows(const dsd_opts* opts, const dsd_state* state, const dsd_call_snapshot* call) {
+    const uint64_t target = call->policy_target_id != 0U ? call->policy_target_id : call->ota_target_id;
+    if (target == 0U) {
+        /* Unknown identity (LC never decoded) counts as voice. */
+        return 1;
     }
-    double newest = -1.0;
+    const int encrypted =
+        call->crypto == DSD_CALL_CRYPTO_ENCRYPTED || call->crypto == DSD_CALL_CRYPTO_ENCRYPTED_PENDING;
+    dsd_tg_policy_decision decision;
+    int rc = 0;
+    if (call->kind == DSD_CALL_KIND_PRIVATE_VOICE) {
+        rc = dsd_tg_policy_evaluate_private_call(opts, state, (uint32_t)call->ota_source_id, (uint32_t)target,
+                                                 encrypted, 0, &decision);
+    } else {
+        rc = dsd_tg_policy_evaluate_group_call(opts, state, (uint32_t)target, (uint32_t)call->ota_source_id, encrypted,
+                                               0, &decision);
+    }
+    return rc == 0 && decision.tune_allowed;
+}
+
+int
+dsd_scan_voice_probe(const dsd_opts* opts, const dsd_state* state, dsd_scan_voice_probe_result* out) {
+    if (!out) {
+        return -1;
+    }
+    out->active_media_m = -1.0;
+    out->retained_media_m = -1.0;
+    if (!opts || !state) {
+        return -1;
+    }
     for (int slot_i = 0; slot_i < DSD_CALL_STATE_SLOT_COUNT; slot_i++) {
         dsd_call_snapshot call;
         /* dsd_call_state_get() fills the whole snapshot on success; a failed get skips the slot. */
@@ -66,29 +95,17 @@ dsd_scan_voice_probe(const dsd_opts* opts, const dsd_state* state) {
         if (!scan_voice_snapshot_is_voice(&call)) {
             continue;
         }
-        uint64_t target = call.policy_target_id != 0U ? call.policy_target_id : call.ota_target_id;
-        if (target != 0U) {
-            const int encrypted =
-                (call.crypto == DSD_CALL_CRYPTO_ENCRYPTED || call.crypto == DSD_CALL_CRYPTO_ENCRYPTED_PENDING);
-            dsd_tg_policy_decision decision;
-            int rc = 0;
-            if (call.kind == DSD_CALL_KIND_PRIVATE_VOICE) {
-                rc = dsd_tg_policy_evaluate_private_call(opts, state, (uint32_t)call.ota_source_id, (uint32_t)target,
-                                                         encrypted, 0, &decision);
-            } else {
-                rc = dsd_tg_policy_evaluate_group_call(opts, state, (uint32_t)target, (uint32_t)call.ota_source_id,
-                                                       encrypted, 0, &decision);
-            }
-            if (rc != 0 || !decision.tune_allowed) {
-                continue;
-            }
+        if (!scan_voice_snapshot_policy_allows(opts, state, &call)) {
+            continue;
         }
-        /* Unknown identity (LC never decoded) counts as voice. */
-        if (call.updated_m > newest) {
-            newest = call.updated_m;
+        if (call.media_updated_m > out->retained_media_m) {
+            out->retained_media_m = call.media_updated_m;
+        }
+        if (call.phase == DSD_CALL_PHASE_ACTIVE && call.media_active && call.media_updated_m > out->active_media_m) {
+            out->active_media_m = call.media_updated_m;
         }
     }
-    return newest;
+    return out->retained_media_m >= 0.0 ? 1 : 0;
 }
 
 void
@@ -118,6 +135,7 @@ scan_voice_gate_track_visit(dsd_state* state, double now_m) {
      * legacy hangtime rule. */
     const uint8_t hold_now = state->lcn_scan_hold ? 1U : 0U;
     if (state->scan_voice_gate_hold_seen && !hold_now) {
+        state->scan_voice_gate_arrive_m = now_m;
         state->scan_voice_gate_sync_m = -1.0;
         state->scan_voice_gate_voice_m = -1.0;
     }
@@ -158,12 +176,15 @@ dsd_scan_voice_gate_tick(const dsd_opts* opts, dsd_state* state, int synced, dou
     if (state->scan_voice_gate_sync_m < 0.0 && synced) {
         state->scan_voice_gate_sync_m = now_m;
     }
-    const double media_m = dsd_scan_voice_probe(opts, state);
-    const int media_in_visit = media_m >= 0.0 && media_m >= state->scan_voice_gate_arrive_m;
-    if (media_in_visit && media_m > state->scan_voice_gate_voice_m) {
-        state->scan_voice_gate_voice_m = media_m;
+    dsd_scan_voice_probe_result media;
+    (void)dsd_scan_voice_probe(opts, state, &media);
+    const int retained_in_visit =
+        media.retained_media_m >= 0.0 && media.retained_media_m >= state->scan_voice_gate_arrive_m;
+    const int active_in_visit = media.active_media_m >= 0.0 && media.active_media_m >= state->scan_voice_gate_arrive_m;
+    if (retained_in_visit && media.retained_media_m > state->scan_voice_gate_voice_m) {
+        state->scan_voice_gate_voice_m = media.retained_media_m;
     }
-    scan_voice_gate_publish_phase(state, media_in_visit);
+    scan_voice_gate_publish_phase(state, active_in_visit);
 }
 
 int

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -2644,12 +2644,15 @@ trunk_scan_refresh_voice_media_hold(const dsd_opts* opts, dsd_state* state, dsd_
         return;
     }
     const double hold_s = (double)rt->target.activity_hold_ms / 1000.0;
-    const double media_m = dsd_scan_voice_probe(opts, state);
-    if (media_m > rt->last_allowed_activity_m) {
-        rt->last_allowed_activity_m = media_m;
-        rt->idle_since_m = -1.0;
+    dsd_scan_voice_probe_result media;
+    (void)dsd_scan_voice_probe(opts, state, &media);
+    if (media.retained_media_m > rt->last_allowed_activity_m) {
+        rt->last_allowed_activity_m = media.retained_media_m;
+        if ((now_m - media.retained_media_m) < hold_s) {
+            rt->idle_since_m = -1.0;
+        }
     }
-    if (media_m >= 0.0 && (now_m - media_m) < hold_s) {
+    if (media.active_media_m >= 0.0 && (now_m - media.active_media_m) < hold_s) {
         state->scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_VOICE;
     } else if (rt->last_allowed_activity_m > 0.0 && (now_m - rt->last_allowed_activity_m) < hold_s) {
         state->scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_TAIL;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -2413,7 +2413,7 @@ trunk_scan_retry_active_if_due(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_
 }
 
 static int
-trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coord) {
+trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coord, double now_m) {
     const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
     if (rt->tune_pending) {
         return 1;
@@ -2428,7 +2428,6 @@ trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coor
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
         return opts->trunk_is_tuned == 1;
     }
-    double now_m = trunk_scan_now_m();
     double hold_s = (double)rt->target.activity_hold_ms / 1000.0;
     return rt->last_allowed_activity_m > 0.0 && (now_m - rt->last_allowed_activity_m) < hold_s;
 }
@@ -2645,12 +2644,9 @@ trunk_scan_refresh_voice_media_hold(const dsd_opts* opts, dsd_state* state, dsd_
     }
     const double hold_s = (double)rt->target.activity_hold_ms / 1000.0;
     dsd_scan_voice_probe_result media;
-    (void)dsd_scan_voice_probe(opts, state, &media);
-    if (media.retained_media_m > rt->last_allowed_activity_m) {
+    const int probe_rc = dsd_scan_voice_probe(opts, state, &media);
+    if (probe_rc > 0 && media.retained_media_m > rt->last_allowed_activity_m) {
         rt->last_allowed_activity_m = media.retained_media_m;
-        if ((now_m - media.retained_media_m) < hold_s) {
-            rt->idle_since_m = -1.0;
-        }
     }
     if (media.active_media_m >= 0.0 && (now_m - media.active_media_m) < hold_s) {
         state->scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_VOICE;
@@ -2682,7 +2678,7 @@ trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* c
         trunk_scan_share_peer_idens(coord, state, rt);
     }
     trunk_scan_refresh_voice_media_hold(opts, state, rt, now_m);
-    if (trunk_scan_active_is_held(opts, coord)) {
+    if (trunk_scan_active_is_held(opts, coord, now_m)) {
         rt->idle_since_m = -1.0;
         return;
     }

--- a/tests/core/test_core_call_state.c
+++ b/tests/core/test_core_call_state.c
@@ -6,11 +6,17 @@
 #include <dsd-neo/core/synctype_ids.h>
 
 #include <assert.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+
+static int
+double_near(double actual, double expected) {
+    return fabs(actual - expected) < 1e-9;
+}
 
 static dsd_call_observation
 group_call(uint8_t slot, uint32_t target, uint32_t source, double observed_m) {
@@ -129,7 +135,7 @@ test_retained_crypto_update(void) {
     // re-describe it for as long as the receiver stays on the frequency, and
     // moving updated_m past ended_m makes a finished call look freshly updated
     // to consumers that order by recency.
-    assert(snapshot.ended_m == 2.0);
+    assert(double_near(snapshot.ended_m, 2.0));
     assert(snapshot.updated_m <= snapshot.ended_m);
 
     // Re-applying the identical crypto must not churn the revision: pollers
@@ -162,8 +168,8 @@ test_media_timestamps(void) {
 
     dsd_call_snapshot snapshot;
     assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
-    assert(snapshot.media_started_m == 0.0);
-    assert(snapshot.media_updated_m == 0.0);
+    assert(double_near(snapshot.media_started_m, 0.0));
+    assert(double_near(snapshot.media_updated_m, 0.0));
     assert(dsd_call_state_update_media(state, 0U, 1, 1.1) == 1);
     assert(dsd_call_state_update_media(state, 0U, 0, 1.2) == 1);
     assert(dsd_call_state_update_media(state, 0U, 1, 1.3) == 1);
@@ -178,20 +184,20 @@ test_media_timestamps(void) {
     assert(dsd_call_state_end_ex(state, 0U, 1.6, DSD_CALL_END_TERMINATOR) == 1);
     assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
     assert(snapshot.media_active == 0U);
-    assert(snapshot.media_started_m == 1.1);
-    assert(snapshot.media_updated_m == 1.3);
+    assert(double_near(snapshot.media_started_m, 1.1));
+    assert(double_near(snapshot.media_updated_m, 1.3));
 
     dsd_call_state_snapshot saved;
     assert(dsd_call_state_copy_snapshot(state, &saved) == 1);
     observation.observed_m = 2.0;
     assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
     assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
-    assert(snapshot.media_started_m == 0.0);
-    assert(snapshot.media_updated_m == 0.0);
+    assert(double_near(snapshot.media_started_m, 0.0));
+    assert(double_near(snapshot.media_updated_m, 0.0));
     assert(dsd_call_state_restore_snapshot(state, &saved) == 1);
     assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
-    assert(snapshot.media_started_m == 1.1);
-    assert(snapshot.media_updated_m == 1.3);
+    assert(double_near(snapshot.media_started_m, 1.1));
+    assert(double_near(snapshot.media_updated_m, 1.3));
 
     dsd_state_ext_free_all(state);
     free(state);
@@ -222,14 +228,14 @@ test_reacquisition_carries_media_timestamps(void) {
         dsd_call_snapshot snapshot;
         assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
         assert(snapshot.phase == DSD_CALL_PHASE_ACTIVE);
-        assert(snapshot.started_m == 10.3);
-        assert(snapshot.media_started_m == 10.05);
-        assert(snapshot.media_updated_m == 10.15);
+        assert(double_near(snapshot.started_m, 10.3));
+        assert(double_near(snapshot.media_started_m, 10.05));
+        assert(double_near(snapshot.media_updated_m, 10.15));
         assert(snapshot.media_active == 0U);
         assert(dsd_call_state_update_media(state, 0U, 1, 10.35) == 1);
         assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
-        assert(snapshot.media_started_m == 10.05);
-        assert(snapshot.media_updated_m == 10.35);
+        assert(double_near(snapshot.media_started_m, 10.05));
+        assert(double_near(snapshot.media_updated_m, 10.35));
 
         dsd_state_ext_free_all(state);
         free(state);

--- a/tests/core/test_core_call_state.c
+++ b/tests/core/test_core_call_state.c
@@ -154,6 +154,89 @@ test_retained_crypto_update(void) {
 }
 
 static void
+test_media_timestamps(void) {
+    dsd_state* state = (dsd_state*)calloc(1U, sizeof(*state));
+    assert(state != NULL);
+    dsd_call_observation observation = group_call(0U, 500U, 600U, 1.0);
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+
+    dsd_call_snapshot snapshot;
+    assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
+    assert(snapshot.media_started_m == 0.0);
+    assert(snapshot.media_updated_m == 0.0);
+    assert(dsd_call_state_update_media(state, 0U, 1, 1.1) == 1);
+    assert(dsd_call_state_update_media(state, 0U, 0, 1.2) == 1);
+    assert(dsd_call_state_update_media(state, 0U, 1, 1.3) == 1);
+
+    observation.observed_m = 1.4;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_CONTINUE) == 0);
+    const dsd_call_crypto_update crypto = {
+        .classification = DSD_CALL_CRYPTO_CLEAR,
+        .observed_m = 1.5,
+    };
+    assert(dsd_call_state_update_crypto(state, 0U, &crypto) == 1);
+    assert(dsd_call_state_end_ex(state, 0U, 1.6, DSD_CALL_END_TERMINATOR) == 1);
+    assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
+    assert(snapshot.media_active == 0U);
+    assert(snapshot.media_started_m == 1.1);
+    assert(snapshot.media_updated_m == 1.3);
+
+    dsd_call_state_snapshot saved;
+    assert(dsd_call_state_copy_snapshot(state, &saved) == 1);
+    observation.observed_m = 2.0;
+    assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+    assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
+    assert(snapshot.media_started_m == 0.0);
+    assert(snapshot.media_updated_m == 0.0);
+    assert(dsd_call_state_restore_snapshot(state, &saved) == 1);
+    assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
+    assert(snapshot.media_started_m == 1.1);
+    assert(snapshot.media_updated_m == 1.3);
+
+    dsd_state_ext_free_all(state);
+    free(state);
+}
+
+static void
+test_reacquisition_carries_media_timestamps(void) {
+    static const dsd_call_end_reason reasons[] = {
+        DSD_CALL_END_SYNC_LOSS,
+        DSD_CALL_END_UNVERIFIED_TERMINATOR,
+    };
+    for (size_t i = 0U; i < sizeof(reasons) / sizeof(reasons[0]); i++) {
+        dsd_state* state = (dsd_state*)calloc(1U, sizeof(*state));
+        assert(state != NULL);
+        dsd_call_observation observation = group_call(0U, 500U, 600U, 10.0);
+        assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+        assert(dsd_call_state_update_media(state, 0U, 1, 10.05) == 1);
+        assert(dsd_call_state_update_media(state, 0U, 1, 10.15) == 1);
+        assert(dsd_call_state_end_ex(state, 0U, 10.2, reasons[i]) == 1);
+
+        observation.observed_m = 10.3;
+        if (reasons[i] == DSD_CALL_END_UNVERIFIED_TERMINATOR) {
+            observation.ota_target_id = 0U;
+            observation.policy_target_id = 0U;
+            observation.ota_source_id = 0U;
+        }
+        assert(dsd_call_state_observe(state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+        dsd_call_snapshot snapshot;
+        assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
+        assert(snapshot.phase == DSD_CALL_PHASE_ACTIVE);
+        assert(snapshot.started_m == 10.3);
+        assert(snapshot.media_started_m == 10.05);
+        assert(snapshot.media_updated_m == 10.15);
+        assert(snapshot.media_active == 0U);
+        assert(dsd_call_state_update_media(state, 0U, 1, 10.35) == 1);
+        assert(dsd_call_state_get(state, 0U, &snapshot) == 1);
+        assert(snapshot.media_started_m == 10.05);
+        assert(snapshot.media_updated_m == 10.35);
+
+        dsd_state_ext_free_all(state);
+        free(state);
+    }
+}
+
+static void
 test_recent_activity(dsd_state* state) {
     dsd_call_observation activity0 = group_call(0U, 100U, 9U, 1.0);
     dsd_call_observation activity1 = group_call(1U, 200U, 10U, 2.0);
@@ -512,6 +595,8 @@ main(void) {
     test_epochs_and_late_identity(state);
     test_crypto_and_slot_isolation(state);
     test_retained_crypto_update();
+    test_media_timestamps();
+    test_reacquisition_carries_media_timestamps();
     test_recent_activity(state);
     test_snapshot_clone(state);
     test_voice_specialization_and_sparse_metadata();

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -835,12 +835,16 @@ main(void) {
     rc |= expect_true("voice-gate-idle-resets-voice", state->scan_voice_gate_voice_m < 0.0);
     rc |= expect_true("voice-gate-idle-restamps-arrive", fabs(state->scan_voice_gate_arrive_m - gate_now_m) < 5.0);
 
-    // Recent voice holds past qualify even though the hangtime (1 s, deadline 11 s old) is due.
+    // A terminator-ended call discovered on an unsynced tick still obeys a custom five-second
+    // voice hold even though the legacy hangtime (1 s, deadline 11 s old) is due. This is the
+    // post-dispatch shape of DMR BS: one processFrame() consumes the voice and terminator before
+    // the engine gets its first gate tick, so sync_m is not available to select the gate.
     opts->trunk_hangtime = 1;
+    opts->scan_voice_hold_ms = 5000;
     state->lcn_freq_roll = 1;
     state->last_cc_sync_time = time(NULL) - 11;
     gate_now_m = dsd_time_now_monotonic_s();
-    dsd_scan_voice_gate_note_retune(state, gate_now_m - 0.6);
+    dsd_scan_voice_gate_note_retune(state, gate_now_m - 3.0);
     dsd_call_observation gate_voice_call = {0};
     gate_voice_call.protocol = DSD_SYNC_NXDN_POS;
     gate_voice_call.slot = 0U;
@@ -848,14 +852,18 @@ main(void) {
     gate_voice_call.ota_target_id = 7202U;
     gate_voice_call.policy_target_id = 7202U;
     gate_voice_call.ota_source_id = 8202U;
-    gate_voice_call.observed_m = gate_now_m - 0.5;
+    gate_voice_call.observed_m = gate_now_m - 2.8;
     rc |= expect_true("voice-gate-voice-seeds-call",
                       dsd_call_state_observe(state, &gate_voice_call, DSD_CALL_BOUNDARY_BEGIN) == 1);
     rc |= expect_true("voice-gate-voice-seeds-media",
-                      dsd_call_state_update_media(state, 0U, 1, gate_now_m - 0.5) == 1
-                          && dsd_call_state_update_media(state, 0U, 1, gate_now_m - 0.3) == 1);
-    dsd_scan_voice_gate_tick(opts, state, 1, gate_now_m);
-    rc |= expect_true("voice-gate-voice-phase", state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_VOICE);
+                      dsd_call_state_update_media(state, 0U, 1, gate_now_m - 2.8) == 1
+                          && dsd_call_state_update_media(state, 0U, 1, gate_now_m - 2.6) == 1);
+    rc |= expect_true("voice-gate-voice-terminates-before-tick",
+                      dsd_call_state_end_ex(state, 0U, gate_now_m - 2.5, DSD_CALL_END_TERMINATOR) == 1);
+    dsd_scan_voice_gate_tick(opts, state, 0, gate_now_m);
+    rc |= expect_true("voice-gate-tail-phase", state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_TAIL);
+    rc |= expect_true("voice-gate-sync-remains-unset", state->scan_voice_gate_sync_m < 0.0);
+    rc |= expect_true("voice-gate-retained-media-arms", state->scan_voice_gate_voice_m > 0.0);
     rc |= expect_true("voice-gate-voice-holds",
                       dsd_scan_voice_gate_should_step(opts, state, dsd_time_now_monotonic_s()) == 0);
     const time_t voice_hold_deadline = state->last_cc_sync_time;
@@ -865,7 +873,7 @@ main(void) {
     rc |= expect_true("voice-gate-voice-keeps-roll", state->lcn_freq_roll == 1);
     rc |= expect_true("voice-gate-voice-keeps-deadline", state->last_cc_sync_time == voice_hold_deadline);
 
-    // Gate off: the stale gate anchors above are ignored and the hangtime rule decides alone.
+    // Gate off: the retained gate anchor above is ignored and the hangtime rule decides alone.
     opts->scan_voice_only = 0;
     state->last_cc_sync_time = time(NULL);
     g_rtl_tune_calls = 0;
@@ -889,7 +897,7 @@ main(void) {
 
     state->last_cc_sync_time = time(NULL) - 11;
     gate_now_m = dsd_time_now_monotonic_s();
-    dsd_scan_voice_gate_note_retune(state, gate_now_m - 5.0);
+    dsd_scan_voice_gate_note_retune(state, gate_now_m);
     dsd_scan_voice_gate_tick(opts, state, 0, gate_now_m);
     rc |= expect_true("voice-gate-unsynced-abstains",
                       dsd_scan_voice_gate_should_step(opts, state, dsd_time_now_monotonic_s()) == 0);

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -872,6 +872,7 @@ main(void) {
     rc |= expect_true("voice-gate-voice-no-retune", g_rtl_tune_calls == 0);
     rc |= expect_true("voice-gate-voice-keeps-roll", state->lcn_freq_roll == 1);
     rc |= expect_true("voice-gate-voice-keeps-deadline", state->last_cc_sync_time == voice_hold_deadline);
+    opts->scan_voice_hold_ms = 2000;
 
     // Gate off: the retained gate anchor above is ignored and the hangtime rule decides alone.
     opts->scan_voice_only = 0;

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -133,6 +133,7 @@ probe_voice(const gate_fixture* fix) {
     dsd_scan_voice_probe_result result;
     const int rc = dsd_scan_voice_probe(fix ? fix->opts : NULL, fix ? fix->state : NULL, &result);
     CHECK("probe succeeds", rc >= 0);
+    CHECK("probe status matches retained media", rc == (result.retained_media_m >= 0.0 ? 1 : 0));
     return result;
 }
 
@@ -180,6 +181,7 @@ test_gate_off_never_steps(void) {
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
     CHECK("phase off", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_OFF);
+    CHECK("gate off abstains", dsd_scan_voice_gate_owns_step(fix.opts, fix.state) == 0);
     CHECK("no step", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 200.0) == 0);
     fixture_free(&fix);
 }
@@ -195,6 +197,7 @@ test_idle_only_steps_at_qualify(void) {
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
     CHECK("qualify phase", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_QUALIFY);
+    CHECK("synced gate owns step", dsd_scan_voice_gate_owns_step(fix.opts, fix.state) != 0);
     CHECK("no early step", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 100.9) == 0);
     CHECK("steps at qualify", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 101.0) != 0);
     const dsd_scan_voice_probe_result media = probe_voice(&fix);
@@ -213,6 +216,7 @@ test_never_synced_falls_back(void) {
     }
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 0, 100.0);
+    CHECK("unsynced gate abstains", dsd_scan_voice_gate_owns_step(fix.opts, fix.state) == 0);
     CHECK("no step without sync", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 500.0) == 0);
     fixture_free(&fix);
 }
@@ -260,6 +264,7 @@ test_terminator_before_first_tick_holds(void) {
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.625);
     CHECK("ended media publishes tail", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_TAIL);
     CHECK("ended media arms last frame", fabs(fix.state->scan_voice_gate_voice_m - 100.375) < 1e-6);
+    CHECK("retained media owns step", dsd_scan_voice_gate_owns_step(fix.opts, fix.state) != 0);
     CHECK("custom hold remains before boundary", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 105.374) == 0);
     CHECK("custom hold expires at boundary", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 105.375) != 0);
     fixture_free(&fix);
@@ -282,6 +287,49 @@ test_span_debounce(void) {
     CHECK("long active span counts", media.active_media_m > 0.0);
     CHECK("long retained span counts", media.retained_media_m > 0.0);
     fixture_free(&fix);
+}
+
+static void
+test_reacquired_segment_reearns_span(void) {
+    static const dsd_call_end_reason reasons[] = {
+        DSD_CALL_END_SYNC_LOSS,
+        DSD_CALL_END_UNVERIFIED_TERMINATOR,
+    };
+    for (size_t i = 0U; i < sizeof(reasons) / sizeof(reasons[0]); i++) {
+        gate_fixture fix;
+        if (fixture_init(&fix) != 0) {
+            DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+            g_failures++;
+            return;
+        }
+        dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+        open_voice_epoch(&fix, 100.1, 0.2, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
+        (void)dsd_call_state_end_ex(fix.state, 0U, 100.35, reasons[i]);
+
+        /* This is the vocoder's production reopen shape: identity-less BEGIN followed by one
+         * media mark. It must not borrow the prior segment's span and refresh a dead channel. */
+        dsd_call_observation observation;
+        DSD_MEMSET(&observation, 0, sizeof(observation));
+        observation.protocol = 1;
+        observation.slot = 0U;
+        observation.kind = DSD_CALL_KIND_VOICE;
+        observation.observed_m = 100.45;
+        CHECK("recoverable end reopens", dsd_call_state_observe(fix.state, &observation, DSD_CALL_BOUNDARY_BEGIN) == 1);
+        CHECK("first reacquired media marks", dsd_call_state_update_media(fix.state, 0U, 1, 100.45) == 1);
+        dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.45);
+        dsd_scan_voice_probe_result media = probe_voice(&fix);
+        CHECK("single reacquired frame is not voice", media.active_media_m < 0.0 && media.retained_media_m < 0.0);
+        CHECK("single reacquired frame does not arm hold", fix.state->scan_voice_gate_voice_m < 0.0);
+        CHECK("single reacquired frame stays qualify",
+              fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_QUALIFY);
+
+        CHECK("reacquired media continues", dsd_call_state_update_media(fix.state, 0U, 1, 100.56) == 1);
+        dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.56);
+        media = probe_voice(&fix);
+        CHECK("reacquired span counts", fabs(media.active_media_m - 100.56) < 1e-6);
+        CHECK("reacquired span arms hold", fabs(fix.state->scan_voice_gate_voice_m - 100.56) < 1e-6);
+        fixture_free(&fix);
+    }
 }
 
 static void
@@ -502,6 +550,7 @@ main(void) {
     test_voice_holds_through_tail();
     test_terminator_before_first_tick_holds();
     test_span_debounce();
+    test_reacquired_segment_reearns_span();
     test_non_media_updates_do_not_extend_hold();
     test_probe_tracks_active_and_retained_slots_independently();
     test_policy_gating();

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -8,9 +8,10 @@
  * @brief Voice-gated scan unit tests (issue #381).
  *
  * Pins the -Y gate: off never steps, IDLE-only sync steps at qualify, voice
- * holds through the tail from the last media time even after a SYNC_LOSS end,
- * 0.10 s span debounce, policy gating (blocked encrypted, private evaluator,
- * unknown identity), DATA ignored, operator hold, and visit resets.
+ * holds through the tail from the last media time even when a terminator ends
+ * the call before the first gate tick, 0.10 s span debounce, policy gating
+ * (blocked encrypted, private evaluator, unknown identity), DATA ignored,
+ * operator hold, and visit resets.
  */
 
 #include <dsd-neo/core/call_state.h>
@@ -127,15 +128,23 @@ fixture_free(gate_fixture* fix) {
     dsd_state_ext_free_all(fix->state);
 }
 
-/* Open a voice epoch on slot 0 at time t with the given identity/crypto, then
+static dsd_scan_voice_probe_result
+probe_voice(const gate_fixture* fix) {
+    dsd_scan_voice_probe_result result;
+    const int rc = dsd_scan_voice_probe(fix ? fix->opts : NULL, fix ? fix->state : NULL, &result);
+    CHECK("probe succeeds", rc >= 0);
+    return result;
+}
+
+/* Open a voice epoch on one slot at time t with the given identity/crypto, then
  * run media at t and t + span so the caller controls the media span. */
 static void
-open_voice_epoch(gate_fixture* fix, double t, double span, dsd_call_kind kind, uint64_t src, uint64_t dst,
-                 dsd_call_crypto_state crypto) {
+open_voice_epoch_slot(gate_fixture* fix, uint8_t slot, double t, double span, dsd_call_kind kind, uint64_t src,
+                      uint64_t dst, dsd_call_crypto_state crypto) {
     dsd_call_observation obs;
     DSD_MEMSET(&obs, 0, sizeof(obs));
     obs.protocol = 1;
-    obs.slot = 0;
+    obs.slot = slot;
     obs.kind = kind;
     obs.ota_source_id = src;
     obs.ota_target_id = dst;
@@ -147,10 +156,16 @@ open_voice_epoch(gate_fixture* fix, double t, double span, dsd_call_kind kind, u
         DSD_MEMSET(&update, 0, sizeof(update));
         update.classification = crypto;
         update.observed_m = t;
-        (void)dsd_call_state_update_crypto(fix->state, 0, &update);
+        (void)dsd_call_state_update_crypto(fix->state, slot, &update);
     }
-    (void)dsd_call_state_update_media(fix->state, 0, 1, t);
-    (void)dsd_call_state_update_media(fix->state, 0, 1, t + span);
+    (void)dsd_call_state_update_media(fix->state, slot, 1, t);
+    (void)dsd_call_state_update_media(fix->state, slot, 1, t + span);
+}
+
+static void
+open_voice_epoch(gate_fixture* fix, double t, double span, dsd_call_kind kind, uint64_t src, uint64_t dst,
+                 dsd_call_crypto_state crypto) {
+    open_voice_epoch_slot(fix, 0U, t, span, kind, src, dst, crypto);
 }
 
 static void
@@ -182,7 +197,9 @@ test_idle_only_steps_at_qualify(void) {
     CHECK("qualify phase", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_QUALIFY);
     CHECK("no early step", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 100.9) == 0);
     CHECK("steps at qualify", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 101.0) != 0);
-    CHECK("probe idle", dsd_scan_voice_probe(fix.opts, fix.state) < 0.0);
+    const dsd_scan_voice_probe_result media = probe_voice(&fix);
+    CHECK("probe idle active", media.active_media_m < 0.0);
+    CHECK("probe idle retained", media.retained_media_m < 0.0);
     fixture_free(&fix);
 }
 
@@ -212,14 +229,39 @@ test_voice_holds_through_tail(void) {
     open_voice_epoch(&fix, 100.2, 0.15, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.4);
     CHECK("voice phase", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_VOICE);
-    CHECK("probe at media", fabs(dsd_scan_voice_probe(fix.opts, fix.state) - 100.35) < 1e-6);
+    dsd_scan_voice_probe_result media = probe_voice(&fix);
+    CHECK("active probe at media", fabs(media.active_media_m - 100.35) < 1e-6);
+    CHECK("retained probe at media", fabs(media.retained_media_m - 100.35) < 1e-6);
     /* Sync loss ends the epoch; the tail still runs from the last media. */
     (void)dsd_call_state_end_ex(fix.state, 0, 100.5, DSD_CALL_END_SYNC_LOSS);
-    CHECK("probe after end", dsd_scan_voice_probe(fix.opts, fix.state) < 0.0);
+    media = probe_voice(&fix);
+    CHECK("active probe after end", media.active_media_m < 0.0);
+    CHECK("retained probe after end", fabs(media.retained_media_m - 100.35) < 1e-6);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 0, 100.6);
     CHECK("tail phase", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_TAIL);
     CHECK("holds in tail", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 101.0) == 0);
     CHECK("steps after hold", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 102.36) != 0);
+    fixture_free(&fix);
+}
+
+static void
+test_terminator_before_first_tick_holds(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_voice_hold_ms = 5000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    open_voice_epoch(&fix, 100.25, 0.125, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
+    /* DMR BS dispatch consumes the terminator before returning to the engine's first gate tick. */
+    (void)dsd_call_state_end_ex(fix.state, 0, 100.5, DSD_CALL_END_TERMINATOR);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.625);
+    CHECK("ended media publishes tail", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_TAIL);
+    CHECK("ended media arms last frame", fabs(fix.state->scan_voice_gate_voice_m - 100.375) < 1e-6);
+    CHECK("custom hold remains before boundary", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 105.374) == 0);
+    CHECK("custom hold expires at boundary", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 105.375) != 0);
     fixture_free(&fix);
 }
 
@@ -232,9 +274,66 @@ test_span_debounce(void) {
         return;
     }
     open_voice_epoch(&fix, 100.0, 0.05, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
-    CHECK("short span ignored", dsd_scan_voice_probe(fix.opts, fix.state) < 0.0);
+    dsd_scan_voice_probe_result media = probe_voice(&fix);
+    CHECK("short active span ignored", media.active_media_m < 0.0);
+    CHECK("short retained span ignored", media.retained_media_m < 0.0);
     (void)dsd_call_state_update_media(fix.state, 0, 1, 100.2);
-    CHECK("long span counts", dsd_scan_voice_probe(fix.opts, fix.state) > 0.0);
+    media = probe_voice(&fix);
+    CHECK("long active span counts", media.active_media_m > 0.0);
+    CHECK("long retained span counts", media.retained_media_m > 0.0);
+    fixture_free(&fix);
+}
+
+static void
+test_non_media_updates_do_not_extend_hold(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    open_voice_epoch(&fix, 100.0, 0.2, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
+    dsd_call_observation obs;
+    DSD_MEMSET(&obs, 0, sizeof(obs));
+    obs.protocol = 1;
+    obs.slot = 0;
+    obs.kind = DSD_CALL_KIND_GROUP_VOICE;
+    obs.ota_source_id = 11;
+    obs.ota_target_id = 22;
+    obs.policy_target_id = 22;
+    obs.observed_m = 101.0;
+    (void)dsd_call_state_observe(fix.state, &obs, DSD_CALL_BOUNDARY_CONTINUE);
+    dsd_call_crypto_update crypto;
+    DSD_MEMSET(&crypto, 0, sizeof(crypto));
+    crypto.classification = DSD_CALL_CRYPTO_CLEAR;
+    crypto.observed_m = 102.0;
+    (void)dsd_call_state_update_crypto(fix.state, 0, &crypto);
+    (void)dsd_call_state_end_ex(fix.state, 0, 103.0, DSD_CALL_END_TERMINATOR);
+    const dsd_scan_voice_probe_result media = probe_voice(&fix);
+    CHECK("ended call is not active", media.active_media_m < 0.0);
+    CHECK("metadata and end preserve media anchor", fabs(media.retained_media_m - 100.2) < 1e-6);
+    fixture_free(&fix);
+}
+
+static void
+test_probe_tracks_active_and_retained_slots_independently(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    open_voice_epoch_slot(&fix, 0U, 100.25, 0.25, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
+    (void)dsd_call_state_end_ex(fix.state, 0U, 100.625, DSD_CALL_END_TERMINATOR);
+    open_voice_epoch_slot(&fix, 1U, 100.125, 0.25, DSD_CALL_KIND_GROUP_VOICE, 33, 44, DSD_CALL_CRYPTO_CLEAR);
+
+    const dsd_scan_voice_probe_result media = probe_voice(&fix);
+    CHECK("active slot reported", fabs(media.active_media_m - 100.375) < 1e-6);
+    CHECK("newer ended slot retained", fabs(media.retained_media_m - 100.5) < 1e-6);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.75);
+    CHECK("active slot keeps voice phase", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_VOICE);
+    CHECK("newer retained slot anchors hold", fabs(fix.state->scan_voice_gate_voice_m - 100.5) < 1e-6);
     fixture_free(&fix);
 }
 
@@ -248,7 +347,7 @@ test_policy_gating(void) {
     }
     enc.opts->trunk_tune_enc_calls = 0;
     open_voice_epoch(&enc, 100.0, 0.15, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_ENCRYPTED);
-    CHECK("blocked encrypted ignored", dsd_scan_voice_probe(enc.opts, enc.state) < 0.0);
+    CHECK("blocked encrypted ignored", probe_voice(&enc).retained_media_m < 0.0);
     fixture_free(&enc);
 
     gate_fixture clear;
@@ -258,7 +357,7 @@ test_policy_gating(void) {
         return;
     }
     open_voice_epoch(&clear, 100.0, 0.15, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_ENCRYPTED);
-    CHECK("policy-allowed encrypted holds", dsd_scan_voice_probe(clear.opts, clear.state) > 0.0);
+    CHECK("policy-allowed encrypted holds", probe_voice(&clear).retained_media_m > 0.0);
     fixture_free(&clear);
 
     gate_fixture unknown;
@@ -268,7 +367,7 @@ test_policy_gating(void) {
         return;
     }
     open_voice_epoch(&unknown, 100.0, 0.15, DSD_CALL_KIND_VOICE, 0, 0, DSD_CALL_CRYPTO_UNKNOWN);
-    CHECK("unknown identity holds", dsd_scan_voice_probe(unknown.opts, unknown.state) > 0.0);
+    CHECK("unknown identity holds", probe_voice(&unknown).retained_media_m > 0.0);
     fixture_free(&unknown);
 
     gate_fixture priv;
@@ -279,7 +378,7 @@ test_policy_gating(void) {
     }
     priv.opts->trunk_tune_private_calls = 0;
     open_voice_epoch(&priv, 100.0, 0.15, DSD_CALL_KIND_PRIVATE_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
-    CHECK("private blocked", dsd_scan_voice_probe(priv.opts, priv.state) < 0.0);
+    CHECK("private blocked", probe_voice(&priv).retained_media_m < 0.0);
     fixture_free(&priv);
 
     gate_fixture data;
@@ -293,7 +392,7 @@ test_policy_gating(void) {
     (void)dsd_call_state_observe(data.state, &obs, DSD_CALL_BOUNDARY_BEGIN);
     (void)dsd_call_state_update_media(data.state, 0, 1, 100.0);
     (void)dsd_call_state_update_media(data.state, 0, 1, 100.2);
-    CHECK("data ignored", dsd_scan_voice_probe(data.opts, data.state) < 0.0);
+    CHECK("data ignored", probe_voice(&data).retained_media_m < 0.0);
     fixture_free(&data);
 }
 
@@ -352,6 +451,7 @@ test_stale_epoch_cannot_rearm(void) {
     }
     /* Voice before the visit arrived must not arm the new visit. */
     open_voice_epoch(&fix, 50.0, 0.15, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
+    (void)dsd_call_state_end_ex(fix.state, 0, 50.2, DSD_CALL_END_TERMINATOR);
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.1);
     CHECK("stale voice ignored", fix.state->scan_voice_gate_voice_m < 0.0);
@@ -400,7 +500,10 @@ main(void) {
     test_idle_only_steps_at_qualify();
     test_never_synced_falls_back();
     test_voice_holds_through_tail();
+    test_terminator_before_first_tick_holds();
     test_span_debounce();
+    test_non_media_updates_do_not_extend_hold();
+    test_probe_tracks_active_and_retained_slots_independently();
     test_policy_gating();
     test_operator_hold_and_visit_reset();
     test_stale_epoch_cannot_rearm();

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -3296,6 +3296,80 @@ test_conventional_voice_gate_media_hold(void) {
     return test_rc;
 }
 
+/* A protocol terminator may end the canonical call before the coordinator gets its first
+ * post-dispatch tick. The retained last-media stamp must still start the target's full hold;
+ * otherwise this sequence rotates on dwell and makes activity_hold_ms appear ineffective. */
+static int
+test_conventional_voice_gate_terminator_before_first_tick(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,dmr-conventional,461000000,,250,5000,\n"
+                             "b,dmr-conventional,462000000,,250,5000,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.scan_voice_only = 1;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "terminator-first voice-gate scan init failed: %s\n", err);
+        test_rc = 1;
+    }
+    if (seed_voice_gate_media_epoch(&state, 0.10, 0.25, DSD_CALL_CRYPTO_CLEAR) != 0
+        || dsd_call_state_end_ex(&state, 0U, 0.26, DSD_CALL_END_TERMINATOR) != 1) {
+        DSD_FPRINTF(stderr, "terminator-first voice-gate media seed failed\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.30);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0
+        || state.scan_voice_gate_phase != (uint8_t)DSD_SCAN_VOICE_GATE_TAIL) {
+        DSD_FPRINTF(stderr, "terminator-first media did not enter TAIL on the original target\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(5.249);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "terminator-first target rotated before the five-second hold\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(5.25);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0
+        || state.scan_voice_gate_phase != (uint8_t)DSD_SCAN_VOICE_GATE_QUALIFY) {
+        DSD_FPRINTF(stderr, "terminator-first target did not leave TAIL at the hold boundary\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(5.501);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1
+        || state.scan_voice_gate_phase != (uint8_t)DSD_SCAN_VOICE_GATE_OFF) {
+        DSD_FPRINTF(stderr, "terminator-first target did not rotate after hold plus dwell\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(5.51);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (state.scan_voice_gate_phase != (uint8_t)DSD_SCAN_VOICE_GATE_QUALIFY) {
+        DSD_FPRINTF(stderr, "retained media crossed into the next target context\n");
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_state_ext_free_all(&state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
 /* Policy still gates the media hold: encrypted voice the operator locks out
  * (trunk_tune_enc_calls=0) never refreshes it, so the target rotates on dwell. */
 static int
@@ -6896,6 +6970,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_conventional_voice_gate_data_header_no_hold);
     rc |= run_with_default_tune_hook(test_conventional_voice_gate_voice_header_no_hold);
     rc |= run_with_default_tune_hook(test_conventional_voice_gate_media_hold);
+    rc |= run_with_default_tune_hook(test_conventional_voice_gate_terminator_before_first_tick);
     rc |= run_with_default_tune_hook(test_conventional_voice_gate_enc_lockout_media_rotates);
     rc |= run_with_default_tune_hook(test_trunked_voice_gate_control_only_unchanged);
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_holds_while_tuned);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -3356,10 +3356,15 @@ test_conventional_voice_gate_terminator_before_first_tick(void) {
         DSD_FPRINTF(stderr, "terminator-first target did not rotate after hold plus dwell\n");
         test_rc = 1;
     }
+    dsd_call_snapshot incoming_call;
+    if (dsd_call_state_get(&state, 0U, &incoming_call) != 0) {
+        DSD_FPRINTF(stderr, "retained media crossed into the next target's call snapshot\n");
+        test_rc = 1;
+    }
     trunk_scan_test_set_now(5.51);
     dsd_engine_trunk_scan_tick(&opts, &state);
     if (state.scan_voice_gate_phase != (uint8_t)DSD_SCAN_VOICE_GATE_QUALIFY) {
-        DSD_FPRINTF(stderr, "retained media crossed into the next target context\n");
+        DSD_FPRINTF(stderr, "incoming conventional target did not enter QUALIFY\n");
         test_rc = 1;
     }
 

--- a/tests/test_support/call_state_stubs.c
+++ b/tests/test_support/call_state_stubs.c
@@ -176,7 +176,12 @@ dsd_call_state_update_media(dsd_state* state, uint8_t slot, int media_active, do
     }
     stub_select_state(state);
     g_stub_calls[slot].media_active = media_active != 0;
-    (void)observed_m;
+    if (media_active && observed_m > 0.0) {
+        if (g_stub_calls[slot].media_started_m <= 0.0) {
+            g_stub_calls[slot].media_started_m = observed_m;
+        }
+        g_stub_calls[slot].media_updated_m = observed_m;
+    }
     return 0;
 }
 

--- a/tests/test_support/call_state_stubs.c
+++ b/tests/test_support/call_state_stubs.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/platform/threading.h>
 #include <stdint.h>
 #include <string.h>
+#include <time.h>
 
 static const dsd_state* g_stub_state;
 
@@ -175,14 +176,23 @@ dsd_call_state_update_media(dsd_state* state, uint8_t slot, int media_active, do
         return -1;
     }
     stub_select_state(state);
-    g_stub_calls[slot].media_active = media_active != 0;
-    if (media_active && observed_m > 0.0) {
-        if (g_stub_calls[slot].media_started_m <= 0.0) {
-            g_stub_calls[slot].media_started_m = observed_m;
-        }
-        g_stub_calls[slot].media_updated_m = observed_m;
+    dsd_call_snapshot* call = &g_stub_calls[slot];
+    if (call->epoch == 0U || call->phase != DSD_CALL_PHASE_ACTIVE) {
+        return 0;
     }
-    return 0;
+    /* Production substitutes its monotonic clock when callers pass zero. These source-isolation
+     * tests deliberately link no timing backend, so wall time supplies the same positive-stamp
+     * contract; tests that exercise a specific timeline pass it explicitly. */
+    const double now_m = observed_m > 0.0 ? observed_m : (double)time(NULL);
+    call->media_active = media_active != 0;
+    call->updated_m = now_m;
+    if (media_active) {
+        if (call->media_started_m <= 0.0) {
+            call->media_started_m = now_m;
+        }
+        call->media_updated_m = now_m;
+    }
+    return 1;
 }
 
 int


### PR DESCRIPTION
## Summary

- Retain first and latest decoded-media timestamps independently from generic call updates, including across call end and recoverable reacquisition.
- Split the scan voice probe into active and retained media clocks so a terminator received before the first scanner tick enters `TAIL` and honors the full configured hold for both `-Y` and conventional trunk-scan targets.
- Add call-state lifecycle, exact hold-boundary, visit-isolation, no-carrier, and trunk-scan regressions, and document the corrected behavior.

Reported in [this follow-up comment on #473](https://github.com/arancormonk/dsd-neo/pull/473#issuecomment-5539387110). Related to #381.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] This is a focused core/engine correction; Claude and OMP independently reviewed the implementation plan and their lifecycle and edge-case feedback was incorporated.
- [x] High-risk areas touched: none.
- [x] Outside review was requested when available: Claude and OMP reviewed the plan.
- [x] All implemented and generated changes were read, understood, and adapted to DSD-neo conventions.
- [x] The commit includes a DCO sign-off.

## Quality Review

- [x] Scanner and call-state changes include focused regression tests.
- [x] The core/engine lifecycle changes received extra scrutiny through independent plan review and full guardrails.
- [x] No static-analysis suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or workflow permissions were added.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` (604/604)
- [x] Radio-off configure, build, and test (560/560)
- [x] Focused `CORE_CALL_STATE`, `ENGINE_SCAN_VOICE_GATE`, `ENGINE_NO_CARRIER_RESET`, and `ENGINE_TRUNK_SCAN` tests
- [x] `tools/preflight_ci.sh`
- [ ] `tools/quality_preflight.sh` (not run; focused, non-high-risk correction)
- [x] CMake/workflow/dependency-specific checks are not applicable; no such files changed.

## Risk

- Security/dependency impact: None.
- CLI/UI behavior impact: `--scan-voice-hold-ms` and conventional `activity_hold_ms` now retain their full tail after an over-the-air terminator; the status reports `TAIL` after the call closes.
- Compatibility or packaging impact: No packaging change. The call snapshot adds media timestamps, and the engine scan probe now returns separate active and retained clocks; all in-tree callers are updated.
