### PR TITLE
fix(p25): select a new control channel from the Frequency command (#476)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -536,9 +536,10 @@ Notes
     - `DSD_NEO_TG_PREEMPT_COOLDOWN_MS=<ms>` — cooldown between displacement attempts (default `1000`)
 
 During single-system P25 trunking, **Input > RTL-SDR > Frequency** selects a new control channel and keeps trunk
-following enabled. This also works in mixed `-ft` mode when P25 is active. An accepted tune ends current calls and
-relearns the NAC and site, while preserving explicit identity/modulation overrides, same-network band plans (including
-`--p25-bandplan`), channel mappings, groups, and keys. Subsequent calls return to the newly selected channel.
+following enabled. This also works in mixed `-ft` mode when P25 is active, including after sync loss on a learned
+P25 control channel. An accepted tune ends current calls and relearns the NAC and site, while preserving explicit
+identity/modulation overrides, same-network band plans (including `--p25-bandplan`), channel mappings, groups, and keys.
+Subsequent calls return to the newly selected channel.
 A failed or deferred request leaves the previous channel and calls intact; retry a deferred request. Pending tunes
 receive the configured CC acquisition grace after hardware completion. If completion fails, hunting retries the
 selected channel. Old site candidates are discarded; disk candidates require a freshly learned site and its own

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -535,6 +535,15 @@ Notes
     - `DSD_NEO_TG_PREEMPT_MIN_DWELL_MS=<ms>` — minimum active call dwell before displacement (default `750`)
     - `DSD_NEO_TG_PREEMPT_COOLDOWN_MS=<ms>` — cooldown between displacement attempts (default `1000`)
 
+During single-system P25 trunking, **Input > RTL-SDR > Frequency** selects a new control channel and keeps trunk
+following enabled. This also works in mixed `-ft` mode when P25 is active. An accepted tune ends current calls and
+relearns the NAC and site, while preserving explicit identity/modulation overrides, same-network band plans (including
+`--p25-bandplan`), channel mappings, groups, and keys. Subsequent calls return to the newly selected channel.
+A failed or deferred request leaves the previous channel and calls intact; retry a deferred request. Pending tunes
+receive the configured CC acquisition grace after hardware completion. If completion fails, hunting retries the
+selected channel. Old site candidates are discarded; disk candidates require a freshly learned site and its own
+cache file. Direct frequency changes are disabled during `--trunk-scan`, whose target list controls tuning.
+
 ## RTL‑SDR details (`-i rtl` / `-i rtltcp`)
 
 - Fields: `dev` (device index), `freq` (Hz/MHz), `gain` (0–49), `ppm`, `bw` (kHz: 4, 6, 8, 12, 16, 24, 48), `sql` (negative = threshold in dB, `0` = off, positive = linear mean power), `vol` (monitor gain, 0–3; typical 1–3), optional `bias[=on|off]`.

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -354,6 +354,11 @@ Notes:
 - Optional codec integrations are expressed via feature interface targets:
   - `dsd-neo_feature_codec2` → `USE_CODEC2` (used by M17 when available)
 
+P25 manual control-channel selection lives in `src/protocol/p25/p25_cc_selection.c`. The Frequency command routes
+active single-system P25 sessions here; the module holds the watchdog guard through the runtime CC tuning hook,
+call teardown, and acquisition restart. Extension ID 26 (`DSD_STATE_EXT_PROTO_P25_CC_SELECTION`) retains the
+site-specific cache requirement across no-carrier resets, while network band plans and user settings survive.
+
 Key public headers (selection):
 
 - DMR: `<dsd-neo/protocol/dmr/dmr_utils_api.h>`, `<dsd-neo/protocol/dmr/dmr_trunk_sm.h>`

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -356,8 +356,10 @@ Notes:
 
 P25 manual control-channel selection lives in `src/protocol/p25/p25_cc_selection.c`. The Frequency command routes
 active single-system P25 sessions here; the module holds the watchdog guard through the runtime CC tuning hook,
-call teardown, and acquisition restart. Extension ID 26 (`DSD_STATE_EXT_PROTO_P25_CC_SELECTION`) retains the
-site-specific cache requirement across no-carrier resets, while network band plans and user settings survive.
+call teardown, and acquisition restart. A learned CC type identifies quiet P25 sessions in mixed modes;
+`noCarrier()` clears that evidence after another trunking protocol takes over. Extension ID 26
+(`DSD_STATE_EXT_PROTO_P25_CC_SELECTION`) retains the site-specific cache requirement across no-carrier resets,
+while network band plans and user settings survive.
 
 Key public headers (selection):
 

--- a/include/dsd-neo/app_control/commands.h
+++ b/include/dsd-neo/app_control/commands.h
@@ -146,8 +146,10 @@ enum dsd_app_command_id {
     // RTL-SDR controls
     DSD_APP_CMD_RTL_ENABLE_INPUT = 480,
     DSD_APP_CMD_RTL_RESTART = 481,
-    DSD_APP_CMD_RTL_SET_DEV = 482,         // payload: int32_t index
-    DSD_APP_CMD_RTL_SET_FREQ = 483,        // payload: uint32_t hz
+    DSD_APP_CMD_RTL_SET_DEV = 482, // payload: int32_t index
+    // payload: uint32_t Hz; selects the CC during single-system P25 trunking.
+    // Refused during trunk scan; conventional/scanner frequency semantics are unchanged.
+    DSD_APP_CMD_RTL_SET_FREQ = 483,
     DSD_APP_CMD_RTL_SET_GAIN = 484,        // payload: int32_t gain
     DSD_APP_CMD_RTL_SET_PPM = 485,         // payload: int32_t ppm
     DSD_APP_CMD_RTL_SET_BW = 486,          // payload: int32_t khz

--- a/include/dsd-neo/core/state_ext.h
+++ b/include/dsd-neo/core/state_ext.h
@@ -58,6 +58,7 @@ typedef enum DSD_ATTR_PACKED dsd_state_ext_id {
     DSD_STATE_EXT_CORE_CALL_STATE = 4,
     DSD_STATE_EXT_PROTO_NXDN_TRUNK_DIAG = 24,
     DSD_STATE_EXT_PROTO_DMR_RC = 25,
+    DSD_STATE_EXT_PROTO_P25_CC_SELECTION = 26,
 } dsd_state_ext_id;
 
 typedef void (*dsd_state_ext_cleanup_fn)(void*);

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -19,6 +19,7 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -337,6 +338,17 @@ void p25_sm_event(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25
  * @param state Decoder state.
  */
 void p25_sm_seed_cc_from_current_tuner_if_unknown(const dsd_opts* opts, dsd_state* state);
+
+/**
+ * @brief Select a new control channel during single-system P25 trunk following.
+ *
+ * Owns the watchdog guard; call on the decoder thread without holding it.
+ * FAILED/DEFERRED leave the old channel and calls intact. OK/PENDING end the
+ * old calls, forget site acquisition data, and retain the new CC through
+ * asynchronous completion/recovery. Network band plans and user settings
+ * survive. Requires an initialized context and a positive frequency in Hz.
+ */
+dsd_trunk_tune_result p25_sm_select_control_channel(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, long hz);
 
 /**
  * @brief Start CC acquisition after a completed external retune.

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -37,6 +37,7 @@
 #include <dsd-neo/platform/threading.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/exitflag.h>
@@ -1014,11 +1015,56 @@ apply_cmd_io_and_import_rtl_a(dsd_opts* opts, dsd_state* state, const struct dsd
     return ui_cmd_apply_handler_table(k_handlers, sizeof k_handlers / sizeof k_handlers[0], opts, state, c);
 }
 
+static int cc_has_active_p25_context(const dsd_opts* opts, const dsd_state* state);
+
+static int
+manual_frequency_selects_p25_cc(const dsd_opts* opts, const dsd_state* state) {
+    if (opts->trunk_enable != 1) {
+        return 0;
+    }
+    if (cc_has_active_p25_context(opts, state)) {
+        return 1;
+    }
+    if (state->synctype != DSD_SYNC_NONE || state->lastsynctype != DSD_SYNC_NONE) {
+        return 0;
+    }
+    const dsdneoUserDecodeMode mode = dsd_infer_decode_mode_preset_exact(opts);
+    return mode == DSDCFG_MODE_P25P1 || mode == DSDCFG_MODE_P25P2;
+}
+
+static int
+ui_cmd_handle_p25_cc_selection(dsd_opts* opts, dsd_state* state, uint32_t hz) {
+    const dsd_trunk_tune_result result = p25_sm_select_control_channel(p25_sm_get_ctx(), opts, state, (long)hz);
+    if (dsd_trunk_tune_result_is_ok(result)) {
+        ui_set_toast(state, 3, "%s: P25 control channel -> %u Hz",
+                     result == DSD_TRUNK_TUNE_RESULT_PENDING ? "Accepted (pending)" : "Applied", hz);
+        return UI_CMD_APPLY_COMPLETED;
+    }
+    ui_set_toast(state, 4, "%s: P25 control channel -> %u Hz",
+                 result == DSD_TRUNK_TUNE_RESULT_DEFERRED ? "Deferred; retry" : "Failed", hz);
+    return UI_CMD_APPLY_FAILED;
+}
+
 static int
 ui_cmd_handle_rtl_set_freq(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     uint32_t v = 0;
     int result = UI_CMD_APPLY_COMPLETED;
     if (state && ui_cmd_parse_u32_payload(c, &v)) {
+        if (opts->trunk_scan_enabled) {
+            ui_set_toast(state, 3, "Trunk scan active: frequency control disabled");
+            return UI_CMD_APPLY_FAILED;
+        }
+        if (v == 0
+#if LONG_MAX < UINT32_MAX
+            || v > (uint32_t)LONG_MAX
+#endif
+        ) {
+            ui_set_toast(state, 3, "Invalid frequency");
+            return UI_CMD_APPLY_INVALID_PAYLOAD;
+        }
+        if (manual_frequency_selects_p25_cc(opts, state)) {
+            return ui_cmd_handle_p25_cc_selection(opts, state, v);
+        }
         int rc = svc_rtl_set_freq(opts, state, v);
         result = ui_cmd_apply_status_from_tune_rc(rc);
         if (rc == 0) {
@@ -1042,8 +1088,8 @@ static void reset_call_tracking(dsd_opts* opts, dsd_state* state, int clear_trun
  * Live retune from a spectrum tap.
  *
  * Kept separate from ui_cmd_handle_rtl_set_freq() on purpose. That one is the
- * settings-menu tune and documents a no-bookkeeping contract; here the tune is
- * a navigation gesture, so it (a) evaluates the tuner-ownership gate at drain
+ * settings-menu tune, which selects a CC during P25 trunk following; here the
+ * tune is a navigation gesture, so it (a) evaluates the tuner-ownership gate at drain
  * time on the authoritative live opts rather than trusting the frontend's
  * affordance, and (b) drops the stale auto-modulation votes and per-slot call
  * state that would otherwise slow or corrupt re-acquisition in decode mode

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -1019,7 +1019,7 @@ static int cc_has_active_p25_context(const dsd_opts* opts, const dsd_state* stat
 
 static int
 manual_frequency_selects_p25_cc(const dsd_opts* opts, const dsd_state* state) {
-    if (opts->trunk_enable != 1) {
+    if (opts->trunk_enable != 1 || (opts->frame_p25p1 != 1 && opts->frame_p25p2 != 1)) {
         return 0;
     }
     if (cc_has_active_p25_context(opts, state)) {
@@ -1027,6 +1027,12 @@ manual_frequency_selects_p25_cc(const dsd_opts* opts, const dsd_state* state) {
     }
     if (state->synctype != DSD_SYNC_NONE || state->lastsynctype != DSD_SYNC_NONE) {
         return 0;
+    }
+    // A learned CC type survives P25 sync loss; noCarrier retires it after
+    // another trunking protocol takes over. The shared frequency alone is not
+    // P25 evidence, since DMR/NXDN/EDACS also use that anchor.
+    if (state->p25_cc_freq > 0 && (state->p25_cc_is_tdma == 0 || state->p25_cc_is_tdma == 1)) {
+        return 1;
     }
     const dsdneoUserDecodeMode mode = dsd_infer_decode_mode_preset_exact(opts);
     return mode == DSDCFG_MODE_P25P1 || mode == DSDCFG_MODE_P25P2;

--- a/src/app_control/services.h
+++ b/src/app_control/services.h
@@ -198,7 +198,7 @@ int svc_rtl_enable_input(dsd_opts* opts, dsd_state* state);
 int svc_rtl_restart(dsd_opts* opts, dsd_state* state);
 /** @brief Set RTL device index and mark stream for restart (applied immediately if active). */
 int svc_rtl_set_dev_index(dsd_opts* opts, dsd_state* state, int index);
-/** @brief Tune RTL center frequency (Hz), applying live when stream active. */
+/** @brief Tune receiver frequency (Hz); caller owns trunking and call bookkeeping. */
 int svc_rtl_set_freq(dsd_opts* opts, dsd_state* state, uint32_t hz);
 /** @brief Set RTL manual gain (0–49), clamping and restarting if needed. */
 int svc_rtl_set_gain(dsd_opts* opts, dsd_state* state, int value);

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1494,6 +1494,7 @@ no_carrier_clear_stale_p25_return_hints_after_generic_activity(const dsd_opts* o
     state->p2_sysid = 0;
     state->p2_rfssid = 0;
     state->p2_siteid = 0;
+    state->p25_cc_is_tdma = 2; // The shared CC anchor no longer identifies a P25 session.
     state->p25_sys_is_tdma = 0;
     state->p25_vc_freq[0] = 0;
     state->p25_vc_freq[1] = 0;

--- a/src/protocol/p25/CMakeLists.txt
+++ b/src/protocol/p25/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
         p25_lcw.c
         p25_trunk_sm.c
         p25_cc_candidates.c
+        p25_cc_selection.c
         p25_extended_function.c
         p25_mfid90_utils.c
         p25_response_reason.c

--- a/src/protocol/p25/p25_cc_candidates.c
+++ b/src/protocol/p25/p25_cc_candidates.c
@@ -12,6 +12,7 @@
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_frequency.h>
@@ -24,6 +25,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "p25_cc_selection.h"
 
 static int p25_cc_build_cache_path(const dsd_state* state, char* out, size_t out_len);
 static void p25_cc_try_load_cache(const dsd_opts* opts, dsd_state* state);
@@ -77,6 +79,10 @@ p25_cc_build_cache_path(const dsd_state* state, char* out, size_t out_len) {
     }
     if (state->p2_wacn == 0 || state->p2_sysid == 0) {
         return 0; // require system identity
+    }
+    const p25_cc_selection* selection = dsd_state_ext_get_const(state, DSD_STATE_EXT_PROTO_P25_CC_SELECTION);
+    if (selection && selection->require_site_cache && (state->p2_rfssid == 0 || state->p2_siteid == 0)) {
+        return 0; // A manual selection must learn its site before loading any disk candidates.
     }
 
     char path[1024] = {0};

--- a/src/protocol/p25/p25_cc_selection.c
+++ b/src/protocol/p25/p25_cc_selection.c
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/vocoder.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/protocol/p25/p25p2_frame.h>
+#ifdef USE_RADIO
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#endif
+#include <dsd-neo/runtime/trunk_cc_candidates.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/runtime/trunk_tuning_hooks.h"
+#include "p25_cc_selection.h"
+#include "p25_trunk_sm_internal.h"
+
+static p25_cc_selection*
+p25_sm_prepare_cc_selection(dsd_state* state) {
+    p25_cc_selection* selection = dsd_state_ext_get(state, DSD_STATE_EXT_PROTO_P25_CC_SELECTION);
+    if (!selection) {
+        selection = calloc(1, sizeof(*selection));
+        if (selection && dsd_state_ext_set(state, DSD_STATE_EXT_PROTO_P25_CC_SELECTION, selection, free) != 0) {
+            free(selection);
+            return NULL;
+        }
+    }
+    return selection;
+}
+
+static void
+p25_sm_forget_selected_site(p25_sm_ctx_t* ctx, dsd_state* state) {
+    ctx->expected_cc_nac = 0;
+    ctx->nac_mismatch_count = 0;
+    state->nac = 0;
+    if (!state->p2_hardset) {
+        state->p2_cc = 0;
+    }
+    state->p2_rfssid = 0;
+    state->p2_siteid = 0;
+    state->p25_site_lra_valid = 0;
+    state->p25_site_lra = 0;
+    state->p25_site_network_active_valid = 0;
+    state->p25_site_network_active = 0;
+    state->p25_cc_prot_valid = 0;
+    state->p25_cc_prot_algid = 0;
+    state->last_cc_sync_time = 0;
+    state->last_cc_sync_time_m = 0.0;
+    state->p25_last_cc_msg_time = 0;
+    state->p25_last_cc_msg_time_m = 0.0;
+    state->p25_cc_eval_freq = 0;
+    state->p25_cc_eval_start_m = 0.0;
+    state->p25_cc_cache_loaded = 0;
+    dsd_trunk_cc_candidates_reset(state);
+    state->p25_nb_count = 0;
+    DSD_MEMSET(state->p25_nb_entries, 0, sizeof(state->p25_nb_entries));
+    state->p25_secondary_cc_count = 0;
+    DSD_MEMSET(state->p25_secondary_cc_entries, 0, sizeof(state->p25_secondary_cc_entries));
+    state->p25_pending_announcement_count = 0;
+    DSD_MEMSET(state->p25_pending_announcements, 0, sizeof(state->p25_pending_announcements));
+}
+
+static int
+p25_cc_selection_sps(const dsd_opts* opts, int is_tdma) {
+    int demod_rate = dsd_opts_current_input_timing_rate(opts);
+#ifdef USE_RADIO
+    if (opts->audio_in_type == AUDIO_IN_RTL) {
+        const int rtl_rate = (int)dsd_rtl_stream_metrics_hook_output_rate_hz();
+        if (rtl_rate > 0) {
+            demod_rate = rtl_rate;
+        }
+    }
+#endif
+    return dsd_opts_compute_sps_rate(opts, is_tdma ? 6000 : 4800, demod_rate);
+}
+
+dsd_trunk_tune_result
+p25_sm_select_control_channel(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, long hz) {
+    if (!ctx || !opts || !state || hz <= 0 || opts->trunk_enable != 1 || opts->trunk_scan_enabled) {
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+#if LONG_MAX > UINT32_MAX
+    if ((unsigned long)hz > UINT32_MAX) {
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+#endif
+    p25_sm_tick_guard_enter();
+    p25_cc_selection* selection = ctx->initialized ? p25_sm_prepare_cc_selection(state) : NULL;
+    if (!selection) {
+        p25_sm_tick_guard_leave();
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+
+    // Both the hardware profile and decoder timing use the saved CC type, even
+    // when this command interrupts a 6000-symbol traffic channel.
+    const int is_tdma = state->p25_cc_is_tdma == 1;
+    const int sps = p25_cc_selection_sps(opts, is_tdma);
+    uint64_t request_id = 0;
+    const dsd_trunk_tune_result result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, hz, sps, &request_id);
+    if (dsd_trunk_tune_result_is_ok(result)) {
+        p25_sm_clear_manual_selection_calls(ctx, opts, state);
+        dsd_mbe_purge_slot_audio(state, 0);
+        dsd_mbe_purge_slot_audio(state, 1);
+        p25_p2_frame_reset();
+        p25_sm_forget_selected_site(ctx, state);
+        selection->require_site_cache = 1;
+        state->p25_cc_freq = hz;
+        state->trunk_cc_freq = hz;
+        opts->rtlsdr_center_freq = (uint32_t)hz;
+        if (!dsd_state_trunk_lcn_user_list_present(opts, state)) {
+            state->trunk_lcn_freq[0] = hz;
+            state->lcn_freq_count = 1;
+            state->lcn_freq_roll = 0;
+        }
+        state->samplesPerSymbol = sps;
+        state->symbolCenter = dsd_opts_symbol_center(sps);
+        state->sps_hunt_idx = is_tdma ? DSD_FRAME_SYNC_SPS_PROFILE_6000_4 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+        state->sps_hunt_counter = 0;
+        dsd_frame_sync_reset_mod_state();
+        if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+            (void)p25_sm_await_pending_cc_tune(ctx, opts, state, request_id, "manual-cc");
+        } else {
+            (void)p25_sm_restart_pending_cc_acquisition(ctx, opts, state, 0.0, "manual-cc");
+        }
+    }
+    p25_sm_tick_guard_leave();
+    return result;
+}

--- a/src/protocol/p25/p25_cc_selection.c
+++ b/src/protocol/p25/p25_cc_selection.c
@@ -116,6 +116,10 @@ p25_sm_select_control_channel(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* stat
         state->trunk_cc_freq = hz;
         opts->rtlsdr_center_freq = (uint32_t)hz;
         if (!dsd_state_trunk_lcn_user_list_present(opts, state)) {
+            // Secondary-CC announcements seed only empty fixed slots. Retire
+            // the old site's entries before publishing the new automatic anchor.
+            DSD_MEMSET(state->trunk_lcn_freq, 0, sizeof(state->trunk_lcn_freq));
+            (void)dsd_state_trunk_lcn_avoid_clear(state);
             state->trunk_lcn_freq[0] = hz;
             state->lcn_freq_count = 1;
             state->lcn_freq_roll = 0;

--- a/src/protocol/p25/p25_cc_selection.h
+++ b/src/protocol/p25/p25_cc_selection.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#ifndef DSD_NEO_SRC_PROTOCOL_P25_P25_CC_SELECTION_H_
+#define DSD_NEO_SRC_PROTOCOL_P25_P25_CC_SELECTION_H_
+
+/* Session policy, deliberately outside the acquisition/no-carrier reset state. */
+typedef struct {
+    int require_site_cache;
+} p25_cc_selection;
+
+#endif

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -4637,7 +4637,7 @@ p25_release_return_to_cc_accepted(const p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_s
 }
 
 static void
-p25_release_clear_context(p25_sm_ctx_t* ctx) {
+p25_release_clear_context(p25_sm_ctx_t* ctx, int count_return) {
     p25_grant_clear_slot_state(ctx);
     p25_sm_clear_followed_history(ctx);
     ctx->vc_freq_hz = 0;
@@ -4651,12 +4651,14 @@ p25_release_clear_context(p25_sm_ctx_t* ctx) {
     ctx->t_voice_m = 0.0;
     ctx->vc_activity_seen = 0;
     p25_sm_reset_vc_reacquire_tracking(ctx);
-    ctx->release_count++;
-    ctx->cc_return_count++;
+    if (count_return) {
+        ctx->release_count++;
+        ctx->cc_return_count++;
+    }
 }
 
 static void
-p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
+p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state, int count_return) {
     if (state) {
         (void)dsd_tg_policy_clear_active_call(state, -1);
         state->p25_p2_audio_allowed[0] = 0;
@@ -4680,15 +4682,41 @@ p25_release_clear_decoder_state(dsd_opts* opts, dsd_state* state) {
         state->dmr_soR = 0;
         p25_crypto_reset_slot(state, 0);
         p25_crypto_reset_slot(state, 1);
-        state->p25_sm_release_count++;
         // Mirror of ctx->cc_return_count for readers without the ctx (UI, NULL-ctx
         // diag lines); p25_release_clear_context() bumps the ctx side on the same
         // two release paths that call this helper.
-        state->p25_sm_cc_return_count++;
+        if (count_return) {
+            state->p25_sm_release_count++;
+            state->p25_sm_cc_return_count++;
+        }
     }
     if (opts) {
         opts->trunk_is_tuned = 0;
     }
+}
+
+void
+p25_sm_clear_manual_selection_calls(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
+    const double ended_m = dsd_time_now_monotonic_s();
+    p25_call_end_slot(opts, state, 0, ended_m);
+    p25_call_end_slot(opts, state, 1, ended_m);
+    p25_release_clear_context(ctx, 0);
+    p25_release_clear_decoder_state(opts, state, 0);
+    ctx->vc_is_tdma = 0;
+    ctx->vc_cqpsk_retry_done = 0;
+    DSD_MEMSET(ctx->recent_call_ends, 0, sizeof(ctx->recent_call_ends));
+    state->p25_sm_force_release = 0;
+    state->trunk_sm_force_release = 0;
+    state->p25_sm_posthang_start = 0;
+    state->p25_sm_posthang_start_m = 0.0;
+    state->payload_mi = state->payload_miR = 0;
+    state->last_vc_sync_time = 0;
+    state->last_vc_sync_time_m = 0.0;
+    state->p2_is_lcch = 0;
+    state->p25_vc_cqpsk_override = -1;
+    state->p25_p1_nid_evidence = 0;
+    state->p25_p1_nid_evidence_symbolcnt = 0;
+    (void)dsd_recent_activity_clear_all(state);
 }
 
 static void
@@ -4785,8 +4813,8 @@ p25_release_locked(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const ch
     p25_call_end_slot(opts, state, 0, ended_m);
     p25_call_end_slot(opts, state, 1, ended_m);
 
-    p25_release_clear_context(ctx);
-    p25_release_clear_decoder_state(opts, state);
+    p25_release_clear_context(ctx, 1);
+    p25_release_clear_decoder_state(opts, state, 1);
     p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, tune_request_id, tune_start_m, "release",
                                            P25_SM_CC_ACQUISITION_RETURN);
 
@@ -4822,7 +4850,7 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
         const double ended_m = dsd_time_now_monotonic_s();
         p25_call_end_slot(opts, state, 0, ended_m);
         p25_call_end_slot(opts, state, 1, ended_m);
-        p25_release_clear_context(ctx);
+        p25_release_clear_context(ctx, 1);
         const uint32_t release_count = ctx->release_count;
         const uint32_t cc_return_count = ctx->cc_return_count;
         // The reprobe backoff is session state, like the counters below: it
@@ -4832,7 +4860,7 @@ do_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
         // next grant repeat.
         p25_sm_enc_reprobe_memo_t enc_reprobes[P25_SM_ENC_REPROBE_MEMO_MAX];
         DSD_MEMCPY(enc_reprobes, ctx->enc_reprobes, sizeof(enc_reprobes));
-        p25_release_clear_decoder_state(opts, state);
+        p25_release_clear_decoder_state(opts, state, 1);
         p25_sm_init_ctx(ctx, opts, state);
         DSD_MEMCPY(ctx->enc_reprobes, enc_reprobes, sizeof(ctx->enc_reprobes));
         ctx->tune_count = tune_count;

--- a/src/protocol/p25/p25_trunk_sm_internal.h
+++ b/src/protocol/p25/p25_trunk_sm_internal.h
@@ -9,11 +9,15 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* Accepted manual retunes end both epochs without another tune or resetting session counters. */
+void p25_sm_clear_manual_selection_calls(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state);
 
 void p25_sm_note_encrypted_call_typed(dsd_opts* opts, dsd_state* state, int target, int is_group, int algid, int keyid);
 

--- a/src/ui/terminal/menu_items.c
+++ b/src/ui/terminal/menu_items.c
@@ -105,7 +105,10 @@ static const NcMenuItem RTL_DSP_ITEMS[] = {
 };
 
 static const NcMenuItem RTL_MENU_ITEMS[] = {
-    {.id = "rtl.freq", .label_fn = lbl_rtl_freq, .help = "Set the center frequency in Hz.", .on_select = rtl_set_freq},
+    {.id = "rtl.freq",
+     .label_fn = lbl_rtl_freq,
+     .help = "Set frequency in Hz; selects a new CC during P25 trunking. Disabled during trunk scan.",
+     .on_select = rtl_set_freq},
     {.id = "rtl.gain",
      .label_fn = lbl_rtl_gain,
      .help = "Tuner gain in driver units; 0 hands gain to the AGC.",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4641,6 +4641,18 @@ if(NOT APPLE AND NOT WIN32 AND (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang"))
 endif()
 add_test(NAME APP_COMMAND_QUEUE COMMAND dsd-neo_test_app_command_queue)
 
+# Portable command-drain coverage: runtime hook installation, no linker wrapping.
+add_executable(dsd-neo_test_app_p25_cc_selection ui/test_app_p25_cc_selection.c)
+target_include_directories(
+    dsd-neo_test_app_p25_cc_selection
+    PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_app_p25_cc_selection
+    PRIVATE ${_DSD_RUNTIME_CONFIG_APPLY_LIBS} ${LIBS} dsd-neo_test_support
+)
+add_test(NAME APP_P25_CC_SELECTION COMMAND dsd-neo_test_app_p25_cc_selection)
+
 add_executable(dsd-neo_test_app_control_rr_apply ui/test_app_control_rr_apply.c)
 target_include_directories(
     dsd-neo_test_app_control_rr_apply

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -1465,6 +1465,33 @@ main(void) {
     assert(g_rtl_symbol_rate_hz == 4800);
     assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
     rtl_stream_clear_pending_retune_profile();
+    /* Manual CC selection may interrupt P2 voice. CC type, including the
+     * unknown/4800 fallback, must win over the active voice slot and rate. */
+    for (int cc_type = -1; cc_type <= 1; cc_type++) {
+        DSD_MEMSET(opts, 0, sizeof(*opts));
+        DSD_MEMSET(state, 0, sizeof(*state));
+        opts->audio_in_type = AUDIO_IN_RTL;
+        opts->trunk_enable = 1;
+        opts->trunk_is_tuned = 1;
+        opts->frame_p25p1 = opts->frame_p25p2 = opts->frame_dmr = 1;
+        state->rtl_ctx = (RtlSdrContext*)state;
+        state->p25_cc_is_tdma = cc_type;
+        state->p25_p2_active_slot = 1;
+        state->synctype = state->lastsynctype = DSD_SYNC_P25P2_POS;
+        state->rf_mod = 1;
+        state->p25_p1_validated_rf_mod = -1;
+        g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+        g_rtl_symbol_rate_hz = 6000;
+        g_rtl_ted_sps = 8;
+        g_rtl_pending_active = 0;
+        const int sps = cc_type == 1 ? 8 : 10;
+        assert(dsd_engine_trunk_tune_to_cc_request(opts, state, 852000000, sps, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+        assert(g_rtl_symbol_rate_hz == (cc_type == 1 ? 6000 : 4800));
+        assert(g_rtl_ted_sps == sps);
+        assert(g_rtl_channel_profile
+               == (cc_type == 1 ? RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK : RTL_STREAM_CHANNEL_PROFILE_P25_C4FM));
+        rtl_stream_clear_pending_retune_profile();
+    }
 #endif
 
     printf("ENGINE_TRUNK_RETUNE_REGRESSION: OK\n");

--- a/tests/ui/test_app_p25_cc_selection.c
+++ b/tests/ui/test_app_p25_cc_selection.c
@@ -17,6 +17,7 @@
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_frequency.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/protocol/p25/p25_vpdu.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
@@ -330,6 +331,10 @@ test_overrides(dsd_opts* opts, dsd_state* state) {
     opts->mod_qpsk = 1;
     opts->mod_c4fm = 0;
     DSD_SNPRINTF(opts->chan_in_file, sizeof(opts->chan_in_file), "user.csv");
+    state->trunk_lcn_freq[1] = CC_A + 25000;
+    state->trunk_lcn_freq[2] = CC_A + 50000;
+    state->lcn_freq_count = 3;
+    assert(dsd_state_trunk_lcn_avoid_set(state, 1, 1) == 0);
     state->p25_bandplan_row_count = 1;
     state->p25_bandplan_rows[0].iden = 1;
     state->p25_bandplan_rows[0].is_tdma = 1;
@@ -342,6 +347,9 @@ test_overrides(dsd_opts* opts, dsd_state* state) {
     assert(state->p2_cc == 0x123 && state->p2_hardset == 1);
     assert(opts->mod_cli_lock == 1 && opts->mod_qpsk == 1 && opts->mod_c4fm == 0);
     assert(state->trunk_lcn_freq[0] == CC_A && state->p25_bandplan_row_count == 1);
+    assert(state->trunk_lcn_freq[1] == CC_A + 25000 && state->trunk_lcn_freq[2] == CC_A + 50000);
+    assert(state->lcn_freq_count == 3);
+    assert(dsd_state_trunk_lcn_avoid_get(state, 1) == 1);
     dsd_tg_policy_lookup lookup;
     assert(state->R == 0x12345);
     assert(dsd_tg_policy_lookup_id(state, 1200, &lookup) == 0 && lookup.match == DSD_TG_POLICY_MATCH_EXACT);
@@ -390,7 +398,69 @@ test_cache(dsd_opts* opts, dsd_state* state) {
     assert(remove(legacy) == 0 && remove(site) == 0);
 }
 
+static void
+test_secondary_lcn_reseed(dsd_opts* opts, dsd_state* state) {
+    setup(opts, state);
+    state->trunk_lcn_freq[1] = CC_A + 25000;
+    state->trunk_lcn_freq[2] = CC_A + 50000;
+    state->lcn_freq_count = 3;
+    assert(dsd_state_trunk_lcn_avoid_set(state, 1, 1) == 0);
+    select_cc(opts, state, CC_B);
+    assert(state->trunk_lcn_freq[1] == 0 && state->trunk_lcn_freq[2] == 0);
+    assert(state->lcn_avoid_count == 0 && dsd_state_trunk_lcn_avoid_get(state, 1) == 0);
+    acquire_cc(opts, state);
+    // Native SCCB implicit: the two downlink channels use the preserved IDEN/map.
+    unsigned long long mac[24] = {0};
+    mac[1] = 0x79;
+    mac[2] = 2;
+    mac[3] = 3;
+    mac[4] = 0x10;
+    mac[5] = 0;
+    mac[6] = 1;
+    mac[7] = 0x10;
+    mac[8] = 2;
+    mac[9] = 1;
+    process_MAC_VPDU(opts, state, 0, P25_MAC_PDU_ACTIVE, mac);
+    assert(state->lcn_freq_count == 3);
+    assert(state->trunk_lcn_freq[1] == VC && state->trunk_lcn_freq[2] == VC + 12500);
+    freeState(state);
+}
+
 #ifdef USE_RADIO
+static void
+test_quiet_p25_command(dsd_opts* opts, dsd_state* state) {
+    for (int type = 0; type <= 1; type++) {
+        setup(opts, state);
+        state->p25_cc_is_tdma = type;
+        state->synctype = DSD_SYNC_NONE;
+        noCarrier(opts, state);
+        assert(state->lastsynctype == DSD_SYNC_NONE);
+        assert(opts->trunk_is_tuned == 0 && state->p25_cc_is_tdma == type);
+        select_cc(opts, state, CC_B);
+        assert(cc_calls == 1 && state->p25_cc_freq == CC_B);
+        acquire_cc(opts, state);
+        start_voice(opts, state);
+        p25_sm_release(p25_sm_get_ctx(), opts, state, "quiet-test-return");
+        assert(return_calls == 1 && last_freq == CC_B);
+        freeState(state);
+    }
+}
+
+static void
+test_quiet_generic_command(dsd_opts* opts, dsd_state* state) {
+    const int syncs[] = {DSD_SYNC_DMR_BS_DATA_POS, DSD_SYNC_NXDN_POS, DSD_SYNC_EDACS_POS, DSD_SYNC_X2TDMA_DATA_POS};
+    for (unsigned i = 0; i < sizeof(syncs) / sizeof(syncs[0]); i++) {
+        setup(opts, state);
+        state->synctype = DSD_SYNC_NONE;
+        state->lastsynctype = syncs[i];
+        noCarrier(opts, state);
+        assert(state->p25_cc_is_tdma == 2 && state->lastsynctype == DSD_SYNC_NONE);
+        select_cc(opts, state, CC_B);
+        assert(cc_calls == 0 && state->p25_cc_freq == CC_A);
+        freeState(state);
+    }
+}
+
 static void
 test_command_scope(dsd_opts* opts, dsd_state* state) {
     setup(opts, state);
@@ -415,7 +485,9 @@ test_command_scope(dsd_opts* opts, dsd_state* state) {
     state->synctype = state->lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
     select_cc(opts, state, CC_B);
     assert(cc_calls == 0 && state->p25_cc_freq == CC_A);
-    state->synctype = state->lastsynctype = DSD_SYNC_NONE;
+    state->synctype = DSD_SYNC_NONE;
+    noCarrier(opts, state); // Generic trunk activity retires the old P25 evidence.
+    assert(state->p25_cc_is_tdma == 2 && state->lastsynctype == DSD_SYNC_NONE);
     select_cc(opts, state, CC_B); // mixed -ft without P25 evidence stays generic
     assert(cc_calls == 0);
     assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_P25P1, DSD_DECODE_PRESET_PROFILE_CLI, opts, state) == 0);
@@ -443,8 +515,11 @@ main(void) {
     test_pending(opts, state, 1, 1);
     test_superseded_completion(opts, state);
     test_overrides(opts, state);
+    test_secondary_lcn_reseed(opts, state);
     test_cache(opts, state);
 #ifdef USE_RADIO
+    test_quiet_p25_command(opts, state);
+    test_quiet_generic_command(opts, state);
     test_command_scope(opts, state);
 #endif
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});

--- a/tests/ui/test_app_p25_cc_selection.c
+++ b/tests/ui/test_app_p25_cc_selection.c
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <assert.h>
+#include <dsd-neo/app_control/commands.h>
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/init.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/engine/frame_processing.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/protocol/p25/p25_cc_candidates.h>
+#include <dsd-neo/protocol/p25/p25_frequency.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/trunk_cc_candidates.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <limits.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "../../src/app_control/commands_internal.h"
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "test_support.h"
+
+#define CC_A 851000000L
+#define CC_B 852000000L
+#define VC   853000000L
+
+static dsd_trunk_tune_result tune_result;
+static int early_completion;
+static uint64_t last_request;
+static long last_freq;
+static int last_sps;
+static int cc_calls;
+static int vc_calls;
+static int return_calls;
+
+static dsd_trunk_tune_result
+cc_tune(dsd_opts* opts, dsd_state* state, long hz, int sps, uint64_t request_id) {
+    (void)opts;
+    (void)state;
+    cc_calls++;
+    last_freq = hz;
+    last_sps = sps;
+    last_request = request_id;
+    if (early_completion) {
+        dsd_trunk_tuning_request_publish(request_id, early_completion > 0 ? DSD_TRUNK_TUNE_RESULT_OK
+                                                                          : DSD_TRUNK_TUNE_RESULT_FAILED);
+        assert(!dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
+    }
+    return tune_result;
+}
+
+static dsd_trunk_tune_result
+vc_tune(dsd_opts* opts, dsd_state* state, long hz, int sps, uint64_t request_id) {
+    (void)opts;
+    (void)state;
+    (void)sps;
+    (void)request_id;
+    vc_calls++;
+    last_freq = hz;
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static dsd_trunk_tune_result
+return_cc(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
+    (void)opts;
+    (void)request_id;
+    return_calls++;
+    last_freq = state->p25_cc_freq;
+    assert(state->p25_cc_freq == state->trunk_cc_freq);
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static void
+setup(dsd_opts* opts, dsd_state* state) {
+    initOpts(opts);
+    initState(state);
+    state->cli_argc_effective = 0;
+    state->cli_argv = NULL;
+    assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_TDMA, DSD_DECODE_PRESET_PROFILE_CLI, opts, state) == 0);
+    opts->verbose = 0;
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->rtlsdr_center_freq = CC_A;
+    opts->trunk_enable = 1;
+    opts->trunk_tune_group_calls = 1;
+    state->p25_cc_freq = state->trunk_cc_freq = CC_A;
+    state->synctype = state->lastsynctype = DSD_SYNC_P25P1_POS;
+    state->p25_cc_is_tdma = 0;
+    state->p2_wacn = 0xBEE00;
+    state->p2_sysid = 0x37D;
+    state->nac = 0x123;
+    state->p2_cc = 0x123;
+    state->p2_rfssid = 1;
+    state->p2_siteid = 1;
+    state->trunk_lcn_freq[0] = CC_A;
+    state->lcn_freq_count = 1;
+    state->p25_iden_tdma[1].base_freq = VC / 5;
+    state->p25_iden_tdma[1].chan_spac = 100;
+    state->p25_iden_tdma[1].chan_type = 3;
+    state->p25_iden_tdma[1].trust = 2;
+    state->p25_iden_tdma[1].populated = 1;
+    state->p25_iden_tdma[1].wacn = state->p2_wacn;
+    state->p25_iden_tdma[1].sysid = state->p2_sysid;
+    state->p25_chan_tdma_explicit[1] = 2;
+    state->p25_sys_is_tdma = 1;
+    state->trunk_chan_map[0x1000] = VC;
+    state->trunk_chan_map[0x1001] = VC;
+    p25_sm_init_ctx(p25_sm_get_ctx(), opts, state);
+    p25_sm_get_ctx()->config.cc_grace_s = 30.0;
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    early_completion = 0;
+    cc_calls = vc_calls = return_calls = 0;
+    dsd_trunk_tuning_requests_reset();
+    const dsd_trunk_tuning_hooks hooks = {vc_tune, cc_tune, return_cc};
+    dsd_trunk_tuning_hooks_set(hooks);
+}
+
+static void
+select_cc(dsd_opts* opts, dsd_state* state, uint32_t hz) {
+#ifdef USE_RADIO
+    assert(dsd_app_command_set_u32(DSD_APP_CMD_RTL_SET_FREQ, hz) == DSD_APP_COMMAND_SUBMIT_QUEUED);
+    assert(dsd_app_drain_cmds(opts, state) == 1);
+#else
+    (void)p25_sm_select_control_channel(p25_sm_get_ctx(), opts, state, (long)hz);
+#endif
+}
+
+static void
+start_voice(dsd_opts* opts, dsd_state* state) {
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    for (int slot = 0; slot < 2; slot++) {
+        p25_sm_event_t grant = p25_sm_ev_group_grant(0x1000 + slot, VC, 1200 + slot, 300 + slot, 0);
+        p25_sm_event(ctx, opts, state, &grant);
+        p25_sm_event_t ptt = p25_sm_ev_ptt_call(slot, 1200 + slot, 0, 300 + slot, 1, 0);
+        p25_sm_event(ctx, opts, state, &ptt);
+        dsd_call_snapshot call;
+        assert(dsd_call_state_get(state, (uint8_t)slot, &call) == 1);
+        assert(call.phase == DSD_CALL_PHASE_ACTIVE);
+    }
+    assert(ctx->vc_is_tdma == 1);
+    state->synctype = state->lastsynctype = DSD_SYNC_P25P2_POS;
+    state->p25_sm_force_release = 1;
+    state->payload_mi = state->payload_miR = 42;
+    state->audio_out_temp_buf[0] = 1.0f;
+    state->audio_out_temp_bufR[0] = 1.0f;
+}
+
+static void
+acquire_cc(dsd_opts* opts, dsd_state* state) {
+    state->nac = 0x456;
+    state->p2_cc = 0x456;
+    state->p2_rfssid = 2;
+    state->p2_siteid = 3;
+    state->synctype = state->lastsynctype = DSD_SYNC_P25P1_POS;
+    state->p25_last_cc_msg_time_m = dsd_time_now_monotonic_s() + 0.001;
+    p25_sm_event_t sync = {0};
+    sync.type = P25_SM_EV_CC_SYNC;
+    p25_sm_event(p25_sm_get_ctx(), opts, state, &sync);
+    assert(!p25_sm_get_ctx()->cc_sync_pending);
+    assert(p25_sm_get_ctx()->expected_cc_nac == 0x456);
+}
+
+static void
+test_selection(dsd_opts* opts, dsd_state* state, int voice, int cc_type) {
+    setup(opts, state);
+    if (voice) {
+        start_voice(opts, state);
+    }
+    state->p25_cc_is_tdma = cc_type;
+    assert(p25_cc_add_candidate(state, CC_A + 25000, 1) == 1);
+    dsd_trunk_cc_candidates_set_cooldown(state, CC_A + 25000, 900.0);
+    state->p25_pending_announcement_count = 1;
+    state->p25_secondary_cc_count = 1;
+    state->p25_cc_eval_freq = CC_A + 25000;
+    state->p25_last_cc_msg_time_m = 42.0;
+    const uint32_t grants = p25_sm_get_ctx()->grant_count;
+    const uint32_t releases = p25_sm_get_ctx()->release_count;
+    const uint64_t generation = dsd_trunk_tuning_generation();
+    select_cc(opts, state, CC_B);
+    assert(cc_calls == 1 && last_freq == CC_B && return_calls == 0);
+    assert(last_sps
+           == dsd_opts_compute_sps_rate(opts, cc_type == 1 ? 6000 : 4800, dsd_opts_current_input_timing_rate(opts)));
+    assert(state->samplesPerSymbol == last_sps);
+    assert(state->sps_hunt_idx
+           == (cc_type == 1 ? DSD_FRAME_SYNC_SPS_PROFILE_6000_4 : DSD_FRAME_SYNC_SPS_PROFILE_4800_4));
+    assert(p25_sm_get_ctx()->grant_count == grants && p25_sm_get_ctx()->release_count == releases);
+    assert(opts->trunk_enable == 1 && opts->trunk_is_tuned == 0);
+    assert(state->p25_cc_freq == CC_B && state->trunk_cc_freq == CC_B && opts->rtlsdr_center_freq == CC_B);
+    assert(state->p25_vc_freq[0] == 0 && state->p25_vc_freq[1] == 0);
+    assert(state->trunk_lcn_freq[0] == CC_B && state->lcn_freq_count == 1);
+    assert(state->p2_wacn == 0xBEE00 && state->p2_sysid == 0x37D);
+    assert(state->p2_cc == 0 && state->nac == 0 && p25_sm_get_ctx()->expected_cc_nac == 0);
+    assert(state->p2_rfssid == 0 && state->p2_siteid == 0);
+    assert(state->p25_iden_tdma[1].base_freq == VC / 5 && state->p25_iden_tdma[1].trust == 2);
+    assert(state->trunk_chan_map[0x1000] == VC && state->p25_sys_is_tdma == 1);
+    assert(dsd_trunk_cc_candidates_peek(state)->count == 0);
+    assert(state->p25_pending_announcement_count == 0 && state->p25_secondary_cc_count == 0);
+    assert(!state->p25_sm_force_release && !state->payload_mi && !state->payload_miR);
+    assert(fabsf(state->audio_out_temp_buf[0]) < 0.0001f && fabsf(state->audio_out_temp_bufR[0]) < 0.0001f);
+    assert(!dsd_trunk_tuning_frame_is_current(generation));
+    if (voice) {
+        for (int slot = 0; slot < 2; slot++) {
+            dsd_call_snapshot call;
+            assert(dsd_call_state_get(state, (uint8_t)slot, &call) == 1 && call.phase == DSD_CALL_PHASE_ENDED);
+            assert(state->event_history_s[slot].Event_History_Items[1].target_id == (uint32_t)(1200 + slot));
+        }
+    }
+    acquire_cc(opts, state);
+    start_voice(opts, state);
+    p25_sm_release(p25_sm_get_ctx(), opts, state, "test-return");
+    assert(return_calls == 1 && last_freq == CC_B);
+    freeState(state);
+}
+
+static void
+test_rejected(dsd_opts* opts, dsd_state* state, dsd_trunk_tune_result result) {
+    setup(opts, state);
+    start_voice(opts, state);
+    tune_result = result;
+    const p25_sm_ctx_t before = *p25_sm_get_ctx();
+    select_cc(opts, state, CC_B);
+    const p25_sm_ctx_t* after = p25_sm_get_ctx();
+    assert(after->state == before.state && after->vc_freq_hz == before.vc_freq_hz);
+    assert(after->cc_tune_request_id == before.cc_tune_request_id && after->cc_sync_pending == before.cc_sync_pending);
+    assert(after->expected_cc_nac == before.expected_cc_nac && after->grant_count == before.grant_count);
+    assert(fabs(after->t_tune_m - before.t_tune_m) < 0.0001);
+    assert(fabs(after->t_cc_sync_m - before.t_cc_sync_m) < 0.0001);
+    for (int slot = 0; slot < 2; slot++) {
+        assert(after->slots[slot].voice_active == before.slots[slot].voice_active);
+        assert(after->slots[slot].target_id == before.slots[slot].target_id);
+        assert(fabs(after->slots[slot].last_active_m - before.slots[slot].last_active_m) < 0.0001);
+    }
+    assert(state->p25_cc_freq == CC_A && state->p2_siteid == 1 && state->nac == 0x123);
+    assert(opts->trunk_is_tuned == 1 && state->p25_vc_freq[0] == VC);
+    dsd_call_snapshot call;
+    assert(dsd_call_state_get(state, 0, &call) == 1 && call.phase == DSD_CALL_PHASE_ACTIVE);
+    freeState(state);
+}
+
+static void
+test_pending(dsd_opts* opts, dsd_state* state, int early, int fail) {
+    setup(opts, state);
+    start_voice(opts, state);
+    tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    early_completion = 0;
+    if (early) {
+        early_completion = fail ? -1 : 1;
+    }
+    select_cc(opts, state, CC_B);
+    p25_sm_ctx_t* ctx = p25_sm_get_ctx();
+    const uint64_t request = last_request;
+    assert(ctx->cc_sync_pending);
+    if (early && !fail) {
+        assert(!ctx->cc_tune_pending); // wrapper observes completion before returning
+    } else {
+        assert(ctx->cc_tune_pending && ctx->cc_tune_request_id == request);
+    }
+    if (!early) {
+        assert(!dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
+        ctx->t_cc_sync_m = dsd_time_now_monotonic_s() - 100.0;
+        p25_sm_tick_ctx(ctx, opts, state);
+        assert(ctx->cc_tune_pending && cc_calls == 1);
+        dsd_trunk_tuning_request_publish(request, fail ? DSD_TRUNK_TUNE_RESULT_FAILED : DSD_TRUNK_TUNE_RESULT_OK);
+    }
+    if (fail) {
+        tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+    p25_sm_tick_ctx(ctx, opts, state);
+    assert(!ctx->cc_tune_pending && state->p25_cc_freq == CC_B);
+    if (fail) {
+        assert(ctx->state == P25_SM_HUNTING);
+        assert(!dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
+        assert(last_freq == CC_B && cc_calls == 2);
+        tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+        ctx->t_hunt_try_m = 0.0;
+        p25_sm_tick_ctx(ctx, opts, state);
+        assert(last_freq == CC_B && cc_calls == 3);
+    } else {
+        double completed_m = 0.0;
+        assert(dsd_trunk_tuning_request_status(request, &completed_m) == DSD_TRUNK_TUNE_RESULT_OK);
+        assert(fabs(ctx->t_cc_tune_m - completed_m) < 0.01);
+        assert(ctx->state == P25_SM_ON_CC && ctx->cc_sync_pending);
+        p25_sm_tick_ctx(ctx, opts, state);
+        assert(cc_calls == 1);
+    }
+    const uint64_t generation = dsd_trunk_tuning_generation();
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_generation() == generation);
+    freeState(state);
+}
+
+static void
+test_superseded_completion(dsd_opts* opts, dsd_state* state) {
+    setup(opts, state);
+    tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    select_cc(opts, state, CC_B);
+    const uint64_t older = last_request;
+    select_cc(opts, state, CC_B + 25000);
+    const uint64_t newer = last_request;
+    assert(newer != older);
+    dsd_trunk_tuning_request_publish(older, DSD_TRUNK_TUNE_RESULT_OK);
+    p25_sm_tick_ctx(p25_sm_get_ctx(), opts, state);
+    assert(p25_sm_get_ctx()->cc_tune_pending && p25_sm_get_ctx()->cc_tune_request_id == newer);
+    assert(state->p25_cc_freq == CC_B + 25000);
+    assert(!dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()));
+    dsd_trunk_tuning_request_publish(newer, DSD_TRUNK_TUNE_RESULT_OK);
+    p25_sm_tick_ctx(p25_sm_get_ctx(), opts, state);
+    assert(!p25_sm_get_ctx()->cc_tune_pending && state->p25_cc_freq == CC_B + 25000);
+    const uint64_t generation = dsd_trunk_tuning_generation();
+    dsd_trunk_tuning_request_publish(older, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_trunk_tuning_frame_is_current(generation));
+    freeState(state);
+}
+
+static void
+test_overrides(dsd_opts* opts, dsd_state* state) {
+    setup(opts, state);
+    state->p2_hardset = 1;
+    opts->mod_cli_lock = 1;
+    opts->mod_qpsk = 1;
+    opts->mod_c4fm = 0;
+    DSD_SNPRINTF(opts->chan_in_file, sizeof(opts->chan_in_file), "user.csv");
+    state->p25_bandplan_row_count = 1;
+    state->p25_bandplan_rows[0].iden = 1;
+    state->p25_bandplan_rows[0].is_tdma = 1;
+    state->p25_bandplan_rows[0].entry = state->p25_iden_tdma[1];
+    state->keyloader = 0;
+    state->R = 0x12345;
+    const dsd_tg_policy_entry group = {.id_start = 1200, .id_end = 1200, .mode = "A", .name = "test"};
+    assert(dsd_tg_policy_append_exact(state, &group) == 0);
+    select_cc(opts, state, CC_B);
+    assert(state->p2_cc == 0x123 && state->p2_hardset == 1);
+    assert(opts->mod_cli_lock == 1 && opts->mod_qpsk == 1 && opts->mod_c4fm == 0);
+    assert(state->trunk_lcn_freq[0] == CC_A && state->p25_bandplan_row_count == 1);
+    dsd_tg_policy_lookup lookup;
+    assert(state->R == 0x12345);
+    assert(dsd_tg_policy_lookup_id(state, 1200, &lookup) == 0 && lookup.match == DSD_TG_POLICY_MATCH_EXACT);
+    assert(p25_update_system_identity(state, 0xBEE00, 0x37D) == 1);
+    assert(state->p25_iden_tdma[1].base_freq == VC / 5 && state->trunk_chan_map[0x1000] == VC);
+    assert(p25_update_system_identity(state, 0xBEE00, 0x123) == 1);
+    assert(state->p25_iden_tdma[1].populated == 0);
+    assert(state->trunk_chan_map[0x1000] == 0 && state->p25_bandplan_row_count == 1);
+    freeState(state);
+}
+
+static void
+test_cache(dsd_opts* opts, dsd_state* state) {
+    char dir[DSD_TEST_PATH_MAX];
+    char legacy[DSD_TEST_PATH_MAX];
+    char site[DSD_TEST_PATH_MAX];
+    assert(dsd_test_mkdtemp(dir, sizeof(dir), "dsdneo_manual_cc"));
+    assert(dsd_test_path_join(legacy, sizeof(legacy), dir, "p25_cc_BEE00_37D.txt") == 0);
+    assert(dsd_test_path_join(site, sizeof(site), dir, "p25_cc_BEE00_37D_R002_S003.txt") == 0);
+    FILE* fp = dsd_fopen_private(legacy, "w");
+    assert(fp);
+    DSD_FPRINTF(fp, "cc %ld\n", CC_A);
+    assert(fclose(fp) == 0);
+    fp = dsd_fopen_private(site, "w");
+    assert(fp);
+    DSD_FPRINTF(fp, "cc %ld\n", CC_B + 25000);
+    assert(fclose(fp) == 0);
+    assert(dsd_test_setenv("DSD_NEO_CACHE_DIR", dir, 1) == 0);
+    assert(dsd_test_setenv("DSD_NEO_CC_CACHE", "1", 1) == 0);
+    dsd_neo_config_init();
+    setup(opts, state);
+    select_cc(opts, state, CC_B);
+    const long no_neighbor = 0;
+    p25_cc_record_neighbor_frequencies(opts, state, &no_neighbor, 1);
+    assert(state->p25_cc_cache_loaded == 0);
+    noCarrier(opts, state);
+    p25_cc_record_neighbor_frequencies(opts, state, &no_neighbor, 1);
+    assert(state->p25_cc_cache_loaded == 0);
+    assert(dsd_trunk_cc_candidates_peek(state)->count == 0);
+    state->p2_rfssid = 2;
+    state->p2_siteid = 3;
+    p25_cc_record_neighbor_frequencies(opts, state, &no_neighbor, 1);
+    const dsd_trunk_cc_candidates* cc = dsd_trunk_cc_candidates_peek(state);
+    assert(state->p25_cc_cache_loaded && cc && cc->count == 1 && cc->candidates[0] == CC_B + 25000);
+    freeState(state);
+    assert(remove(legacy) == 0 && remove(site) == 0);
+}
+
+#ifdef USE_RADIO
+static void
+test_command_scope(dsd_opts* opts, dsd_state* state) {
+    setup(opts, state);
+    opts->trunk_scan_enabled = 1;
+    select_cc(opts, state, CC_B);
+    assert(cc_calls == 0 && state->p25_cc_freq == CC_A);
+    opts->trunk_scan_enabled = 0;
+    select_cc(opts, state, 0);
+    assert(cc_calls == 0);
+#if LONG_MAX < UINT32_MAX
+    select_cc(opts, state, UINT32_MAX);
+    assert(cc_calls == 0);
+#endif
+    opts->trunk_enable = 0;
+    select_cc(opts, state, CC_B);
+    assert(cc_calls == 0 && state->p25_cc_freq == CC_A);
+    opts->scanner_mode = 1;
+    select_cc(opts, state, CC_B);
+    assert(cc_calls == 0);
+    opts->scanner_mode = 0;
+    opts->trunk_enable = 1;
+    state->synctype = state->lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    select_cc(opts, state, CC_B);
+    assert(cc_calls == 0 && state->p25_cc_freq == CC_A);
+    state->synctype = state->lastsynctype = DSD_SYNC_NONE;
+    select_cc(opts, state, CC_B); // mixed -ft without P25 evidence stays generic
+    assert(cc_calls == 0);
+    assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_P25P1, DSD_DECODE_PRESET_PROFILE_CLI, opts, state) == 0);
+    select_cc(opts, state, CC_B);
+    assert(cc_calls == 1 && state->p25_cc_freq == CC_B);
+    freeState(state);
+}
+#endif
+
+int
+main(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts && state);
+    for (int voice = 0; voice < 2; voice++) {
+        for (int type = -1; type <= 1; type++) {
+            test_selection(opts, state, voice, type);
+        }
+    }
+    test_rejected(opts, state, DSD_TRUNK_TUNE_RESULT_FAILED);
+    test_rejected(opts, state, DSD_TRUNK_TUNE_RESULT_DEFERRED);
+    test_pending(opts, state, 0, 0);
+    test_pending(opts, state, 1, 0);
+    test_pending(opts, state, 0, 1);
+    test_pending(opts, state, 1, 1);
+    test_superseded_completion(opts, state);
+    test_overrides(opts, state);
+    test_cache(opts, state);
+#ifdef USE_RADIO
+    test_command_scope(opts, state);
+#endif
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    dsd_trunk_tuning_requests_reset();
+    free(state);
+    free(opts);
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #476. Changing Input > RTL-SDR > Frequency while following P25 now selects a new control channel and keeps trunk following enabled, including after sync loss on a learned P25 control channel in mixed `-ft` mode. Both frequency displays and later return-to-CC operations use the selected channel.

The P25 module commits only accepted tunes, ends both call epochs, clears voice/audio/crypto and site acquisition state, and preserves network band plans, channel mappings, groups, keys, and explicit overrides. Pending requests retain their request ID and receive acquisition grace after hardware completion. Cache loading after a manual selection requires newly learned site identity and that site's cache file, including after no-carrier resets. Trunk-scan rejects direct frequency changes.

## Review

- [x] Changes reviewed against the surrounding module design, ownership boundaries, and failure modes.
- [ ] Human review of behavior, ownership boundaries, and failure modes.
- [x] Claude and OMP performed source reviews after this PR was opened. Claude's two actionable findings were reproduced and fixed: quiet mixed-mode P25 routing and stale automatic secondary-channel slots. Regression coverage verifies both fixes and preserves generic tuning and user channel lists.
- Both reviewers confirmed those fixes in a follow-up review. Claude's additional note about row-based scan avoids was also verified and fixed: rebuilt automatic lists discard obsolete avoids, while user lists retain them.
- High-risk areas: decoder/trunk-tuning state and asynchronous completion; no workflow, dependency, or security-policy changes.
- [x] Generated code read and adapted to project conventions; commit carries a DCO sign-off.

## Tests And Guardrails

- [x] Full `dev-debug` build and CTest: 605 tests pass.
- [x] Radio-disabled build and CTest: 561 tests pass.
- [x] Portable `APP_P25_CC_SELECTION`: real command drain/runtime hooks, parked and dual-slot P2 voice, FDMA/TDMA/unknown CC profiles, failure/defer, pending/early/stale completions, NAC/site reacquisition, preserved configuration, cache reload, quiet mixed-mode recovery, generic protocol takeover, real SCCB channel-list reseeding, and command scope.
- [x] Extended `ENGINE_TRUNK_RETUNE_REGRESSION` checks CC profiles while interrupting Phase 2 voice.
- [x] Architecture and CMake-format checks.
- [x] `tools/preflight_ci.sh` and `tools/quality_preflight.sh`: all checks pass, including the full scan-build analysis and seven fuzz smoke targets.
- [x] ASan/UBSan: CC-selection, no-carrier, and engine-retune regressions pass.
- [x] Initial GitHub CI completed without failures, including native Windows MSVC release compilation. Final follow-up commit checks are tracked on this PR.
- [ ] Native Windows CTest and hardware smoke with two valid CCs, with/without `--p25-bandplan`: unavailable in the local Linux environment. The reporter's radio behavior has not been reproduced locally.

## Risk And Follow-up

The command and payload are unchanged; no new flags or configuration keys. Conventional/scanner frequency handling and spectrum-tap semantics remain as before. An asynchronous failure retains the selected CC and uses normal hunting recovery rather than restoring stale calls.

Review tradeoff: a generic-protocol sync retires the learned P25 CC type together with the existing P25 identity hints. A false generic sync can therefore require normal profile hunting to relearn a TDMA CC; this follows the existing generic takeover policy and was assessed as a bounded, non-blocking risk in review.

Separate follow-up: RadioReference import's `rr_apply_tune()` still retunes through `io_control_set_freq()`, and `rr_apply_reacquire()` clears candidates/calls without selecting a new P25 anchor. That analogous workflow needs its own fix and regression coverage.
