### PR TITLE
feat(engine): support per-channel decoder modes (#446)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -467,6 +467,10 @@ Notes
   manual `L` cycling. Existing dwell and voice-hold defaults remain unchanged.
   The open audio sink retains its rate/channel count while logical DMR slot decoding may change. Global mode and
   modulation commands update the saved configuration, and exiting scanning restores it.
+  Blank-mode rows retain that saved configuration while AUTO hunts. Loading a configuration that disables scanning
+  releases the row's decoder and keys. A manual frequency setting exits a typed scan and reports that in its status
+  message; legacy untyped scans retain their existing manual-tune behavior. Manual `L` skips zero-frequency placeholders,
+  while automatic scanning continues to park on them for the configured dwell.
 - Single-tuner trunk scan mode: `--trunk-scan <targets.csv>`
   - Rotates one tuner across CSV-defined P25 trunk, DMR trunk, DMR conventional, NXDN trunk, NXDN96 conventional
     (`nxdn-conventional`) and NXDN48 conventional (`nxdn48-conventional`) targets. Full guide: `docs/trunk-scan.md`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Levels/Audio: `-g 0|1..50`, `-n 0..100`, `-nm`, `-8`, `-V 0|1|2|3`, `-z 0|1|2`, `-y`, `-v 0xF`
 - Modes: `-fa | -fs | -fr | -f1 | -f2 | -fd | -fx | -fy | -fz | -fU | -fi | -fn | -fp | -fh | -fH | -fe | -fE | -fm`
 - Inversions/filtering: `-xx`, `-xr`, `-xd`, `-xz`, `-l`, `-q`
-- Trunking/scan: `-T`, `-Y`, `--trunk-scan targets.csv` (P25/DMR/NXDN96/NXDN48 targets; use `-fa` for mixed lists with NXDN), `-C chan.csv`, `-G group.csv`, `--p25-bandplan plan.csv`, `--p25-bandplan-export plan.csv`, `-W`, `-E`, `-p`, `-e`, `-I 1234`, `-U 4532`, `-B 12000`, `-t 1`, `--enc-lockout|--enc-follow`, `--scan-voice-only`, `--scan-voice-qualify-ms <ms>`, `--scan-voice-hold-ms <ms>`
+- Trunking/scan: `-T`, `-Y`, `--trunk-scan targets.csv` (P25/DMR/NXDN96/NXDN48 targets; each type selects its decoder class), `-C chan.csv`, `-G group.csv`, `--p25-bandplan plan.csv`, `--p25-bandplan-export plan.csv`, `-W`, `-E`, `-p`, `-e`, `-I 1234`, `-U 4532`, `-B 12000`, `-t 1`, `--enc-lockout|--enc-follow`, `--scan-voice-only`, `--scan-voice-qualify-ms <ms>`, `--scan-voice-hold-ms <ms>`
 - RTL‑SDR strings: `-i rtl:dev:freq:gain:ppm:bw:sql:vol[:bias=on|off]` or `-i rtltcp:host:port:freq:gain:ppm:bw:sql:vol[:bias=on|off]`
 - Soapy selection: `-i soapy`, `-i soapy:driver=airspy[,serial=...]`, or `-i soapy[:args]:freq[:gain[:ppm[:bw[:sql[:vol]]]]]` (discover args with `SoapySDRUtil --find`)
 - RTL retune control: `--rtl-udp-control <port>` binds to loopback by default; use
@@ -445,7 +445,7 @@ Notes
 ## Trunking & Scanning
 
 - Enable trunking (NXDN/P25/EDACS/DMR): `-T`
-- Conventional scan mode: `-Y` (not trunking; scans for sync on enabled decoders). For NXDN the hold is refreshed
+- Conventional scan mode: `-Y` (not trunking; scans for sync on the row's decoder class or the global decoders). For NXDN the hold is refreshed
   only by frames whose content passed a CRC, so an open squelch on an empty channel no longer parks the scan.
   A channel map with a `name` column (see `docs/csv-formats.md`) names the row being listened to in the Scan Mode
   row, in Call Info, and on the event history rows recorded while it is tuned. A map can load a per-row key set from
@@ -461,6 +461,12 @@ Notes
   voice without a key holds unless the talkgroup policy blocks it; unknown identity counts as voice. The last-media
   time survives an over-the-air terminator, so the full hold still runs when a protocol closes the call before the
   scanner's next tick.
+  Optional channel-map `mode` values select `p25`, `dmr`, `nxdn96`, `nxdn48`, `dpmr`, `dstar`, `ysf`, or `m17` for
+  each row. See [the mixed-mode example](../examples/conventional_scan_modes.csv). Declared rows work even when
+  excluded by the global preset; blank rows inherit it. Modes take effect at the first scheduled row entry, including
+  manual `L` cycling. Existing dwell and voice-hold defaults remain unchanged.
+  The open audio sink retains its rate/channel count while logical DMR slot decoding may change. Global mode and
+  modulation commands update the saved configuration, and exiting scanning restores it.
 - Single-tuner trunk scan mode: `--trunk-scan <targets.csv>`
   - Rotates one tuner across CSV-defined P25 trunk, DMR trunk, DMR conventional, NXDN trunk, NXDN96 conventional
     (`nxdn-conventional`) and NXDN48 conventional (`nxdn48-conventional`) targets. Full guide: `docs/trunk-scan.md`.

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -107,14 +107,21 @@ Tests: `tests/engine/test_engine_trunk_scan.c` (`ENGINE_TRUNK_SCAN`) and
   Suspend/update/resume supports global commands; scalar snapshot copies keep frontend state independent of live storage.
   Blank rows retain scope ownership. `dsd_scan_mode_configured_view()` borrows the baseline without copying its output
   label; consumers use their published snapshot, and persistence uses the exact configured preset (including custom sets).
+  `dsd_scan_mode_apply_modulation()` owns target flags/locks for both entry and scope updates. Inherited profiles use the
+  restored SPS hunt index, so AUTO's saved timing and the frontend's rate/levels agree after leaving a row.
 - Engine `channel_scan.c` (extension slot 7) stages typed `-Y` entries for automatic, manual, and avoid stepping through
   tracked tuning. It commits mode/keys only after success and retains generation protection across pending requests.
   Configuration edits retry pending tunes on a later service pass; live output-rate changes do not trigger another tune.
+  Failed rows advance to the next candidate; a later successful tune recovers any gate held by a partial backend failure.
+  `dsd_engine_channel_scan_waiting()` only inspects ownership; `dsd_engine_channel_scan_service_sync()` services pending
+  work and invalidates sync gathered before the transaction. Pending rows defer no-carrier call finalization until commit.
   `dsd_engine_reset_no_carrier_state()` shares decoder cleanup without recursively stepping or changing tuner ownership.
   `trunk_scan.c` selects the same classes from target types while retaining target snapshots and modulation/gain ownership.
 - DSP `dsd_frame_sync_reset_acquisition()` drops outgoing profile proof, modulation votes, symbol history, hunt budgets,
   and slicer windows at committed row boundaries. Conventional rows also discard learned P25 modulation; trunk targets
   retain their own learned modulation. Normal no-carrier protocol confirmation resets remain in use.
+  Unlocked RTL P25 trunk-scan targets try CQPSK after their first unproductive 4800-symbol/s dwell, before visiting 6000,
+  so the default three-second target visit includes the trial. This changes acquisition scheduling, not symbol timing.
 - Frontend snapshots deep-copy only scalar scope metadata. `dsd_app_snapshot_configured_mode()` exposes the baseline;
   `dsd_scan_mode_active()` and `dsd_scan_mode_effective_profile()` distinguish combined P25 from global AUTO.
 

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -98,6 +98,23 @@ trust 1 (`trunk_scan_share_peer_idens()`), and `dsd_engine_p25_bandplan_export()
 Tests: `tests/engine/test_engine_trunk_scan.c` (`ENGINE_TRUNK_SCAN`) and
 `tests/engine/test_engine_synced_trunk_scan_tick.c` (`ENGINE_SYNCED_TRUNK_SCAN_TICK`).
 
+### Per-channel decoder modes
+
+- Core owns positional channel-map modes through `core/channel_mode.h`, implemented beside the LCN heap stores in
+  `core/util/dsd_state_trunk_lcn.c`. Extension slot 5 transfers with map adoption and is cleared on map teardown.
+- Runtime owns the exact configured decoder baseline and temporary class through `runtime/scan_mode.h` and
+  `runtime/scan_mode.c` (extension slot 6). It uses the existing preset definitions while keeping the audio sink fixed.
+  Suspend/update/resume supports global commands; scalar snapshot copies keep frontend state independent of live storage.
+- Engine `channel_scan.c` (extension slot 7) stages typed `-Y` entries for automatic, manual, and avoid stepping through
+  tracked tuning. It commits mode/keys only after success and retains generation protection across pending requests.
+  `trunk_scan.c` selects the same classes from target types while retaining target snapshots and modulation/gain ownership.
+- DSP `dsd_frame_sync_reset_acquisition()` drops outgoing profile proof, modulation votes, symbol history, hunt budgets,
+  and slicer windows at committed row boundaries. Conventional rows also discard learned P25 modulation; trunk targets
+  retain their own learned modulation. Normal no-carrier protocol confirmation resets remain in use.
+- Frontend snapshots deep-copy only scalar scope metadata. `dsd_app_snapshot_configured_mode()` exposes the baseline;
+  `dsd_scan_mode_active()` and `dsd_scan_mode_effective_profile()` distinguish combined P25 from global AUTO.
+
+
 ## Platform
 
 - Path: `src/platform`, `include/dsd-neo/platform`

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -105,8 +105,12 @@ Tests: `tests/engine/test_engine_trunk_scan.c` (`ENGINE_TRUNK_SCAN`) and
 - Runtime owns the exact configured decoder baseline and temporary class through `runtime/scan_mode.h` and
   `runtime/scan_mode.c` (extension slot 6). It uses the existing preset definitions while keeping the audio sink fixed.
   Suspend/update/resume supports global commands; scalar snapshot copies keep frontend state independent of live storage.
+  Blank rows retain scope ownership. `dsd_scan_mode_configured_view()` borrows the baseline without copying its output
+  label; consumers use their published snapshot, and persistence uses the exact configured preset (including custom sets).
 - Engine `channel_scan.c` (extension slot 7) stages typed `-Y` entries for automatic, manual, and avoid stepping through
   tracked tuning. It commits mode/keys only after success and retains generation protection across pending requests.
+  Configuration edits retry pending tunes on a later service pass; live output-rate changes do not trigger another tune.
+  `dsd_engine_reset_no_carrier_state()` shares decoder cleanup without recursively stepping or changing tuner ownership.
   `trunk_scan.c` selects the same classes from target types while retaining target snapshots and modulation/gain ownership.
 - DSP `dsd_frame_sync_reset_acquisition()` drops outgoing profile proof, modulation votes, symbol history, hunt budgets,
   and slicer windows at committed row boundaries. Conventional rows also discard learned P25 modulation; trunk targets

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -844,6 +844,8 @@ Channel-map `mode` cells and trunk-scan target types are temporary decoder const
 settings continue to describe the configured global settings. Saving from a frontend or shutdown while parked on a
 typed row writes those configured settings. A global mode/modulation command updates that baseline and reapplies the
 current row constraint. Clearing/replacing the map, leaving the scanner, or manually tuning away restores configuration.
+Filter and source-monitor toggles show and edit the configured baseline, even when a row's decoder preset constrains
+their effective values. Changing source monitoring alone preserves the active call and decoder acquisition.
 
 P25 scan mode enables both phases; it is a scan class rather than a new global `decode` value. No CLI preset or
 persisted decode enum changes. Channel numbers and frequencies remain decimal integer channel numbers and Hz.

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -837,3 +837,13 @@ restart to take full effect.
 - Profile support for switching configurations.
 - Include directive for modular configs.
 - Interactive bootstrap can persist user choices automatically.
+
+### Decoder settings while scanning
+
+Channel-map `mode` cells and trunk-scan target types are temporary decoder constraints. `[mode] decode` and demod
+settings continue to describe the configured global settings. Saving from a frontend or shutdown while parked on a
+typed row writes those configured settings. A global mode/modulation command updates that baseline and reapplies the
+current row constraint. Clearing/replacing the map, leaving the scanner, or manually tuning away restores configuration.
+
+P25 scan mode enables both phases; it is a scan class rather than a new global `decode` value. No CLI preset or
+persisted decode enum changes. Channel numbers and frequencies remain decimal integer channel numbers and Hz.

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -92,6 +92,8 @@ Notes:
   trimmed: `name`, `mode`, `keys_hex_csv`, `keys_dec_csv`, `single_key_hex`, and `single_key_dec`. They may appear in
   any order, including after column 16. Unrecognized columns are ignored. The first `name` column wins; duplicate
   `mode` or key headers reject the file. This preserves legacy free-text note columns, including notes with commas.
+- Channel-map headers and data rows are read in full up to 1 MiB (including the line ending and terminating NUL).
+  Longer rows reject the import with an error; they are never split into additional channels.
 - `mode` accepts `p25`, `dmr`, `nxdn96`, `nxdn48`, `dpmr`, `dstar`, `ysf`, and `m17`, case-insensitively and trimmed.
   Empty or missing values inherit the configured global decoder settings. Invalid nonempty values reject the import
   with file and row diagnostics, including on rows whose channel number is invalid.

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -88,10 +88,20 @@ Notes:
   reach. A row outside it (including `0`) is skipped with a warning, and its slot in the LCN list below is left at 0 so
   later rows keep their LCN numbers. This is what tells a channel map apart from a decimal key list, which has the same
   `number,number` shape.
-- Extra columns are ignored; use them for labels like "default CC". Column 3 is one of them unless the header line
-  names it: a header whose third field is `name` (any capitalisation, surrounding spaces allowed) turns column 3 into
-  a channel name for every row of the file. This opt-in keeps the older maps working - two of the examples shipped in
-  `examples/` put a comma inside their third column, which a name column could not hold.
+- Optional headers after the two required columns are matched case-insensitively, with surrounding whitespace
+  trimmed: `name`, `mode`, `keys_hex_csv`, `keys_dec_csv`, `single_key_hex`, and `single_key_dec`. They may appear in
+  any order, including after column 16. Unrecognized columns are ignored. The first `name` column wins; duplicate
+  `mode` or key headers reject the file. This preserves legacy free-text note columns, including notes with commas.
+- `mode` accepts `p25`, `dmr`, `nxdn96`, `nxdn48`, `dpmr`, `dstar`, `ysf`, and `m17`, case-insensitively and trimmed.
+  Empty or missing values inherit the configured global decoder settings. Invalid nonempty values reject the import
+  with file and row diagnostics, including on rows whose channel number is invalid.
+- Under `-Y`, a declared mode selects its decoder class even when the global preset excludes it. P25 enables both
+  phases and excludes DMR and X2-TDMA. Fully declared mixed lists work without `-fa`; untyped lists retain their
+  existing behavior. The initial input uses global settings until the first scheduled row entry. Explicit global
+  modulation locks remain effective. Manual `L` cycling and avoid/advance use the same row-entry rules and visit
+  same-frequency rows with different metadata. Zero-frequency placeholders change neither the mode nor keys.
+- Modes are stored by scan-list slot: duplicate channel numbers and repeated frequencies remain distinct rows.
+  Trunk-scan target `type` is authoritative; `mode` values inside a target's `chan_csv` are validated and discarded.
 - A `name` is trimmed of surrounding whitespace, capped at 63 bytes (never splitting a UTF-8 character), and must not
   contain a comma. It is stored per row of the LCN list below, so a row whose frequency was skipped keeps its name and
   the rest stay aligned. A row whose *channel number* does not parse is different: it takes no LCN slot at all, so it
@@ -162,6 +172,15 @@ channel,frequency_hz,name,keys_hex_csv,keys_dec_csv,single_key_dec,single_key_he
 2,462587500,System B,,multi_key.csv,,
 3,462612500,Shared,,,1,0000001F00
 ```
+
+Declared modes use these symbol profiles:
+
+| Mode | Symbols per second | Levels |
+| --- | ---: | ---: |
+| P25 (both phases) | 4800 and 6000 | 4 |
+| DMR, NXDN96, YSF, M17 | 4800 | 4 |
+| NXDN48, dPMR | 2400 | 4 |
+| D-STAR | 4800 | 2 |
 
 ## Trunk Scan Target CSV (`--trunk-scan <file>` / `[trunk_scan] targets_csv`)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -313,6 +313,13 @@ tools/replay_ab.sh --capture ~/captures/nxdn.json --mode -fi --reps 12 \
 tools/replay_ab_report.py /tmp/ab/summary.tsv
 ```
 
+For a declared channel mode, build `dsd-neo_test_scan_mode_replay` and pass it as the comparison binary.
+This test-only host parses the real `-C` map, prepares and enters row zero through the production scoped-mode
+API, and asserts the override before starting the real engine. It leaves scanner retuning disabled because the
+I/Q replay API rejects live retunes. For example, compare native `-fi` with a map whose first row declares
+`nxdn48`, using `--mode "-fi -Z -C /path/to/map.csv"` for both binaries. The baseline ignores the optional mode
+column. `DECODE_IQ_SCAN_*` additionally tests overrides from global presets that exclude the declared class.
+
 Reading it:
 
 - **Errors per decoded voice frame**, never the raw error total. A build that

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -148,6 +148,13 @@ global modulation lock. Modes declared in a target's `chan_csv` do not override 
 Global mode/modulation commands update the configured settings while the parked target remains constrained.
 Stopping trunk scan restores those configured settings, and configuration saves record them rather than the parked
 target's decoder. Target gain, trunking state, and learned P25 modulation retain their existing coordinator ownership.
+The restored frontend rate and slicer levels follow the saved hunt profile, including a global AUTO preset captured
+on a rate other than 4800 symbols/s. Modulation controls display the saved configuration while a target is active.
+
+For unlocked RTL P25 targets, the first unproductive 4800-symbol/s dwell tries CQPSK before the hunt moves to Phase 2.
+Each Phase 1 demodulator gets 1125 ms of unproductive symbol input; CQPSK starts at 1125 ms and Phase 2 at 2250 ms,
+both within the default 3000 ms target dwell. Shorter custom dwells can still end before a trial; use an explicit
+target modulation or allow more acquisition time in that case.
 
 ## Config Usage
 

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -256,9 +256,8 @@ During scanning:
   it is parked (`NOTICE: NXDN trunking: grant: CH 12 has no frequency mapping in chan_csv (site.csv)`), and a summary
   for each such target at exit. Every target keeps its own list, so one target's gaps are never attributed to another.
 - `nxdn48-conventional` targets park at 2400 sym/s with the 6.25 kHz channel filter; every other GFSK-family target
-  parks at 4800 sym/s with the 12.5 kHz filter. Set `modulation = gfsk` on NXDN48 rows: that pins the symbol-rate
-  hunt to the 2400 profile for the whole dwell, whereas an empty or `auto` column lets the hunt rotate through the
-  other enabled rates during dead air, which also swings the channel filter. The parked target's type selects the
+  parks at 4800 sym/s with the 12.5 kHz filter. Each target's decoder class keeps the hunt on its allowed
+  symbol profile throughout dead air, including with empty or `auto` modulation. The parked target's type selects the
   symbol rate and channel filter even under a global `-m` modulation lock; the lock still governs symbol slicing, so
   DMR and NXDN rows under `-mc` or `-mq` need `modulation = gfsk` (or `auto`) to decode.
 - When a retune fails, DSD-neo logs a warning, briefly cools that target down, and tries another eligible target.

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -105,11 +105,10 @@ Target list limits and validation:
 
 ## CLI Usage
 
-For a mixed scan with an RTL-SDR (the shipped starter file contains P25, DMR, NXDN96 and NXDN48 rows, so use `-fa`;
-`-ft` is enough for a list with no NXDN targets):
+For a mixed scan with an RTL-SDR (each target selects its decoder class):
 
 ```sh
-dsd-neo -fa -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal
+dsd-neo -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal
 ```
 
 For an external receiver that sends PCM audio over TCP and is tuned through rigctl:
@@ -140,15 +139,15 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
   `--scan-voice-qualify-ms` and `--scan-voice-hold-ms` timings apply to the `-Y` conventional scan only, not to
   trunk-scan targets.
 
-Use the `-fa` (AUTO) command-line mode for mixed scan lists that contain NXDN targets: `-ft` enables the P25/DMR
-decoders but neither NXDN rate, so NXDN rows would sit idle with a startup warning. The two NXDN rates are separate
-decoders with separate mode presets -- `-fn` enables NXDN96 only and `-fi` enables NXDN48 only -- so **a list mixing
-`nxdn-conventional` and `nxdn48-conventional` rows requires `-fa`**. Single-rate lists can use the narrower preset.
-DSD-neo logs a warning at scan start for any target whose decoder is not enabled by the selected mode; it does not
-silently flip mode-preset frame flags.
+Each target's `type` selects its decoder class regardless of the configured global preset. P25 targets enable
+both phases and exclude DMR and X2-TDMA; DMR and NXDN targets enable only their declared class and rate. Mixed
+lists, including both NXDN rates, work without `-fa`. The target's `modulation` column keeps its existing precedence:
+an explicit value, including `auto`, overrides global modulation handling. An empty value preserves an explicit
+global modulation lock. Modes declared in a target's `chan_csv` do not override its type.
 
-`mode.decode = "auto"` in a config file is equivalent to `-fa` for decoder selection, so it serves mixed lists too.
-Use `mode.decode = "nxdn96"` or `mode.decode = "nxdn48"` when a single-rate list is all you want enabled.
+Global mode/modulation commands update the configured settings while the parked target remains constrained.
+Stopping trunk scan restores those configured settings, and configuration saves record them rather than the parked
+target's decoder. Target gain, trunking state, and learned P25 modulation retain their existing coordinator ownership.
 
 ## Config Usage
 
@@ -270,8 +269,6 @@ Expected log messages include:
 ```text
 Trunk scan target 'county-p25' at 851012500 Hz
 Trunk scan enabled with 6 targets
-2 trunk scan target(s) have no enabled NXDN96 decoder (first: 'site-nxdn'); use -fn or -fa to decode them
-1 trunk scan target(s) have no enabled NXDN48 decoder (first: 'field-nxdn48'); use -fi or -fa to decode them
 Trunk scan target 'city-dmr' retune failed; cooling down briefly
 ```
 
@@ -320,14 +317,6 @@ values are intentionally omitted from error messages.
 
 Remove either the `single_key_dec`/`single_key_hex` values or the key-file paths from that row. Direct and file key
 sources cannot be mixed for one target.
-
-`N trunk scan target(s) have no enabled <NAME> decoder (first: '<id>'); use <flags> to decode them`
-
-The selected decode mode does not enable the decoder those targets need, so they park and dwell without ever
-decoding. One line is logged per decoder class, not per target, and NXDN96 and NXDN48 are separate classes. Use
-`-fa` for a mixed list, `-fn` for an NXDN96-only list, `-fi` for an NXDN48-only list, `-ft`/`-f1`/`-f2` for P25, or
-`-fs`/`-ft` for DMR. A list holding both NXDN rates needs `-fa`, or `mode.decode = "auto"` in a config file, which
-selects the same decoders. DSD-neo does not flip mode-preset frame flags for you.
 
 `--trunk-scan cannot be combined with global -C/channel-map config`
 

--- a/examples/conventional_scan_modes.csv
+++ b/examples/conventional_scan_modes.csv
@@ -1,0 +1,10 @@
+channel,frequency_hz,name,mode
+1,467756250,NXDN48 example,nxdn48
+2,851012500,P25 example,p25
+3,461000000,DMR example,dmr
+4,461556250,NXDN96 example,nxdn96
+5,145670000,D-STAR example,dstar
+6,439987500,YSF example,ysf
+7,145500000,M17 example,m17
+8,446100000,dPMR example,dpmr
+9,150000000,Inherit configured decoder,

--- a/include/dsd-neo/app_control/snapshot.h
+++ b/include/dsd-neo/app_control/snapshot.h
@@ -30,6 +30,7 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/runtime/scan_mode.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,6 +47,9 @@ const dsd_state* dsd_app_get_latest_snapshot(void);
  * @return Read-only snapshot, or NULL before the first publish.
  */
 const dsd_opts* dsd_app_get_latest_opts_snapshot(void);
+/** Read configured decoder settings from matching frontend snapshots. The state snapshot also
+ * supports dsd_scan_mode_active() and dsd_scan_mode_effective_profile(), including combined P25. */
+void dsd_app_snapshot_configured_mode(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/core/channel_mode.h
+++ b/include/dsd-neo/core/channel_mode.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+/** @file @brief Positional channel-map mode metadata, owned by core extension slot 5. */
+#ifndef DSD_NEO_CORE_CHANNEL_MODE_H
+#define DSD_NEO_CORE_CHANNEL_MODE_H
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <stddef.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+/** Missing slots inherit the configured decoder settings. */
+dsd_scan_mode dsd_channel_mode_get(const dsd_state* state, size_t row);
+/** Set one scan-list slot, growing its heap store. Returns -1 on allocation failure. */
+int dsd_channel_mode_set(dsd_state* state, size_t row, dsd_scan_mode mode);
+/** Release all row modes. Does not restore active decoder settings. */
+void dsd_channel_modes_clear(dsd_state* state);
+/** Transfer ownership, replacing destination modes and clearing the source extension. */
+void dsd_channel_modes_move(dsd_state* dst, dsd_state* src);
+/** Nonzero if at least one row declares a mode. */
+int dsd_channel_modes_present(const dsd_state* state);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -398,15 +398,18 @@ dsd_opts_has_digital_decode_mode(const dsd_opts* opts) {
  * as C4FM.
  */
 static inline int
-dsd_opts_modulation(const dsd_opts* opts) {
-    if (!opts) {
-        return 0;
-    }
-    const int selected = (opts->mod_c4fm != 0) + (opts->mod_qpsk != 0) + (opts->mod_gfsk != 0);
+dsd_modulation_from_flags(int c4fm, int qpsk, int gfsk) {
+    const int selected = (c4fm != 0) + (qpsk != 0) + (gfsk != 0);
     if (selected != 1) {
         return 0;
     }
-    return (opts->mod_qpsk != 0) ? 1 : ((opts->mod_gfsk != 0) ? 2 : 0);
+    return qpsk != 0 ? 1 : (gfsk != 0 ? 2 : 0);
+}
+
+/** @brief Configured modulation; ambiguous/absent flags select the C4FM starting path. */
+static inline int
+dsd_opts_modulation(const dsd_opts* opts) {
+    return opts ? dsd_modulation_from_flags(opts->mod_c4fm, opts->mod_qpsk, opts->mod_gfsk) : 0;
 }
 
 /** @brief Return 1 when an enabled 4800-symbol four-level mode uses the 12.5 kHz channel profile. */

--- a/include/dsd-neo/core/state_ext.h
+++ b/include/dsd-neo/core/state_ext.h
@@ -50,12 +50,15 @@ typedef enum DSD_ATTR_PACKED dsd_state_ext_id {
     DSD_STATE_EXT_ENGINE_TRUNK_CC_CANDIDATES = 1,
     /*
      * Cross-cutting core facilities live in the engine range (0-7) rather than
-     * expanding `dsd_state`. Engine owns 0-1; core owns the documented IDs 2
-     * and 4.
+     * expanding `dsd_state`. Engine owns 0, 1, 3 and 7; core owns IDs
+     * 2, 4 and 5; runtime owns 6.
      */
     DSD_STATE_EXT_CORE_TG_POLICY = 2,
     DSD_STATE_EXT_ENGINE_TRUNK_SCAN = 3,
     DSD_STATE_EXT_CORE_CALL_STATE = 4,
+    DSD_STATE_EXT_CORE_CHANNEL_MODES = 5,
+    DSD_STATE_EXT_RUNTIME_SCAN_MODE = 6,
+    DSD_STATE_EXT_ENGINE_CHANNEL_SCAN = 7,
     DSD_STATE_EXT_PROTO_NXDN_TRUNK_DIAG = 24,
     DSD_STATE_EXT_PROTO_DMR_RC = 25,
     DSD_STATE_EXT_PROTO_P25_CC_SELECTION = 26,

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -92,6 +92,9 @@ typedef enum {
  * @brief Reset modulation auto-detect state used by frame sync.
  */
 void dsd_frame_sync_reset_mod_state(void);
+/** Reset per-acquisition evidence and slicer windows after a committed channel/mode change.
+ * Set forget_p25_modulation for conventional rows; trunk targets own their learned modulation. */
+void dsd_frame_sync_reset_acquisition(const dsd_opts* opts, dsd_state* state, int forget_p25_modulation);
 
 /**
  * @brief Return the NXDN variant selected by the enabled mode and active SPS hunt profile.

--- a/include/dsd-neo/dsp/frame_sync.h
+++ b/include/dsd-neo/dsp/frame_sync.h
@@ -186,6 +186,8 @@ void dsd_frame_sync_sps_hunt_restart_dwell(dsd_state* state);
  * @param state Decoder state; NULL or an out-of-range index yields the 4800/4 default.
  */
 int dsd_frame_sync_active_profile_symbol_rate_hz(const dsd_state* state);
+/** Slicer levels of the active profile; NULL/invalid indices yield four levels. */
+int dsd_frame_sync_active_profile_levels(const dsd_state* state);
 
 /**
  * @brief Scan for a valid frame sync pattern and return its type.

--- a/include/dsd-neo/engine/channel_scan.h
+++ b/include/dsd-neo/engine/channel_scan.h
@@ -11,6 +11,8 @@ extern "C" {
 #endif
 /** Enter the next eligible row. 1 committed, 0 parked/pending, -1 failed. Ignores hold for manual use. */
 int dsd_engine_channel_scan_step(dsd_opts* opts, dsd_state* state);
+/** Manual next-row action: skip zero-frequency placeholders in one bounded pass. */
+int dsd_engine_channel_scan_step_manual(dsd_opts* opts, dsd_state* state);
 /** Resolve an outstanding request before reading samples. Returns 1 while unsettled. */
 int dsd_engine_channel_scan_pending(dsd_opts* opts, dsd_state* state);
 /** Resolve a row transaction before dispatch/next sync search; 0 forces a fresh hunt after servicing it. */

--- a/include/dsd-neo/engine/channel_scan.h
+++ b/include/dsd-neo/engine/channel_scan.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+/** @file @brief Transactional entry for typed conventional scan rows. */
+#ifndef DSD_NEO_ENGINE_CHANNEL_SCAN_H
+#define DSD_NEO_ENGINE_CHANNEL_SCAN_H
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+/** Enter the next eligible row. 1 committed, 0 parked/pending, -1 failed. Ignores hold for manual use. */
+int dsd_engine_channel_scan_step(dsd_opts* opts, dsd_state* state);
+/** Resolve an outstanding request before reading samples. Returns 1 while unsettled. */
+int dsd_engine_channel_scan_pending(dsd_opts* opts, dsd_state* state);
+/** Resolve a row transaction before dispatch/next sync search; 0 forces a fresh hunt after servicing it. */
+int dsd_engine_channel_scan_sync_ready(dsd_opts* opts, dsd_state* state);
+/** Cancel row ownership and restore configured settings. Late completions cannot adopt a row. */
+void dsd_engine_channel_scan_leave(dsd_opts* opts, dsd_state* state);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/dsd-neo/engine/channel_scan.h
+++ b/include/dsd-neo/engine/channel_scan.h
@@ -13,10 +13,13 @@ extern "C" {
 int dsd_engine_channel_scan_step(dsd_opts* opts, dsd_state* state);
 /** Manual next-row action: skip zero-frequency placeholders in one bounded pass. */
 int dsd_engine_channel_scan_step_manual(dsd_opts* opts, dsd_state* state);
+/** Inspect row ownership without servicing the tune; nonzero while a request or retry is outstanding. */
+int dsd_engine_channel_scan_waiting(const dsd_state* state);
 /** Resolve an outstanding request before reading samples. Returns 1 while unsettled. */
 int dsd_engine_channel_scan_pending(dsd_opts* opts, dsd_state* state);
-/** Resolve a row transaction before dispatch/next sync search; 0 forces a fresh hunt after servicing it. */
-int dsd_engine_channel_scan_sync_ready(dsd_opts* opts, dsd_state* state);
+/** Service a row transaction before dispatch/next sync search. Returns 1 when ready;
+ * servicing any outstanding transaction clears synctype and returns 0 for a fresh hunt. */
+int dsd_engine_channel_scan_service_sync(dsd_opts* opts, dsd_state* state);
 /** Cancel row ownership and restore configured settings. Late completions cannot adopt a row. */
 void dsd_engine_channel_scan_leave(dsd_opts* opts, dsd_state* state);
 #ifdef __cplusplus

--- a/include/dsd-neo/engine/frame_processing.h
+++ b/include/dsd-neo/engine/frame_processing.h
@@ -20,6 +20,9 @@ extern "C" {
 
 void processFrame(dsd_opts* opts, dsd_state* state);
 void noCarrier(dsd_opts* opts, dsd_state* state);
+/** Reset decoder buffers and protocol state after calls have been finalized.
+ * Performs no scanner step or return-to-control-channel tuning. */
+void dsd_engine_reset_no_carrier_state(dsd_opts* opts, dsd_state* state);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -14,6 +14,7 @@
 #include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -55,11 +56,11 @@ typedef enum {
 } dsd_trunk_scan_target_type;
 
 typedef enum {
-    DSD_TRUNK_SCAN_MODULATION_UNSET = 0,
-    DSD_TRUNK_SCAN_MODULATION_AUTO = 1,
-    DSD_TRUNK_SCAN_MODULATION_C4FM = 2,
-    DSD_TRUNK_SCAN_MODULATION_CQPSK = 3,
-    DSD_TRUNK_SCAN_MODULATION_GFSK = 4,
+    DSD_TRUNK_SCAN_MODULATION_UNSET = DSD_SCAN_MODULATION_INHERIT,
+    DSD_TRUNK_SCAN_MODULATION_AUTO = DSD_SCAN_MODULATION_AUTO,
+    DSD_TRUNK_SCAN_MODULATION_C4FM = DSD_SCAN_MODULATION_C4FM,
+    DSD_TRUNK_SCAN_MODULATION_CQPSK = DSD_SCAN_MODULATION_CQPSK,
+    DSD_TRUNK_SCAN_MODULATION_GFSK = DSD_SCAN_MODULATION_GFSK,
 } dsd_trunk_scan_modulation;
 
 typedef struct {

--- a/include/dsd-neo/runtime/scan_mode.h
+++ b/include/dsd-neo/runtime/scan_mode.h
@@ -24,6 +24,15 @@ typedef enum {
     DSD_SCAN_MODE_M17
 } dsd_scan_mode;
 
+/** Target modulation precedence shared by scope reapplication and trunk entry. */
+typedef enum {
+    DSD_SCAN_MODULATION_INHERIT = 0,
+    DSD_SCAN_MODULATION_AUTO,
+    DSD_SCAN_MODULATION_C4FM,
+    DSD_SCAN_MODULATION_CQPSK,
+    DSD_SCAN_MODULATION_GFSK
+} dsd_scan_modulation;
+
 /** Scalar snapshot of the exact configured decoder settings; owns no pointers. */
 typedef struct {
     int frame_dstar;
@@ -95,8 +104,10 @@ int dsd_scan_mode_suspend(dsd_opts* opts, dsd_state* state);
 int dsd_scan_mode_resume(dsd_opts* opts, dsd_state* state);
 /** Nonzero between suspend and resume; side effects must wait until effective settings are known. */
 int dsd_scan_mode_updating(const dsd_state* state);
-/** Trunk target modulation precedence: 0 inherit, 1 auto, 2 C4FM, 3 CQPSK, 4 GFSK. */
-void dsd_scan_mode_target_modulation(const dsd_state* state, int modulation);
+/** Retain target modulation precedence across configured-setting updates. */
+void dsd_scan_mode_target_modulation(const dsd_state* state, dsd_scan_modulation modulation);
+/** Apply target flags/locks only; AUTO starts P25 on C4FM and other trunk classes on GFSK. */
+void dsd_scan_mode_apply_modulation(dsd_opts* opts, dsd_scan_mode mode, dsd_scan_modulation modulation);
 /** Snapshot configured settings, even while a row override is active. */
 void dsd_scan_mode_configured(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out);
 /** Borrow saved settings, or NULL without a scope/during an update. Use only on
@@ -104,7 +115,7 @@ void dsd_scan_mode_configured(const dsd_opts* opts, const dsd_state* state, dsd_
 const dsd_scan_settings* dsd_scan_mode_configured_view(const dsd_state* state);
 /** Deep-copy scalar scope metadata for frontend snapshots. No live extension pointer is shared. */
 void dsd_scan_mode_copy_snapshot(dsd_state* dst, const dsd_state* src);
-/** Current class profile; combined P25 follows the active Phase 1/2 profile. */
+/** Current class profile; combined P25 and inherited settings follow the active hunt index. */
 dsd_decode_mode_profile dsd_scan_mode_effective_profile(const dsd_opts* opts, const dsd_state* state);
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/runtime/scan_mode.h
+++ b/include/dsd-neo/runtime/scan_mode.h
@@ -81,7 +81,10 @@ int dsd_scan_mode_prepare(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode, 
 int dsd_scan_mode_begin(const dsd_opts* opts, dsd_state* state);
 /** Configured preset for mode selectors; active combined P25 remains a separate scan class. */
 dsdneoUserDecodeMode dsd_scan_mode_configured_preset(const dsd_opts* opts, const dsd_state* state);
-/** Select a row from the saved baseline, keeping the open audio sink layout fixed. */
+/** Configured preset for persistence; UNSET preserves custom decoder combinations. */
+dsdneoUserDecodeMode dsd_scan_mode_configured_preset_exact(const dsd_opts* opts, const dsd_state* state);
+/** Select a row from the saved baseline, keeping the open audio sink layout fixed.
+ * INHERIT restores the baseline for a blank row while retaining scan ownership. */
 int dsd_scan_mode_enter(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode);
 /** Restore the exact configured baseline and release the scope. */
 void dsd_scan_mode_leave(dsd_opts* opts, dsd_state* state);
@@ -96,8 +99,9 @@ int dsd_scan_mode_updating(const dsd_state* state);
 void dsd_scan_mode_target_modulation(const dsd_state* state, int modulation);
 /** Snapshot configured settings, even while a row override is active. */
 void dsd_scan_mode_configured(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out);
-/** Copy only configured option fields into an already initialized options copy. */
-void dsd_scan_mode_configured_opts(const dsd_state* state, dsd_opts* opts);
+/** Borrow saved settings, or NULL without a scope/during an update. Use only on
+ * the decoder thread or a consumer-owned snapshot; invalidated by scope updates. */
+const dsd_scan_settings* dsd_scan_mode_configured_view(const dsd_state* state);
 /** Deep-copy scalar scope metadata for frontend snapshots. No live extension pointer is shared. */
 void dsd_scan_mode_copy_snapshot(dsd_state* dst, const dsd_state* src);
 /** Current class profile; combined P25 follows the active Phase 1/2 profile. */

--- a/include/dsd-neo/runtime/scan_mode.h
+++ b/include/dsd-neo/runtime/scan_mode.h
@@ -87,7 +87,8 @@ int dsd_scan_mode_enter(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode);
 void dsd_scan_mode_leave(dsd_opts* opts, dsd_state* state);
 /** Temporarily restore configuration for an operator update, retaining the row constraint. */
 int dsd_scan_mode_suspend(dsd_opts* opts, dsd_state* state);
-/** Save the updated configuration and reapply the suspended constraint. */
+/** Save updated configuration and reapply the constraint. Return nonzero when decoder
+ * settings changed and acquisition must reset; audio-routing-only updates return zero. */
 int dsd_scan_mode_resume(dsd_opts* opts, dsd_state* state);
 /** Nonzero between suspend and resume; side effects must wait until effective settings are known. */
 int dsd_scan_mode_updating(const dsd_state* state);

--- a/include/dsd-neo/runtime/scan_mode.h
+++ b/include/dsd-neo/runtime/scan_mode.h
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+/** @file @brief Scoped scanner decoder classes, independent of global CLI preset IDs. */
+#ifndef DSD_NEO_RUNTIME_SCAN_MODE_H
+#define DSD_NEO_RUNTIME_SCAN_MODE_H
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    DSD_SCAN_MODE_INHERIT = 0,
+    DSD_SCAN_MODE_P25,
+    DSD_SCAN_MODE_DMR,
+    DSD_SCAN_MODE_NXDN96,
+    DSD_SCAN_MODE_NXDN48,
+    DSD_SCAN_MODE_DPMR,
+    DSD_SCAN_MODE_DSTAR,
+    DSD_SCAN_MODE_YSF,
+    DSD_SCAN_MODE_M17
+} dsd_scan_mode;
+
+/** Scalar snapshot of the exact configured decoder settings; owns no pointers. */
+typedef struct {
+    int frame_dstar;
+    int frame_x2tdma;
+    int frame_p25p1;
+    int frame_p25p2;
+    int frame_nxdn48;
+    int frame_nxdn96;
+    int frame_dmr;
+    int frame_dpmr;
+    int frame_provoice;
+    int frame_ysf;
+    int frame_m17;
+    int mod_c4fm;
+    int mod_qpsk;
+    int mod_gfsk;
+    int mod_cli_lock;
+    int mod_p25p2_c4fm;
+    int mod_p25p2_profile_lock;
+    int inverted_p2;
+    int inverted_x2tdma;
+    int inverted_dmr;
+    int inverted_dpmr;
+    int inverted_ysf;
+    int inverted_m17;
+    int dmr_stereo;
+    int dmr_mono;
+    int use_cosine_filter;
+    int ssize;
+    int msize;
+    int analog_only;
+    int monitor_input_audio;
+    char output_name[1024];
+    int state_rf_mod;
+    int state_samplesPerSymbol;
+    int state_symbolCenter;
+    int state_dmr_stereo;
+    int state_sps_hunt_idx;
+} dsd_scan_settings;
+
+/** Parse a trimmed, case-insensitive class; empty means inherit. Returns -1 on invalid input. */
+int dsd_scan_mode_parse(const char* text, dsd_scan_mode* mode);
+const char* dsd_scan_mode_name(dsd_scan_mode mode);
+dsd_decode_mode_profile dsd_scan_mode_profile(dsd_scan_mode mode);
+/** Active class, including combined P25; INHERIT when no override is installed. */
+dsd_scan_mode dsd_scan_mode_active(const dsd_state* state);
+/** Capture/restore effective fields for a staged tune; no pointers or audio sink fields are changed. */
+void dsd_scan_settings_capture(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out);
+void dsd_scan_settings_restore(const dsd_scan_settings* saved, dsd_opts* opts, dsd_state* state);
+/** Prepare production row settings without committing the row or baseline. */
+int dsd_scan_mode_prepare(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode, dsd_scan_settings* out);
+/** Reserve scope storage before staging a tune or building trunk-target snapshots. */
+int dsd_scan_mode_begin(const dsd_opts* opts, dsd_state* state);
+/** Configured preset for mode selectors; active combined P25 remains a separate scan class. */
+dsdneoUserDecodeMode dsd_scan_mode_configured_preset(const dsd_opts* opts, const dsd_state* state);
+/** Select a row from the saved baseline, keeping the open audio sink layout fixed. */
+int dsd_scan_mode_enter(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode);
+/** Restore the exact configured baseline and release the scope. */
+void dsd_scan_mode_leave(dsd_opts* opts, dsd_state* state);
+/** Temporarily restore configuration for an operator update, retaining the row constraint. */
+int dsd_scan_mode_suspend(dsd_opts* opts, dsd_state* state);
+/** Save the updated configuration and reapply the suspended constraint. */
+int dsd_scan_mode_resume(dsd_opts* opts, dsd_state* state);
+/** Nonzero between suspend and resume; side effects must wait until effective settings are known. */
+int dsd_scan_mode_updating(const dsd_state* state);
+/** Trunk target modulation precedence: 0 inherit, 1 auto, 2 C4FM, 3 CQPSK, 4 GFSK. */
+void dsd_scan_mode_target_modulation(const dsd_state* state, int modulation);
+/** Snapshot configured settings, even while a row override is active. */
+void dsd_scan_mode_configured(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out);
+/** Copy only configured option fields into an already initialized options copy. */
+void dsd_scan_mode_configured_opts(const dsd_state* state, dsd_opts* opts);
+/** Deep-copy scalar scope metadata for frontend snapshots. No live extension pointer is shared. */
+void dsd_scan_mode_copy_snapshot(dsd_state* dst, const dsd_state* src);
+/** Current class profile; combined P25 follows the active Phase 1/2 profile. */
+dsd_decode_mode_profile dsd_scan_mode_effective_profile(const dsd_opts* opts, const dsd_state* state);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/dsd-neo/runtime/scan_mode.h
+++ b/include/dsd-neo/runtime/scan_mode.h
@@ -73,6 +73,8 @@ dsd_scan_mode dsd_scan_mode_active(const dsd_state* state);
 /** Capture/restore effective fields for a staged tune; no pointers or audio sink fields are changed. */
 void dsd_scan_settings_capture(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out);
 void dsd_scan_settings_restore(const dsd_scan_settings* saved, dsd_opts* opts, dsd_state* state);
+/** Compare setting values, ignoring unused label bytes; optionally include live timing/modulation. */
+int dsd_scan_settings_equal(const dsd_scan_settings* a, const dsd_scan_settings* b, int include_timing);
 /** Prepare production row settings without committing the row or baseline. */
 int dsd_scan_mode_prepare(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode, dsd_scan_settings* out);
 /** Reserve scope storage before staging a tune or building trunk-target snapshots. */

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <stdint.h>
 #include <string.h>
 #include "../command_dispatch.h"
@@ -47,8 +48,8 @@ ui_modulation_demod_rate(const dsd_opts* opts, const dsd_state* state) {
  * combination) answers 4800/4, which is where the hunt starts anyway.
  */
 static dsd_decode_mode_profile
-ui_modulation_profile(const dsd_opts* opts) {
-    return dsd_decode_mode_profile_for(dsd_infer_decode_mode_preset(opts));
+ui_modulation_profile(const dsd_opts* opts, const dsd_state* state) {
+    return dsd_scan_mode_effective_profile(opts, state);
 }
 
 /**
@@ -64,8 +65,8 @@ ui_modulation_profile(const dsd_opts* opts) {
  * can never fire, so every tap rebuilds the timing for nothing.
  */
 static int
-ui_effective_modulation(const dsd_opts* opts, int mod) {
-    return dsd_frame_sync_profile_modulation(ui_modulation_profile(opts).levels, mod);
+ui_effective_modulation(const dsd_opts* opts, const dsd_state* state, int mod) {
+    return dsd_frame_sync_profile_modulation(ui_modulation_profile(opts, state).levels, mod);
 }
 
 static int
@@ -111,7 +112,7 @@ ui_handle_invert_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
 static void
 ui_apply_modulation(dsd_opts* opts, dsd_state* state, int mod) {
     const int leaving_p25p2_helper = opts->mod_p25p2_c4fm == 1 || opts->mod_p25p2_profile_lock == 1;
-    const dsd_decode_mode_profile profile = ui_modulation_profile(opts);
+    const dsd_decode_mode_profile profile = ui_modulation_profile(opts, state);
     const int sps = dsd_opts_compute_sps_rate(opts, profile.symbol_rate_hz, ui_modulation_demod_rate(opts, state));
     /* Through the profile, so the flags and rf_mod written below are a modulation
        the decode set can actually run and the SPS hunt will not move off. */
@@ -176,7 +177,7 @@ ui_handle_mod_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_command
      * C4FM there is already satisfied and rebuilding the timing for it would be
      * the same pointless churn on every tap. */
     const int mod_in_effect = dsd_opts_modulation(opts);
-    const int mod_effective = ui_effective_modulation(opts, (int)want);
+    const int mod_effective = ui_effective_modulation(opts, state, (int)want);
     if (state->rf_mod == mod_effective && mod_in_effect == mod_effective && opts->mod_p25p2_c4fm == 0
         && opts->mod_p25p2_profile_lock == 0) {
         return 1;

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -47,9 +47,8 @@ ui_modulation_demod_rate(const dsd_opts* opts, const dsd_state* state) {
  * combination) answers 4800/4, which is where the hunt starts anyway.
  */
 static dsd_decode_mode_profile
-ui_modulation_profile(const dsd_opts* opts, const dsd_state* state) {
+ui_modulation_profile(const dsd_opts* opts) {
     /* Command dispatch suspends the scan scope before modulation edits. */
-    (void)state;
     return dsd_decode_mode_profile_for(dsd_infer_decode_mode_preset(opts));
 }
 
@@ -66,8 +65,8 @@ ui_modulation_profile(const dsd_opts* opts, const dsd_state* state) {
  * can never fire, so every tap rebuilds the timing for nothing.
  */
 static int
-ui_effective_modulation(const dsd_opts* opts, const dsd_state* state, int mod) {
-    return dsd_frame_sync_profile_modulation(ui_modulation_profile(opts, state).levels, mod);
+ui_effective_modulation(const dsd_opts* opts, int mod) {
+    return dsd_frame_sync_profile_modulation(ui_modulation_profile(opts).levels, mod);
 }
 
 static int
@@ -113,7 +112,7 @@ ui_handle_invert_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_c
 static void
 ui_apply_modulation(dsd_opts* opts, dsd_state* state, int mod) {
     const int leaving_p25p2_helper = opts->mod_p25p2_c4fm == 1 || opts->mod_p25p2_profile_lock == 1;
-    const dsd_decode_mode_profile profile = ui_modulation_profile(opts, state);
+    const dsd_decode_mode_profile profile = ui_modulation_profile(opts);
     const int sps = dsd_opts_compute_sps_rate(opts, profile.symbol_rate_hz, ui_modulation_demod_rate(opts, state));
     /* Through the profile, so the flags and rf_mod written below are a modulation
        the decode set can actually run and the SPS hunt will not move off. */
@@ -178,7 +177,7 @@ ui_handle_mod_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_command
      * C4FM there is already satisfied and rebuilding the timing for it would be
      * the same pointless churn on every tap. */
     const int mod_in_effect = dsd_opts_modulation(opts);
-    const int mod_effective = ui_effective_modulation(opts, state, (int)want);
+    const int mod_effective = ui_effective_modulation(opts, (int)want);
     if (state->rf_mod == mod_effective && mod_in_effect == mod_effective && opts->mod_p25p2_c4fm == 0
         && opts->mod_p25p2_profile_lock == 0) {
         return 1;

--- a/src/app_control/actions/actions_radio.c
+++ b/src/app_control/actions/actions_radio.c
@@ -11,7 +11,6 @@
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
-#include <dsd-neo/runtime/scan_mode.h>
 #include <stdint.h>
 #include <string.h>
 #include "../command_dispatch.h"
@@ -49,7 +48,9 @@ ui_modulation_demod_rate(const dsd_opts* opts, const dsd_state* state) {
  */
 static dsd_decode_mode_profile
 ui_modulation_profile(const dsd_opts* opts, const dsd_state* state) {
-    return dsd_scan_mode_effective_profile(opts, state);
+    /* Command dispatch suspends the scan scope before modulation edits. */
+    (void)state;
+    return dsd_decode_mode_profile_for(dsd_infer_decode_mode_preset(opts));
 }
 
 /**

--- a/src/app_control/actions/actions_trunk.c
+++ b/src/app_control/actions/actions_trunk.c
@@ -58,8 +58,10 @@ ui_handle_trunk_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_comma
         // ui_handle_scanner_toggle clears trunking for the same reason: whichever
         // one was asked for last is the one driving, not both at once.
         // Leaving -Y hands the foreground keyring back to the globals.
-        dsd_engine_channel_scan_leave(opts, state);
-        dsd_scan_keys_leave(state);
+        if (opts->trunk_scan_enabled != 1) {
+            dsd_engine_channel_scan_leave(opts, state);
+            dsd_scan_keys_leave(state);
+        }
         opts->scanner_mode = 0;
     }
     return 1;
@@ -71,7 +73,7 @@ ui_handle_scanner_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_
     const int was_scanner = opts->scanner_mode ? 1 : 0;
     opts->scanner_mode = opts->scanner_mode ? 0 : 1;
     opts->trunk_enable = 0;
-    if (was_scanner) {
+    if (was_scanner && opts->trunk_scan_enabled != 1) {
         dsd_engine_channel_scan_leave(opts, state);
         dsd_scan_keys_leave(state);
     }

--- a/src/app_control/actions/actions_trunk.c
+++ b/src/app_control/actions/actions_trunk.c
@@ -12,8 +12,8 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
-#include <stddef.h>
 #include <stdint.h>
+#include <time.h>
 #include "../command_dispatch.h"
 
 #include "dsd-neo/app_control/commands.h"
@@ -70,6 +70,14 @@ ui_handle_trunk_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_comma
 static int
 ui_handle_scanner_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     (void)c;
+    if (opts->trunk_scan_enabled == 1) {
+        if (state) {
+            DSD_SNPRINTF(state->ui_msg, sizeof(state->ui_msg), "%s",
+                         "Trunk scan active: conventional scanner unavailable");
+            state->ui_msg_expire = time(NULL) + 3;
+        }
+        return 1;
+    }
     const int was_scanner = opts->scanner_mode ? 1 : 0;
     opts->scanner_mode = opts->scanner_mode ? 0 : 1;
     opts->trunk_enable = 0;

--- a/src/app_control/actions/actions_trunk.c
+++ b/src/app_control/actions/actions_trunk.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -57,6 +58,7 @@ ui_handle_trunk_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_comma
         // ui_handle_scanner_toggle clears trunking for the same reason: whichever
         // one was asked for last is the one driving, not both at once.
         // Leaving -Y hands the foreground keyring back to the globals.
+        dsd_engine_channel_scan_leave(opts, state);
         dsd_scan_keys_leave(state);
         opts->scanner_mode = 0;
     }
@@ -70,6 +72,7 @@ ui_handle_scanner_toggle(dsd_opts* opts, dsd_state* state, const struct dsd_app_
     opts->scanner_mode = opts->scanner_mode ? 0 : 1;
     opts->trunk_enable = 0;
     if (was_scanner) {
+        dsd_engine_channel_scan_leave(opts, state);
         dsd_scan_keys_leave(state);
     }
     return 1;

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -3182,8 +3182,10 @@ apply_tuner_release(dsd_opts* opts, dsd_state* state) {
     opts->trunk_enable = 0;
     opts->scanner_mode = 0;
     // Leaving -Y hands the foreground keyring back to the globals.
-    dsd_engine_channel_scan_leave(opts, state);
-    dsd_scan_keys_leave(state);
+    if (opts->trunk_scan_enabled != 1) {
+        dsd_engine_channel_scan_leave(opts, state);
+        dsd_scan_keys_leave(state);
+    }
     reset_call_tracking(opts, state, 1);
     ui_set_toast(state, 3, "Automatic tuning stopped");
     return UI_CMD_APPLY_COMPLETED;
@@ -4210,7 +4212,9 @@ static int
 apply_cmd(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     const int mode_update = c
                             && (c->id == DSD_APP_CMD_DECODE_MODE_SET || c->id == DSD_APP_CMD_MOD_SET
-                                || c->id == DSD_APP_CMD_MOD_TOGGLE || c->id == DSD_APP_CMD_CONFIG_APPLY);
+                                || c->id == DSD_APP_CMD_MOD_TOGGLE || c->id == DSD_APP_CMD_MOD_P2_TOGGLE
+                                || c->id == DSD_APP_CMD_INVERT_TOGGLE || c->id == DSD_APP_CMD_COSINE_FILTER_TOGGLE
+                                || c->id == DSD_APP_CMD_INPUT_MONITOR_TOGGLE || c->id == DSD_APP_CMD_CONFIG_APPLY);
     const int scoped = mode_update && opts && state && dsd_scan_mode_suspend(opts, state);
     const int result = apply_cmd_unscoped(opts, state, c);
     if (scoped && dsd_scan_mode_resume(opts, state)) {

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -4219,6 +4219,10 @@ apply_cmd_unscoped(dsd_opts* opts, dsd_state* state, const struct dsd_app_comman
 
 static int
 command_updates_scan_mode(const struct dsd_app_command* c) {
+    /* Commands that edit configuration in place run against the saved baseline.
+     * Ownership changes (including RR import) release the scope before editing.
+     * Live controls must continue to inspect the effective row, so suspending
+     * every command and diffing afterward would change their behavior. */
     static const int commands[] = {
         DSD_APP_CMD_DECODE_MODE_SET,      DSD_APP_CMD_MOD_SET,
         DSD_APP_CMD_MOD_TOGGLE,           DSD_APP_CMD_MOD_P2_TOGGLE,

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -1055,6 +1055,19 @@ ui_cmd_handle_p25_cc_selection(dsd_opts* opts, dsd_state* state, uint32_t hz) {
 }
 
 static int
+ui_cmd_leave_typed_scan_after_tune(dsd_opts* opts, dsd_state* state, int result) {
+    if ((result != 0 && result != RTL_STREAM_TUNE_TIMEOUT) || opts->scanner_mode != 1
+        || !dsd_channel_modes_present(state)) {
+        return 0;
+    }
+    dsd_engine_channel_scan_leave(opts, state);
+    dsd_scan_keys_leave(state);
+    opts->scanner_mode = 0;
+    state->lcn_freq_roll = 0;
+    return 1;
+}
+
+static int
 ui_cmd_handle_rtl_set_freq(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     uint32_t v = 0;
     int result = UI_CMD_APPLY_COMPLETED;
@@ -1076,16 +1089,12 @@ ui_cmd_handle_rtl_set_freq(dsd_opts* opts, dsd_state* state, const struct dsd_ap
         }
         int rc = svc_rtl_set_freq(opts, state, v);
         result = ui_cmd_apply_status_from_tune_rc(rc);
-        if ((rc == 0 || rc == RTL_STREAM_TUNE_TIMEOUT) && opts->scanner_mode == 1) {
-            dsd_engine_channel_scan_leave(opts, state);
-            dsd_scan_keys_leave(state);
-            opts->scanner_mode = 0;
-            state->lcn_freq_roll = 0;
-        }
+        const int stop_scanner = ui_cmd_leave_typed_scan_after_tune(opts, state, rc);
         if (rc == 0) {
-            ui_set_toast(state, 3, "Applied: RTL frequency -> %u Hz", v);
+            ui_set_toast(state, 3, "Applied: RTL frequency -> %u Hz%s", v, stop_scanner ? " (scanner stopped)" : "");
         } else if (rc == RTL_STREAM_TUNE_TIMEOUT) {
-            ui_set_toast(state, 3, "Accepted: RTL frequency -> %u Hz (pending)", v);
+            ui_set_toast(state, 3, "Accepted: RTL frequency -> %u Hz (pending)%s", v,
+                         stop_scanner ? " (scanner stopped)" : "");
         } else if (ui_rc_is_not_supported(rc)) {
             ui_set_toast(state, 3, "Unsupported: frequency control not available on active backend");
         } else {
@@ -2068,7 +2077,7 @@ apply_manual_lcn_cycle_untyped(dsd_opts* opts, dsd_state* state) {
 static int
 apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
     if (opts->scanner_mode == 1 && dsd_channel_modes_present(state)) {
-        return dsd_engine_channel_scan_step(opts, state) < 0 ? UI_CMD_APPLY_FAILED : UI_CMD_APPLY_COMPLETED;
+        return dsd_engine_channel_scan_step_manual(opts, state) < 0 ? UI_CMD_APPLY_FAILED : UI_CMD_APPLY_COMPLETED;
     }
     return apply_manual_lcn_cycle_untyped(opts, state);
 }
@@ -4209,14 +4218,37 @@ apply_cmd_unscoped(dsd_opts* opts, dsd_state* state, const struct dsd_app_comman
 }
 
 static int
+command_updates_scan_mode(const struct dsd_app_command* c) {
+    static const int commands[] = {
+        DSD_APP_CMD_DECODE_MODE_SET,      DSD_APP_CMD_MOD_SET,
+        DSD_APP_CMD_MOD_TOGGLE,           DSD_APP_CMD_MOD_P2_TOGGLE,
+        DSD_APP_CMD_INVERT_TOGGLE,        DSD_APP_CMD_COSINE_FILTER_TOGGLE,
+        DSD_APP_CMD_INV_X2_TOGGLE,        DSD_APP_CMD_INV_DMR_TOGGLE,
+        DSD_APP_CMD_INV_DPMR_TOGGLE,      DSD_APP_CMD_INV_M17_TOGGLE,
+        DSD_APP_CMD_INPUT_MONITOR_TOGGLE, DSD_APP_CMD_CONFIG_APPLY,
+    };
+    if (!c) {
+        return 0;
+    }
+    for (size_t i = 0; i < sizeof(commands) / sizeof(commands[0]); i++) {
+        if (commands[i] == c->id) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
 apply_cmd(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
-    const int mode_update = c
-                            && (c->id == DSD_APP_CMD_DECODE_MODE_SET || c->id == DSD_APP_CMD_MOD_SET
-                                || c->id == DSD_APP_CMD_MOD_TOGGLE || c->id == DSD_APP_CMD_MOD_P2_TOGGLE
-                                || c->id == DSD_APP_CMD_INVERT_TOGGLE || c->id == DSD_APP_CMD_COSINE_FILTER_TOGGLE
-                                || c->id == DSD_APP_CMD_INPUT_MONITOR_TOGGLE || c->id == DSD_APP_CMD_CONFIG_APPLY);
+    const int mode_update = command_updates_scan_mode(c);
+    const int was_scanner = opts && opts->scanner_mode == 1;
     const int scoped = mode_update && opts && state && dsd_scan_mode_suspend(opts, state);
     const int result = apply_cmd_unscoped(opts, state, c);
+    if (was_scanner && opts->scanner_mode != 1 && opts->trunk_scan_enabled != 1) {
+        /* A suspended scope leaves the newly applied configuration in place. */
+        dsd_engine_channel_scan_leave(opts, state);
+        dsd_scan_keys_leave(state);
+    }
     if (scoped && dsd_scan_mode_resume(opts, state)) {
         reset_call_tracking(opts, state, 1);
         dsd_frame_sync_reset_acquisition(opts, state, opts->trunk_scan_enabled != 1);

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/app_control/rr_import_apply.h>
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/csv_validate.h>
 #include <dsd-neo/core/dsd_time.h>
@@ -26,6 +27,7 @@
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/crypto/dmr_keystream.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/io/control.h>
 #include <dsd-neo/io/rigctl_client.h>
@@ -43,6 +45,7 @@
 #include <dsd-neo/runtime/exitflag.h>
 #include <dsd-neo/runtime/freq_parse.h>
 #include <dsd-neo/runtime/log.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/telemetry.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
@@ -1073,6 +1076,12 @@ ui_cmd_handle_rtl_set_freq(dsd_opts* opts, dsd_state* state, const struct dsd_ap
         }
         int rc = svc_rtl_set_freq(opts, state, v);
         result = ui_cmd_apply_status_from_tune_rc(rc);
+        if ((rc == 0 || rc == RTL_STREAM_TUNE_TIMEOUT) && opts->scanner_mode == 1) {
+            dsd_engine_channel_scan_leave(opts, state);
+            dsd_scan_keys_leave(state);
+            opts->scanner_mode = 0;
+            state->lcn_freq_roll = 0;
+        }
         if (rc == 0) {
             ui_set_toast(state, 3, "Applied: RTL frequency -> %u Hz", v);
         } else if (rc == RTL_STREAM_TUNE_TIMEOUT) {
@@ -2012,7 +2021,7 @@ try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
 }
 
 static int
-apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
+apply_manual_lcn_cycle_untyped(dsd_opts* opts, dsd_state* state) {
     int count = state->lcn_freq_count;
     if (count <= 0) {
         return UI_CMD_APPLY_COMPLETED;
@@ -2057,7 +2066,18 @@ apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
 }
 
 static int
+apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
+    if (opts->scanner_mode == 1 && dsd_channel_modes_present(state)) {
+        return dsd_engine_channel_scan_step(opts, state) < 0 ? UI_CMD_APPLY_FAILED : UI_CMD_APPLY_COMPLETED;
+    }
+    return apply_manual_lcn_cycle_untyped(opts, state);
+}
+
+static int
 apply_manual_channel_cycle(dsd_opts* opts, dsd_state* state) {
+    if (opts->scanner_mode == 1 && dsd_channel_modes_present(state)) {
+        return apply_manual_lcn_cycle(opts, state);
+    }
     const int candidate_status = try_manual_candidate_cycle(opts, state);
     if (candidate_status != UI_CMD_APPLY_UNHANDLED) {
         return candidate_status;
@@ -3162,6 +3182,7 @@ apply_tuner_release(dsd_opts* opts, dsd_state* state) {
     opts->trunk_enable = 0;
     opts->scanner_mode = 0;
     // Leaving -Y hands the foreground keyring back to the globals.
+    dsd_engine_channel_scan_leave(opts, state);
     dsd_scan_keys_leave(state);
     reset_call_tracking(opts, state, 1);
     ui_set_toast(state, 3, "Automatic tuning stopped");
@@ -3311,8 +3332,10 @@ decode_mode_apply_value(dsd_opts* opts, dsd_state* state, dsdneoUserDecodeMode m
     /* The decoder was hunting for a different protocol a moment ago: its
        modulation votes describe frames of the old kind, and any call open on the
        old protocol will never be closed by the new one. */
-    dsd_frame_sync_reset_mod_state();
-    reset_call_tracking(opts, state, 1);
+    if (!dsd_scan_mode_updating(state)) {
+        dsd_frame_sync_reset_acquisition(opts, state, opts->trunk_scan_enabled != 1);
+        reset_call_tracking(opts, state, 1);
+    }
     ui_set_toast(state, 3, "Decoding %s", dsd_decode_mode_display_name(mode));
     return UI_CMD_APPLY_COMPLETED;
 }
@@ -3334,8 +3357,7 @@ apply_decode_mode_set(dsd_opts* opts, dsd_state* state, const struct dsd_app_com
  * @brief Everything that can refuse a RadioReference apply before it mutates anything.
  *
  * After this returns COMPLETED the sequence is best-effort and cannot roll back;
- * svc_import_channel_map() in particular writes opts->chan_in_file before it
- * validates and never restores it.
+ * Each channel-map import validates before adoption and preserves its previous path on failure.
  */
 static int
 rr_apply_preflight(const dsd_opts* opts, dsd_state* state, const dsd_app_rr_apply_payload* p) {
@@ -3419,6 +3441,7 @@ rr_apply_tuner_owner(dsd_opts* opts, dsd_state* state, const dsd_app_rr_apply_pa
         opts->scanner_mode = 0;
     }
     if (!p->scanner) {
+        dsd_engine_channel_scan_leave(opts, state);
         dsd_scan_keys_leave(state);
     }
 }
@@ -3489,8 +3512,10 @@ rr_apply_reacquire(dsd_opts* opts, dsd_state* state) {
     state->last_cc_sync_time = 0;
     state->last_vc_sync_time = 0;
     state->last_vc_sync_time_m = 0.0;
-    dsd_frame_sync_reset_mod_state();
-    reset_call_tracking(opts, state, 1);
+    if (!dsd_scan_mode_updating(state)) {
+        dsd_frame_sync_reset_acquisition(opts, state, opts->trunk_scan_enabled != 1);
+        reset_call_tracking(opts, state, 1);
+    }
 }
 
 /**
@@ -3518,6 +3543,7 @@ apply_rr_import(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* 
         return pre;
     }
     const dsdneoUserDecodeMode mode = (dsdneoUserDecodeMode)p.decode_mode;
+    dsd_engine_channel_scan_leave(opts, state);
     if (decode_mode_apply_value(opts, state, mode) != UI_CMD_APPLY_COMPLETED) {
         ui_set_toast(state, 4, "Failed: RR import -> decode mode");
         return UI_CMD_APPLY_FAILED;
@@ -4129,7 +4155,7 @@ apply_cmd_misc_config(dsd_opts* opts, dsd_state* state, const struct dsd_app_com
 }
 
 static int
-apply_cmd(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+apply_cmd_unscoped(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     static const dsd_app_command_handler_fn k_command_groups[] = {
         apply_cmd_basic_a,       apply_cmd_slot_controls,  apply_cmd_payload_filters,  apply_cmd_constellation,
         apply_cmd_eye_spectrum,  apply_cmd_trunk_controls, apply_cmd_lockout_slot,     apply_cmd_provoice_m17,
@@ -4178,6 +4204,21 @@ apply_cmd(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
         }
     }
     return UI_CMD_APPLY_UNSUPPORTED;
+}
+
+static int
+apply_cmd(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    const int mode_update = c
+                            && (c->id == DSD_APP_CMD_DECODE_MODE_SET || c->id == DSD_APP_CMD_MOD_SET
+                                || c->id == DSD_APP_CMD_MOD_TOGGLE || c->id == DSD_APP_CMD_CONFIG_APPLY);
+    const int scoped = mode_update && opts && state && dsd_scan_mode_suspend(opts, state);
+    const int result = apply_cmd_unscoped(opts, state, c);
+    if (scoped && dsd_scan_mode_resume(opts, state)) {
+        reset_call_tracking(opts, state, 1);
+        dsd_frame_sync_reset_acquisition(opts, state, opts->trunk_scan_enabled != 1);
+        svc_publish_symbol_profile(opts, state, dsd_scan_mode_effective_profile(opts, state));
+    }
+    return result;
 }
 
 int

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/csv_validate.h>
@@ -16,6 +17,7 @@
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/string_utils.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/p25_bandplan_export.h>
 #include <dsd-neo/io/control.h>
 #include <dsd-neo/io/rigctl_client.h>
@@ -346,7 +348,7 @@ svc_udp_output_config(dsd_opts* opts, dsd_state* state, const char* host, int po
  * untouched and the imported one for that same call to free exactly once.
  */
 static int
-chan_map_adopt(dsd_state* dst, dsd_state* src) {
+chan_map_adopt(dsd_opts* opts, dsd_state* dst, dsd_state* src) {
     // src is an arbitrary dsd_state*, so the sign and the tail are checked here rather
     // than inherited from the importer: a negative count would become a huge size_t.
     const int src_count = src->lcn_freq_count > 0 ? src->lcn_freq_count : 0;
@@ -358,6 +360,8 @@ chan_map_adopt(dsd_state* dst, dsd_state* src) {
         LOG_ERROR("channel map adopt out of memory\n");
         return -1;
     }
+    dsd_engine_channel_scan_leave(opts, dst);
+    dsd_scan_keys_leave(dst);
     DSD_MEMCPY(dst->trunk_chan_map, src->trunk_chan_map, sizeof dst->trunk_chan_map);
     DSD_MEMCPY(dst->trunk_chan_map_used, src->trunk_chan_map_used, sizeof dst->trunk_chan_map_used);
     dst->trunk_chan_map_used_count = src->trunk_chan_map_used_count;
@@ -366,6 +370,7 @@ chan_map_adopt(dsd_state* dst, dsd_state* src) {
         DSD_MEMCPY(dst->trunk_lcn_freq_ext, src->trunk_lcn_freq_ext,
                    (size_t)(src_count - DSD_TRUNK_LCN_EMBEDDED) * sizeof(dst->trunk_lcn_freq_ext[0]));
     }
+    dsd_channel_modes_move(dst, src);
     dsd_state_trunk_lcn_name_free(dst);
     dst->trunk_lcn_name = src->trunk_lcn_name;
     dst->trunk_lcn_name_capacity = src->trunk_lcn_name_capacity;
@@ -399,6 +404,8 @@ svc_import_channel_map(dsd_opts* opts, dsd_state* state, const char* path) {
     if (opts->trunk_scan_enabled == 1) {
         return -1;
     }
+    char old_path[sizeof(opts->chan_in_file)];
+    DSD_MEMCPY(old_path, opts->chan_in_file, sizeof(old_path));
     DSD_STRNCPY(opts->chan_in_file, path, sizeof opts->chan_in_file - 1);
     opts->chan_in_file[sizeof opts->chan_in_file - 1] = '\0';
 
@@ -409,6 +416,7 @@ svc_import_channel_map(dsd_opts* opts, dsd_state* state, const char* path) {
     // dsd_tg_policy_reload_group_file() uses for the same reason.
     dsd_state* imported = (dsd_state*)calloc(1, sizeof(*imported));
     if (!imported) {
+        DSD_MEMCPY(opts->chan_in_file, old_path, sizeof(old_path));
         return -1;
     }
     const int import_rc = csvChanImport(opts, imported);
@@ -419,7 +427,7 @@ svc_import_channel_map(dsd_opts* opts, dsd_state* state, const char* path) {
     const int mapped_any = (imported->trunk_chan_map_used_count > 0);
     int adopt_rc = -1;
     if (import_rc == 0 && mapped_any) {
-        adopt_rc = chan_map_adopt(state, imported);
+        adopt_rc = chan_map_adopt(opts, state, imported);
     }
     if (import_rc == 0 && mapped_any && adopt_rc == 0) {
         dsd_scan_row_keys_warn_if_unused(state, opts->scanner_mode);
@@ -427,7 +435,11 @@ svc_import_channel_map(dsd_opts* opts, dsd_state* state, const char* path) {
     dsd_state_ext_free_all(imported);
     dsd_state_trunk_lcn_free(imported);
     free(imported);
-    return (import_rc == 0 && mapped_any && adopt_rc == 0) ? 0 : -1;
+    if (import_rc == 0 && mapped_any && adopt_rc == 0) {
+        return 0;
+    }
+    DSD_MEMCPY(opts->chan_in_file, old_path, sizeof(old_path));
+    return -1;
 }
 
 int
@@ -484,6 +496,7 @@ svc_clear_channel_map(dsd_opts* opts, dsd_state* state) {
     DSD_MEMSET(state->trunk_lcn_freq, 0, sizeof state->trunk_lcn_freq);
     // Releases the per-row name, avoid and key stores along with the scan-list heap tail.
     // Clearing the map leaves -Y: hand the foreground keyring back to the globals first.
+    dsd_engine_channel_scan_leave(opts, state);
     dsd_scan_keys_leave(state);
     dsd_state_trunk_lcn_free(state);
     state->lcn_freq_count = 0;

--- a/src/app_control/symbol_profile.c
+++ b/src/app_control/symbol_profile.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "services.h"
@@ -30,6 +31,11 @@ svc_publish_symbol_profile(const dsd_opts* opts, dsd_state* state, dsd_decode_mo
     }
 
     state->sps_hunt_idx = (int)profile.sps_profile_index;
+    if (dsd_scan_mode_updating(state)) {
+        /* The saved configuration needs its new profile, but acquisition and
+         * frontend changes wait until the row constraint has been reapplied. */
+        return;
+    }
     state->sps_hunt_counter = 0;
 
 #ifdef USE_RADIO

--- a/src/app_control/ui_snapshot.c
+++ b/src/app_control/ui_snapshot.c
@@ -6,11 +6,13 @@
 #include <dsd-neo/app_control/notification_status.h>
 #include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/events.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/platform/atomic_compat.h>
 #include <dsd-neo/platform/threading.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -289,6 +291,7 @@ dsd_app_telemetry_publish_snapshot(const dsd_state* state) {
     ensure_mu_init();
     dsd_mutex_lock(&g_mu);
     ui_snapshot_copy_render_state(&g_pub, state);
+    dsd_scan_mode_copy_snapshot(&g_pub, state);
     ui_snapshot_copy_trunk_cc_candidates(&g_pub, state, &g_pub_cc_candidates);
     // Clone canonical calls, recent activity, and history under the core transaction lock.
     if (state->event_history_s != NULL) {
@@ -331,6 +334,7 @@ dsd_app_get_latest_snapshot(void) {
     }
     if (g_consume_seq != g_pub_seq) {
         ui_snapshot_copy_render_state(&g_consume, &g_pub);
+        dsd_scan_mode_copy_snapshot(&g_consume, &g_pub);
         ui_snapshot_copy_trunk_cc_candidates(&g_consume, &g_pub, &g_consume_cc_candidates);
         (void)dsd_call_state_copy_to_state(&g_consume, &g_pub);
         g_consume_seq = g_pub_seq;
@@ -350,4 +354,9 @@ dsd_app_get_latest_snapshot(void) {
     }
     dsd_mutex_unlock(&g_mu);
     return &g_consume;
+}
+
+void
+dsd_app_snapshot_configured_mode(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out) {
+    dsd_scan_mode_configured(opts, state, out);
 }

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: ISC
 #include <dsd-neo/core/bit_packing.h>
+#include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/csv_validate.h>
 #include <dsd-neo/core/key_set.h>
@@ -12,6 +13,7 @@
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/path_policy.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -666,18 +668,49 @@ csv_key_import_dec_apply_field(dsd_state* state, int field_count, const char* fi
 
 /*
  * The channel map's columns past the frequency have always been free-text notes
- * -- two shipped examples put commas in theirs -- so column 3 is a channel name
- * only when the header line says `name`. The per-row key columns opt in the
- * same way, by header name at any field index >= 2; a duplicated key header
- * rejects the file.
+ * -- two shipped examples put commas in theirs -- so metadata opts in by header
+ * name at any field index >= 2. Unknown fields stay notes; the first name wins,
+ * and duplicated mode/key headers reject the file.
  */
+enum {
+    CHAN_NUMBER,
+    CHAN_FREQUENCY,
+    CHAN_NAME,
+    CHAN_MODE,
+    CHAN_KEYS_HEX,
+    CHAN_KEYS_DEC,
+    CHAN_SINGLE_HEX,
+    CHAN_SINGLE_DEC,
+    CHAN_FIELD_COUNT
+};
+
 typedef struct {
-    int has_name;
-    int keys_hex_idx;
-    int keys_dec_idx;
-    int single_key_hex_idx;
-    int single_key_dec_idx;
+    int index[CHAN_FIELD_COUNT];
 } chan_header_cols;
+
+/* Walk every field, retaining only the named columns. No field-count truncation. */
+static size_t
+chan_select_fields(char* line, const chan_header_cols* cols, char** fields) {
+    size_t count = 0;
+    char* cell = line;
+    for (int i = 0; i < CHAN_FIELD_COUNT; i++) {
+        fields[i] = NULL;
+    }
+    while (cell) {
+        char* next = strchr(cell, ',');
+        if (next) {
+            *next++ = '\0';
+        }
+        for (int i = 0; i < CHAN_FIELD_COUNT; i++) {
+            if (cols->index[i] >= 0 && (size_t)cols->index[i] == count) {
+                fields[i] = cell;
+            }
+        }
+        count++;
+        cell = next;
+    }
+    return count;
+}
 
 static const char*
 chan_key_cell(char** fields, size_t field_count, int idx) {
@@ -708,43 +741,35 @@ chan_resolve_key_cell(const char* base_path, const char* cell, char* out, size_t
 
 static int
 chan_parse_header(char* header_line, chan_header_cols* out) {
-    char* fields[16];
-    out->has_name = 0;
-    out->keys_hex_idx = -1;
-    out->keys_dec_idx = -1;
-    out->single_key_hex_idx = -1;
-    out->single_key_dec_idx = -1;
-    const size_t field_count = csv_split_preserve_empty(header_line, fields, sizeof(fields) / sizeof(fields[0]));
-    if (field_count >= 3 && csv_ascii_casecmp(trim_ws(fields[2]), "name") == 0) {
-        out->has_name = 1;
+    static const char* const names[CHAN_FIELD_COUNT] = {
+        "", "", "name", "mode", "keys_hex_csv", "keys_dec_csv", "single_key_hex", "single_key_dec"};
+    for (int i = 0; i < CHAN_FIELD_COUNT; i++) {
+        out->index[i] = i < 2 ? i : -1;
     }
-    for (size_t i = 2; i < field_count; i++) {
-        const char* name = trim_ws(fields[i]);
-        if (csv_ascii_casecmp(name, "keys_hex_csv") == 0) {
-            if (out->keys_hex_idx >= 0) {
-                LOG_ERROR("channel map header duplicates 'keys_hex_csv'\n");
-                return -1;
-            }
-            out->keys_hex_idx = (int)i;
-        } else if (csv_ascii_casecmp(name, "keys_dec_csv") == 0) {
-            if (out->keys_dec_idx >= 0) {
-                LOG_ERROR("channel map header duplicates 'keys_dec_csv'\n");
-                return -1;
-            }
-            out->keys_dec_idx = (int)i;
-        } else if (csv_ascii_casecmp(name, "single_key_hex") == 0) {
-            if (out->single_key_hex_idx >= 0) {
-                LOG_ERROR("channel map header duplicates 'single_key_hex'\n");
-                return -1;
-            }
-            out->single_key_hex_idx = (int)i;
-        } else if (csv_ascii_casecmp(name, "single_key_dec") == 0) {
-            if (out->single_key_dec_idx >= 0) {
-                LOG_ERROR("channel map header duplicates 'single_key_dec'\n");
-                return -1;
-            }
-            out->single_key_dec_idx = (int)i;
+    char* cell = header_line;
+    int index = 0;
+    while (cell) {
+        char* next = strchr(cell, ',');
+        if (next) {
+            *next++ = '\0';
         }
+        const char* name = trim_ws(cell);
+        for (int i = CHAN_NAME; index >= 2 && i < CHAN_FIELD_COUNT; i++) {
+            if (csv_ascii_casecmp(name, names[i]) != 0) {
+                continue;
+            }
+            if (out->index[i] >= 0) {
+                if (i == CHAN_NAME) {
+                    break;
+                }
+                LOG_ERROR("channel map header duplicates '%s'\n", names[i]);
+                return -1;
+            }
+            out->index[i] = index;
+            break;
+        }
+        index++;
+        cell = next;
     }
     return 0;
 }
@@ -803,12 +828,12 @@ chan_import_key_files(dsd_key_set* ks, const char* hex_cell, const char* dec_cel
 }
 
 static int
-chan_import_row_keys(dsd_state* state, char** fields, size_t field_count, const chan_header_cols* cols,
-                     const char* base_path, int row_number, int show_keys, int store, size_t slot) {
-    const char* hex_cell = chan_key_cell(fields, field_count, cols->keys_hex_idx);
-    const char* dec_cell = chan_key_cell(fields, field_count, cols->keys_dec_idx);
-    const char* single_hex_cell = chan_key_cell(fields, field_count, cols->single_key_hex_idx);
-    const char* single_dec_cell = chan_key_cell(fields, field_count, cols->single_key_dec_idx);
+chan_import_row_keys(dsd_state* state, char** fields, size_t field_count, const char* base_path, int row_number,
+                     int show_keys, int store, size_t slot) {
+    const char* hex_cell = chan_key_cell(fields, field_count, CHAN_KEYS_HEX);
+    const char* dec_cell = chan_key_cell(fields, field_count, CHAN_KEYS_DEC);
+    const char* single_hex_cell = chan_key_cell(fields, field_count, CHAN_SINGLE_HEX);
+    const char* single_dec_cell = chan_key_cell(fields, field_count, CHAN_SINGLE_DEC);
     const int have_files = chan_key_cell_present(hex_cell) || chan_key_cell_present(dec_cell);
     const int have_direct = chan_key_cell_present(single_hex_cell) || chan_key_cell_present(single_dec_cell);
     if (!have_files && !have_direct) {
@@ -867,33 +892,33 @@ chan_import_row_keys(dsd_state* state, char** fields, size_t field_count, const 
 static int
 chan_import_row(dsd_state* state, char* buffer, const chan_header_cols* cols, const char* base_path, int row_number,
                 int show_keys, int* out_field_count, long int* out_chan_number) {
-    char* fields[16];
+    char* fields[CHAN_FIELD_COUNT];
     int freq_parsed = 0;
     long int chan_number = -1;
-    // The row's scan-list slot is the count before it: every row that takes one
-    // appends, so the name index and the slot index stay equal by construction.
     const int lcn_before = state->lcn_freq_count;
-
-    const size_t field_count = csv_split_preserve_empty(buffer, fields, sizeof(fields) / sizeof(fields[0]));
-    for (size_t i = 0; i < field_count && i < 2; i++) {
-        if (csv_chan_import_apply_field(state, (int)i, fields[i], &chan_number, &freq_parsed) != 0) {
-            return -1;
-        }
+    const size_t field_count = chan_select_fields(buffer, cols, fields);
+    dsd_scan_mode mode = DSD_SCAN_MODE_INHERIT;
+    if (dsd_scan_mode_parse(fields[CHAN_MODE], &mode) != 0) {
+        LOG_ERROR("channel map file '%s' row %d: invalid mode\n", base_path, row_number);
+        return -1;
     }
-    if (cols->has_name && field_count >= 3 && state->lcn_freq_count > lcn_before) {
-        if (dsd_state_trunk_lcn_name_set(state, (size_t)lcn_before, fields[2]) != 0) {
-            LOG_ERROR("channel map import out of memory\n");
+    for (int i = 0; i < 2 && fields[i]; i++) {
+        if (csv_chan_import_apply_field(state, i, fields[i], &chan_number, &freq_parsed) != 0) {
             return -1;
         }
     }
     const int row_has_slot = state->lcn_freq_count > lcn_before;
-    if (cols->keys_hex_idx >= 0 || cols->keys_dec_idx >= 0 || cols->single_key_hex_idx >= 0
-        || cols->single_key_dec_idx >= 0) {
-        const size_t slot = row_has_slot ? (size_t)lcn_before : 0U;
-        if (chan_import_row_keys(state, fields, field_count, cols, base_path, row_number, show_keys, row_has_slot, slot)
-            != 0) {
+    if (row_has_slot) {
+        if ((fields[CHAN_NAME] && dsd_state_trunk_lcn_name_set(state, (size_t)lcn_before, fields[CHAN_NAME]) != 0)
+            || dsd_channel_mode_set(state, (size_t)lcn_before, mode) != 0) {
+            LOG_ERROR("channel map import out of memory\n");
             return -1;
         }
+    }
+    if (chan_import_row_keys(state, fields, CHAN_FIELD_COUNT, base_path, row_number, show_keys, row_has_slot,
+                             row_has_slot ? (size_t)lcn_before : 0U)
+        != 0) {
+        return -1;
     }
     *out_field_count = (int)field_count;
     *out_chan_number = chan_number;
@@ -941,10 +966,6 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
     int row_count = 0;
     chan_header_cols cols;
     DSD_MEMSET(&cols, 0, sizeof(cols));
-    cols.keys_hex_idx = -1;
-    cols.keys_dec_idx = -1;
-    cols.single_key_hex_idx = -1;
-    cols.single_key_dec_idx = -1;
     int rc = 0;
 
     while (fgets(buffer, BSIZE, fp)) {

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -949,6 +949,48 @@ chan_import_row_report(const dsd_state* state, dsd_csv_validation* stats, const 
     LOG_INFO("\n");
 }
 
+/* Read a physical row intact. A malformed/oversized row must never become two
+ * independent channels or lose a trailing mode/key column. */
+static int
+chan_read_line(FILE* fp, char** buffer, size_t* capacity) {
+    const size_t max_capacity = (size_t)1024 * 1024;
+    size_t used = 0;
+    int ch;
+    while ((ch = fgetc(fp)) != EOF) {
+        if (used + 1 >= *capacity) {
+            if (*capacity >= max_capacity) {
+                return -1;
+            }
+            const size_t next = *capacity ? *capacity * 2 : 1024U;
+            char* grown = (char*)malloc(next);
+            if (!grown) {
+                return -1;
+            }
+            if (*buffer) {
+                /* Rows may contain direct keys; erase the old storage before
+                 * releasing it, just as the final buffer is erased below. */
+                DSD_MEMCPY(grown, *buffer, used);
+                DSD_SECURE_ZERO(*buffer, *capacity);
+                free(*buffer);
+            }
+            *buffer = grown;
+            *capacity = next;
+        }
+        (*buffer)[used++] = (char)ch;
+        if (ch == '\n') {
+            break;
+        }
+    }
+    if (ferror(fp)) {
+        return -1;
+    }
+    if (used == 0) {
+        return 0;
+    }
+    (*buffer)[used] = '\0';
+    return 1;
+}
+
 /* stats may be NULL; when set, counts data rows so a dry run can report them. */
 static int
 chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validation* stats, int show_keys) {
@@ -958,7 +1000,8 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
 
     char filename[CSV_IMPORT_PATH_MAX] = "filename.csv";
 
-    char buffer[BSIZE];
+    char* buffer = NULL;
+    size_t capacity = 0;
     FILE* fp = csv_open_user_read_file("channel map file", chan_file_path, filename, sizeof filename);
     if (fp == NULL) {
         return -1;
@@ -968,7 +1011,8 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
     DSD_MEMSET(&cols, 0, sizeof(cols));
     int rc = 0;
 
-    while (fgets(buffer, BSIZE, fp)) {
+    int read_result;
+    while ((read_result = chan_read_line(fp, &buffer, &capacity)) > 0) {
         int field_count = 0;
         long int chan_number = -1;
         row_count++;
@@ -991,7 +1035,15 @@ chan_import_stats(const char* chan_file_path, dsd_state* state, dsd_csv_validati
         }
         chan_import_row_report(state, stats, filename, row_count, freq_parsed, field_count, chan_number);
     }
-    DSD_SECURE_ZERO(buffer, sizeof(buffer));
+    if (read_result < 0) {
+        LOG_ERROR("channel map file '%s': unable to read row %d (I/O, memory, or 1 MiB row limit)\n", filename,
+                  row_count + 1);
+        rc = -1;
+    }
+    if (buffer) {
+        DSD_SECURE_ZERO(buffer, capacity);
+        free(buffer);
+    }
     fclose(fp);
     return rc;
 }

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -12,9 +12,12 @@
  * without dragging in the full initState/freeState dependency chain.
  */
 
+#include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -414,6 +417,7 @@ dsd_state_trunk_lcn_free(dsd_state* state) {
     if (!state) {
         return;
     }
+    dsd_channel_modes_clear(state);
     free(state->trunk_lcn_freq_ext);
     state->trunk_lcn_freq_ext = NULL;
     state->trunk_lcn_freq_ext_capacity = 0;
@@ -434,4 +438,82 @@ dsd_state_trunk_lcn_user_list_present(const dsd_opts* opts, const dsd_state* sta
         return 0;
     }
     return (state->lcn_freq_count > 1) ? 1 : 0;
+}
+
+typedef struct {
+    size_t capacity;
+    size_t declared_count;
+    dsd_scan_mode* rows;
+} channel_modes;
+
+static void
+channel_modes_cleanup(void* ptr) {
+    channel_modes* modes = (channel_modes*)ptr;
+    free(modes->rows);
+    free(modes);
+}
+
+dsd_scan_mode
+dsd_channel_mode_get(const dsd_state* state, size_t row) {
+    const channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    return modes && row < modes->capacity ? modes->rows[row] : DSD_SCAN_MODE_INHERIT;
+}
+
+int
+dsd_channel_modes_present(const dsd_state* state) {
+    const channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    return modes && modes->declared_count != 0;
+}
+
+int
+dsd_channel_mode_set(dsd_state* state, size_t row, dsd_scan_mode mode) {
+    if (!state || row >= SIZE_MAX / sizeof(dsd_scan_mode) || (unsigned)mode > DSD_SCAN_MODE_M17) {
+        return -1;
+    }
+    channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    if (!modes) {
+        if (mode == DSD_SCAN_MODE_INHERIT) {
+            return 0;
+        }
+        modes = (channel_modes*)calloc(1, sizeof(*modes));
+        if (!modes) {
+            return -1;
+        }
+        (void)dsd_state_ext_set(state, DSD_STATE_EXT_CORE_CHANNEL_MODES, modes, channel_modes_cleanup);
+    }
+    if (row >= modes->capacity) {
+        const size_t capacity = row < SIZE_MAX / 2 / sizeof(dsd_scan_mode) ? (row + 1) * 2 : row + 1;
+        dsd_scan_mode* rows = (dsd_scan_mode*)realloc(modes->rows, capacity * sizeof(*rows));
+        if (!rows) {
+            return -1;
+        }
+        DSD_MEMSET(rows + modes->capacity, 0, (capacity - modes->capacity) * sizeof(*rows));
+        modes->rows = rows;
+        modes->capacity = capacity;
+    }
+    if (modes->rows[row] != DSD_SCAN_MODE_INHERIT) {
+        modes->declared_count--;
+    }
+    modes->rows[row] = mode;
+    if (mode != DSD_SCAN_MODE_INHERIT) {
+        modes->declared_count++;
+    }
+    return 0;
+}
+
+void
+dsd_channel_modes_clear(dsd_state* state) {
+    (void)dsd_state_ext_set(state, DSD_STATE_EXT_CORE_CHANNEL_MODES, NULL, NULL);
+}
+
+void
+dsd_channel_modes_move(dsd_state* dst, dsd_state* src) {
+    if (!dst || !src || dst == src) {
+        return;
+    }
+    void* ptr = dsd_state_ext_get(src, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    /* Detach without cleanup before the source's normal teardown. */
+    src->state_ext[DSD_STATE_EXT_CORE_CHANNEL_MODES] = NULL;
+    src->state_ext_cleanup[DSD_STATE_EXT_CORE_CHANNEL_MODES] = NULL;
+    (void)dsd_state_ext_set(dst, DSD_STATE_EXT_CORE_CHANNEL_MODES, ptr, channel_modes_cleanup);
 }

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -25,6 +25,21 @@
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
 
+/* Shared geometric growth for the positional stores. Allocation and ownership
+ * remain with each store (key arrays must securely erase the old allocation). */
+static size_t
+trunk_lcn_grown_capacity(size_t current, size_t needed, size_t element_size) {
+    size_t capacity = current > 0 ? current : 16;
+    while (capacity < needed) {
+        if (capacity > SIZE_MAX / 2) {
+            capacity = needed;
+            break;
+        }
+        capacity *= 2;
+    }
+    return capacity <= SIZE_MAX / element_size ? capacity : 0;
+}
+
 int
 dsd_state_trunk_lcn_reserve(dsd_state* state, size_t count_needed) {
     if (!state) {
@@ -37,15 +52,8 @@ dsd_state_trunk_lcn_reserve(dsd_state* state, size_t count_needed) {
     if (ext_needed <= state->trunk_lcn_freq_ext_capacity) {
         return 0;
     }
-    size_t capacity = state->trunk_lcn_freq_ext_capacity > 0 ? state->trunk_lcn_freq_ext_capacity : 16;
-    while (capacity < ext_needed) {
-        if (capacity > SIZE_MAX / 2) {
-            capacity = ext_needed;
-            break;
-        }
-        capacity *= 2;
-    }
-    if (capacity > SIZE_MAX / sizeof(long int)) {
+    const size_t capacity = trunk_lcn_grown_capacity(state->trunk_lcn_freq_ext_capacity, ext_needed, sizeof(long int));
+    if (!capacity) {
         return -1;
     }
     long int* ext = (long int*)realloc(state->trunk_lcn_freq_ext, capacity * sizeof *ext);
@@ -67,15 +75,8 @@ dsd_state_trunk_lcn_name_reserve(dsd_state* state, size_t count) {
     if (count <= state->trunk_lcn_name_capacity) {
         return 0;
     }
-    size_t capacity = state->trunk_lcn_name_capacity > 0 ? state->trunk_lcn_name_capacity : 16;
-    while (capacity < count) {
-        if (capacity > SIZE_MAX / 2) {
-            capacity = count;
-            break;
-        }
-        capacity *= 2;
-    }
-    if (capacity > SIZE_MAX / DSD_CHANNEL_LABEL_SIZE) {
+    const size_t capacity = trunk_lcn_grown_capacity(state->trunk_lcn_name_capacity, count, DSD_CHANNEL_LABEL_SIZE);
+    if (!capacity) {
         return -1;
     }
     char (*names)[DSD_CHANNEL_LABEL_SIZE] =
@@ -201,13 +202,9 @@ dsd_state_trunk_lcn_avoid_reserve(dsd_state* state, size_t count) {
     if (count <= state->trunk_lcn_avoid_capacity) {
         return 0;
     }
-    size_t capacity = state->trunk_lcn_avoid_capacity > 0 ? state->trunk_lcn_avoid_capacity : 16;
-    while (capacity < count) {
-        if (capacity > SIZE_MAX / 2) {
-            capacity = count;
-            break;
-        }
-        capacity *= 2;
+    const size_t capacity = trunk_lcn_grown_capacity(state->trunk_lcn_avoid_capacity, count, sizeof(uint8_t));
+    if (!capacity) {
+        return -1;
     }
     uint8_t* flags = (uint8_t*)realloc(state->trunk_lcn_avoid, capacity);
     if (!flags) {
@@ -237,15 +234,8 @@ dsd_state_trunk_lcn_keys_reserve(dsd_state* state, size_t count) {
     if (count <= state->trunk_lcn_keys_capacity) {
         return 0;
     }
-    size_t capacity = state->trunk_lcn_keys_capacity > 0 ? state->trunk_lcn_keys_capacity : 16;
-    while (capacity < count) {
-        if (capacity > SIZE_MAX / 2) {
-            capacity = count;
-            break;
-        }
-        capacity *= 2;
-    }
-    if (capacity > SIZE_MAX / sizeof(dsd_key_set)) {
+    const size_t capacity = trunk_lcn_grown_capacity(state->trunk_lcn_keys_capacity, count, sizeof(dsd_key_set));
+    if (!capacity) {
         return -1;
     }
     dsd_key_set* keys = (dsd_key_set*)calloc(capacity, sizeof(*keys));
@@ -482,7 +472,10 @@ dsd_channel_mode_set(dsd_state* state, size_t row, dsd_scan_mode mode) {
         (void)dsd_state_ext_set(state, DSD_STATE_EXT_CORE_CHANNEL_MODES, modes, channel_modes_cleanup);
     }
     if (row >= modes->capacity) {
-        const size_t capacity = row < SIZE_MAX / 2 / sizeof(dsd_scan_mode) ? (row + 1) * 2 : row + 1;
+        const size_t capacity = trunk_lcn_grown_capacity(modes->capacity, row + 1, sizeof(dsd_scan_mode));
+        if (!capacity) {
+            return -1;
+        }
         dsd_scan_mode* rows = (dsd_scan_mode*)realloc(modes->rows, capacity * sizeof(*rows));
         if (!rows) {
             return -1;

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -3508,6 +3508,14 @@ frame_sync_no_sync_sps_hunt(const dsd_opts* opts, dsd_state* state) {
                                               : frame_sync_sps_hunt_next_index(opts, state));
     const int previous_idx = state->sps_hunt_idx;
     const int previous_mod = state->rf_mod;
+    if (frame_sync_trunk_scan_p25p1_trial(opts, state) && previous_mod != 1) {
+        /* Both P25 phases are enabled per target. Waiting for 4800 -> 6000 ->
+         * 4800 costs 3375 ms before CQPSK can be tried, beyond the default
+         * 3000 ms visit. The scan policy budgets shorter 4800 dwells for each
+         * demodulator before rotating, so Phase 2 also fits in the visit. */
+        next_idx = previous_idx;
+        state->p25_p1_mod_probe_next_qpsk = 1;
+    }
     frame_sync_apply_sps_hunt_profile(opts, state, next_idx, preserve_modulation);
     frame_sync_maybe_probe_p25p1_cqpsk(opts, state, preserve_modulation, previous_idx, previous_mod);
     /* A repeated binary profile is a step too: frame_sync_apply_sps_hunt_profile() normalises

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -395,6 +395,64 @@ typedef enum {
     FRAME_SYNC_P25_CENTER_SKIP = 2,
 } frame_sync_p25_center_mode_t;
 
+static void
+frame_sync_seed_p25_cqpsk_level_windows(const dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return;
+    }
+
+    int minmax_count = dsd_state_minmax_window_size(opts->msize);
+    for (int i = 0; i < minmax_count; i++) {
+        state->minbuf[i] = state->min;
+        state->maxbuf[i] = state->max;
+    }
+    dsd_state_invalidate_minmax_sums(state);
+
+    int symbol_count = opts->ssize;
+    if (symbol_count < 0) {
+        symbol_count = 0;
+    }
+    if (symbol_count > (int)(sizeof(state->sbuf) / sizeof(state->sbuf[0]))) {
+        symbol_count = (int)(sizeof(state->sbuf) / sizeof(state->sbuf[0]));
+    }
+    for (int i = 0; i < symbol_count; i++) {
+        state->sbuf[i] = (i & 1) ? state->max : state->min;
+    }
+}
+
+void
+dsd_frame_sync_reset_acquisition(const dsd_opts* opts, dsd_state* state, int forget_p25_modulation) {
+    if (!opts || !state) {
+        return;
+    }
+    dsd_frame_sync_reset_mod_state();
+    dsd_frame_sync_sps_hunt_restart_dwell(state);
+    state->sps_hunt_last_frame_verdict = 0;
+    state->profile_proof_valid = 0;
+    state->profile_proof_symbolcnt = 0;
+    state->profile_proof_idx = 0;
+    if (forget_p25_modulation) {
+        state->p25_p1_validated_rf_mod = -1;
+    }
+    state->symbol_history_count = 0;
+    state->symbol_history_head = 0;
+    state->sidx = 0;
+    state->midx = 0;
+    state->min = -15000;
+    state->max = 15000;
+    state->center = 0;
+    state->lmid = -9375;
+    state->umid = 9375;
+    state->minref = -12000;
+    state->maxref = 12000;
+    state->rtl_fsk_sps_num = 0;
+    state->rtl_fsk_sps_den = 0;
+    state->rtl_fsk_sps_accum = 0;
+    state->synctype = DSD_SYNC_NONE;
+    state->lastsynctype = DSD_SYNC_NONE;
+    frame_sync_seed_p25_cqpsk_level_windows(opts, state);
+}
+
 #ifdef USE_RADIO
 typedef struct {
     float center;
@@ -486,31 +544,6 @@ frame_sync_fit_p25_cqpsk_raw_sync(const frame_sync_match_ctx* ctx, const char* r
         return result;
     }
     return frame_sync_fit_p25_cqpsk_raw_levels(sum, count, out_fit);
-}
-
-static void
-frame_sync_seed_p25_cqpsk_level_windows(const dsd_opts* opts, dsd_state* state) {
-    if (!opts || !state) {
-        return;
-    }
-
-    int minmax_count = dsd_state_minmax_window_size(opts->msize);
-    for (int i = 0; i < minmax_count; i++) {
-        state->minbuf[i] = state->min;
-        state->maxbuf[i] = state->max;
-    }
-    dsd_state_invalidate_minmax_sums(state);
-
-    int symbol_count = opts->ssize;
-    if (symbol_count < 0) {
-        symbol_count = 0;
-    }
-    if (symbol_count > (int)(sizeof(state->sbuf) / sizeof(state->sbuf[0]))) {
-        symbol_count = (int)(sizeof(state->sbuf) / sizeof(state->sbuf[0]));
-    }
-    for (int i = 0; i < symbol_count; i++) {
-        state->sbuf[i] = (i & 1) ? state->max : state->min;
-    }
 }
 
 static void

--- a/src/dsp/frame_sync_internal.h
+++ b/src/dsp/frame_sync_internal.h
@@ -17,7 +17,10 @@ extern "C" {
  * The no-sync timeout fires after this many consecutive matchless symbols, and the SPS
  * hunt's dwell is a whole number of these (see dsd_frame_sync_sps_hunt_dwell_passes()).
  */
-#define DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS         1800
+#define DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS 1800
+
+/** Unlocked RTL trunk-scan P25 acquisition needs both demodulators within one visit. */
+int frame_sync_trunk_scan_p25p1_trial(const dsd_opts* opts, const dsd_state* state);
 
 /* How long a P25p1 frame that decoded its NID keeps the modulation heuristics off the
  * demodulator that carried it, in symbols at 4800 sym/s (two seconds). Long enough to span the

--- a/src/dsp/frame_sync_policy.c
+++ b/src/dsp/frame_sync_policy.c
@@ -95,11 +95,23 @@ dsd_frame_sync_suppress_tcp_no_signal_console(const dsd_opts* opts, const dsd_st
 }
 
 int
+frame_sync_trunk_scan_p25p1_trial(const dsd_opts* opts, const dsd_state* state) {
+    return opts && state && opts->trunk_scan_enabled == 1 && !opts->mod_cli_lock && opts->frame_p25p1 == 1
+           && opts->frame_p25p2 == 1 && opts->audio_in_type == AUDIO_IN_RTL && state->rtl_ctx
+           && state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+}
+
+int
 dsd_frame_sync_sps_hunt_dwell_passes(const dsd_opts* opts, const dsd_state* state) {
     if (!opts || !state) {
         return 3;
     }
     if (opts->trunk_enable == 1 && opts->trunk_is_tuned == 0 && (opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1)) {
+        if (frame_sync_trunk_scan_p25p1_trial(opts, state)) {
+            /* C4FM and CQPSK each get 5400 symbols (1125 ms); Phase 2 then
+             * starts at 2250 ms, also inside the default 3000 ms target visit. */
+            return 3;
+        }
         return 5;
     }
     return 3;

--- a/src/dsp/frame_sync_profile.c
+++ b/src/dsp/frame_sync_profile.c
@@ -38,6 +38,12 @@ dsd_frame_sync_active_profile_symbol_rate_hz(const dsd_state* state) {
     return frame_sync_sps_profile_for_index(profile_index)->symbol_rate_hz;
 }
 
+int
+dsd_frame_sync_active_profile_levels(const dsd_state* state) {
+    const int profile_index = state ? state->sps_hunt_idx : DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    return frame_sync_sps_profile_for_index(profile_index)->levels;
+}
+
 dsd_nxdn_variant
 dsd_frame_sync_active_nxdn_variant(const dsd_opts* opts, const dsd_state* state) {
     if (!opts) {

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(
     dsd-neo_engine
     PRIVATE
         engine.c
+        channel_scan.c
         frame_sync_hooks_install.c
         p25_bandplan_export.c
         p25_optional_hooks_install.c

--- a/src/engine/channel_scan.c
+++ b/src/engine/channel_scan.c
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/channel_mode.h>
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/events.h>
+#include <dsd-neo/core/key_set.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/engine/channel_scan.h>
+#include <dsd-neo/engine/frame_processing.h>
+#include <dsd-neo/engine/scan_voice_gate.h>
+#include <dsd-neo/engine/trunk_tuning.h>
+#include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct {
+    uint64_t request;
+    uint64_t map_sequence;
+    int row;
+    dsd_scan_mode mode;
+    dsd_scan_settings prepared;
+} channel_scan;
+
+static channel_scan*
+channel_scan_get(const dsd_state* state) {
+    return DSD_STATE_EXT_GET_AS(channel_scan, state, DSD_STATE_EXT_ENGINE_CHANNEL_SCAN);
+}
+
+static void
+channel_scan_end_calls(dsd_opts* opts, dsd_state* state) {
+    const double now = dsd_time_now_monotonic_s();
+    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+        if (dsd_call_state_end(state, (uint8_t)slot, now) > 0) {
+            dsd_event_sync_slot(opts, state, (uint8_t)slot);
+        }
+    }
+}
+
+static int
+channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
+    dsd_scan_settings latest;
+    if (dsd_scan_mode_prepare(opts, state, scan->mode, &latest) != 0) {
+        return -1;
+    }
+    if (memcmp(&latest, &scan->prepared, sizeof(latest)) != 0) {
+        /* A configured setting changed while tuning. Stage the new effective
+         * profile in a fresh request before any frame can use it. */
+        scan->request = 0;
+        return dsd_engine_channel_scan_step(opts, state);
+    }
+    /* End calls with the outgoing row's keys and label still installed. */
+    channel_scan_end_calls(opts, state);
+    const int scanner = opts->scanner_mode;
+    opts->scanner_mode = 0;
+    noCarrier(opts, state);
+    opts->scanner_mode = scanner;
+    if (dsd_scan_mode_enter(opts, state, scan->mode) != 0) {
+        return -1;
+    }
+    state->lcn_freq_roll = scan->row + 1;
+    (void)dsd_scan_row_keys_apply(state, scan->row);
+    dsd_frame_sync_reset_acquisition(opts, state, 1);
+    state->last_cc_sync_time = time(NULL);
+    state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
+    state->nxdn_last_ran = -1;
+    dsd_scan_voice_gate_note_retune(state, state->last_cc_sync_time_m);
+    scan->request = 0;
+    return 1;
+}
+
+int
+dsd_engine_channel_scan_pending(dsd_opts* opts, dsd_state* state) {
+    channel_scan* scan = channel_scan_get(state);
+    if (!scan || !scan->request) {
+        return 0;
+    }
+    const dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(scan->request, NULL);
+    if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        return 1;
+    }
+    if (result == DSD_TRUNK_TUNE_RESULT_OK && scan->map_sequence == state->trunk_chan_map_seq
+        && opts->scanner_mode == 1) {
+        scan->request = 0;
+        (void)channel_scan_commit(opts, state, scan);
+        return scan->request != 0;
+    }
+    channel_scan_end_calls(opts, state);
+    scan->request = 0;
+    return 0;
+}
+
+int
+dsd_engine_channel_scan_sync_ready(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return 0;
+    }
+    const channel_scan* scan = channel_scan_get(state);
+    if (!scan || !scan->request) {
+        return 1;
+    }
+    (void)dsd_engine_channel_scan_pending(opts, state);
+    /* Even a completed tune invalidates sync collected before the row commit. */
+    state->synctype = DSD_SYNC_NONE;
+    return 0;
+}
+
+static int
+channel_scan_next_row(const dsd_state* state) {
+    int row = state->lcn_freq_roll;
+    if (row < 0 || row >= state->lcn_freq_count) {
+        row = 0;
+    }
+    if (state->lcn_avoid_count) {
+        row = dsd_state_trunk_lcn_next_unavoided(state, row);
+    }
+    return row;
+}
+
+int
+dsd_engine_channel_scan_step(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state || state->lcn_freq_count <= 0) {
+        return 0;
+    }
+    channel_scan* scan = channel_scan_get(state);
+    if (scan && scan->request) {
+        (void)dsd_engine_channel_scan_pending(opts, state);
+        return 0;
+    }
+    const int row = channel_scan_next_row(state);
+    if (row < 0) {
+        return 0;
+    }
+    const long freq = *dsd_state_trunk_lcn_slot(state, row);
+    if (!freq) {
+        state->lcn_freq_roll = row + 1;
+        state->last_cc_sync_time = time(NULL);
+        state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
+        dsd_scan_voice_gate_note_retune(state, state->last_cc_sync_time_m);
+        return 0;
+    }
+    if (!scan) {
+        scan = (channel_scan*)calloc(1, sizeof(*scan));
+        if (!scan) {
+            return -1;
+        }
+        (void)dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_CHANNEL_SCAN, scan, free);
+    }
+    scan->row = row;
+    scan->mode = dsd_channel_mode_get(state, (size_t)row);
+    scan->map_sequence = state->trunk_chan_map_seq;
+    dsd_scan_settings before;
+    dsd_scan_settings next;
+    dsd_scan_settings_capture(opts, state, &before);
+    if (dsd_scan_mode_prepare(opts, state, scan->mode, &next) != 0) {
+        return -1;
+    }
+    scan->prepared = next;
+    dsd_scan_settings_restore(&next, opts, state);
+    const dsd_trunk_tune_result result =
+        dsd_engine_scan_tune_to_freq(opts, state, freq, state->samplesPerSymbol, &scan->request);
+    dsd_scan_settings_restore(&before, opts, state);
+    if (result == DSD_TRUNK_TUNE_RESULT_OK) {
+        return channel_scan_commit(opts, state, scan);
+    }
+    if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        return 0;
+    }
+    /* A failed second backend may already have moved the first one. Keep the tune
+     * ledger's frame gate closed until a subsequent successful request recovers. */
+    channel_scan_end_calls(opts, state);
+    scan->request = 0;
+    return -1;
+}
+
+void
+dsd_engine_channel_scan_leave(dsd_opts* opts, dsd_state* state) {
+    const int active = channel_scan_get(state) != NULL || dsd_scan_mode_active(state) != DSD_SCAN_MODE_INHERIT;
+    if (active) {
+        channel_scan_end_calls(opts, state);
+    }
+    (void)dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_CHANNEL_SCAN, NULL, NULL);
+    dsd_scan_mode_leave(opts, state);
+    if (active) {
+        dsd_frame_sync_reset_acquisition(opts, state, 1);
+        if (opts->audio_in_type == AUDIO_IN_RTL) {
+            const dsd_decode_mode_profile profile = dsd_scan_mode_effective_profile(opts, state);
+            const int filter =
+                opts->analog_only || !dsd_opts_has_digital_decode_mode(opts)
+                    ? DSD_RTL_STREAM_CHANNEL_PROFILE_WIDE
+                    : dsd_rtl_channel_profile_for(opts, profile.symbol_rate_hz, profile.levels, state->rf_mod);
+            (void)dsd_rtl_stream_metrics_hook_apply_demod_profile(state->rf_mod == 1, profile.symbol_rate_hz,
+                                                                  profile.levels, filter, state->samplesPerSymbol);
+        }
+    }
+}

--- a/src/engine/channel_scan.c
+++ b/src/engine/channel_scan.c
@@ -40,13 +40,18 @@ channel_scan_get(const dsd_state* state) {
     return DSD_STATE_EXT_GET_AS(channel_scan, state, DSD_STATE_EXT_ENGINE_CHANNEL_SCAN);
 }
 
-static int
-channel_scan_waiting(const dsd_state* state) {
+int
+dsd_engine_channel_scan_waiting(const dsd_state* state) {
     const channel_scan* scan = channel_scan_get(state);
     return scan && (scan->request != 0 || scan->retry);
 }
 
 static int channel_scan_start_row(dsd_opts* opts, dsd_state* state, int row);
+
+static int
+channel_scan_row_is_current(const dsd_opts* opts, const dsd_state* state, const channel_scan* scan) {
+    return opts->scanner_mode == 1 && opts->trunk_scan_enabled != 1 && scan->map_sequence == state->trunk_chan_map_seq;
+}
 
 static void
 channel_scan_end_calls(dsd_opts* opts, dsd_state* state) {
@@ -90,17 +95,19 @@ channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
 
 int
 dsd_engine_channel_scan_pending(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return 0;
+    }
     channel_scan* scan = channel_scan_get(state);
     if (!scan) {
         return 0;
     }
     if (scan->retry) {
         scan->retry = 0;
-        if (opts->scanner_mode == 1 && opts->trunk_scan_enabled != 1
-            && scan->map_sequence == state->trunk_chan_map_seq) {
+        if (channel_scan_row_is_current(opts, state, scan)) {
             (void)channel_scan_start_row(opts, state, scan->row);
         }
-        return channel_scan_waiting(state);
+        return dsd_engine_channel_scan_waiting(state);
     }
     if (!scan->request) {
         return 0;
@@ -109,19 +116,21 @@ dsd_engine_channel_scan_pending(dsd_opts* opts, dsd_state* state) {
     if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
         return 1;
     }
-    if (result == DSD_TRUNK_TUNE_RESULT_OK && scan->map_sequence == state->trunk_chan_map_seq && opts->scanner_mode == 1
-        && opts->trunk_scan_enabled != 1) {
+    if (result == DSD_TRUNK_TUNE_RESULT_OK && channel_scan_row_is_current(opts, state, scan)) {
         scan->request = 0;
         (void)channel_scan_commit(opts, state, scan);
-        return channel_scan_waiting(state);
+        return dsd_engine_channel_scan_waiting(state);
     }
     channel_scan_end_calls(opts, state);
+    if (result == DSD_TRUNK_TUNE_RESULT_FAILED && scan->map_sequence == state->trunk_chan_map_seq) {
+        state->lcn_freq_roll = scan->row + 1;
+    }
     scan->request = 0;
     return 0;
 }
 
 int
-dsd_engine_channel_scan_sync_ready(dsd_opts* opts, dsd_state* state) {
+dsd_engine_channel_scan_service_sync(dsd_opts* opts, dsd_state* state) {
     if (!opts || !state) {
         return 0;
     }
@@ -150,7 +159,7 @@ channel_scan_next_row(const dsd_state* state) {
 static int
 channel_scan_start_row(dsd_opts* opts, dsd_state* state, int row) {
     channel_scan* scan = channel_scan_get(state);
-    if (row < 0) {
+    if (row < 0 || row >= state->lcn_freq_count) {
         return 0;
     }
     const long freq = *dsd_state_trunk_lcn_slot(state, row);
@@ -191,6 +200,11 @@ channel_scan_start_row(dsd_opts* opts, dsd_state* state, int row) {
     /* A failed second backend may already have moved the first one. Keep the tune
      * ledger's frame gate closed until a subsequent successful request recovers. */
     channel_scan_end_calls(opts, state);
+    if (result == DSD_TRUNK_TUNE_RESULT_FAILED) {
+        /* A bad row must not prevent a later successful row from recovering
+         * the receiver and retiring the failed tune's frame gate. */
+        state->lcn_freq_roll = row + 1;
+    }
     scan->request = 0;
     return -1;
 }
@@ -200,7 +214,7 @@ dsd_engine_channel_scan_step(dsd_opts* opts, dsd_state* state) {
     if (!opts || !state || opts->trunk_scan_enabled == 1 || state->lcn_freq_count <= 0) {
         return 0;
     }
-    if (channel_scan_waiting(state)) {
+    if (dsd_engine_channel_scan_waiting(state)) {
         (void)dsd_engine_channel_scan_pending(opts, state);
         return 0;
     }
@@ -236,6 +250,9 @@ dsd_engine_channel_scan_step_manual(dsd_opts* opts, dsd_state* state) {
 
 void
 dsd_engine_channel_scan_leave(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return;
+    }
     const int active = channel_scan_get(state) != NULL || dsd_scan_mode_configured_view(state) != NULL
                        || dsd_scan_mode_updating(state);
     if (active) {
@@ -244,7 +261,7 @@ dsd_engine_channel_scan_leave(dsd_opts* opts, dsd_state* state) {
     (void)dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_CHANNEL_SCAN, NULL, NULL);
     dsd_scan_mode_leave(opts, state);
     if (active) {
-        dsd_frame_sync_reset_acquisition(opts, state, 1);
+        dsd_frame_sync_reset_acquisition(opts, state, opts->trunk_scan_enabled != 1);
         if (opts->audio_in_type == AUDIO_IN_RTL) {
             const dsd_decode_mode_profile profile = dsd_scan_mode_effective_profile(opts, state);
             const int filter =

--- a/src/engine/channel_scan.c
+++ b/src/engine/channel_scan.c
@@ -18,6 +18,7 @@
 #include <dsd-neo/engine/scan_voice_gate.h>
 #include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
@@ -29,14 +30,23 @@ typedef struct {
     uint64_t request;
     uint64_t map_sequence;
     int row;
+    int retry;
     dsd_scan_mode mode;
-    dsd_scan_settings prepared;
+    dsd_scan_settings configured;
 } channel_scan;
 
 static channel_scan*
 channel_scan_get(const dsd_state* state) {
     return DSD_STATE_EXT_GET_AS(channel_scan, state, DSD_STATE_EXT_ENGINE_CHANNEL_SCAN);
 }
+
+static int
+channel_scan_waiting(const dsd_state* state) {
+    const channel_scan* scan = channel_scan_get(state);
+    return scan && (scan->request != 0 || scan->retry);
+}
+
+static int channel_scan_start_row(dsd_opts* opts, dsd_state* state, int row);
 
 static void
 channel_scan_end_calls(dsd_opts* opts, dsd_state* state) {
@@ -46,26 +56,24 @@ channel_scan_end_calls(dsd_opts* opts, dsd_state* state) {
             dsd_event_sync_slot(opts, state, (uint8_t)slot);
         }
     }
+    (void)dsd_recent_activity_clear_all(state);
+    opts->trunk_is_tuned = 0;
 }
 
 static int
 channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
     dsd_scan_settings latest;
-    if (dsd_scan_mode_prepare(opts, state, scan->mode, &latest) != 0) {
-        return -1;
-    }
-    if (!dsd_scan_settings_equal(&latest, &scan->prepared, 1)) {
+    dsd_scan_mode_configured(opts, state, &latest);
+    if (!dsd_scan_settings_equal(&latest, &scan->configured, 1)) {
         /* A configured setting changed while tuning. Stage the new effective
          * profile in a fresh request before any frame can use it. */
         scan->request = 0;
-        return dsd_engine_channel_scan_step(opts, state);
+        scan->retry = 1;
+        return 0;
     }
     /* End calls with the outgoing row's keys and label still installed. */
     channel_scan_end_calls(opts, state);
-    const int scanner = opts->scanner_mode;
-    opts->scanner_mode = 0;
-    noCarrier(opts, state);
-    opts->scanner_mode = scanner;
+    dsd_engine_reset_no_carrier_state(opts, state);
     if (dsd_scan_mode_enter(opts, state, scan->mode) != 0) {
         return -1;
     }
@@ -83,18 +91,29 @@ channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
 int
 dsd_engine_channel_scan_pending(dsd_opts* opts, dsd_state* state) {
     channel_scan* scan = channel_scan_get(state);
-    if (!scan || !scan->request) {
+    if (!scan) {
+        return 0;
+    }
+    if (scan->retry) {
+        scan->retry = 0;
+        if (opts->scanner_mode == 1 && opts->trunk_scan_enabled != 1
+            && scan->map_sequence == state->trunk_chan_map_seq) {
+            (void)channel_scan_start_row(opts, state, scan->row);
+        }
+        return channel_scan_waiting(state);
+    }
+    if (!scan->request) {
         return 0;
     }
     const dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(scan->request, NULL);
     if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
         return 1;
     }
-    if (result == DSD_TRUNK_TUNE_RESULT_OK && scan->map_sequence == state->trunk_chan_map_seq
-        && opts->scanner_mode == 1) {
+    if (result == DSD_TRUNK_TUNE_RESULT_OK && scan->map_sequence == state->trunk_chan_map_seq && opts->scanner_mode == 1
+        && opts->trunk_scan_enabled != 1) {
         scan->request = 0;
         (void)channel_scan_commit(opts, state, scan);
-        return scan->request != 0;
+        return channel_scan_waiting(state);
     }
     channel_scan_end_calls(opts, state);
     scan->request = 0;
@@ -107,7 +126,7 @@ dsd_engine_channel_scan_sync_ready(dsd_opts* opts, dsd_state* state) {
         return 0;
     }
     const channel_scan* scan = channel_scan_get(state);
-    if (!scan || !scan->request) {
+    if (!scan || (!scan->request && !scan->retry)) {
         return 1;
     }
     (void)dsd_engine_channel_scan_pending(opts, state);
@@ -128,17 +147,9 @@ channel_scan_next_row(const dsd_state* state) {
     return row;
 }
 
-int
-dsd_engine_channel_scan_step(dsd_opts* opts, dsd_state* state) {
-    if (!opts || !state || state->lcn_freq_count <= 0) {
-        return 0;
-    }
+static int
+channel_scan_start_row(dsd_opts* opts, dsd_state* state, int row) {
     channel_scan* scan = channel_scan_get(state);
-    if (scan && scan->request) {
-        (void)dsd_engine_channel_scan_pending(opts, state);
-        return 0;
-    }
-    const int row = channel_scan_next_row(state);
     if (row < 0) {
         return 0;
     }
@@ -166,7 +177,7 @@ dsd_engine_channel_scan_step(dsd_opts* opts, dsd_state* state) {
     if (dsd_scan_mode_prepare(opts, state, scan->mode, &next) != 0) {
         return -1;
     }
-    scan->prepared = next;
+    dsd_scan_mode_configured(opts, state, &scan->configured);
     dsd_scan_settings_restore(&next, opts, state);
     const dsd_trunk_tune_result result =
         dsd_engine_scan_tune_to_freq(opts, state, freq, state->samplesPerSymbol, &scan->request);
@@ -184,9 +195,49 @@ dsd_engine_channel_scan_step(dsd_opts* opts, dsd_state* state) {
     return -1;
 }
 
+int
+dsd_engine_channel_scan_step(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state || opts->trunk_scan_enabled == 1 || state->lcn_freq_count <= 0) {
+        return 0;
+    }
+    if (channel_scan_waiting(state)) {
+        (void)dsd_engine_channel_scan_pending(opts, state);
+        return 0;
+    }
+    return channel_scan_start_row(opts, state, channel_scan_next_row(state));
+}
+
+int
+dsd_engine_channel_scan_step_manual(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state || opts->trunk_scan_enabled == 1 || state->lcn_freq_count <= 0) {
+        return 0;
+    }
+    const channel_scan* scan = channel_scan_get(state);
+    if (scan && (scan->request || scan->retry)) {
+        return dsd_engine_channel_scan_step(opts, state);
+    }
+    int row = state->lcn_freq_roll;
+    if (row < 0 || row >= state->lcn_freq_count) {
+        row = 0;
+    }
+    for (int examined = 0; examined < state->lcn_freq_count; examined++) {
+        const long freq = *dsd_state_trunk_lcn_slot(state, row);
+        if (freq != 0 && !dsd_state_trunk_lcn_avoid_get(state, (size_t)row)) {
+            const int result = channel_scan_start_row(opts, state, row);
+            if (result >= 0) {
+                LOG_INFO("Channel Cycle: tuning to %.06lf MHz\n", (double)freq / 1000000);
+            }
+            return result;
+        }
+        row = (row + 1) % state->lcn_freq_count;
+    }
+    return 0;
+}
+
 void
 dsd_engine_channel_scan_leave(dsd_opts* opts, dsd_state* state) {
-    const int active = channel_scan_get(state) != NULL || dsd_scan_mode_active(state) != DSD_SCAN_MODE_INHERIT;
+    const int active = channel_scan_get(state) != NULL || dsd_scan_mode_configured_view(state) != NULL
+                       || dsd_scan_mode_updating(state);
     if (active) {
         channel_scan_end_calls(opts, state);
     }

--- a/src/engine/channel_scan.c
+++ b/src/engine/channel_scan.c
@@ -23,7 +23,6 @@
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <string.h>
 #include <time.h>
 
 typedef struct {
@@ -55,7 +54,7 @@ channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
     if (dsd_scan_mode_prepare(opts, state, scan->mode, &latest) != 0) {
         return -1;
     }
-    if (memcmp(&latest, &scan->prepared, sizeof(latest)) != 0) {
+    if (!dsd_scan_settings_equal(&latest, &scan->prepared, 1)) {
         /* A configured setting changed while tuning. Stage the new effective
          * profile in a fresh request before any frame can use it. */
         scan->request = 0;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -6,6 +6,7 @@
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/audio_filters.h>
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/dsd_time.h>
@@ -22,6 +23,7 @@
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/dsp/sps_filters.h>
 #include <dsd-neo/dsp/symbol.h>
+#include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/engine.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/p25_bandplan_export.h>
@@ -1366,7 +1368,7 @@ no_carrier_scanner_step_is_due(const dsd_opts* opts, const dsd_state* state, tim
 }
 
 static int
-no_carrier_step_scanner_mode_if_needed(const dsd_opts* opts, dsd_state* state, time_t now) {
+no_carrier_step_scanner_mode_if_needed(dsd_opts* opts, dsd_state* state, time_t now) {
     if (opts->scanner_mode != 1 || !no_carrier_scanner_step_is_due(opts, state, now)) {
         return 0;
     }
@@ -1376,6 +1378,9 @@ no_carrier_step_scanner_mode_if_needed(const dsd_opts* opts, dsd_state* state, t
         return 0;
     }
 
+    if (dsd_channel_modes_present(state)) {
+        return dsd_engine_channel_scan_step(opts, state) > 0;
+    }
     no_carrier_reset_nxdn_scan_markers(state);
     if (state->lcn_freq_roll >= state->lcn_freq_count) {
         state->lcn_freq_roll = 0;
@@ -2194,13 +2199,15 @@ no_carrier_reset_p25_metrics_and_cache(dsd_state* state) {
 }
 
 static int
-engine_trunk_tuning_owner_active(const dsd_opts* opts) {
-    return opts && (opts->trunk_enable == 1 || opts->trunk_scan_enabled == 1);
+engine_trunk_tuning_owner_active(const dsd_opts* opts, const dsd_state* state) {
+    return opts
+           && (opts->trunk_enable == 1 || opts->trunk_scan_enabled == 1
+               || (opts->scanner_mode == 1 && dsd_channel_modes_present(state)));
 }
 
 static void
-no_carrier_retire_inactive_tune_failures(const dsd_opts* opts) {
-    if (!engine_trunk_tuning_owner_active(opts)) {
+no_carrier_retire_inactive_tune_failures(const dsd_opts* opts, const dsd_state* state) {
+    if (!engine_trunk_tuning_owner_active(opts, state)) {
         dsd_trunk_tuning_retire_failed_requests();
     }
 }
@@ -2318,7 +2325,14 @@ void
 noCarrier(dsd_opts* opts, dsd_state* state) {
     const time_t now = time(NULL);
 
-    no_carrier_retire_inactive_tune_failures(opts);
+    if (dsd_channel_modes_present(state)) {
+        /* Typed rows use tracked tunes, bypassing the legacy scan caches. */
+        s_last_rigctl_freq = -1;
+#ifdef USE_RADIO
+        s_last_rtl_freq = 0;
+#endif
+    }
+    no_carrier_retire_inactive_tune_failures(opts, state);
 
 #ifdef USE_RADIO
     maybe_request_rtl_fsk_reacquire_on_no_sync(opts, state, now);
@@ -2491,12 +2505,12 @@ live_scanner_update_thresholds(dsd_state* state, int* last_max, int* last_min) {
 static void
 live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_max, int* last_min,
                                    uint64_t* frame_tune_generation) {
-    while (state->synctype != DSD_SYNC_NONE) {
+    while (state->synctype != DSD_SYNC_NONE && dsd_engine_channel_scan_sync_ready(opts, state)) {
         p25_sm_tick_guard_enter();
         const uint64_t dispatch_generation =
             frame_tune_generation ? *frame_tune_generation : dsd_trunk_tuning_generation();
         const int frame_dispatchable =
-            dsd_trunk_tuning_frame_is_dispatchable(dispatch_generation, engine_trunk_tuning_owner_active(opts));
+            dsd_trunk_tuning_frame_is_dispatchable(dispatch_generation, engine_trunk_tuning_owner_active(opts, state));
         if (!frame_tune_generation || frame_dispatchable) {
             processFrame(opts, state);
         } else {
@@ -2517,6 +2531,9 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
             }
         }
         dsd_runtime_pump_controls(opts, state);
+        if (!dsd_engine_channel_scan_sync_ready(opts, state)) {
+            break;
+        }
         if (frame_tune_generation) {
             *frame_tune_generation = dsd_trunk_tuning_generation();
         }
@@ -2538,7 +2555,15 @@ live_scanner_main_loop(dsd_opts* opts, dsd_state* state) {
         dsd_scan_voice_gate_tick(opts, state, 0, dsd_time_now_monotonic_s());
         dsd_runtime_pump_controls(opts, state);
 
+        if (dsd_engine_channel_scan_pending(opts, state)) {
+            dsd_sleep_ms(1);
+            continue;
+        }
         noCarrier(opts, state);
+        if (dsd_engine_channel_scan_pending(opts, state)) {
+            dsd_sleep_ms(1);
+            continue;
+        }
         frame_tune_generation = dsd_trunk_tuning_generation();
         state->synctype = getFrameSync(opts, state);
         live_scanner_update_thresholds(state, &last_max, &last_min);
@@ -2738,6 +2763,7 @@ dsd_engine_cleanup(dsd_opts* opts, dsd_state* state) {
         }
     }
     dsd_engine_trunk_scan_shutdown(opts, state);
+    dsd_engine_channel_scan_leave(opts, state);
     autosave_user_config(opts, state);
     dsd_engine_cleanup_print_stats(state);
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2350,8 +2350,9 @@ noCarrier(dsd_opts* opts, dsd_state* state) {
     // calls as it retunes, so the finalizer has to know whether the frequency moved out from under
     // whatever it is about to close.
     const int scanner_retuned = no_carrier_step_scanner_mode_if_needed(opts, state, now);
-    if (scanner_retuned && dsd_channel_modes_present(state)) {
-        /* The committed row finalized its outgoing calls and reset once. */
+    if (dsd_channel_modes_present(state) && (scanner_retuned || dsd_engine_channel_scan_waiting(state))) {
+        /* Row ownership ends outgoing calls at commit/failure with an explicit
+         * hop reason. A pending tune must not close them as sync loss first. */
         return;
     }
     no_carrier_return_to_control_channel_if_needed(opts, state, now);
@@ -2515,7 +2516,10 @@ live_scanner_update_thresholds(dsd_state* state, int* last_max, int* last_min) {
 static void
 live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_max, int* last_min,
                                    uint64_t* frame_tune_generation) {
-    while (state->synctype != DSD_SYNC_NONE && dsd_engine_channel_scan_sync_ready(opts, state)) {
+    while (state->synctype != DSD_SYNC_NONE) {
+        if (!dsd_engine_channel_scan_service_sync(opts, state)) {
+            break;
+        }
         p25_sm_tick_guard_enter();
         const uint64_t dispatch_generation =
             frame_tune_generation ? *frame_tune_generation : dsd_trunk_tuning_generation();
@@ -2541,7 +2545,7 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
             }
         }
         dsd_runtime_pump_controls(opts, state);
-        if (!dsd_engine_channel_scan_sync_ready(opts, state)) {
+        if (!dsd_engine_channel_scan_service_sync(opts, state)) {
             break;
         }
         if (frame_tune_generation) {

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1369,7 +1369,7 @@ no_carrier_scanner_step_is_due(const dsd_opts* opts, const dsd_state* state, tim
 
 static int
 no_carrier_step_scanner_mode_if_needed(dsd_opts* opts, dsd_state* state, time_t now) {
-    if (opts->scanner_mode != 1 || !no_carrier_scanner_step_is_due(opts, state, now)) {
+    if (opts->scanner_mode != 1 || opts->trunk_scan_enabled == 1 || !no_carrier_scanner_step_is_due(opts, state, now)) {
         return 0;
     }
     // An operator hold pauses the rotation where it stands. The dwell timer is left alone:
@@ -2325,7 +2325,7 @@ void
 noCarrier(dsd_opts* opts, dsd_state* state) {
     const time_t now = time(NULL);
 
-    if (dsd_channel_modes_present(state)) {
+    if (opts->scanner_mode == 1 && opts->trunk_scan_enabled != 1 && dsd_channel_modes_present(state)) {
         /* Typed rows use tracked tunes, bypassing the legacy scan caches. */
         s_last_rigctl_freq = -1;
 #ifdef USE_RADIO
@@ -2350,8 +2350,18 @@ noCarrier(dsd_opts* opts, dsd_state* state) {
     // calls as it retunes, so the finalizer has to know whether the frequency moved out from under
     // whatever it is about to close.
     const int scanner_retuned = no_carrier_step_scanner_mode_if_needed(opts, state, now);
+    if (scanner_retuned && dsd_channel_modes_present(state)) {
+        /* The committed row finalized its outgoing calls and reset once. */
+        return;
+    }
     no_carrier_return_to_control_channel_if_needed(opts, state, now);
     no_carrier_finalize_canonical_calls(opts, state, scanner_retuned);
+    dsd_engine_reset_no_carrier_state(opts, state);
+}
+
+void
+dsd_engine_reset_no_carrier_state(dsd_opts* opts, dsd_state* state) {
+    const time_t now = time(NULL);
     no_carrier_clear_stale_p25_return_hints_after_generic_activity(opts, state);
     no_carrier_reset_dibit_and_dmr_buffers(state);
     no_carrier_close_mbe_outputs_if_needed(opts, state);
@@ -2375,7 +2385,7 @@ noCarrier(dsd_opts* opts, dsd_state* state) {
     no_carrier_clear_stale_follow_state_if_needed(opts, state, now);
     no_carrier_reset_ysf_and_dstar_strings(state);
     no_carrier_reset_m17_and_sample_buffers(state);
-} //nocarrier
+}
 
 static int
 live_scanner_apply_audio_gain(dsd_opts* opts, dsd_state* state) {

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -5,6 +5,7 @@
 
 #include <ctype.h>
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/events.h>
@@ -13,8 +14,10 @@
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
 #include <dsd-neo/engine/trunk_scan.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #ifdef USE_RADIO
 #include <dsd-neo/io/rtl_stream_c.h>
 #endif
@@ -1980,7 +1983,7 @@ trunk_scan_apply_target_opts(dsd_opts* opts, const dsd_trunk_scan_coord* coord, 
     if (!opts || !coord || !target) {
         return;
     }
-    trunk_scan_restore_saved_mod_gain_opts(opts, coord);
+    opts->rtl_gain_value = coord->saved_rtl_gain_value;
     trunk_scan_apply_target_mod_opts(opts, target);
     trunk_scan_apply_target_gain_opts(opts, target);
     opts->trunk_is_tuned = 0;
@@ -2055,6 +2058,7 @@ trunk_scan_import_target_chan_csv(const dsd_opts* opts, dsd_state* state, const 
     dsd_state_trunk_lcn_name_free(state);
     /* Per-row key columns are likewise discarded: keys arrive per trunk-scan target, not
      * per chan_csv row, and a kept set would install on the wrong target's hop. */
+    dsd_channel_modes_clear(state);
     dsd_state_trunk_lcn_keys_free(state);
     free(tmp_opts);
     if (import_rc != 0) {
@@ -2106,8 +2110,10 @@ trunk_scan_build_target_runtime(dsd_trunk_scan_coord* coord, dsd_opts* opts, dsd
             DSD_SECURE_ZERO(&rt->target.single_key_scalars, sizeof(rt->target.single_key_scalars));
             rt->target.single_keys_present = 0U;
         }
+        trunk_scan_restore_saved_mod_gain_opts(opts, coord);
         trunk_scan_restore_snapshot(state, empty_snapshot);
         trunk_scan_apply_target_opts(opts, coord, &rt->target);
+        dsd_scan_mode_target_modulation(state, (int)rt->target.modulation);
         trunk_scan_apply_target_demod(opts, state, &rt->target);
         trunk_scan_seed_target_state(state, &rt->target, now_m);
         if (trunk_scan_import_target_chan_csv(opts, state, &rt->target, err, err_sz) != 0) {
@@ -2275,6 +2281,19 @@ trunk_scan_share_peer_idens(const dsd_trunk_scan_coord* coord, dsd_state* state,
     }
 }
 
+static dsd_scan_mode
+trunk_scan_target_mode(dsd_trunk_scan_target_type type) {
+    switch (type) {
+        case DSD_TRUNK_SCAN_TARGET_P25_TRUNK: return DSD_SCAN_MODE_P25;
+        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL: return DSD_SCAN_MODE_DMR;
+        case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL: return DSD_SCAN_MODE_NXDN96;
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return DSD_SCAN_MODE_NXDN48;
+    }
+    return DSD_SCAN_MODE_INHERIT;
+}
+
 static int
 trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord, size_t next, int save_current) {
     if (!coord || next >= coord->count) {
@@ -2289,12 +2308,17 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
      * here until the caller decides otherwise, and the label has to say so. */
     trunk_scan_publish_active_target(state, coord);
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    if (dsd_scan_mode_enter(opts, state, trunk_scan_target_mode(rt->target.type)) != 0) {
+        return -1;
+    }
     trunk_scan_restore_target_snapshot(coord, state, rt);
     trunk_scan_share_peer_idens(coord, state, rt);
     trunk_scan_apply_target_opts(opts, coord, &rt->target);
+    dsd_scan_mode_target_modulation(state, (int)rt->target.modulation);
     trunk_scan_apply_target_keys(state, rt);
     trunk_scan_apply_target_demod(opts, state, &rt->target);
     trunk_scan_sync_active_sm_mode(state, rt);
+    dsd_frame_sync_reset_acquisition(opts, state, 0);
 
     double now_m = trunk_scan_now_m();
     rt->parked_since_m = now_m;
@@ -2388,8 +2412,10 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
      * necessarily this one -- the original is skipped when its own retry cooldown is still
      * running. Republish, or the label names a target the receiver never reached. */
     trunk_scan_publish_active_target(state, coord);
+    (void)dsd_scan_mode_enter(opts, state, trunk_scan_target_mode(coord->targets[coord->active].target.type));
     trunk_scan_restore_snapshot(state, original_snapshot);
     trunk_scan_apply_target_opts(opts, coord, &coord->targets[coord->active].target);
+    dsd_scan_mode_target_modulation(state, (int)coord->targets[coord->active].target.modulation);
     trunk_scan_apply_target_keys(state, &coord->targets[coord->active]);
     trunk_scan_apply_target_demod(opts, state, &coord->targets[coord->active].target);
     trunk_scan_sync_active_sm_mode(state, &coord->targets[coord->active]);
@@ -2470,76 +2496,6 @@ trunk_scan_warn_ignored_target_gain(const dsd_opts* opts, const dsd_state* state
         return;
     }
     LOG_WARN("WARNING: Trunk scan rtl_gain target overrides require RTL-family input; ignoring target gain settings\n");
-}
-
-typedef enum {
-    TRUNK_SCAN_DECODER_P25 = 0,
-    TRUNK_SCAN_DECODER_DMR = 1,
-    TRUNK_SCAN_DECODER_NXDN96 = 2,
-    TRUNK_SCAN_DECODER_NXDN48 = 3,
-    TRUNK_SCAN_DECODER_COUNT = 4,
-} trunk_scan_decoder_class;
-
-/* Exhaustive switch with no default: adding a target type must fail the build here rather than
- * silently classing the new type as "always decodable". */
-static trunk_scan_decoder_class
-trunk_scan_target_decoder_class(dsd_trunk_scan_target_type type) {
-    switch (type) {
-        case DSD_TRUNK_SCAN_TARGET_P25_TRUNK: return TRUNK_SCAN_DECODER_P25;
-        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
-        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL: return TRUNK_SCAN_DECODER_DMR;
-        case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK:
-        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL: return TRUNK_SCAN_DECODER_NXDN96;
-        case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return TRUNK_SCAN_DECODER_NXDN48;
-    }
-    return TRUNK_SCAN_DECODER_P25;
-}
-
-static void
-trunk_scan_warn_disabled_target_decoders(const dsd_opts* opts, const dsd_trunk_scan_target_list* list) {
-    if (!opts || !list) {
-        return;
-    }
-
-    static const struct {
-        const char* name;
-        const char* hint;
-    } k_decoders[TRUNK_SCAN_DECODER_COUNT] = {
-        {"P25", "-ft, -f1, -f2, or -fa"},
-        {"DMR", "-fs, -ft, or -fa"},
-        {"NXDN96", "-fn or -fa"},
-        {"NXDN48", "-fi or -fa"},
-    };
-
-    /* P25 mirrors the engine's own no_carrier_p25_frames_enabled(): a TDMA control channel is
-     * followed with -f2 alone, which leaves frame_p25p1 clear. The two NXDN variants are separate
-     * gates because -fn and -fi each enable only one of them; -fa enables both. */
-    const int enabled[TRUNK_SCAN_DECODER_COUNT] = {
-        (opts->frame_p25p1 == 1 || opts->frame_p25p2 == 1),
-        (opts->frame_dmr == 1),
-        (opts->frame_nxdn96 == 1),
-        (opts->frame_nxdn48 == 1),
-    };
-
-    /* One line per decoder class, not per target: scan lists are unbounded. */
-    size_t missing[TRUNK_SCAN_DECODER_COUNT] = {0};
-    const char* first_id[TRUNK_SCAN_DECODER_COUNT] = {0};
-    for (size_t i = 0; i < list->count; i++) {
-        const trunk_scan_decoder_class cls = trunk_scan_target_decoder_class(list->targets[i].type);
-        if (enabled[cls]) {
-            continue;
-        }
-        if (missing[cls]++ == 0) {
-            first_id[cls] = list->targets[i].id;
-        }
-    }
-    for (int cls = 0; cls < (int)TRUNK_SCAN_DECODER_COUNT; cls++) {
-        if (missing[cls] == 0) {
-            continue;
-        }
-        LOG_WARN("WARNING: %zu trunk scan target(s) have no enabled %s decoder (first: '%s'); use %s to decode them\n",
-                 missing[cls], k_decoders[cls].name, first_id[cls], k_decoders[cls].hint);
-    }
 }
 
 static void
@@ -3005,8 +2961,9 @@ trunk_scan_coord_create(const dsd_trunk_scan_target_list* list, const dsd_opts* 
 static void
 trunk_scan_init_release(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord,
                         dsd_trunk_scan_target_list* list) {
-    dsd_scan_keys_leave(state);
     trunk_scan_restore_saved_opts(opts, coord);
+    dsd_engine_channel_scan_leave(opts, state);
+    dsd_scan_keys_leave(state);
     trunk_scan_coord_free(coord);
     dsd_trunk_scan_target_list_reset(list);
 }
@@ -3025,7 +2982,6 @@ dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t e
         return -1;
     }
     trunk_scan_warn_ignored_target_gain(opts, state, &list);
-    trunk_scan_warn_disabled_target_decoders(opts, &list);
 
     dsd_trunk_scan_coord* coord = trunk_scan_coord_create(&list, opts, err, err_sz);
     if (!coord) {
@@ -3033,7 +2989,8 @@ dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t e
         return -1;
     }
 
-    if (trunk_scan_build_target_runtime(coord, opts, state, &list, err, err_sz) != 0) {
+    if (dsd_scan_mode_begin(opts, state) != 0
+        || trunk_scan_build_target_runtime(coord, opts, state, &list, err, err_sz) != 0) {
         trunk_scan_init_release(opts, state, coord, &list);
         return -1;
     }
@@ -3079,8 +3036,9 @@ dsd_engine_trunk_scan_shutdown(dsd_opts* opts, dsd_state* state) {
         return;
     }
     trunk_scan_log_nxdn_diag_summaries(coord, state);
-    dsd_scan_keys_leave(state);
     trunk_scan_restore_saved_opts(opts, coord);
+    dsd_engine_channel_scan_leave(opts, state);
+    dsd_scan_keys_leave(state);
     trunk_scan_uninstall_runtime_hooks(coord);
     trunk_scan_clear_published_target(state);
     (void)dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_TRUNK_SCAN, NULL, NULL);

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -1930,44 +1930,11 @@ trunk_scan_restore_saved_mod_gain_opts(dsd_opts* opts, const dsd_trunk_scan_coor
 
 static void
 trunk_scan_apply_target_mod_opts(dsd_opts* opts, const dsd_trunk_scan_target* target) {
-    if (!opts || !target || target->modulation == DSD_TRUNK_SCAN_MODULATION_UNSET) {
+    if (!target) {
         return;
     }
-    opts->mod_p25p2_c4fm = 0;
-    opts->mod_p25p2_profile_lock = 0;
-    switch (target->modulation) {
-        case DSD_TRUNK_SCAN_MODULATION_AUTO:
-            if (target->type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
-                opts->mod_c4fm = 1;
-                opts->mod_qpsk = 0;
-                opts->mod_gfsk = 0;
-            } else {
-                opts->mod_c4fm = 0;
-                opts->mod_qpsk = 0;
-                opts->mod_gfsk = 1;
-            }
-            opts->mod_cli_lock = 0;
-            break;
-        case DSD_TRUNK_SCAN_MODULATION_C4FM:
-            opts->mod_c4fm = 1;
-            opts->mod_qpsk = 0;
-            opts->mod_gfsk = 0;
-            opts->mod_cli_lock = 1;
-            break;
-        case DSD_TRUNK_SCAN_MODULATION_CQPSK:
-            opts->mod_c4fm = 0;
-            opts->mod_qpsk = 1;
-            opts->mod_gfsk = 0;
-            opts->mod_cli_lock = 1;
-            break;
-        case DSD_TRUNK_SCAN_MODULATION_GFSK:
-            opts->mod_c4fm = 0;
-            opts->mod_qpsk = 0;
-            opts->mod_gfsk = 1;
-            opts->mod_cli_lock = 1;
-            break;
-        case DSD_TRUNK_SCAN_MODULATION_UNSET: break;
-    }
+    dsd_scan_mode_apply_modulation(opts, trunk_scan_target_is_p25(target) ? DSD_SCAN_MODE_P25 : DSD_SCAN_MODE_DMR,
+                                   (dsd_scan_modulation)target->modulation);
 }
 
 static void
@@ -2113,7 +2080,6 @@ trunk_scan_build_target_runtime(dsd_trunk_scan_coord* coord, dsd_opts* opts, dsd
         trunk_scan_restore_saved_mod_gain_opts(opts, coord);
         trunk_scan_restore_snapshot(state, empty_snapshot);
         trunk_scan_apply_target_opts(opts, coord, &rt->target);
-        dsd_scan_mode_target_modulation(state, (int)rt->target.modulation);
         trunk_scan_apply_target_demod(opts, state, &rt->target);
         trunk_scan_seed_target_state(state, &rt->target, now_m);
         if (trunk_scan_import_target_chan_csv(opts, state, &rt->target, err, err_sz) != 0) {
@@ -2314,7 +2280,7 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     trunk_scan_restore_target_snapshot(coord, state, rt);
     trunk_scan_share_peer_idens(coord, state, rt);
     trunk_scan_apply_target_opts(opts, coord, &rt->target);
-    dsd_scan_mode_target_modulation(state, (int)rt->target.modulation);
+    dsd_scan_mode_target_modulation(state, (dsd_scan_modulation)rt->target.modulation);
     trunk_scan_apply_target_keys(state, rt);
     trunk_scan_apply_target_demod(opts, state, &rt->target);
     trunk_scan_sync_active_sm_mode(state, rt);
@@ -2415,7 +2381,7 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
     (void)dsd_scan_mode_enter(opts, state, trunk_scan_target_mode(coord->targets[coord->active].target.type));
     trunk_scan_restore_snapshot(state, original_snapshot);
     trunk_scan_apply_target_opts(opts, coord, &coord->targets[coord->active].target);
-    dsd_scan_mode_target_modulation(state, (int)coord->targets[coord->active].target.modulation);
+    dsd_scan_mode_target_modulation(state, (dsd_scan_modulation)coord->targets[coord->active].target.modulation);
     trunk_scan_apply_target_keys(state, &coord->targets[coord->active]);
     trunk_scan_apply_target_demod(opts, state, &coord->targets[coord->active].target);
     trunk_scan_sync_active_sm_mode(state, &coord->targets[coord->active]);
@@ -2961,8 +2927,8 @@ trunk_scan_coord_create(const dsd_trunk_scan_target_list* list, const dsd_opts* 
 static void
 trunk_scan_init_release(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord,
                         dsd_trunk_scan_target_list* list) {
-    trunk_scan_restore_saved_opts(opts, coord);
     dsd_engine_channel_scan_leave(opts, state);
+    trunk_scan_restore_saved_opts(opts, coord);
     dsd_scan_keys_leave(state);
     trunk_scan_coord_free(coord);
     dsd_trunk_scan_target_list_reset(list);
@@ -3036,8 +3002,8 @@ dsd_engine_trunk_scan_shutdown(dsd_opts* opts, dsd_state* state) {
         return;
     }
     trunk_scan_log_nxdn_diag_summaries(coord, state);
-    trunk_scan_restore_saved_opts(opts, coord);
     dsd_engine_channel_scan_leave(opts, state);
+    trunk_scan_restore_saved_opts(opts, coord);
     dsd_scan_keys_leave(state);
     trunk_scan_uninstall_runtime_hooks(coord);
     trunk_scan_clear_published_target(state);

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -433,24 +433,32 @@ dsd_engine_update_vc_tune_state(dsd_opts* opts, dsd_state* state, long int freq)
     state->p25_last_vc_tune_time_m = state->last_vc_sync_time_m;
 }
 
+static int
+dsd_engine_tune_rigctl(const dsd_opts* opts, long int freq) {
+    if (opts->setmod_bw != 0 && !SetModulation(opts->rigctl_sockfd, opts->setmod_bw)) {
+        DSD_FPRINTF(stderr, "Rigctl modulation update failed for bandwidth %d.\n", opts->setmod_bw);
+    }
+    if (!SetFreq(opts->rigctl_sockfd, freq)) {
+        DSD_FPRINTF(stderr, "Rigctl frequency update failed for %ld Hz.\n", freq);
+        return 0;
+    }
+    return 1;
+}
+
 static dsd_trunk_tune_result
 dsd_engine_tune_with_backend(const dsd_opts* opts, dsd_state* state, long int freq, uint64_t request_id) {
     if (opts->use_rigctl == 1) {
-        if (opts->setmod_bw != 0) {
-            if (!SetModulation(opts->rigctl_sockfd, opts->setmod_bw)) {
-                DSD_FPRINTF(stderr, "Rigctl modulation update failed for bandwidth %d.\n", opts->setmod_bw);
-            }
-        }
-        if (!SetFreq(opts->rigctl_sockfd, freq)) {
-            DSD_FPRINTF(stderr, "Rigctl frequency update failed for %ld Hz.\n", freq);
+        if (!dsd_engine_tune_rigctl(opts, freq)) {
             return DSD_TRUNK_TUNE_RESULT_FAILED;
         }
 #ifdef USE_RADIO
-        if (opts->audio_in_type == AUDIO_IN_RTL) {
+        if (opts->audio_in_type == AUDIO_IN_RTL && opts->scanner_mode != 1) {
             rtl_stream_apply_pending_retune_profile_for_target((uint32_t)freq);
         }
 #endif
-        return DSD_TRUNK_TUNE_RESULT_OK;
+        if (opts->scanner_mode != 1 || opts->audio_in_type != AUDIO_IN_RTL) {
+            return DSD_TRUNK_TUNE_RESULT_OK;
+        }
     }
     if (opts->audio_in_type != AUDIO_IN_RTL) {
         return DSD_TRUNK_TUNE_RESULT_FAILED;
@@ -731,6 +739,36 @@ dsd_engine_trunk_tune_to_cc_request(dsd_opts* opts, dsd_state* state, long int f
     return result;
 }
 
+#ifdef USE_RADIO
+static void
+dsd_engine_prepare_scan_profile(const dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+    if (opts->audio_in_type == AUDIO_IN_RTL && ted_sps > 0) {
+        if (opts->scanner_mode == 1) {
+            const int rate = dsd_frame_sync_active_profile_symbol_rate_hz(state);
+            const int levels = state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_2
+                                       || state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_9600_2
+                                   ? 2
+                                   : 4;
+            dsd_engine_prepare_retune_profile_for_target(opts, state, (uint32_t)freq, state->rf_mod == 1, rate, levels,
+                                                         dsd_rtl_channel_profile_for(opts, rate, levels, state->rf_mod),
+                                                         ted_sps, 0);
+        } else {
+            dsd_engine_prepare_cc_rtl_chain(opts, state, freq, ted_sps);
+        }
+    }
+}
+#endif
+
+static void
+dsd_engine_scan_tune_failed(const dsd_opts* opts, uint64_t request_id, dsd_trunk_tune_result result) {
+    if (opts->scanner_mode == 1 && opts->use_rigctl == 1 && opts->audio_in_type == AUDIO_IN_RTL) {
+        /* A rigctl leg may have moved before RTL failed. Completion disagreement
+         * retains the frame gate until the scanner establishes a new boundary. */
+        dsd_trunk_tuning_request_publish(request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    }
+    dsd_trunk_tuning_request_complete(request_id, result);
+}
+
 dsd_trunk_tune_result
 dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t* out_request_id) {
     dsd_trunk_tune_result result = DSD_TRUNK_TUNE_RESULT_OK;
@@ -756,9 +794,7 @@ dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, in
     (void)ted_sps;
 #else
     dsd_engine_rtl_profile_snapshot_capture(opts, state, &rtl_snapshot);
-    if (opts->audio_in_type == AUDIO_IN_RTL && ted_sps > 0) {
-        dsd_engine_prepare_cc_rtl_chain(opts, state, freq, ted_sps);
-    }
+    dsd_engine_prepare_scan_profile(opts, state, freq, ted_sps);
 #endif
 
     dsd_engine_maybe_drain_audio(opts, state);
@@ -767,7 +803,7 @@ dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, in
 #ifdef USE_RADIO
         dsd_engine_rtl_profile_snapshot_restore(state, &rtl_snapshot);
 #endif
-        dsd_trunk_tuning_request_complete(tune_request_id, result);
+        dsd_engine_scan_tune_failed(opts, tune_request_id, result);
         return result;
     }
 

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -445,18 +445,24 @@ dsd_engine_tune_rigctl(const dsd_opts* opts, long int freq) {
     return 1;
 }
 
+static int
+dsd_engine_conventional_scan_active(const dsd_opts* opts) {
+    return opts->scanner_mode == 1 && opts->trunk_scan_enabled != 1;
+}
+
 static dsd_trunk_tune_result
 dsd_engine_tune_with_backend(const dsd_opts* opts, dsd_state* state, long int freq, uint64_t request_id) {
+    const int conventional_scan = dsd_engine_conventional_scan_active(opts);
     if (opts->use_rigctl == 1) {
         if (!dsd_engine_tune_rigctl(opts, freq)) {
             return DSD_TRUNK_TUNE_RESULT_FAILED;
         }
 #ifdef USE_RADIO
-        if (opts->audio_in_type == AUDIO_IN_RTL && opts->scanner_mode != 1) {
+        if (opts->audio_in_type == AUDIO_IN_RTL && !conventional_scan) {
             rtl_stream_apply_pending_retune_profile_for_target((uint32_t)freq);
         }
 #endif
-        if (opts->scanner_mode != 1 || opts->audio_in_type != AUDIO_IN_RTL) {
+        if (!conventional_scan || opts->audio_in_type != AUDIO_IN_RTL) {
             return DSD_TRUNK_TUNE_RESULT_OK;
         }
     }
@@ -743,12 +749,9 @@ dsd_engine_trunk_tune_to_cc_request(dsd_opts* opts, dsd_state* state, long int f
 static void
 dsd_engine_prepare_scan_profile(const dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
     if (opts->audio_in_type == AUDIO_IN_RTL && ted_sps > 0) {
-        if (opts->scanner_mode == 1) {
+        if (dsd_engine_conventional_scan_active(opts)) {
             const int rate = dsd_frame_sync_active_profile_symbol_rate_hz(state);
-            const int levels = state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_2
-                                       || state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_9600_2
-                                   ? 2
-                                   : 4;
+            const int levels = dsd_frame_sync_active_profile_levels(state);
             dsd_engine_prepare_retune_profile_for_target(opts, state, (uint32_t)freq, state->rf_mod == 1, rate, levels,
                                                          dsd_rtl_channel_profile_for(opts, rate, levels, state->rf_mod),
                                                          ted_sps, 0);
@@ -761,7 +764,7 @@ dsd_engine_prepare_scan_profile(const dsd_opts* opts, dsd_state* state, long int
 
 static void
 dsd_engine_scan_tune_failed(const dsd_opts* opts, uint64_t request_id, dsd_trunk_tune_result result) {
-    if (opts->scanner_mode == 1 && opts->use_rigctl == 1 && opts->audio_in_type == AUDIO_IN_RTL) {
+    if (dsd_engine_conventional_scan_active(opts) && opts->use_rigctl == 1 && opts->audio_in_type == AUDIO_IN_RTL) {
         /* A rigctl leg may have moved before RTL failed. Completion disagreement
          * retains the frame gate until the scanner establishes a new boundary. */
         dsd_trunk_tuning_request_publish(request_id, DSD_TRUNK_TUNE_RESULT_OK);

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
         config_user_validation.cpp
         config_schema.c
         decode_mode.c
+        scan_mode.c
         config_expand.c
         control_pump.c
         freq_parse.c

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -384,7 +384,7 @@ static void
 dsd_cli_usage_section_trunking_and_tools(void) {
     printf("Trunking Options:\n");
     printf("  -C <file>     Import Channel to Frequency Map (channum, freq) from csv file. (Capital C)\n");
-    printf("                 (See channel_map.csv for example)\n");
+    printf("                 Optional name, mode and key columns; see examples/conventional_scan_modes.csv.\n");
     printf("  -G <file>     Import Group List Allow/Block and Label from csv file.\n");
     printf("                 (See group.csv for example)\n");
     printf("      --p25-bandplan <file>   P25 band plan CSV (IDEN table) for sites that never send IDEN_UP.\n");
@@ -392,9 +392,8 @@ dsd_cli_usage_section_trunking_and_tools(void) {
     printf("      --p25-bandplan-export <file>  Write the learned P25 band plan CSV once at clean shutdown.\n");
     printf("  -T            Enable Trunking Features (NXDN/P25/EDACS/DMR) with RIGCTL/TCP or RTL Input\n");
     printf("  -Y            Enable Scanning Mode with RIGCTL/TCP or RTL Input\n");
-    printf(
-        "                 Experimental -- Can only scan for sync with enabled decoders, don't mix NXDN and DMR/P25!\n");
-    printf("                 This is not a Trunking Feature, just scans through conventional frequencies fast!\n");
+    printf("                 Row mode: p25, dmr, nxdn96, nxdn48, dpmr, dstar, ysf or m17; blank inherits globals.\n");
+    printf("                 Scans conventional frequencies; use -T for trunking.\n");
     printf("      --trunk-scan <targets.csv>  Enable single-tuner trunk scan target rotation.\n");
     printf("                 Uses per-target chan_csv values; cannot be combined with global -C or IQ replay.\n");
     printf("      --trunk-scan-dwell-ms <ms>  Set default idle dwell per target (250..600000, default 3000).\n");

--- a/src/runtime/config_user.cpp
+++ b/src/runtime/config_user.cpp
@@ -1712,9 +1712,10 @@ snapshot_mode_config(const dsd_opts* opts, const dsd_state* state, dsdneoUserCon
     /* Exact, not the AUTO-falling-back spelling: a decoder set no preset reproduces must render
        no `decode` key at all. Saving it as "auto" would reload as every decoder enabled, so a
        session that never chose a mode would come back wider than it was saved. */
-    cfg->decode_mode = dsd_infer_decode_mode_preset_exact(opts);
+    cfg->decode_mode = dsd_scan_mode_configured_preset_exact(opts, state);
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(state);
     cfg->has_dmr_mono = 1;
-    cfg->dmr_mono = opts->dmr_mono ? 1 : 0;
+    cfg->dmr_mono = (configured ? configured->dmr_mono : opts->dmr_mono) ? 1 : 0;
     cfg->dmr_lrrp_ports[0] = '\0';
     for (int i = 0; i < opts->lrrp_extra_port_count && i < DSD_LRRP_EXTRA_PORT_MAX; i++) {
         size_t used = strlen(cfg->dmr_lrrp_ports);
@@ -1737,16 +1738,17 @@ snapshot_mode_config(const dsd_opts* opts, const dsd_state* state, dsdneoUserCon
 }
 
 static void
-snapshot_demod_config(const dsd_opts* opts, dsdneoUserConfig* cfg) {
-    if (!opts->mod_cli_lock) {
+snapshot_demod_config(const dsd_opts* opts, const dsd_state* state, dsdneoUserConfig* cfg) {
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(state);
+    if (!(configured ? configured->mod_cli_lock : opts->mod_cli_lock)) {
         return;
     }
     cfg->has_demod = 1;
-    if (opts->mod_gfsk) {
+    if (configured ? configured->mod_gfsk : opts->mod_gfsk) {
         cfg->demod_path = DSDCFG_DEMOD_GFSK;
-    } else if (opts->mod_qpsk) {
+    } else if (configured ? configured->mod_qpsk : opts->mod_qpsk) {
         cfg->demod_path = DSDCFG_DEMOD_QPSK;
-    } else if (opts->mod_c4fm) {
+    } else if (configured ? configured->mod_c4fm : opts->mod_c4fm) {
         cfg->demod_path = DSDCFG_DEMOD_C4FM;
     } else {
         cfg->demod_path = DSDCFG_DEMOD_AUTO;
@@ -1855,21 +1857,11 @@ dsd_snapshot_opts_to_user_config(const dsd_opts* opts, const dsd_state* state, d
         return;
     }
 
-    dsd_opts* configured = nullptr;
-    if (dsd_scan_mode_active(state) != DSD_SCAN_MODE_INHERIT) {
-        configured = static_cast<dsd_opts*>(malloc(sizeof(*configured)));
-        if (!configured) {
-            return;
-        }
-        DSD_MEMCPY(configured, opts, sizeof(*configured));
-        dsd_scan_mode_configured_opts(state, configured);
-        opts = configured;
-    }
     user_cfg_reset(cfg);
     snapshot_input_config(opts, cfg);
     snapshot_output_config(opts, cfg);
     snapshot_mode_config(opts, state, cfg);
-    snapshot_demod_config(opts, cfg);
+    snapshot_demod_config(opts, state, cfg);
     snapshot_trunking_config(opts, cfg);
     snapshot_radioreference_config(opts, cfg);
     snapshot_trunk_scan_config(opts, cfg);
@@ -1877,7 +1869,6 @@ dsd_snapshot_opts_to_user_config(const dsd_opts* opts, const dsd_state* state, d
     snapshot_alerts_config(opts, cfg);
     snapshot_recording_config(opts, cfg);
     snapshot_dsp_config(cfg);
-    free(configured);
 }
 
 // Template generation ---------------------------------------------------------

--- a/src/runtime/config_user.cpp
+++ b/src/runtime/config_user.cpp
@@ -27,6 +27,7 @@
 #include <dsd-neo/runtime/freq_parse.h>
 #include <dsd-neo/runtime/path_policy.h>
 #include <dsd-neo/runtime/rdio_export.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdint.h>
@@ -1854,6 +1855,16 @@ dsd_snapshot_opts_to_user_config(const dsd_opts* opts, const dsd_state* state, d
         return;
     }
 
+    dsd_opts* configured = nullptr;
+    if (dsd_scan_mode_active(state) != DSD_SCAN_MODE_INHERIT) {
+        configured = static_cast<dsd_opts*>(malloc(sizeof(*configured)));
+        if (!configured) {
+            return;
+        }
+        DSD_MEMCPY(configured, opts, sizeof(*configured));
+        dsd_scan_mode_configured_opts(state, configured);
+        opts = configured;
+    }
     user_cfg_reset(cfg);
     snapshot_input_config(opts, cfg);
     snapshot_output_config(opts, cfg);
@@ -1866,6 +1877,7 @@ dsd_snapshot_opts_to_user_config(const dsd_opts* opts, const dsd_state* state, d
     snapshot_alerts_config(opts, cfg);
     snapshot_recording_config(opts, cfg);
     snapshot_dsp_config(cfg);
+    free(configured);
 }
 
 // Template generation ---------------------------------------------------------

--- a/src/runtime/scan_mode.c
+++ b/src/runtime/scan_mode.c
@@ -165,20 +165,64 @@ dsd_scan_settings_restore(const dsd_scan_settings* saved, dsd_opts* opts, dsd_st
     state->sps_hunt_idx = saved->state_sps_hunt_idx;
 }
 
+static int
+scan_settings_fields_equal(const dsd_scan_settings* a, const dsd_scan_settings* b, const size_t* fields, size_t count) {
+    for (size_t i = 0; i < count; i++) {
+        const int* av = (const int*)((const unsigned char*)a + fields[i]);
+        const int* bv = (const int*)((const unsigned char*)b + fields[i]);
+        if (*av != *bv) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
 int
 dsd_scan_settings_equal(const dsd_scan_settings* a, const dsd_scan_settings* b, int include_timing) {
+    /* Explicit membership, independent of struct order and padding. */
+    static const size_t options[] = {
+        offsetof(dsd_scan_settings, frame_dstar),
+        offsetof(dsd_scan_settings, frame_x2tdma),
+        offsetof(dsd_scan_settings, frame_p25p1),
+        offsetof(dsd_scan_settings, frame_p25p2),
+        offsetof(dsd_scan_settings, frame_nxdn48),
+        offsetof(dsd_scan_settings, frame_nxdn96),
+        offsetof(dsd_scan_settings, frame_dmr),
+        offsetof(dsd_scan_settings, frame_dpmr),
+        offsetof(dsd_scan_settings, frame_provoice),
+        offsetof(dsd_scan_settings, frame_ysf),
+        offsetof(dsd_scan_settings, frame_m17),
+        offsetof(dsd_scan_settings, mod_c4fm),
+        offsetof(dsd_scan_settings, mod_qpsk),
+        offsetof(dsd_scan_settings, mod_gfsk),
+        offsetof(dsd_scan_settings, mod_cli_lock),
+        offsetof(dsd_scan_settings, mod_p25p2_c4fm),
+        offsetof(dsd_scan_settings, mod_p25p2_profile_lock),
+        offsetof(dsd_scan_settings, inverted_p2),
+        offsetof(dsd_scan_settings, inverted_x2tdma),
+        offsetof(dsd_scan_settings, inverted_dmr),
+        offsetof(dsd_scan_settings, inverted_dpmr),
+        offsetof(dsd_scan_settings, inverted_ysf),
+        offsetof(dsd_scan_settings, inverted_m17),
+        offsetof(dsd_scan_settings, dmr_stereo),
+        offsetof(dsd_scan_settings, dmr_mono),
+        offsetof(dsd_scan_settings, use_cosine_filter),
+        offsetof(dsd_scan_settings, ssize),
+        offsetof(dsd_scan_settings, msize),
+        offsetof(dsd_scan_settings, analog_only),
+        offsetof(dsd_scan_settings, monitor_input_audio),
+    };
+    static const size_t timing[] = {
+        offsetof(dsd_scan_settings, state_rf_mod),       offsetof(dsd_scan_settings, state_samplesPerSymbol),
+        offsetof(dsd_scan_settings, state_symbolCenter), offsetof(dsd_scan_settings, state_dmr_stereo),
+        offsetof(dsd_scan_settings, state_sps_hunt_idx),
+    };
     if (!a || !b) {
         return 0;
     }
-    if (memcmp(a, b, offsetof(dsd_scan_settings, output_name)) != 0
-        || strncmp(a->output_name, b->output_name, sizeof(a->output_name)) != 0) {
-        return 0;
-    }
-    const size_t timing_offset = offsetof(dsd_scan_settings, state_rf_mod);
-    return !include_timing
-           || memcmp((const unsigned char*)a + timing_offset, (const unsigned char*)b + timing_offset,
-                     sizeof(*a) - timing_offset)
-                  == 0;
+    return scan_settings_fields_equal(a, b, options, sizeof(options) / sizeof(options[0]))
+           && strncmp(a->output_name, b->output_name, sizeof(a->output_name)) == 0
+           && (!include_timing || scan_settings_fields_equal(a, b, timing, sizeof(timing) / sizeof(timing[0])));
 }
 
 dsd_decode_mode_profile
@@ -266,7 +310,7 @@ dsd_scan_mode_begin(const dsd_opts* opts, dsd_state* state) {
         return -1;
     }
     dsd_scan_settings_capture(opts, state, &scope->configured);
-    scope->configured_mode = dsd_infer_decode_mode_preset(opts);
+    scope->configured_mode = dsd_infer_decode_mode_preset_exact(opts);
     (void)dsd_state_ext_set(state, DSD_STATE_EXT_RUNTIME_SCAN_MODE, scope, free);
     return 0;
 }
@@ -275,10 +319,6 @@ int
 dsd_scan_mode_enter(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode) {
     if (!opts || !state || (unsigned)mode >= sizeof(mode_presets) / sizeof(mode_presets[0])) {
         return -1;
-    }
-    if (mode == DSD_SCAN_MODE_INHERIT) {
-        dsd_scan_mode_leave(opts, state);
-        return 0;
     }
     if (dsd_scan_mode_begin(opts, state) != 0) {
         return -1;
@@ -296,8 +336,14 @@ dsd_scan_mode_enter(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode) {
 
 dsdneoUserDecodeMode
 dsd_scan_mode_configured_preset(const dsd_opts* opts, const dsd_state* state) {
+    const dsdneoUserDecodeMode mode = dsd_scan_mode_configured_preset_exact(opts, state);
+    return mode == DSDCFG_MODE_UNSET ? DSDCFG_MODE_AUTO : mode;
+}
+
+dsdneoUserDecodeMode
+dsd_scan_mode_configured_preset_exact(const dsd_opts* opts, const dsd_state* state) {
     const scan_scope* scope = scan_scope_get(state);
-    return scope && !scope->suspended ? scope->configured_mode : dsd_infer_decode_mode_preset(opts);
+    return scope && !scope->suspended ? scope->configured_mode : dsd_infer_decode_mode_preset_exact(opts);
 }
 
 void
@@ -333,11 +379,11 @@ dsd_scan_mode_updating(const dsd_state* state) {
 int
 dsd_scan_mode_resume(dsd_opts* opts, dsd_state* state) {
     scan_scope* scope = scan_scope_get(state);
-    if (!scope || !opts || !scope->suspended) {
+    if (!scope || !opts || !state || !scope->suspended) {
         return 0;
     }
     dsd_scan_settings_capture(opts, state, &scope->configured);
-    scope->configured_mode = dsd_infer_decode_mode_preset(opts);
+    scope->configured_mode = dsd_infer_decode_mode_preset_exact(opts);
     scope->suspended = 0;
     scan_scope_apply(opts, state, scope);
     if (scope->mode == DSD_SCAN_MODE_P25) {
@@ -383,12 +429,10 @@ dsd_scan_mode_configured(const dsd_opts* opts, const dsd_state* state, dsd_scan_
     }
 }
 
-void
-dsd_scan_mode_configured_opts(const dsd_state* state, dsd_opts* opts) {
+const dsd_scan_settings*
+dsd_scan_mode_configured_view(const dsd_state* state) {
     const scan_scope* scope = scan_scope_get(state);
-    if (scope && !scope->suspended && opts) {
-        scan_settings_restore_opts(&scope->configured, opts);
-    }
+    return scope && !scope->suspended ? &scope->configured : NULL;
 }
 
 void
@@ -409,7 +453,16 @@ dsd_scan_mode_copy_snapshot(dsd_state* dst, const dsd_state* src) {
         }
         (void)dsd_state_ext_set(dst, DSD_STATE_EXT_RUNTIME_SCAN_MODE, copy, free);
     }
-    *copy = *source;
+    copy->configured = source->configured;
+    copy->modulation = source->modulation;
+    copy->mode = source->mode;
+    copy->configured_mode = source->configured_mode;
+    copy->suspended = source->suspended;
+    /* The effective backup matters only between suspend and resume. A normal
+     * published snapshot never consumes it; a later suspend captures its own. */
+    if (source->suspended) {
+        copy->effective = source->effective;
+    }
 }
 
 dsd_decode_mode_profile
@@ -427,7 +480,7 @@ dsd_scan_mode_prepare(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode, dsd_
     if (!opts || !state || !out || (unsigned)mode >= sizeof(mode_presets) / sizeof(mode_presets[0])) {
         return -1;
     }
-    if (mode != DSD_SCAN_MODE_INHERIT && dsd_scan_mode_begin(opts, state) != 0) {
+    if (dsd_scan_mode_begin(opts, state) != 0) {
         return -1;
     }
     dsd_scan_settings effective;

--- a/src/runtime/scan_mode.c
+++ b/src/runtime/scan_mode.c
@@ -352,6 +352,9 @@ dsd_scan_mode_resume(dsd_opts* opts, dsd_state* state) {
     }
     dsd_scan_settings effective;
     dsd_scan_settings_capture(opts, state, &effective);
+    /* Monitoring is audio routing. Fold it into the restored effective values
+     * without treating it as an acquisition change or replacing live timing. */
+    scope->effective.monitor_input_audio = opts->monitor_input_audio;
     if (dsd_scan_settings_equal(&scope->effective, &effective, 0)) {
         dsd_scan_settings_restore(&scope->effective, opts, state);
         return 0;

--- a/src/runtime/scan_mode.c
+++ b/src/runtime/scan_mode.c
@@ -20,7 +20,7 @@
 typedef struct {
     dsd_scan_settings configured;
     dsd_scan_settings effective;
-    int modulation;
+    dsd_scan_modulation modulation;
     dsd_scan_mode mode;
     dsdneoUserDecodeMode configured_mode;
     int suspended;
@@ -279,15 +279,9 @@ scan_scope_apply(dsd_opts* opts, dsd_state* state, const scan_scope* scope) {
         }
         state->rf_mod = dsd_opts_modulation(opts);
     }
-    if (scope->modulation) {
-        const int mod = scope->modulation == 1 ? (scope->mode == DSD_SCAN_MODE_P25 ? 0 : 2) : scope->modulation - 2;
-        opts->mod_cli_lock = scope->modulation == 1 ? 0 : 1;
-        opts->mod_p25p2_c4fm = 0;
-        opts->mod_p25p2_profile_lock = 0;
-        opts->mod_c4fm = mod == 0;
-        opts->mod_qpsk = mod == 1;
-        opts->mod_gfsk = mod == 2;
-        state->rf_mod = mod;
+    if (scope->modulation != DSD_SCAN_MODULATION_INHERIT) {
+        dsd_scan_mode_apply_modulation(opts, scope->mode, scope->modulation);
+        state->rf_mod = dsd_opts_modulation(opts);
     }
     dsd_decode_mode_profile profile = dsd_scan_mode_profile(scope->mode);
     if (scope->mode == DSD_SCAN_MODE_P25 && opts->mod_p25p2_profile_lock
@@ -409,11 +403,32 @@ dsd_scan_mode_resume(dsd_opts* opts, dsd_state* state) {
 }
 
 void
-dsd_scan_mode_target_modulation(const dsd_state* state, int modulation) {
+dsd_scan_mode_target_modulation(const dsd_state* state, dsd_scan_modulation modulation) {
     scan_scope* scope = scan_scope_get(state);
-    if (scope && modulation >= 0 && modulation <= 4) {
+    if (scope && (unsigned)modulation <= DSD_SCAN_MODULATION_GFSK) {
         scope->modulation = modulation;
     }
+}
+
+void
+dsd_scan_mode_apply_modulation(dsd_opts* opts, dsd_scan_mode mode, dsd_scan_modulation modulation) {
+    if (!opts || modulation == DSD_SCAN_MODULATION_INHERIT || (unsigned)modulation > DSD_SCAN_MODULATION_GFSK) {
+        return;
+    }
+    int mod;
+    switch (modulation) {
+        case DSD_SCAN_MODULATION_AUTO: mod = mode == DSD_SCAN_MODE_P25 ? 0 : 2; break;
+        case DSD_SCAN_MODULATION_C4FM: mod = 0; break;
+        case DSD_SCAN_MODULATION_CQPSK: mod = 1; break;
+        case DSD_SCAN_MODULATION_GFSK: mod = 2; break;
+        default: return;
+    }
+    opts->mod_cli_lock = modulation != DSD_SCAN_MODULATION_AUTO;
+    opts->mod_p25p2_c4fm = 0;
+    opts->mod_p25p2_profile_lock = 0;
+    opts->mod_c4fm = mod == 0;
+    opts->mod_qpsk = mod == 1;
+    opts->mod_gfsk = mod == 2;
 }
 
 void
@@ -468,6 +483,18 @@ dsd_scan_mode_copy_snapshot(dsd_state* dst, const dsd_state* src) {
 dsd_decode_mode_profile
 dsd_scan_mode_effective_profile(const dsd_opts* opts, const dsd_state* state) {
     const dsd_scan_mode mode = dsd_scan_mode_active(state);
+    if (mode == DSD_SCAN_MODE_INHERIT && state) {
+        /* AUTO/custom baselines may have been captured anywhere in the hunt.
+         * The restored index, timing and frontend must describe the same profile. */
+        switch (state->sps_hunt_idx) {
+            case DSD_FRAME_SYNC_SPS_PROFILE_4800_4: return dsd_decode_mode_profile_for(DSDCFG_MODE_P25P1);
+            case DSD_FRAME_SYNC_SPS_PROFILE_2400_4: return dsd_decode_mode_profile_for(DSDCFG_MODE_NXDN48);
+            case DSD_FRAME_SYNC_SPS_PROFILE_9600_2: return dsd_decode_mode_profile_for(DSDCFG_MODE_EDACS_PV);
+            case DSD_FRAME_SYNC_SPS_PROFILE_6000_4: return dsd_decode_mode_profile_for(DSDCFG_MODE_P25P2);
+            case DSD_FRAME_SYNC_SPS_PROFILE_4800_2: return dsd_decode_mode_profile_for(DSDCFG_MODE_DSTAR);
+            default: break;
+        }
+    }
     if (mode == DSD_SCAN_MODE_P25 && state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4) {
         return dsd_decode_mode_profile_for(DSDCFG_MODE_P25P2);
     }

--- a/src/runtime/scan_mode.c
+++ b/src/runtime/scan_mode.c
@@ -165,6 +165,22 @@ dsd_scan_settings_restore(const dsd_scan_settings* saved, dsd_opts* opts, dsd_st
     state->sps_hunt_idx = saved->state_sps_hunt_idx;
 }
 
+int
+dsd_scan_settings_equal(const dsd_scan_settings* a, const dsd_scan_settings* b, int include_timing) {
+    if (!a || !b) {
+        return 0;
+    }
+    if (memcmp(a, b, offsetof(dsd_scan_settings, output_name)) != 0
+        || strncmp(a->output_name, b->output_name, sizeof(a->output_name)) != 0) {
+        return 0;
+    }
+    const size_t timing_offset = offsetof(dsd_scan_settings, state_rf_mod);
+    return !include_timing
+           || memcmp((const unsigned char*)a + timing_offset, (const unsigned char*)b + timing_offset,
+                     sizeof(*a) - timing_offset)
+                  == 0;
+}
+
 dsd_decode_mode_profile
 dsd_scan_mode_profile(dsd_scan_mode mode) {
     return dsd_decode_mode_profile_for(
@@ -213,6 +229,10 @@ scan_scope_apply(dsd_opts* opts, dsd_state* state, const scan_scope* scope) {
         opts->mod_c4fm = scope->configured.mod_c4fm;
         opts->mod_qpsk = scope->configured.mod_qpsk;
         opts->mod_gfsk = scope->configured.mod_gfsk;
+        if (scope->mode == DSD_SCAN_MODE_P25) {
+            opts->mod_p25p2_c4fm = scope->configured.mod_p25p2_c4fm;
+            opts->mod_p25p2_profile_lock = scope->configured.mod_p25p2_profile_lock;
+        }
         state->rf_mod = dsd_opts_modulation(opts);
     }
     if (scope->modulation) {
@@ -225,7 +245,11 @@ scan_scope_apply(dsd_opts* opts, dsd_state* state, const scan_scope* scope) {
         opts->mod_gfsk = mod == 2;
         state->rf_mod = mod;
     }
-    const dsd_decode_mode_profile profile = dsd_scan_mode_profile(scope->mode);
+    dsd_decode_mode_profile profile = dsd_scan_mode_profile(scope->mode);
+    if (scope->mode == DSD_SCAN_MODE_P25 && opts->mod_p25p2_profile_lock
+        && scope->configured.state_sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4) {
+        profile = dsd_decode_mode_profile_for(DSDCFG_MODE_P25P2);
+    }
     scan_scope_apply_timing(opts, state, profile);
 }
 
@@ -260,6 +284,9 @@ dsd_scan_mode_enter(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode) {
         return -1;
     }
     scan_scope* scope = scan_scope_get(state);
+    if (!scope) {
+        return -1;
+    }
     scope->modulation = 0;
     scope->mode = mode;
     scope->suspended = 0;
@@ -325,7 +352,7 @@ dsd_scan_mode_resume(dsd_opts* opts, dsd_state* state) {
     }
     dsd_scan_settings effective;
     dsd_scan_settings_capture(opts, state, &effective);
-    if (memcmp(&scope->effective, &effective, offsetof(dsd_scan_settings, state_rf_mod)) == 0) {
+    if (dsd_scan_settings_equal(&scope->effective, &effective, 0)) {
         dsd_scan_settings_restore(&scope->effective, opts, state);
         return 0;
     }

--- a/src/runtime/scan_mode.c
+++ b/src/runtime/scan_mode.c
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <ctype.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    dsd_scan_settings configured;
+    dsd_scan_settings effective;
+    int modulation;
+    dsd_scan_mode mode;
+    dsdneoUserDecodeMode configured_mode;
+    int suspended;
+} scan_scope;
+
+static const char* const mode_names[] = {"", "p25", "dmr", "nxdn96", "nxdn48", "dpmr", "dstar", "ysf", "m17"};
+static const dsdneoUserDecodeMode mode_presets[] = {DSDCFG_MODE_AUTO,   DSDCFG_MODE_TDMA,   DSDCFG_MODE_DMR,
+                                                    DSDCFG_MODE_NXDN96, DSDCFG_MODE_NXDN48, DSDCFG_MODE_DPMR,
+                                                    DSDCFG_MODE_DSTAR,  DSDCFG_MODE_YSF,    DSDCFG_MODE_M17};
+
+const char*
+dsd_scan_mode_name(dsd_scan_mode mode) {
+    return (unsigned)mode < sizeof(mode_names) / sizeof(mode_names[0]) ? mode_names[mode] : "";
+}
+
+int
+dsd_scan_mode_parse(const char* text, dsd_scan_mode* mode) {
+    if (!mode) {
+        return -1;
+    }
+    if (!text) {
+        *mode = DSD_SCAN_MODE_INHERIT;
+        return 0;
+    }
+    while (isspace((unsigned char)*text)) {
+        text++;
+    }
+    size_t len = strlen(text);
+    while (len && isspace((unsigned char)text[len - 1])) {
+        len--;
+    }
+    for (size_t i = 0; i < sizeof(mode_names) / sizeof(mode_names[0]); i++) {
+        if (strlen(mode_names[i]) != len) {
+            continue;
+        }
+        size_t j = 0;
+        while (j < len && tolower((unsigned char)text[j]) == mode_names[i][j]) {
+            j++;
+        }
+        if (j == len) {
+            *mode = (dsd_scan_mode)i;
+            return 0;
+        }
+    }
+    return -1;
+}
+
+static scan_scope*
+scan_scope_get(const dsd_state* state) {
+    return DSD_STATE_EXT_GET_AS(scan_scope, state, DSD_STATE_EXT_RUNTIME_SCAN_MODE);
+}
+
+void
+dsd_scan_settings_capture(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out) {
+    if (!opts || !state || !out) {
+        return;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->frame_dstar = opts->frame_dstar;
+    out->frame_x2tdma = opts->frame_x2tdma;
+    out->frame_p25p1 = opts->frame_p25p1;
+    out->frame_p25p2 = opts->frame_p25p2;
+    out->frame_nxdn48 = opts->frame_nxdn48;
+    out->frame_nxdn96 = opts->frame_nxdn96;
+    out->frame_dmr = opts->frame_dmr;
+    out->frame_dpmr = opts->frame_dpmr;
+    out->frame_provoice = opts->frame_provoice;
+    out->frame_ysf = opts->frame_ysf;
+    out->frame_m17 = opts->frame_m17;
+    out->mod_c4fm = opts->mod_c4fm;
+    out->mod_qpsk = opts->mod_qpsk;
+    out->mod_gfsk = opts->mod_gfsk;
+    out->mod_cli_lock = opts->mod_cli_lock;
+    out->mod_p25p2_c4fm = opts->mod_p25p2_c4fm;
+    out->mod_p25p2_profile_lock = opts->mod_p25p2_profile_lock;
+    out->inverted_p2 = opts->inverted_p2;
+    out->inverted_x2tdma = opts->inverted_x2tdma;
+    out->inverted_dmr = opts->inverted_dmr;
+    out->inverted_dpmr = opts->inverted_dpmr;
+    out->inverted_ysf = opts->inverted_ysf;
+    out->inverted_m17 = opts->inverted_m17;
+    out->dmr_stereo = opts->dmr_stereo;
+    out->dmr_mono = opts->dmr_mono;
+    out->use_cosine_filter = opts->use_cosine_filter;
+    out->ssize = opts->ssize;
+    out->msize = opts->msize;
+    out->analog_only = opts->analog_only;
+    out->monitor_input_audio = opts->monitor_input_audio;
+    DSD_MEMCPY(out->output_name, opts->output_name, sizeof(out->output_name));
+    out->state_rf_mod = state->rf_mod;
+    out->state_samplesPerSymbol = state->samplesPerSymbol;
+    out->state_symbolCenter = state->symbolCenter;
+    out->state_dmr_stereo = state->dmr_stereo;
+    out->state_sps_hunt_idx = state->sps_hunt_idx;
+}
+
+static void
+scan_settings_restore_opts(const dsd_scan_settings* saved, dsd_opts* opts) {
+    opts->frame_dstar = saved->frame_dstar;
+    opts->frame_x2tdma = saved->frame_x2tdma;
+    opts->frame_p25p1 = saved->frame_p25p1;
+    opts->frame_p25p2 = saved->frame_p25p2;
+    opts->frame_nxdn48 = saved->frame_nxdn48;
+    opts->frame_nxdn96 = saved->frame_nxdn96;
+    opts->frame_dmr = saved->frame_dmr;
+    opts->frame_dpmr = saved->frame_dpmr;
+    opts->frame_provoice = saved->frame_provoice;
+    opts->frame_ysf = saved->frame_ysf;
+    opts->frame_m17 = saved->frame_m17;
+    opts->mod_c4fm = saved->mod_c4fm;
+    opts->mod_qpsk = saved->mod_qpsk;
+    opts->mod_gfsk = saved->mod_gfsk;
+    opts->mod_cli_lock = saved->mod_cli_lock;
+    opts->mod_p25p2_c4fm = saved->mod_p25p2_c4fm;
+    opts->mod_p25p2_profile_lock = saved->mod_p25p2_profile_lock;
+    opts->inverted_p2 = saved->inverted_p2;
+    opts->inverted_x2tdma = saved->inverted_x2tdma;
+    opts->inverted_dmr = saved->inverted_dmr;
+    opts->inverted_dpmr = saved->inverted_dpmr;
+    opts->inverted_ysf = saved->inverted_ysf;
+    opts->inverted_m17 = saved->inverted_m17;
+    opts->dmr_stereo = saved->dmr_stereo;
+    opts->dmr_mono = saved->dmr_mono;
+    opts->use_cosine_filter = saved->use_cosine_filter;
+    opts->ssize = saved->ssize;
+    opts->msize = saved->msize;
+    opts->analog_only = saved->analog_only;
+    opts->monitor_input_audio = saved->monitor_input_audio;
+    DSD_MEMCPY(opts->output_name, saved->output_name, sizeof(opts->output_name));
+}
+
+void
+dsd_scan_settings_restore(const dsd_scan_settings* saved, dsd_opts* opts, dsd_state* state) {
+    if (!saved || !opts || !state) {
+        return;
+    }
+    scan_settings_restore_opts(saved, opts);
+    state->rf_mod = saved->state_rf_mod;
+    state->samplesPerSymbol = saved->state_samplesPerSymbol;
+    state->symbolCenter = saved->state_symbolCenter;
+    state->dmr_stereo = saved->state_dmr_stereo;
+    state->sps_hunt_idx = saved->state_sps_hunt_idx;
+}
+
+dsd_decode_mode_profile
+dsd_scan_mode_profile(dsd_scan_mode mode) {
+    return dsd_decode_mode_profile_for(
+        (unsigned)mode < sizeof(mode_presets) / sizeof(mode_presets[0]) ? mode_presets[mode] : DSDCFG_MODE_AUTO);
+}
+
+dsd_scan_mode
+dsd_scan_mode_active(const dsd_state* state) {
+    const scan_scope* scope = scan_scope_get(state);
+    return scope && !scope->suspended ? scope->mode : DSD_SCAN_MODE_INHERIT;
+}
+
+static void
+scan_scope_apply_timing(const dsd_opts* opts, dsd_state* state, dsd_decode_mode_profile profile) {
+    int input_rate = dsd_opts_current_input_timing_rate(opts);
+    if (opts->audio_in_type == AUDIO_IN_RTL) {
+        const int live_rate = (int)dsd_rtl_stream_metrics_hook_output_rate_hz();
+        if (live_rate > 0) {
+            input_rate = live_rate;
+        }
+    }
+    state->samplesPerSymbol = dsd_opts_compute_sps_rate(opts, profile.symbol_rate_hz, input_rate);
+    state->symbolCenter = dsd_opts_symbol_center(state->samplesPerSymbol);
+    state->sps_hunt_idx = (int)profile.sps_profile_index;
+}
+
+static void
+scan_scope_apply(dsd_opts* opts, dsd_state* state, const scan_scope* scope) {
+    dsd_scan_settings_restore(&scope->configured, opts, state);
+    if (scope->mode == DSD_SCAN_MODE_INHERIT) {
+        return;
+    }
+    opts->mod_p25p2_c4fm = 0;
+    opts->mod_p25p2_profile_lock = 0;
+    const int channels = opts->pulse_digi_out_channels;
+    const int rate = opts->pulse_digi_rate_out;
+    (void)dsd_apply_decode_mode_preset(mode_presets[scope->mode], DSD_DECODE_PRESET_PROFILE_CLI, opts, state);
+    if (scope->mode == DSD_SCAN_MODE_P25) {
+        opts->frame_dmr = 0;
+        opts->frame_x2tdma = 0;
+        DSD_SNPRINTF(opts->output_name, sizeof(opts->output_name), "%s", "P25");
+    }
+    opts->pulse_digi_out_channels = channels;
+    opts->pulse_digi_rate_out = rate;
+    if (scope->configured.mod_cli_lock) {
+        opts->mod_c4fm = scope->configured.mod_c4fm;
+        opts->mod_qpsk = scope->configured.mod_qpsk;
+        opts->mod_gfsk = scope->configured.mod_gfsk;
+        state->rf_mod = dsd_opts_modulation(opts);
+    }
+    if (scope->modulation) {
+        const int mod = scope->modulation == 1 ? (scope->mode == DSD_SCAN_MODE_P25 ? 0 : 2) : scope->modulation - 2;
+        opts->mod_cli_lock = scope->modulation == 1 ? 0 : 1;
+        opts->mod_p25p2_c4fm = 0;
+        opts->mod_p25p2_profile_lock = 0;
+        opts->mod_c4fm = mod == 0;
+        opts->mod_qpsk = mod == 1;
+        opts->mod_gfsk = mod == 2;
+        state->rf_mod = mod;
+    }
+    const dsd_decode_mode_profile profile = dsd_scan_mode_profile(scope->mode);
+    scan_scope_apply_timing(opts, state, profile);
+}
+
+int
+dsd_scan_mode_begin(const dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return -1;
+    }
+    if (scan_scope_get(state)) {
+        return 0;
+    }
+    scan_scope* scope = (scan_scope*)calloc(1, sizeof(*scope));
+    if (!scope) {
+        return -1;
+    }
+    dsd_scan_settings_capture(opts, state, &scope->configured);
+    scope->configured_mode = dsd_infer_decode_mode_preset(opts);
+    (void)dsd_state_ext_set(state, DSD_STATE_EXT_RUNTIME_SCAN_MODE, scope, free);
+    return 0;
+}
+
+int
+dsd_scan_mode_enter(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode) {
+    if (!opts || !state || (unsigned)mode >= sizeof(mode_presets) / sizeof(mode_presets[0])) {
+        return -1;
+    }
+    if (mode == DSD_SCAN_MODE_INHERIT) {
+        dsd_scan_mode_leave(opts, state);
+        return 0;
+    }
+    if (dsd_scan_mode_begin(opts, state) != 0) {
+        return -1;
+    }
+    scan_scope* scope = scan_scope_get(state);
+    scope->modulation = 0;
+    scope->mode = mode;
+    scope->suspended = 0;
+    scan_scope_apply(opts, state, scope);
+    return 0;
+}
+
+dsdneoUserDecodeMode
+dsd_scan_mode_configured_preset(const dsd_opts* opts, const dsd_state* state) {
+    const scan_scope* scope = scan_scope_get(state);
+    return scope && !scope->suspended ? scope->configured_mode : dsd_infer_decode_mode_preset(opts);
+}
+
+void
+dsd_scan_mode_leave(dsd_opts* opts, dsd_state* state) {
+    scan_scope* scope = scan_scope_get(state);
+    if (!scope || !opts) {
+        return;
+    }
+    if (!scope->suspended) {
+        dsd_scan_settings_restore(&scope->configured, opts, state);
+    }
+    (void)dsd_state_ext_set(state, DSD_STATE_EXT_RUNTIME_SCAN_MODE, NULL, NULL);
+}
+
+int
+dsd_scan_mode_suspend(dsd_opts* opts, dsd_state* state) {
+    scan_scope* scope = scan_scope_get(state);
+    if (!scope || !opts || scope->suspended) {
+        return 0;
+    }
+    dsd_scan_settings_capture(opts, state, &scope->effective);
+    dsd_scan_settings_restore(&scope->configured, opts, state);
+    scope->suspended = 1;
+    return 1;
+}
+
+int
+dsd_scan_mode_updating(const dsd_state* state) {
+    const scan_scope* scope = scan_scope_get(state);
+    return scope && scope->suspended;
+}
+
+int
+dsd_scan_mode_resume(dsd_opts* opts, dsd_state* state) {
+    scan_scope* scope = scan_scope_get(state);
+    if (!scope || !opts || !scope->suspended) {
+        return 0;
+    }
+    dsd_scan_settings_capture(opts, state, &scope->configured);
+    scope->configured_mode = dsd_infer_decode_mode_preset(opts);
+    scope->suspended = 0;
+    scan_scope_apply(opts, state, scope);
+    if (scope->mode == DSD_SCAN_MODE_P25) {
+        /* Configuration updates do not move the receiver off its Phase 2 channel
+         * or erase an unlocked modulation acquired on the current P25 row. */
+        if (scope->effective.state_sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4) {
+            scan_scope_apply_timing(opts, state, dsd_decode_mode_profile_for(DSDCFG_MODE_P25P2));
+        }
+        if (!opts->mod_cli_lock) {
+            state->rf_mod = scope->effective.state_rf_mod;
+        }
+    }
+    dsd_scan_settings effective;
+    dsd_scan_settings_capture(opts, state, &effective);
+    if (memcmp(&scope->effective, &effective, offsetof(dsd_scan_settings, state_rf_mod)) == 0) {
+        dsd_scan_settings_restore(&scope->effective, opts, state);
+        return 0;
+    }
+    return 1;
+}
+
+void
+dsd_scan_mode_target_modulation(const dsd_state* state, int modulation) {
+    scan_scope* scope = scan_scope_get(state);
+    if (scope && modulation >= 0 && modulation <= 4) {
+        scope->modulation = modulation;
+    }
+}
+
+void
+dsd_scan_mode_configured(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out) {
+    if (!opts || !state || !out) {
+        return;
+    }
+    const scan_scope* scope = scan_scope_get(state);
+    if (scope && !scope->suspended) {
+        *out = scope->configured;
+    } else {
+        dsd_scan_settings_capture(opts, state, out);
+    }
+}
+
+void
+dsd_scan_mode_configured_opts(const dsd_state* state, dsd_opts* opts) {
+    const scan_scope* scope = scan_scope_get(state);
+    if (scope && !scope->suspended && opts) {
+        scan_settings_restore_opts(&scope->configured, opts);
+    }
+}
+
+void
+dsd_scan_mode_copy_snapshot(dsd_state* dst, const dsd_state* src) {
+    if (!dst || dst == src) {
+        return;
+    }
+    const scan_scope* source = scan_scope_get(src);
+    if (!source) {
+        (void)dsd_state_ext_set(dst, DSD_STATE_EXT_RUNTIME_SCAN_MODE, NULL, NULL);
+        return;
+    }
+    scan_scope* copy = scan_scope_get(dst);
+    if (!copy) {
+        copy = (scan_scope*)calloc(1, sizeof(*copy));
+        if (!copy) {
+            return;
+        }
+        (void)dsd_state_ext_set(dst, DSD_STATE_EXT_RUNTIME_SCAN_MODE, copy, free);
+    }
+    *copy = *source;
+}
+
+dsd_decode_mode_profile
+dsd_scan_mode_effective_profile(const dsd_opts* opts, const dsd_state* state) {
+    const dsd_scan_mode mode = dsd_scan_mode_active(state);
+    if (mode == DSD_SCAN_MODE_P25 && state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4) {
+        return dsd_decode_mode_profile_for(DSDCFG_MODE_P25P2);
+    }
+    return mode != DSD_SCAN_MODE_INHERIT ? dsd_scan_mode_profile(mode)
+                                         : dsd_decode_mode_profile_for(dsd_infer_decode_mode_preset(opts));
+}
+
+int
+dsd_scan_mode_prepare(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode, dsd_scan_settings* out) {
+    if (!opts || !state || !out || (unsigned)mode >= sizeof(mode_presets) / sizeof(mode_presets[0])) {
+        return -1;
+    }
+    if (mode != DSD_SCAN_MODE_INHERIT && dsd_scan_mode_begin(opts, state) != 0) {
+        return -1;
+    }
+    dsd_scan_settings effective;
+    dsd_scan_settings_capture(opts, state, &effective);
+    scan_scope temporary;
+    DSD_MEMSET(&temporary, 0, sizeof(temporary));
+    dsd_scan_mode_configured(opts, state, &temporary.configured);
+    temporary.mode = mode;
+    if (mode == DSD_SCAN_MODE_INHERIT) {
+        *out = temporary.configured;
+    } else {
+        scan_scope_apply(opts, state, &temporary);
+        dsd_scan_settings_capture(opts, state, out);
+        dsd_scan_settings_restore(&effective, opts, state);
+    }
+    return 0;
+}

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -199,8 +199,9 @@ MetricsModel::fillDecoderView(View& next, const dsd_opts* opts_snapshot, const d
      * C4FM as already-selected on a session that was never on it. Through the
      * shared helper so this and ui_handle_mod_set()'s skip test cannot drift. */
     const dsd_scan_settings* configured = dsd_scan_mode_configured_view(snapshot);
-    next.modulation =
-        configured ? (configured->mod_qpsk ? 1 : (configured->mod_gfsk ? 2 : 0)) : dsd_opts_modulation(opts_snapshot);
+    next.modulation = configured
+                          ? dsd_modulation_from_flags(configured->mod_c4fm, configured->mod_qpsk, configured->mod_gfsk)
+                          : dsd_opts_modulation(opts_snapshot);
     /* Gated on radio_input like center_freq_hz above, and for the same reason:
      * on a WAV, UDP, TCP or symbol-file session these are options the front end
      * never applied, and publishing them would put three plausible tuner

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -17,6 +17,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/scan_mode.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -163,7 +164,8 @@ MetricsModel::fillScanControlView(View& next, const dsd_opts* opts_snapshot, con
 
 void
 MetricsModel::fillDecoderView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot, double now_m) {
-    next.decode_mode = static_cast<int>(dsd_infer_decode_mode_preset(opts_snapshot));
+    next.scan_mode = QString::fromLatin1(dsd_scan_mode_name(dsd_scan_mode_active(snapshot)));
+    next.decode_mode = static_cast<int>(dsd_scan_mode_configured_preset(opts_snapshot, snapshot));
 
     /* Held for a moment after the last live sync, rather than latched until
      * something explicitly clears it.

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -198,7 +198,9 @@ MetricsModel::fillDecoderView(View& next, const dsd_opts* opts_snapshot, const d
      * select, and folding it into C4FM made a control bound to this reading show
      * C4FM as already-selected on a session that was never on it. Through the
      * shared helper so this and ui_handle_mod_set()'s skip test cannot drift. */
-    next.modulation = dsd_opts_modulation(opts_snapshot);
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(snapshot);
+    next.modulation =
+        configured ? (configured->mod_qpsk ? 1 : (configured->mod_gfsk ? 2 : 0)) : dsd_opts_modulation(opts_snapshot);
     /* Gated on radio_input like center_freq_hz above, and for the same reason:
      * on a WAV, UDP, TCP or symbol-file session these are options the front end
      * never applied, and publishing them would put three plausible tuner

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -571,40 +571,42 @@ class MetricsModel : public QObject {
     };
 
     struct View {
+        /* Group equally aligned fields; this private value is copied on each
+         * refresh and is never serialized or initialized by member position. */
         double snr_db = 0.0;
-        bool snr_valid = false;
-        bool carrier_lock = false;
         double cfo_hz = 0.0;
-        QString tuner_gain_text;
-        bool radio_input = false;
-        bool stream_active = false;
         double center_freq_hz = 0.0;
-        int channel_bandwidth_hz = 0;
-        bool synced_here = false;
-        QString sync_label;
-        bool trunkable_sync = false;
-        int decode_mode = 0;
-        QString scan_mode;
-        int modulation = 0;
-        int tuner_gain_db = 0;
         double squelch_db = 0.0;
-        bool squelch_off = false;
-        int ppm = 0;
-        bool audio_muted = false;
         qulonglong held_tg = 0;
-        int enc_lockout_count = 0;
-        bool tuner_controlled = false;
-        bool trunking_enabled = false;
-        bool scanner_mode = false;
-        bool scan_rotation_active = false;
-        bool scan_hold = false;
-        int scan_avoid_count = 0;
-        bool scan_target_avoided = false;
+        QString tuner_gain_text;
+        QString sync_label;
+        QString scan_mode;
         QString ui_message;
         /* Sized from the canonical constant rather than a literal 2: leadSlot() ranks the
          * whole array through dsd_app_lead_slot(), so the two must agree or the ranking
          * would read past the end the day a third slot appears. */
         SlotCall slot_call[DSD_CALL_STATE_SLOT_COUNT];
+        int channel_bandwidth_hz = 0;
+        int decode_mode = 0;
+        int modulation = 0;
+        int tuner_gain_db = 0;
+        int ppm = 0;
+        int enc_lockout_count = 0;
+        int scan_avoid_count = 0;
+        bool snr_valid = false;
+        bool carrier_lock = false;
+        bool radio_input = false;
+        bool stream_active = false;
+        bool synced_here = false;
+        bool trunkable_sync = false;
+        bool squelch_off = false;
+        bool audio_muted = false;
+        bool tuner_controlled = false;
+        bool trunking_enabled = false;
+        bool scanner_mode = false;
+        bool scan_rotation_active = false;
+        bool scan_hold = false;
+        bool scan_target_avoided = false;
 
         /* Exact comparison is right for the two doubles: they are carried through
          * unmodified from the metrics boundary, so "unchanged" means the identical

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -78,6 +78,7 @@ class MetricsModel : public QObject {
     Q_PROPERTY(QString syncLabel READ syncLabel NOTIFY tunerChanged)
     Q_PROPERTY(bool trunkableSync READ trunkableSync NOTIFY tunerChanged)
     Q_PROPERTY(int decodeMode READ decodeMode NOTIFY controlChanged)
+    Q_PROPERTY(QString scanMode READ scanMode NOTIFY controlChanged)
     Q_PROPERTY(int modulation READ modulation NOTIFY controlChanged)
     Q_PROPERTY(int tunerGainDb READ tunerGainDb NOTIFY controlChanged)
     Q_PROPERTY(double squelchDb READ squelchDb NOTIFY controlChanged)
@@ -248,6 +249,11 @@ class MetricsModel : public QObject {
      * decodeMode is a dsdneoUserDecodeMode; modulation is 0 for C4FM, 1 for QPSK
      * and 2 for GFSK, matching DSD_APP_CMD_MOD_SET's payload and dsd_state::rf_mod.
      */
+    QString
+    scanMode() const {
+        return m_view.scan_mode;
+    }
+
     int
     decodeMode() const {
         return m_view.decode_mode;
@@ -578,6 +584,7 @@ class MetricsModel : public QObject {
         QString sync_label;
         bool trunkable_sync = false;
         int decode_mode = 0;
+        QString scan_mode;
         int modulation = 0;
         int tuner_gain_db = 0;
         double squelch_db = 0.0;
@@ -626,9 +633,9 @@ class MetricsModel : public QObject {
             return audio_muted == other.audio_muted && held_tg == other.held_tg
                    && enc_lockout_count == other.enc_lockout_count && tuner_controlled == other.tuner_controlled
                    && trunking_enabled == other.trunking_enabled && scanner_mode == other.scanner_mode
-                   && scanControlEquals(other) && decode_mode == other.decode_mode && modulation == other.modulation
-                   && tuner_gain_db == other.tuner_gain_db && squelch_db == other.squelch_db
-                   && squelch_off == other.squelch_off && ppm == other.ppm;
+                   && scanControlEquals(other) && scan_mode == other.scan_mode && decode_mode == other.decode_mode
+                   && modulation == other.modulation && tuner_gain_db == other.tuner_gain_db
+                   && squelch_db == other.squelch_db && squelch_off == other.squelch_off && ppm == other.ppm;
         }
     };
 

--- a/src/ui/terminal/menu_actions.c
+++ b/src/ui/terminal/menu_actions.c
@@ -19,6 +19,7 @@
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1499,7 +1500,8 @@ act_decode_mode(void* v) {
        and Auto is the one choice the command layer never treats as a no-op: it
        re-enables every protocol and resets the modulation, so a stray second Enter
        would drag a settled QPSK session back to C4FM. */
-    const dsdneoUserDecodeMode now = (c && c->opts) ? dsd_infer_decode_mode_preset(c->opts) : DSDCFG_MODE_AUTO;
+    const dsdneoUserDecodeMode now =
+        (c && c->opts) ? dsd_scan_mode_configured_preset(c->opts, c->state) : DSDCFG_MODE_AUTO;
     ui_chooser_start_at("Decoder mode", g_decode_mode_labels, (int)DECODE_MODE_CHOICE_COUNT,
                         decode_mode_choice_index(now), chooser_done_decode_mode, NULL);
 }

--- a/src/ui/terminal/menu_actions.c
+++ b/src/ui/terminal/menu_actions.c
@@ -11,8 +11,10 @@
 #include "menu_actions.h"
 #include <dsd-neo/app_control/commands.h>
 #include <dsd-neo/app_control/frontend.h>
+#include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/platform/audio.h>
@@ -263,8 +265,14 @@ act_config_save_current(void* v) {
         return;
     }
 
+    const dsd_opts* opts_snapshot = dsd_app_get_latest_opts_snapshot();
+    const dsd_state* snapshot = dsd_app_get_latest_snapshot();
+    if (!opts_snapshot || !snapshot) {
+        ui_statusf("Decoder settings are not available yet");
+        return;
+    }
     dsdneoUserConfig cfg;
-    dsd_snapshot_opts_to_user_config(c->opts, c->state, &cfg);
+    dsd_snapshot_opts_to_user_config(opts_snapshot, snapshot, &cfg);
     if (dsd_user_config_save_atomic(path, &cfg) == 0) {
         ui_statusf("Config saved to %s", path);
     } else {
@@ -284,8 +292,14 @@ act_config_save_default(void* v) {
         ui_statusf("No default config path; nothing saved");
         return;
     }
+    const dsd_opts* opts_snapshot = dsd_app_get_latest_opts_snapshot();
+    const dsd_state* snapshot = dsd_app_get_latest_snapshot();
+    if (!opts_snapshot || !snapshot) {
+        ui_statusf("Decoder settings are not available yet");
+        return;
+    }
     dsdneoUserConfig cfg;
-    dsd_snapshot_opts_to_user_config(c->opts, c->state, &cfg);
+    dsd_snapshot_opts_to_user_config(opts_snapshot, snapshot, &cfg);
     if (dsd_user_config_save_atomic(path, &cfg) == 0) {
         ui_submit_config_metadata(1, path);
         ui_statusf("Config saved to %s", path);
@@ -1500,8 +1514,10 @@ act_decode_mode(void* v) {
        and Auto is the one choice the command layer never treats as a no-op: it
        re-enables every protocol and resets the modulation, so a stray second Enter
        would drag a settled QPSK session back to C4FM. */
+    const dsd_opts* opts_snapshot = c ? dsd_app_get_latest_opts_snapshot() : NULL;
+    const dsd_state* snapshot = c ? dsd_app_get_latest_snapshot() : NULL;
     const dsdneoUserDecodeMode now =
-        (c && c->opts) ? dsd_scan_mode_configured_preset(c->opts, c->state) : DSDCFG_MODE_AUTO;
+        opts_snapshot ? dsd_scan_mode_configured_preset(opts_snapshot, snapshot) : DSDCFG_MODE_AUTO;
     ui_chooser_start_at("Decoder mode", g_decode_mode_labels, (int)DECODE_MODE_CHOICE_COUNT,
                         decode_mode_choice_index(now), chooser_done_decode_mode, NULL);
 }

--- a/src/ui/terminal/menu_callbacks.c
+++ b/src/ui/terminal/menu_callbacks.c
@@ -11,9 +11,12 @@
 #include "menu_callbacks.h"
 #include <dsd-neo/app_control/commands.h>
 #include <dsd-neo/app_control/rr_import_apply.h>
+#include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/config.h>
 #include <stdint.h>
@@ -303,8 +306,14 @@ cb_config_save_as(void* v, const char* path) {
         ui_statusf("Config save canceled");
         return;
     }
+    const dsd_opts* opts_snapshot = dsd_app_get_latest_opts_snapshot();
+    const dsd_state* snapshot = dsd_app_get_latest_snapshot();
+    if (!opts_snapshot || !snapshot) {
+        ui_statusf("Decoder settings are not available yet");
+        return;
+    }
     dsdneoUserConfig cfg;
-    dsd_snapshot_opts_to_user_config(c->opts, c->state, &cfg);
+    dsd_snapshot_opts_to_user_config(opts_snapshot, snapshot, &cfg);
     if (dsd_user_config_save_atomic(path, &cfg) == 0) {
         ui_submit_config_metadata(1, path);
         ui_statusf("Config saved to %s", path);

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -11,6 +11,7 @@
 #include "menu_labels.h"
 #include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/app_control/history.h>
+#include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/enc_lockout.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
@@ -217,9 +218,14 @@ is_ted_allowed(const void* v) {
 const char*
 lbl_decode_mode(const void* v, char* b, size_t n) {
     const UiCtx* c = (const UiCtx*)v;
-    dsdneoUserDecodeMode mode = (c && c->opts) ? dsd_scan_mode_configured_preset(c->opts, c->state) : DSDCFG_MODE_AUTO;
+    /* Menu contexts point at the live decoder. Extension-backed reads must use the
+     * published copies, whose lifetime belongs to this UI consumer thread. */
+    const dsd_state* snapshot = c ? dsd_app_get_latest_snapshot() : NULL;
+    const dsd_opts* opts_snapshot = c ? dsd_app_get_latest_opts_snapshot() : NULL;
+    dsdneoUserDecodeMode mode =
+        opts_snapshot ? dsd_scan_mode_configured_preset(opts_snapshot, snapshot) : DSDCFG_MODE_AUTO;
     /* "..." because the row opens a picker; without it the grammar promises a toggle. */
-    const dsd_scan_mode active = c ? dsd_scan_mode_active(c->state) : DSD_SCAN_MODE_INHERIT;
+    const dsd_scan_mode active = dsd_scan_mode_active(snapshot);
     if (active != DSD_SCAN_MODE_INHERIT) {
         DSD_SNPRINTF(b, n, "Mode... [%s; scan %s]", dsd_decode_mode_display_name(mode), dsd_scan_mode_name(active));
     } else {

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -19,6 +19,7 @@
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/radioreference.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <stdint.h>
 #include <string.h>
 #include "dsd-neo/core/opts_fwd.h"
@@ -216,9 +217,14 @@ is_ted_allowed(const void* v) {
 const char*
 lbl_decode_mode(const void* v, char* b, size_t n) {
     const UiCtx* c = (const UiCtx*)v;
-    dsdneoUserDecodeMode mode = (c && c->opts) ? dsd_infer_decode_mode_preset(c->opts) : DSDCFG_MODE_AUTO;
+    dsdneoUserDecodeMode mode = (c && c->opts) ? dsd_scan_mode_configured_preset(c->opts, c->state) : DSDCFG_MODE_AUTO;
     /* "..." because the row opens a picker; without it the grammar promises a toggle. */
-    DSD_SNPRINTF(b, n, "Mode... [%s]", dsd_decode_mode_display_name(mode));
+    const dsd_scan_mode active = c ? dsd_scan_mode_active(c->state) : DSD_SCAN_MODE_INHERIT;
+    if (active != DSD_SCAN_MODE_INHERIT) {
+        DSD_SNPRINTF(b, n, "Mode... [%s; scan %s]", dsd_decode_mode_display_name(mode), dsd_scan_mode_name(active));
+    } else {
+        DSD_SNPRINTF(b, n, "Mode... [%s]", dsd_decode_mode_display_name(mode));
+    }
     return b;
 }
 

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -815,19 +815,27 @@ lbl_gain_ana(const void* v, char* b, size_t n) {
 
 const char*
 lbl_monitor(const void* v, char* b, size_t n) {
-    (void)v;
-    dsd_scan_settings configured = {0};
-    dsd_app_snapshot_configured_mode(dsd_app_get_latest_opts_snapshot(), dsd_app_get_latest_snapshot(), &configured);
-    DSD_SNPRINTF(b, n, "Source audio monitor [%s]", onoff(configured.monitor_input_audio));
+    const UiCtx* c = (const UiCtx*)v;
+    const dsd_opts* opts = dsd_app_get_latest_opts_snapshot();
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(dsd_app_get_latest_snapshot());
+    if (!opts) {
+        opts = c ? c->opts : NULL;
+    }
+    const int enabled = configured ? configured->monitor_input_audio : (opts && opts->monitor_input_audio);
+    DSD_SNPRINTF(b, n, "Source audio monitor [%s]", onoff(enabled));
     return b;
 }
 
 const char*
 lbl_cosine(const void* v, char* b, size_t n) {
-    (void)v;
-    dsd_scan_settings configured = {0};
-    dsd_app_snapshot_configured_mode(dsd_app_get_latest_opts_snapshot(), dsd_app_get_latest_snapshot(), &configured);
-    DSD_SNPRINTF(b, n, "Cosine filter [%s]", onoff(configured.use_cosine_filter));
+    const UiCtx* c = (const UiCtx*)v;
+    const dsd_opts* opts = dsd_app_get_latest_opts_snapshot();
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(dsd_app_get_latest_snapshot());
+    if (!opts) {
+        opts = c ? c->opts : NULL;
+    }
+    const int enabled = configured ? configured->use_cosine_filter : (opts && opts->use_cosine_filter);
+    DSD_SNPRINTF(b, n, "Cosine filter [%s]", onoff(enabled));
     return b;
 }
 

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -234,15 +234,39 @@ lbl_decode_mode(const void* v, char* b, size_t n) {
     return b;
 }
 
+typedef struct {
+    int modulation;
+    int qpsk;
+    int p25p2_c4fm;
+    int p25p2_profile_lock;
+    int flag_modulation;
+} menu_modulation_settings;
+
+static menu_modulation_settings
+menu_configured_modulation(const UiCtx* c) {
+    const dsd_state* snapshot = c ? dsd_app_get_latest_snapshot() : NULL;
+    const dsd_opts* opts_snapshot = c ? dsd_app_get_latest_opts_snapshot() : NULL;
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(snapshot);
+    if (configured) {
+        const menu_modulation_settings result = {
+            configured->state_rf_mod, configured->mod_qpsk, configured->mod_p25p2_c4fm,
+            configured->mod_p25p2_profile_lock,
+            dsd_modulation_from_flags(configured->mod_c4fm, configured->mod_qpsk, configured->mod_gfsk)};
+        return result;
+    }
+    const dsd_state* state = snapshot ? snapshot : (c ? c->state : NULL);
+    const dsd_opts* opts = opts_snapshot ? opts_snapshot : (c ? c->opts : NULL);
+    const menu_modulation_settings result = {state ? state->rf_mod : -1, opts ? opts->mod_qpsk : 0,
+                                             opts ? opts->mod_p25p2_c4fm : 0, opts ? opts->mod_p25p2_profile_lock : 0,
+                                             dsd_opts_modulation(opts)};
+    return result;
+}
+
 const char*
 lbl_modulation(const void* v, char* b, size_t n) {
-    const UiCtx* c = (const UiCtx*)v;
-    int mod = -1;
-    if (c && c->state && c->state->rf_mod >= 0 && c->state->rf_mod <= 2) {
-        mod = c->state->rf_mod;
-    } else if (c && c->opts) {
-        mod = dsd_opts_modulation(c->opts);
-    }
+    const menu_modulation_settings settings = menu_configured_modulation((const UiCtx*)v);
+    const int mod =
+        settings.modulation >= 0 && settings.modulation <= 2 ? settings.modulation : settings.flag_modulation;
     const char* name = (mod == 1) ? "QPSK" : ((mod == 2) ? "GFSK" : "C4FM");
     DSD_SNPRINTF(b, n, "Modulation [%s]", name);
     return b;
@@ -250,22 +274,16 @@ lbl_modulation(const void* v, char* b, size_t n) {
 
 const char*
 lbl_p25p2_mod_lock(const void* v, char* b, size_t n) {
-    const UiCtx* c = (const UiCtx*)v;
+    const menu_modulation_settings settings = menu_configured_modulation((const UiCtx*)v);
     const char* s = "Off";
-    /* Which modulation the lock pinned, read from the modulation itself. Reading
-       opts->mod_p25p2_c4fm instead reported QPSK forever: ui_handle_mod_p2_toggle()
-       -- the only thing this row and its 'M' hotkey run -- clears that flag on every
-       press and expresses the choice through mod_qpsk/rf_mod. The flag is a CLI-only
-       spelling of "P25p2 C4FM at 6000 sps", so it still counts as a lock. */
-    if (c && c->opts && (c->opts->mod_p25p2_profile_lock || c->opts->mod_p25p2_c4fm)) {
-        int qpsk = (c->opts->mod_qpsk != 0);
-        if (c->state && c->state->rf_mod >= 0 && c->state->rf_mod <= 2) {
-            qpsk = (c->state->rf_mod == 1);
+    /* The toggle expresses its lock through rf_mod; the CLI's C4FM helper
+     * additionally pins C4FM even when the saved live modulation differs. */
+    if (settings.p25p2_profile_lock || settings.p25p2_c4fm) {
+        int qpsk = settings.qpsk != 0;
+        if (settings.modulation >= 0 && settings.modulation <= 2) {
+            qpsk = settings.modulation == 1;
         }
-        if (c->opts->mod_p25p2_c4fm) {
-            qpsk = 0;
-        }
-        s = qpsk ? "QPSK" : "C4FM";
+        s = qpsk && !settings.p25p2_c4fm ? "QPSK" : "C4FM";
     }
     DSD_SNPRINTF(b, n, "P25 Phase 2 modulation lock [%s]", s);
     return b;

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -815,15 +815,19 @@ lbl_gain_ana(const void* v, char* b, size_t n) {
 
 const char*
 lbl_monitor(const void* v, char* b, size_t n) {
-    const UiCtx* c = (const UiCtx*)v;
-    DSD_SNPRINTF(b, n, "Source audio monitor [%s]", onoff(c->opts->monitor_input_audio));
+    (void)v;
+    dsd_scan_settings configured = {0};
+    dsd_app_snapshot_configured_mode(dsd_app_get_latest_opts_snapshot(), dsd_app_get_latest_snapshot(), &configured);
+    DSD_SNPRINTF(b, n, "Source audio monitor [%s]", onoff(configured.monitor_input_audio));
     return b;
 }
 
 const char*
 lbl_cosine(const void* v, char* b, size_t n) {
-    const UiCtx* c = (const UiCtx*)v;
-    DSD_SNPRINTF(b, n, "Cosine filter [%s]", onoff(c->opts->use_cosine_filter));
+    (void)v;
+    dsd_scan_settings configured = {0};
+    dsd_app_snapshot_configured_mode(dsd_app_get_latest_opts_snapshot(), dsd_app_get_latest_snapshot(), &configured);
+    DSD_SNPRINTF(b, n, "Cosine filter [%s]", onoff(configured.use_cosine_filter));
     return b;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4526,7 +4526,7 @@ add_test(NAME ENGINE_CHANNEL_SCAN COMMAND dsd-neo_test_engine_channel_scan)
 add_executable(
     dsd-neo_test_engine_trunk_scan
     engine/test_engine_trunk_scan.c
-    test_support/channel_scan_stubs.c
+    ${PROJECT_SOURCE_DIR}/src/engine/channel_scan.c
     ${PROJECT_SOURCE_DIR}/src/engine/trunk_scan.c
     ${PROJECT_SOURCE_DIR}/src/engine/scan_voice_gate.c
     ${PROJECT_SOURCE_DIR}/src/engine/p25_bandplan_export.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1658,6 +1658,17 @@ target_link_libraries(
     dsd-neo_test_app_control_actions
     PRIVATE dsd-neo_test_call_state_support
 )
+target_sources(
+    dsd-neo_test_app_control_actions
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/src/runtime/scan_mode.c
+        ${PROJECT_SOURCE_DIR}/src/runtime/rtl_stream_metrics_hooks.c
+)
+
+target_sources(
+    dsd-neo_test_app_control_actions
+    PRIVATE test_support/channel_scan_stubs.c
+)
 add_test(NAME APP_CONTROL_ACTIONS COMMAND dsd-neo_test_app_control_actions)
 
 add_executable(
@@ -1674,6 +1685,10 @@ target_compile_definitions(
 target_include_directories(
     dsd-neo_test_app_control_actions_rtl
     PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/app_control
+)
+target_link_libraries(
+    dsd-neo_test_app_control_actions_rtl
+    PRIVATE dsd-neo_runtime
 )
 add_test(
     NAME APP_CONTROL_ACTIONS_RTL
@@ -1707,6 +1722,11 @@ target_link_libraries(
     dsd-neo_test_ui_menu_services
     PRIVATE ${DSD_NEO_TEST_MATH_LIB}
 )
+target_link_libraries(dsd-neo_test_ui_menu_services PRIVATE dsd-neo_runtime)
+target_sources(
+    dsd-neo_test_ui_menu_services
+    PRIVATE test_support/channel_scan_stubs.c
+)
 add_test(NAME UI_MENU_SERVICES COMMAND dsd-neo_test_ui_menu_services)
 
 if(DSD_ENABLE_TERMINAL_UI)
@@ -1722,6 +1742,10 @@ if(DSD_ENABLE_TERMINAL_UI)
             ${PROJECT_SOURCE_DIR}/include
             ${PROJECT_SOURCE_DIR}/src/ui/terminal
             ${CURSES_INCLUDE_DIRS}
+    )
+    target_sources(
+        dsd-neo_test_ui_menu_labels
+        PRIVATE test_support/scan_mode_label_stubs.c
     )
     add_test(NAME UI_MENU_LABELS COMMAND dsd-neo_test_ui_menu_labels)
 
@@ -1741,6 +1765,10 @@ if(DSD_ENABLE_TERMINAL_UI)
     target_compile_definitions(
         dsd-neo_test_ui_menu_labels_radio
         PRIVATE USE_RADIO
+    )
+    target_sources(
+        dsd-neo_test_ui_menu_labels_radio
+        PRIVATE test_support/scan_mode_label_stubs.c
     )
     add_test(
         NAME UI_MENU_LABELS_RADIO
@@ -2067,6 +2095,10 @@ if(DSD_ENABLE_TERMINAL_UI)
     target_link_libraries(
         dsd-neo_test_ui_menu_actions
         PRIVATE ${DSD_NEO_TEST_MATH_LIB}
+    )
+    target_sources(
+        dsd-neo_test_ui_menu_actions
+        PRIVATE test_support/scan_mode_label_stubs.c
     )
     add_test(NAME UI_MENU_ACTIONS COMMAND dsd-neo_test_ui_menu_actions)
 
@@ -2980,6 +3012,10 @@ target_link_libraries(
     dsd-neo_test_app_control_snapshot_event_history
     PRIVATE dsd-neo_test_call_state_support dsd-neo_platform
 )
+target_link_libraries(
+    dsd-neo_test_app_control_snapshot_event_history
+    PRIVATE dsd-neo_runtime
+)
 add_test(
     NAME APP_CONTROL_SNAPSHOT_EVENT_HISTORY
     COMMAND dsd-neo_test_app_control_snapshot_event_history
@@ -3717,6 +3753,13 @@ target_link_libraries(
 )
 add_test(NAME CORE_CSV_IMPORT COMMAND dsd-neo_test_core_csv_import)
 
+add_executable(dsd-neo_test_core_channel_modes core/test_core_channel_modes.c)
+target_link_libraries(
+    dsd-neo_test_core_channel_modes
+    PRIVATE dsd-neo_core dsd-neo_proto_dmr
+)
+add_test(NAME CORE_CHANNEL_MODES COMMAND dsd-neo_test_core_channel_modes)
+
 add_executable(dsd-neo_test_core_key_set core/test_core_key_set.c)
 target_include_directories(
     dsd-neo_test_core_key_set
@@ -3773,6 +3816,10 @@ add_executable(
 target_include_directories(
     dsd-neo_test_core_state_trunk_lcn_avoid
     PRIVATE ${PROJECT_SOURCE_DIR}/include
+)
+target_link_libraries(
+    dsd-neo_test_core_state_trunk_lcn_avoid
+    PRIVATE dsd-neo_runtime
 )
 add_test(
     NAME CORE_STATE_TRUNK_LCN_AVOID
@@ -4453,14 +4500,33 @@ target_link_libraries(
     dsd-neo_test_engine_trunk_retune_regression
     PRIVATE dsd-neo_feature_radio
 )
+target_sources(
+    dsd-neo_test_engine_trunk_retune_regression
+    PRIVATE ${PROJECT_SOURCE_DIR}/src/dsp/frame_sync_profile.c
+)
 add_test(
     NAME ENGINE_TRUNK_RETUNE_REGRESSION
     COMMAND dsd-neo_test_engine_trunk_retune_regression
 )
 
 add_executable(
+    dsd-neo_test_engine_channel_scan
+    engine/test_engine_channel_scan.c
+    ${PROJECT_SOURCE_DIR}/src/engine/channel_scan.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/key_set.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/enc_lockout.c
+)
+target_link_libraries(
+    dsd-neo_test_engine_channel_scan
+    PRIVATE dsd-neo_runtime dsd-neo_test_call_state_support dsd-neo_test_support
+)
+add_test(NAME ENGINE_CHANNEL_SCAN COMMAND dsd-neo_test_engine_channel_scan)
+
+add_executable(
     dsd-neo_test_engine_trunk_scan
     engine/test_engine_trunk_scan.c
+    test_support/channel_scan_stubs.c
     ${PROJECT_SOURCE_DIR}/src/engine/trunk_scan.c
     ${PROJECT_SOURCE_DIR}/src/engine/scan_voice_gate.c
     ${PROJECT_SOURCE_DIR}/src/engine/p25_bandplan_export.c
@@ -4530,6 +4596,16 @@ target_link_libraries(
     PRIVATE dsd-neo_runtime dsd-neo_test_support
 )
 add_test(NAME RUNTIME_RR_PROVENANCE COMMAND dsd-neo_test_runtime_rr_provenance)
+
+add_executable(dsd-neo_test_runtime_scan_mode runtime/test_runtime_scan_mode.c)
+target_link_libraries(dsd-neo_test_runtime_scan_mode PRIVATE dsd-neo_runtime)
+add_test(NAME RUNTIME_SCAN_MODE COMMAND dsd-neo_test_runtime_scan_mode)
+
+add_executable(dsd-neo_test_scan_mode_replay engine/scan_mode_replay.c)
+target_link_libraries(
+    dsd-neo_test_scan_mode_replay
+    PRIVATE dsd-neo_engine ${LIBS}
+)
 
 add_executable(
     dsd-neo_test_runtime_decode_mode
@@ -9721,4 +9797,42 @@ if(DSD_HAS_RADIO)
     )
     add_test(NAME ENGINE_RESTART COMMAND dsd-neo_test_engine_restart)
     set_tests_properties(ENGINE_RESTART PROPERTIES TIMEOUT 240)
+endif()
+
+if(DSD_HAS_RADIO)
+    foreach(scan_case IN ITEMS nxdn48 p25p1_c4fm_vc p25p1_cqpsk_vc)
+        if(scan_case STREQUAL "nxdn48")
+            set(scan_class nxdn48)
+            set(scan_global "-f1")
+            set(scan_expected "Src=901")
+        elseif(scan_case STREQUAL "p25p1_c4fm_vc")
+            set(scan_class p25)
+            set(scan_global "-fi -mc")
+            set(scan_expected "Group Voice Channel User")
+        else()
+            set(scan_class p25)
+            set(scan_global "-fi -mq")
+            set(scan_expected "Group Voice Channel User")
+        endif()
+        set(scan_csv "${CMAKE_CURRENT_BINARY_DIR}/scan_mode_${scan_case}.csv")
+        file(
+            WRITE "${scan_csv}"
+            "channel,frequency_hz,mode\n1,150000000,${scan_class}\n"
+        )
+        string(TOUPPER "${scan_case}" scan_test_suffix)
+        add_test(
+            NAME DECODE_IQ_SCAN_${scan_test_suffix}
+            COMMAND
+                ${CMAKE_COMMAND}
+                -DDSD_BIN=$<TARGET_FILE:dsd-neo_test_scan_mode_replay>
+                "-DMODE=${scan_global} -C ${scan_csv}"
+                -DFIXTURE=${PROJECT_SOURCE_DIR}/tests/fixtures/iq/${scan_case}.iq.json
+                "-DEXPECTED=${scan_expected}" -P
+                ${PROJECT_SOURCE_DIR}/tests/iq_decode_check.cmake
+        )
+        set_tests_properties(
+            DECODE_IQ_SCAN_${scan_test_suffix}
+            PROPERTIES LABELS iq-decode TIMEOUT 120
+        )
+    endforeach()
 endif()

--- a/tests/core/test_core_channel_modes.c
+++ b/tests/core/test_core_channel_modes.c
@@ -96,6 +96,43 @@ main(void) {
     assert(dsd_channel_modes_present(s));
     assert(dsd_channel_mode_set(s, 0, DSD_SCAN_MODE_INHERIT) == 0);
     assert(!dsd_channel_modes_present(s));
+    clear(s);
+    fp = dsd_fopen_private(o->chan_in_file, "w");
+    assert(fp);
+    DSD_FPRINTF(fp, "chan,freq,notes,mode\n1,150000000,");
+    for (int i = 0; i < 2048; i++) {
+        assert(fputc('x', fp) != EOF);
+    }
+    DSD_FPRINTF(fp, ",nxdn48\n2,150000001,,dmr\n");
+    assert(fclose(fp) == 0);
+    assert(csvChanImport(o, s) == 0 && s->lcn_freq_count == 2);
+    assert(dsd_channel_mode_get(s, 0) == DSD_SCAN_MODE_NXDN48);
+    assert(dsd_channel_mode_get(s, 1) == DSD_SCAN_MODE_DMR);
+    clear(s);
+    fp = dsd_fopen_private(o->chan_in_file, "w");
+    assert(fp);
+    DSD_FPRINTF(fp, "chan,freq");
+    for (int i = 0; i < 400; i++) {
+        DSD_FPRINTF(fp, ",ignored");
+    }
+    DSD_FPRINTF(fp, ",mode\n1,150000000");
+    for (int i = 0; i < 400; i++) {
+        assert(fputc(',', fp) != EOF);
+    }
+    DSD_FPRINTF(fp, ",p25"); /* EOF without a newline is still one complete row. */
+    assert(fclose(fp) == 0);
+    assert(csvChanImport(o, s) == 0 && s->lcn_freq_count == 1);
+    assert(dsd_channel_mode_get(s, 0) == DSD_SCAN_MODE_P25);
+    clear(s);
+    fp = dsd_fopen_private(o->chan_in_file, "w");
+    assert(fp);
+    DSD_FPRINTF(fp, "chan,freq,notes,mode\n1,150000000,");
+    for (int i = 0; i < 1024 * 1024; i++) {
+        assert(fputc('x', fp) != EOF);
+    }
+    DSD_FPRINTF(fp, ",dmr\n");
+    assert(fclose(fp) == 0);
+    assert(csvChanImport(o, s) == -1 && s->lcn_freq_count == 0);
     assert(remove(o->chan_in_file) == 0);
     clear(s);
     clear(dst);

--- a/tests/core/test_core_channel_modes.c
+++ b/tests/core/test_core_channel_modes.c
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <assert.h>
+#include <dsd-neo/core/channel_mode.h>
+#include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/protocol/nxdn/nxdn_lfsr.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void
+LFSRN(const char* in, char* out, dsd_state* state) {
+    (void)in;
+    (void)out;
+    (void)state;
+}
+
+static void
+write_csv(const char* path, const char* content) {
+    FILE* fp = dsd_fopen_private(path, "w");
+    assert(fp);
+    assert(fputs(content, fp) >= 0);
+    assert(fclose(fp) == 0);
+}
+
+static void
+clear(dsd_state* s) {
+    dsd_state_trunk_lcn_free(s);
+    dsd_state_ext_free_all(s);
+    DSD_MEMSET(s, 0, sizeof(*s));
+}
+
+int
+main(void) {
+    dsd_opts* o = (dsd_opts*)calloc(1, sizeof(*o));
+    dsd_state* s = (dsd_state*)calloc(1, sizeof(*s));
+    dsd_state* dst = (dsd_state*)calloc(1, sizeof(*dst));
+    assert(o && s && dst);
+    DSD_SNPRINTF(o->chan_in_file, sizeof(o->chan_in_file), "%s", "test-channel-modes.csv");
+    write_csv(o->chan_in_file,
+              "chan,freq,notes,MODE,name,name\n1,150000000,x, NXDN48 ,First,Other\n"
+              "1,150000000,x,P25,Second,Other\n3,0,x,dmr,Placeholder,Other\n4,150000002,x,,Blank,Other\n");
+    assert(csvChanImport(o, s) == 0 && s->lcn_freq_count == 4);
+    assert(dsd_channel_mode_get(s, 0) == DSD_SCAN_MODE_NXDN48);
+    assert(dsd_channel_mode_get(s, 1) == DSD_SCAN_MODE_P25);
+    assert(dsd_channel_mode_get(s, 2) == DSD_SCAN_MODE_DMR);
+    assert(dsd_channel_mode_get(s, 3) == DSD_SCAN_MODE_INHERIT);
+    assert(strcmp(dsd_state_trunk_lcn_name_get(s, 0), "First") == 0);
+    assert(*dsd_state_trunk_lcn_slot(s, 0) == *dsd_state_trunk_lcn_slot(s, 1));
+    assert(*dsd_state_trunk_lcn_slot(s, 2) == 0);
+    assert(dsd_channel_mode_set(dst, 0, DSD_SCAN_MODE_M17) == 0);
+    dsd_channel_modes_move(dst, s);
+    assert(!s->state_ext[DSD_STATE_EXT_CORE_CHANNEL_MODES]);
+    assert(dsd_channel_mode_get(dst, 1) == DSD_SCAN_MODE_P25);
+    clear(s);
+    write_csv(o->chan_in_file, "chan,freq,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,mode,name,single_key_dec\n"
+                               "1,150000000,,,,,,,,,,,,,,,,,nxdn96,Late,123\n");
+    assert(csvChanImport(o, s) == 0);
+    assert(dsd_channel_mode_get(s, 0) == DSD_SCAN_MODE_NXDN96);
+    assert(strcmp(dsd_state_trunk_lcn_name_get(s, 0), "Late") == 0);
+    clear(s);
+    write_csv(o->chan_in_file, "chan,freq,mode\ninvalid,150000000,typo\n");
+    assert(csvChanImport(o, s) == -1);
+    clear(s);
+    write_csv(o->chan_in_file, "chan,freq,mode,MoDe\n1,150000000,dmr,dmr\n");
+    assert(csvChanImport(o, s) == -1);
+    clear(s);
+    write_csv(o->chan_in_file, "chan,freq,mode\ninvalid,150000000,dmr\n1,150000000,m17\n");
+    assert(csvChanImport(o, s) == 0 && s->lcn_freq_count == 1);
+    assert(dsd_channel_mode_get(s, 0) == DSD_SCAN_MODE_M17);
+    clear(s);
+    FILE* fp = dsd_fopen_private(o->chan_in_file, "w");
+    assert(fp);
+    DSD_FPRINTF(fp, "chan,freq,mode\n");
+    for (int i = 0; i < 128; i++) {
+        DSD_FPRINTF(fp, "%d,150000000,%s\n", i, i % 2 ? "dmr" : "nxdn48");
+    }
+    assert(fclose(fp) == 0);
+    assert(csvChanImport(o, s) == 0 && s->lcn_freq_count == 128);
+    assert(dsd_channel_mode_get(s, 127) == DSD_SCAN_MODE_DMR);
+    clear(s);
+    write_csv(o->chan_in_file, "chan,freq,notes\n1,150000000,dmr\n");
+    assert(csvChanImport(o, s) == 0 && !dsd_channel_modes_present(s));
+    assert(dsd_channel_mode_set(s, 0, DSD_SCAN_MODE_DMR) == 0);
+    assert(dsd_channel_modes_present(s));
+    assert(dsd_channel_mode_set(s, 0, DSD_SCAN_MODE_P25) == 0);
+    assert(dsd_channel_modes_present(s));
+    assert(dsd_channel_mode_set(s, 0, DSD_SCAN_MODE_INHERIT) == 0);
+    assert(!dsd_channel_modes_present(s));
+    assert(remove(o->chan_in_file) == 0);
+    clear(s);
+    clear(dst);
+    free(dst);
+    free(s);
+    free(o);
+    return 0;
+}

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -1381,7 +1381,10 @@ test_manual_p25p2_c4fm_bypasses_profile_gating(void) {
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_NONE);
 
     opts.mod_p25p2_c4fm = 1;
+    assert(dsd_scan_mode_enter(&opts, &state, DSD_SCAN_MODE_P25) == 0);
+    assert(opts.mod_p25p2_c4fm == 1);
     assert(dsd_frame_sync_test_try_protocol_matches(&opts, &state, P25P2_SYNC, 20) == DSD_SYNC_P25P2_POS);
+    dsd_scan_mode_leave(&opts, &state);
 }
 
 static void

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/sync_patterns.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
@@ -17,6 +18,8 @@
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <stdlib.h>
 #ifdef USE_RADIO
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #endif
@@ -2923,8 +2926,57 @@ test_p25_trunk_tick_recency(void) {
 }
 #endif
 
+static void
+test_scan_class_matchers_and_no_sync(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts && state);
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 48000;
+    opts->ssize = 36;
+    opts->msize = 15;
+    for (int m = DSD_SCAN_MODE_P25; m <= DSD_SCAN_MODE_M17; m++) {
+        assert(dsd_scan_mode_enter(opts, state, (dsd_scan_mode)m) == 0);
+        const int expected = (int)dsd_scan_mode_profile((dsd_scan_mode)m).sps_profile_index;
+        dsd_frame_sync_reset_acquisition(opts, state, 1);
+        for (int p = 0; p < DSD_FRAME_SYNC_SPS_PROFILE_COUNT; p++) {
+            const int allowed = p == expected || (m == DSD_SCAN_MODE_P25 && p == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+            assert(dsd_frame_sync_test_sps_hunt_profile_has_candidate(opts, p) == allowed);
+        }
+        for (int n = 0; n < 120; n++) {
+            state->sps_hunt_counter =
+                dsd_frame_sync_sps_hunt_dwell_passes(opts, state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
+            (void)frame_sync_no_sync_sps_hunt(opts, state);
+            assert(state->sps_hunt_idx == expected
+                   || (m == DSD_SCAN_MODE_P25 && state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4));
+        }
+        state->sps_hunt_idx = expected;
+        if (m != DSD_SCAN_MODE_P25) {
+            assert(dsd_frame_sync_test_try_protocol_matches(opts, state, P25P1_SYNC, 24) == DSD_SYNC_NONE);
+            assert(dsd_frame_sync_test_try_protocol_matches(opts, state, P25P2_SYNC, 20) == DSD_SYNC_NONE);
+        }
+        if (m != DSD_SCAN_MODE_DMR) {
+            assert(dsd_frame_sync_test_try_protocol_matches(opts, state, DMR_MS_RC_SYNC, 24) == DSD_SYNC_NONE);
+        }
+        state->profile_proof_valid = 1;
+        state->symbol_history_count = 45;
+        state->sps_hunt_counter = 300;
+        state->p25_p1_validated_rf_mod = 1;
+        state->sbuf[0] = 123.0f;
+        dsd_frame_sync_reset_acquisition(opts, state, 1);
+        assert(!state->profile_proof_valid && !state->symbol_history_count && !state->sps_hunt_counter);
+        assert(state->p25_p1_validated_rf_mod == -1 && state->sidx == 0 && state->midx == 0);
+        assert(fabsf(state->sbuf[0] - state->min) < 0.01f);
+    }
+    dsd_scan_mode_leave(opts, state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+}
+
 int
 main(void) {
+    test_scan_class_matchers_and_no_sync();
     test_p25_vc_acquisition_hooks();
     test_sps_hunt_skips_disabled_protocol_rates();
     test_sps_hunt_profile_updates_timing();

--- a/tests/dsp/test_frame_sync_internal_helpers.c
+++ b/tests/dsp/test_frame_sync_internal_helpers.c
@@ -14,6 +14,7 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/protocol_dispatch.h>
+#include <dsd-neo/engine/trunk_scan.h>
 #include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
@@ -2137,6 +2138,47 @@ test_sps_hunt_restores_learned_p25p1_cqpsk(void) {
  * estimate comes from raw un-derotated IQ and the sync-hamming candidate can only tie -- so the
  * hunt tries it on alternate visits to the profile instead.
  */
+/* Pin the acquisition schedule in symbol time: a default target visit must
+ * include a CQPSK trial even though the row enables both P25 phases. */
+static void
+test_trunk_scan_p25_probe_fits_visit(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts && state);
+    const dsd_rtl_stream_metrics_hooks hooks = {.output_rate_hz = fake_output_rate_hz,
+                                                .apply_demod_profile = fake_apply_demod_profile};
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    reset_fake_profile_capture();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_scan_enabled = 1;
+    opts->trunk_enable = 1;
+    state->rtl_ctx = (struct RtlSdrContext*)state;
+    assert(dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25) == 0);
+    state->p25_p1_validated_rf_mod = -1;
+    const int dwell = dsd_frame_sync_sps_hunt_dwell_passes(opts, state) * DSD_FRAME_SYNC_NO_SYNC_PASS_SYMBOLS;
+    const double first_trial_ms = 1000.0 * dwell / 4800;
+    assert(first_trial_ms < DSD_TRUNK_SCAN_IDLE_DWELL_DEFAULT_MS);
+    assert(2.0 * first_trial_ms < DSD_TRUNK_SCAN_IDLE_DWELL_DEFAULT_MS);
+    state->sps_hunt_counter = dwell - 1;
+    assert(!frame_sync_no_sync_sps_hunt(opts, state));
+    assert(state->rf_mod == 0);
+    state->sps_hunt_counter = dwell;
+    assert(frame_sync_no_sync_sps_hunt(opts, state));
+    assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    assert(state->rf_mod == 1 && state->p25_p1_mod_probe_active);
+    assert(g_profile_cqpsk == 1 && g_profile_rate == 4800);
+    assert(g_profile_channel == DSD_RTL_STREAM_CHANNEL_PROFILE_P25_CQPSK);
+    /* An unproductive CQPSK trial must still give Phase 2 its turn. */
+    state->sps_hunt_counter = dwell;
+    assert(frame_sync_no_sync_sps_hunt(opts, state));
+    assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    dsd_scan_mode_leave(opts, state);
+    dsd_state_ext_free_all(state);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    free(state);
+    free(opts);
+}
+
 static void
 test_p25p1_auto_hunt_alternates_cqpsk_probe(void) {
     static dsd_opts opts;
@@ -3023,6 +3065,7 @@ main(void) {
     test_hamming_helpers_find_best_patterns();
 #ifdef USE_RADIO
     test_sps_hunt_restores_learned_p25p1_cqpsk();
+    test_trunk_scan_p25_probe_fits_visit();
     test_p25p1_auto_hunt_alternates_cqpsk_probe();
     test_p25p1_probe_survives_its_dwell();
     test_validated_p25p1_modulation_outranks_the_heuristics();

--- a/tests/dsp/test_frame_sync_policy.c
+++ b/tests/dsp/test_frame_sync_policy.c
@@ -67,6 +67,24 @@ main(void) {
     opts.trunk_enable = 1;
     assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 5);
 
+    /* Combined P25 scan visits must leave room for C4FM, CQPSK and Phase 2.
+     * Explicit locks, fixed inputs and normal trunking keep the original dwell. */
+    opts.trunk_scan_enabled = 1;
+    opts.frame_p25p2 = 1;
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.rtl_ctx = (struct RtlSdrContext*)&state;
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 3);
+    opts.mod_cli_lock = 1;
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 5);
+    opts.mod_cli_lock = 0;
+    opts.audio_in_type = AUDIO_IN_WAV;
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 5);
+    opts.audio_in_type = AUDIO_IN_RTL;
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 5);
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    opts.trunk_scan_enabled = 0;
+    assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 5);
     opts.trunk_is_tuned = 1;
     assert(dsd_frame_sync_sps_hunt_dwell_passes(&opts, &state) == 3);
 

--- a/tests/engine/scan_mode_replay.c
+++ b/tests/engine/scan_mode_replay.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+/** Test-only host: -C parses the real map, row zero prepares the production override,
+ * then the real engine replays without scanner retunes (unsupported by I/Q replay). */
+#include <assert.h>
+#include <dsd-neo/core/channel_mode.h>
+#include <dsd-neo/core/init.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/engine/engine.h>
+#include <dsd-neo/runtime/bootstrap.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int
+main(int argc, char** argv) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts && state);
+    initOpts(opts);
+    initState(state);
+    int rc = 1;
+    if (dsd_runtime_bootstrap(argc, argv, opts, state, NULL, &rc) == DSD_BOOTSTRAP_CONTINUE) {
+        assert(opts->scanner_mode == 0 && opts->trunk_scan_enabled == 0);
+        assert(state->lcn_freq_count > 0);
+        const dsd_scan_mode mode = dsd_channel_mode_get(state, 0);
+        assert(mode != DSD_SCAN_MODE_INHERIT);
+        dsd_scan_settings prepared;
+        assert(dsd_scan_mode_prepare(opts, state, mode, &prepared) == 0);
+        assert(dsd_scan_mode_enter(opts, state, mode) == 0);
+        assert(dsd_scan_mode_active(state) == mode);
+        DSD_FPRINTF(stderr, "Scan override applied: %s (%d symbols/s)\n", dsd_scan_mode_name(mode),
+                    dsd_scan_mode_effective_profile(opts, state).symbol_rate_hz);
+        rc = dsd_engine_run_with_lifecycle(opts, state, NULL);
+    }
+    dsd_scan_mode_leave(opts, state);
+    freeState(state);
+    free(state);
+    free(opts);
+    return rc;
+}

--- a/tests/engine/test_engine_channel_scan.c
+++ b/tests/engine/test_engine_channel_scan.c
@@ -2,6 +2,7 @@
 /* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
 
 #include <assert.h>
+#include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/csv_validate.h>
@@ -27,6 +28,13 @@ static uint64_t request;
 static int tunes;
 static int reset_count;
 static int expected_nxdn;
+static int change_rate_on_tune;
+static uint32_t reported_rate = 48000;
+
+static uint32_t
+output_rate(void) {
+    return reported_rate;
+}
 
 static int restored_frontend;
 
@@ -42,7 +50,11 @@ dsd_trunk_tune_result
 dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long freq, int sps, uint64_t* out) {
     assert(freq == 150000000);
     assert(opts->frame_nxdn48 == expected_nxdn);
-    assert(sps == (expected_nxdn ? 20 : 10));
+    assert(sps == (change_rate_on_tune ? (int)reported_rate / 4800 : (expected_nxdn ? 20 : 10)));
+    if (change_rate_on_tune) {
+        assert(tunes < 100);
+        reported_rate = reported_rate == 48000 ? 96000 : 48000;
+    }
     (void)state;
     tunes++;
     request = dsd_trunk_tuning_request_begin();
@@ -56,8 +68,8 @@ dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long freq, int sp
 }
 
 void
-noCarrier(dsd_opts* opts, dsd_state* state) {
-    (void)opts;
+dsd_engine_reset_no_carrier_state(dsd_opts* opts, dsd_state* state) {
+    assert(opts->scanner_mode == 1);
     (void)state;
     reset_count++;
 }
@@ -124,6 +136,32 @@ main(void) {
     assert(tunes == before_zero && state->lcn_freq_roll == 3 && opts->frame_p25p1);
     assert(dsd_engine_channel_scan_step(opts, state) == 1);
     assert(state->lcn_freq_roll == 4 && opts->frame_dstar == 1 && !opts->frame_p25p1);
+    state->lcn_freq_roll = 2;
+    opts->trunk_is_tuned = 1;
+    assert(dsd_recent_activity_publish(state, 0, NULL, "Outgoing row data", 1) == 1);
+    tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    assert(dsd_engine_channel_scan_step_manual(opts, state) == -1);
+    assert(state->lcn_freq_roll == 2);
+    opts->trunk_is_tuned = 1;
+    assert(dsd_recent_activity_publish(state, 0, NULL, "Outgoing row data", 1) == 1);
+    tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    assert(dsd_engine_channel_scan_step_manual(opts, state) == 0);
+    assert(state->lcn_freq_roll == 2);
+    assert(dsd_scan_mode_suspend(opts, state));
+    opts->inverted_dmr = !opts->inverted_dmr;
+    (void)dsd_scan_mode_resume(opts, state);
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_engine_channel_scan_pending(opts, state) == 1 && state->lcn_freq_roll == 2);
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    assert(dsd_engine_channel_scan_pending(opts, state) == 0);
+    assert(state->lcn_freq_roll == 4);
+    dsd_recent_activity_snapshot recent;
+    assert(dsd_recent_activity_copy_snapshot(state, &recent) == 1);
+    assert(recent.entries[0].notice[0] == '\0' && opts->trunk_is_tuned == 0);
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    state->lcn_freq_roll = 2;
+    assert(dsd_engine_channel_scan_step_manual(opts, state) == 1);
+    assert(state->lcn_freq_roll == 4 && opts->frame_dstar);
     expected_nxdn = 1;
     tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
     assert(dsd_engine_channel_scan_step(opts, state) == 0);
@@ -134,6 +172,40 @@ main(void) {
     state->trunk_chan_map_seq++;
     dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
     assert(dsd_engine_channel_scan_pending(opts, state) == 0 && opts->frame_dstar);
+    /* A tune changes live output timing; it is not a configuration edit and
+     * must not recursively retune the same row. */
+    reported_rate = 48000;
+    opts->audio_in_type = AUDIO_IN_RTL;
+    change_rate_on_tune = 1;
+    expected_nxdn = 0;
+    state->lcn_freq_roll = 1;
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    const dsd_rtl_stream_metrics_hooks rate_hooks = {.output_rate_hz = output_rate};
+    dsd_rtl_stream_metrics_hooks_set(&rate_hooks);
+    const int before_rate_change = tunes;
+    assert(dsd_engine_channel_scan_step(opts, state) == 1);
+    assert(tunes == before_rate_change + 1 && state->samplesPerSymbol == 20);
+    change_rate_on_tune = 0;
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    opts->audio_in_type = AUDIO_IN_WAV;
+    /* A real configuration edit during an outstanding request retries on the
+     * next service pass, without dispatching samples from the old request. */
+    state->lcn_freq_roll = 1;
+    tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    assert(dsd_engine_channel_scan_step(opts, state) == 0);
+    assert(dsd_scan_mode_suspend(opts, state));
+    opts->inverted_dmr = !opts->inverted_dmr;
+    (void)dsd_scan_mode_resume(opts, state);
+    const int before_config_retry = tunes;
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_engine_channel_scan_pending(opts, state) == 1);
+    assert(tunes == before_config_retry && state->lcn_freq_roll == 1);
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    assert(dsd_engine_channel_scan_pending(opts, state) == 0);
+    assert(tunes == before_config_retry + 1 && state->lcn_freq_roll == 2);
+    state->lcn_freq_roll = 0;
+    expected_nxdn = 1;
+    tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
     assert(dsd_engine_channel_scan_step(opts, state) == 0);
     const dsd_rtl_stream_metrics_hooks hooks = {.apply_demod_profile = restore_frontend};
     dsd_rtl_stream_metrics_hooks_set(&hooks);

--- a/tests/engine/test_engine_channel_scan.c
+++ b/tests/engine/test_engine_channel_scan.c
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <assert.h>
+#include <dsd-neo/core/channel_mode.h>
+#include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/csv_validate.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/engine/channel_scan.h>
+#include <dsd-neo/engine/frame_processing.h>
+#include <dsd-neo/engine/scan_voice_gate.h>
+#include <dsd-neo/engine/trunk_tuning.h>
+#include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+static dsd_trunk_tune_result tune_result;
+static uint64_t request;
+static int tunes;
+static int reset_count;
+static int expected_nxdn;
+
+static int restored_frontend;
+
+static int
+restore_frontend(int cqpsk, int rate, int levels, int filter, int sps) {
+    assert(cqpsk == 0 && rate == 4800 && levels == 2 && sps == 10);
+    assert(filter == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
+    restored_frontend++;
+    return 0;
+}
+
+dsd_trunk_tune_result
+dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long freq, int sps, uint64_t* out) {
+    assert(freq == 150000000);
+    assert(opts->frame_nxdn48 == expected_nxdn);
+    assert(sps == (expected_nxdn ? 20 : 10));
+    (void)state;
+    tunes++;
+    request = dsd_trunk_tuning_request_begin();
+    *out = request;
+    if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        dsd_trunk_tuning_request_mark_ready(request);
+    } else {
+        dsd_trunk_tuning_request_complete(request, tune_result);
+    }
+    return tune_result;
+}
+
+void
+noCarrier(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    reset_count++;
+}
+
+void
+dsd_frame_sync_reset_acquisition(const dsd_opts* opts, dsd_state* state, int forget) {
+    (void)opts;
+    (void)forget;
+    state->synctype = DSD_SYNC_NONE;
+    state->profile_proof_valid = 0;
+    state->symbol_history_count = 0;
+    state->sps_hunt_counter = 0;
+}
+
+void
+dsd_scan_voice_gate_note_retune(dsd_state* state, double now) {
+    state->last_cc_sync_time_m = now;
+}
+
+int
+main(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts && state);
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 48000;
+    opts->frame_dstar = 1;
+    opts->scanner_mode = 1;
+    state->samplesPerSymbol = 10;
+    state->lcn_freq_count = 4;
+    for (int i = 0; i < 4; i++) {
+        *dsd_state_trunk_lcn_slot(state, i) = i == 2 ? 0 : 150000000;
+    }
+    assert(dsd_channel_mode_set(state, 0, DSD_SCAN_MODE_NXDN48) == 0);
+    assert(dsd_channel_mode_set(state, 1, DSD_SCAN_MODE_P25) == 0);
+    assert(dsd_channel_mode_set(state, 2, DSD_SCAN_MODE_DMR) == 0);
+    expected_nxdn = 1;
+    tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    assert(dsd_engine_channel_scan_step(opts, state) == 0);
+    assert(state->lcn_freq_roll == 0 && opts->frame_dstar == 1);
+    assert(dsd_engine_channel_scan_pending(opts, state) == 1);
+    state->synctype = DSD_SYNC_P25P1_POS;
+    assert(!dsd_engine_channel_scan_sync_ready(opts, state));
+    assert(state->synctype == DSD_SYNC_NONE);
+    const uint64_t old_generation = dsd_trunk_tuning_generation();
+    assert(!dsd_trunk_tuning_frame_is_dispatchable(old_generation, 1));
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
+    state->synctype = DSD_SYNC_P25P1_POS;
+    assert(!dsd_engine_channel_scan_sync_ready(opts, state));
+    assert(state->lcn_freq_roll == 1 && opts->frame_nxdn48 == 1 && reset_count == 1);
+    assert(!dsd_trunk_tuning_frame_is_dispatchable(old_generation, 1));
+    expected_nxdn = 0;
+    tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    assert(dsd_engine_channel_scan_step(opts, state) == -1);
+    assert(state->lcn_freq_roll == 1 && opts->frame_nxdn48 == 1);
+    tune_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    assert(dsd_engine_channel_scan_step(opts, state) == -1);
+    assert(state->lcn_freq_roll == 1);
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    assert(dsd_engine_channel_scan_step(opts, state) == 1);
+    assert(state->lcn_freq_roll == 2 && opts->frame_p25p1 && opts->frame_p25p2 && !opts->frame_dmr);
+    const int before_zero = tunes;
+    assert(dsd_engine_channel_scan_step(opts, state) == 0);
+    assert(tunes == before_zero && state->lcn_freq_roll == 3 && opts->frame_p25p1);
+    assert(dsd_engine_channel_scan_step(opts, state) == 1);
+    assert(state->lcn_freq_roll == 4 && opts->frame_dstar == 1 && !opts->frame_p25p1);
+    expected_nxdn = 1;
+    tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    assert(dsd_engine_channel_scan_step(opts, state) == 0);
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(dsd_engine_channel_scan_pending(opts, state) == 0);
+    assert(opts->frame_dstar && state->lcn_freq_roll == 4);
+    assert(dsd_engine_channel_scan_step(opts, state) == 0);
+    state->trunk_chan_map_seq++;
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_engine_channel_scan_pending(opts, state) == 0 && opts->frame_dstar);
+    assert(dsd_engine_channel_scan_step(opts, state) == 0);
+    const dsd_rtl_stream_metrics_hooks hooks = {.apply_demod_profile = restore_frontend};
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    opts->audio_in_type = AUDIO_IN_RTL;
+    dsd_engine_channel_scan_leave(opts, state);
+    assert(restored_frontend == 1);
+    dsd_rtl_stream_metrics_hooks_set(NULL);
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_engine_channel_scan_pending(opts, state) == 0 && opts->frame_dstar);
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+    return 0;
+}
+
+int
+csvKeyImportHexPath(const char* path, int show, dsd_state* state, dsd_csv_validation* stats) {
+    (void)stats;
+    (void)show;
+    (void)path;
+    (void)state;
+    return -1;
+}
+
+int
+csvKeyImportDecPath(const char* path, int show, dsd_state* state, dsd_csv_validation* stats) {
+    (void)stats;
+    (void)show;
+    (void)path;
+    (void)state;
+    return -1;
+}

--- a/tests/engine/test_engine_channel_scan.c
+++ b/tests/engine/test_engine_channel_scan.c
@@ -17,6 +17,8 @@
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
 #include <dsd-neo/engine/trunk_tuning.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
@@ -27,6 +29,7 @@ static dsd_trunk_tune_result tune_result;
 static uint64_t request;
 static int tunes;
 static int reset_count;
+static int last_forget_modulation;
 static int expected_nxdn;
 static int change_rate_on_tune;
 static uint32_t reported_rate = 48000;
@@ -37,10 +40,14 @@ output_rate(void) {
 }
 
 static int restored_frontend;
+static int expected_frontend_rate = 4800;
+static int expected_frontend_levels = 2;
+static int expected_frontend_sps = 10;
 
 static int
 restore_frontend(int cqpsk, int rate, int levels, int filter, int sps) {
-    assert(cqpsk == 0 && rate == 4800 && levels == 2 && sps == 10);
+    assert(cqpsk == 0 && rate == expected_frontend_rate && levels == expected_frontend_levels
+           && sps == expected_frontend_sps);
     assert(filter == DSD_RTL_STREAM_CHANNEL_PROFILE_6K25);
     restored_frontend++;
     return 0;
@@ -77,7 +84,7 @@ dsd_engine_reset_no_carrier_state(dsd_opts* opts, dsd_state* state) {
 void
 dsd_frame_sync_reset_acquisition(const dsd_opts* opts, dsd_state* state, int forget) {
     (void)opts;
-    (void)forget;
+    last_forget_modulation = forget;
     state->synctype = DSD_SYNC_NONE;
     state->profile_proof_valid = 0;
     state->symbol_history_count = 0;
@@ -99,6 +106,7 @@ main(void) {
     opts->frame_dstar = 1;
     opts->scanner_mode = 1;
     state->samplesPerSymbol = 10;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
     state->lcn_freq_count = 4;
     for (int i = 0; i < 4; i++) {
         *dsd_state_trunk_lcn_slot(state, i) = i == 2 ? 0 : 150000000;
@@ -112,19 +120,21 @@ main(void) {
     assert(state->lcn_freq_roll == 0 && opts->frame_dstar == 1);
     assert(dsd_engine_channel_scan_pending(opts, state) == 1);
     state->synctype = DSD_SYNC_P25P1_POS;
-    assert(!dsd_engine_channel_scan_sync_ready(opts, state));
+    assert(!dsd_engine_channel_scan_service_sync(opts, state));
     assert(state->synctype == DSD_SYNC_NONE);
     const uint64_t old_generation = dsd_trunk_tuning_generation();
     assert(!dsd_trunk_tuning_frame_is_dispatchable(old_generation, 1));
     dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
     state->synctype = DSD_SYNC_P25P1_POS;
-    assert(!dsd_engine_channel_scan_sync_ready(opts, state));
+    assert(!dsd_engine_channel_scan_service_sync(opts, state));
     assert(state->lcn_freq_roll == 1 && opts->frame_nxdn48 == 1 && reset_count == 1);
     assert(!dsd_trunk_tuning_frame_is_dispatchable(old_generation, 1));
     expected_nxdn = 0;
     tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
     assert(dsd_engine_channel_scan_step(opts, state) == -1);
-    assert(state->lcn_freq_roll == 1 && opts->frame_nxdn48 == 1);
+    assert(state->lcn_freq_roll == 2 && opts->frame_nxdn48 == 1);
+    /* A temporary deferral retries its own row; a hard failure skips it. */
+    state->lcn_freq_roll = 1;
     tune_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
     assert(dsd_engine_channel_scan_step(opts, state) == -1);
     assert(state->lcn_freq_roll == 1);
@@ -141,7 +151,8 @@ main(void) {
     assert(dsd_recent_activity_publish(state, 0, NULL, "Outgoing row data", 1) == 1);
     tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
     assert(dsd_engine_channel_scan_step_manual(opts, state) == -1);
-    assert(state->lcn_freq_roll == 2);
+    assert(state->lcn_freq_roll == 4);
+    state->lcn_freq_roll = 2;
     opts->trunk_is_tuned = 1;
     assert(dsd_recent_activity_publish(state, 0, NULL, "Outgoing row data", 1) == 1);
     tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
@@ -167,7 +178,8 @@ main(void) {
     assert(dsd_engine_channel_scan_step(opts, state) == 0);
     dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_FAILED);
     assert(dsd_engine_channel_scan_pending(opts, state) == 0);
-    assert(opts->frame_dstar && state->lcn_freq_roll == 4);
+    assert(opts->frame_dstar && state->lcn_freq_roll == 1);
+    state->lcn_freq_roll = 0;
     assert(dsd_engine_channel_scan_step(opts, state) == 0);
     state->trunk_chan_map_seq++;
     dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
@@ -211,10 +223,35 @@ main(void) {
     dsd_rtl_stream_metrics_hooks_set(&hooks);
     opts->audio_in_type = AUDIO_IN_RTL;
     dsd_engine_channel_scan_leave(opts, state);
-    assert(restored_frontend == 1);
+    assert(restored_frontend == 1 && last_forget_modulation == 1);
     dsd_rtl_stream_metrics_hooks_set(NULL);
     dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
     assert(dsd_engine_channel_scan_pending(opts, state) == 0 && opts->frame_dstar);
+    /* Releasing a scope captured halfway through AUTO hunting restores its
+     * frontend with the same 2400/4 clock as the saved 20-SPS decoder. */
+    assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_AUTO, DSD_DECODE_PRESET_PROFILE_CLI, opts, state) == 0);
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    state->samplesPerSymbol = 20;
+    state->symbolCenter = 9;
+    state->rf_mod = 2;
+    expected_frontend_rate = 2400;
+    expected_frontend_levels = 4;
+    expected_frontend_sps = 20;
+    dsd_rtl_stream_metrics_hooks_set(&hooks);
+    assert(dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25) == 0);
+    dsd_engine_channel_scan_leave(NULL, state);
+    assert(dsd_scan_mode_active(state) == DSD_SCAN_MODE_P25);
+    assert(!dsd_engine_channel_scan_pending(NULL, state));
+    assert(!dsd_engine_channel_scan_pending(opts, NULL));
+    dsd_engine_channel_scan_leave(opts, NULL);
+    dsd_engine_channel_scan_leave(opts, state);
+    assert(restored_frontend == 2 && state->samplesPerSymbol == 20);
+    opts->trunk_scan_enabled = 1;
+    assert(dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25) == 0);
+    dsd_engine_channel_scan_leave(opts, state);
+    assert(last_forget_modulation == 0);
+    opts->trunk_scan_enabled = 0;
+    dsd_rtl_stream_metrics_hooks_set(NULL);
     dsd_state_trunk_lcn_free(state);
     dsd_state_ext_free_all(state);
     free(state);

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -347,28 +347,39 @@ test_typed_scan_tune_boundaries(void) {
     rc |= expect_true("typed hold prevents automatic entry", g_rtl_tune_calls == 1 && state->lcn_freq_roll == 1);
     state->lcn_scan_hold = 0;
     g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
+    const dsd_call_observation call = {.protocol = DSD_SYNC_NXDN_POS,
+                                       .kind = DSD_CALL_KIND_GROUP_VOICE,
+                                       .ota_target_id = 1201,
+                                       .observed_m = dsd_time_now_monotonic_s()};
+    rc |= expect_true("seed outgoing typed call", dsd_call_state_observe(state, &call, DSD_CALL_BOUNDARY_BEGIN) == 1);
     noCarrier(opts, state);
     const uint64_t pending = dsd_trunk_tuning_pending_request();
     rc |= expect_true("typed timeout leaves outgoing mode", pending != 0 && opts->frame_nxdn48
                                                                 && state->lcn_freq_roll == 1
                                                                 && dsd_engine_channel_scan_pending(opts, state));
+    dsd_call_snapshot pending_call;
+    rc |= expect_true("typed pending hop keeps outgoing call", dsd_call_state_get(state, 0, &pending_call) == 1);
+    rc |= expect_true("typed pending hop avoids premature sync loss", pending_call.phase == DSD_CALL_PHASE_ACTIVE);
     apply_pending_profile(941012500);
     dsd_trunk_tuning_request_publish(pending, DSD_TRUNK_TUNE_RESULT_OK);
     rc |= expect_true("typed async completion commits",
                       !dsd_engine_channel_scan_pending(opts, state) && opts->frame_p25p1 && opts->frame_p25p2
                           && !opts->frame_dmr && state->lcn_freq_roll == 2 && g_rtl_symbol_rate_hz == 4800);
+    dsd_call_snapshot ended;
+    rc |= expect_true("typed pending hop retains call", dsd_call_state_get(state, 0, &ended) == 1);
+    rc |= expect_true("typed pending hop ends explicitly", ended.end_reason == DSD_CALL_END_EXPLICIT);
     opts->use_rigctl = 1;
     opts->setmod_bw = 0;
     g_rigctl_setfreq_ok = 1;
     g_rtl_tune_result = RTL_STREAM_TUNE_FAILED;
     state->last_cc_sync_time -= 11;
     noCarrier(opts, state);
-    rc |= expect_true("typed dual-backend partial failure leaves row", state->lcn_freq_roll == 2 && opts->frame_p25p1);
+    rc |= expect_true("typed dual-backend partial failure leaves row", state->lcn_freq_roll == 1 && opts->frame_p25p1);
     rc |= expect_true("typed partial failure closes frame gate",
                       !dsd_trunk_tuning_frame_is_dispatchable(dsd_trunk_tuning_generation(), 1));
     g_rtl_tune_result = RTL_STREAM_TUNE_OK;
     noCarrier(opts, state);
-    rc |= expect_true("typed recovery commits new row", opts->frame_nxdn48 && state->lcn_freq_roll == 1);
+    rc |= expect_true("typed recovery skips failed row", opts->frame_p25p1 && state->lcn_freq_roll == 2);
     rc |= expect_true("typed recovery reopens frame gate",
                       dsd_trunk_tuning_frame_is_dispatchable(dsd_trunk_tuning_generation(), 1));
     g_rigctl_setfreq_ok = 0;

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/init.h>
@@ -12,6 +13,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -19,6 +21,7 @@
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <math.h>
@@ -280,6 +283,72 @@ free_test_runtime(dsd_opts* opts, dsd_state* state) {
     free(state);
     free(opts);
 }
+
+#if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
+static int
+test_typed_scan_tune_boundaries(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+    int rc = 0;
+    reset_rtl_profile_fakes();
+    dsd_trunk_tuning_requests_reset();
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->scanner_mode = 1;
+    opts->trunk_hangtime = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->lcn_freq_count = 2;
+    state->trunk_lcn_freq[0] = state->trunk_lcn_freq[1] = 941012500;
+    rc |= expect_true("typed mode metadata", dsd_channel_mode_set(state, 0, DSD_SCAN_MODE_NXDN48) == 0);
+    rc |= expect_true("typed P25 metadata", dsd_channel_mode_set(state, 1, DSD_SCAN_MODE_P25) == 0);
+    state->last_cc_sync_time = time(NULL);
+    noCarrier(opts, state);
+    rc |= expect_true("typed startup waits for scheduled entry", g_rtl_tune_calls == 0 && !opts->frame_nxdn48);
+    state->last_cc_sync_time -= 11;
+    noCarrier(opts, state);
+    rc |= expect_true("typed automatic mode and profile commit",
+                      opts->frame_nxdn48 && state->lcn_freq_roll == 1 && g_rtl_symbol_rate_hz == 2400
+                          && g_rtl_symbol_levels == 4 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_6K25);
+    state->lcn_scan_hold = 1;
+    state->last_cc_sync_time -= 11;
+    noCarrier(opts, state);
+    rc |= expect_true("typed hold prevents automatic entry", g_rtl_tune_calls == 1 && state->lcn_freq_roll == 1);
+    state->lcn_scan_hold = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_TIMEOUT;
+    noCarrier(opts, state);
+    const uint64_t pending = dsd_trunk_tuning_pending_request();
+    rc |= expect_true("typed timeout leaves outgoing mode", pending != 0 && opts->frame_nxdn48
+                                                                && state->lcn_freq_roll == 1
+                                                                && dsd_engine_channel_scan_pending(opts, state));
+    apply_pending_profile(941012500);
+    dsd_trunk_tuning_request_publish(pending, DSD_TRUNK_TUNE_RESULT_OK);
+    rc |= expect_true("typed async completion commits",
+                      !dsd_engine_channel_scan_pending(opts, state) && opts->frame_p25p1 && opts->frame_p25p2
+                          && !opts->frame_dmr && state->lcn_freq_roll == 2 && g_rtl_symbol_rate_hz == 4800);
+    opts->use_rigctl = 1;
+    opts->setmod_bw = 0;
+    g_rigctl_setfreq_ok = 1;
+    g_rtl_tune_result = RTL_STREAM_TUNE_FAILED;
+    state->last_cc_sync_time -= 11;
+    noCarrier(opts, state);
+    rc |= expect_true("typed dual-backend partial failure leaves row", state->lcn_freq_roll == 2 && opts->frame_p25p1);
+    rc |= expect_true("typed partial failure closes frame gate",
+                      !dsd_trunk_tuning_frame_is_dispatchable(dsd_trunk_tuning_generation(), 1));
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    noCarrier(opts, state);
+    rc |= expect_true("typed recovery commits new row", opts->frame_nxdn48 && state->lcn_freq_roll == 1);
+    rc |= expect_true("typed recovery reopens frame gate",
+                      dsd_trunk_tuning_frame_is_dispatchable(dsd_trunk_tuning_generation(), 1));
+    g_rigctl_setfreq_ok = 0;
+    dsd_engine_channel_scan_leave(opts, state);
+    state->rtl_ctx = NULL;
+    free_test_runtime(opts, state);
+    dsd_trunk_tuning_requests_reset();
+    return rc;
+}
+#endif
 
 int
 main(void) {
@@ -1952,6 +2021,10 @@ main(void) {
 #endif
 
     free_test_runtime(opts, state);
+
+#if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
+    rc |= test_typed_scan_tune_boundaries();
+#endif
 
     if (rc == 0) {
         printf("ENGINE_NO_CARRIER_RESET: OK\n");

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -286,6 +286,36 @@ free_test_runtime(dsd_opts* opts, dsd_state* state) {
 
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
 static int
+test_trunk_cache_with_mode_metadata(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+    int rc = 0;
+    dsd_trunk_tuning_requests_reset();
+    opts->use_rigctl = 1;
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->trunk_enable = 1;
+    opts->setmod_bw = 0;
+    g_rigctl_setfreq_ok = 1;
+    g_rigctl_setfreq_calls = 0;
+    rc |= expect_true("trunk cache mode metadata", dsd_channel_mode_set(state, 0, DSD_SCAN_MODE_DMR) == 0);
+    for (int i = 0; i < 2; i++) {
+        opts->trunk_is_tuned = 1;
+        state->trunk_cc_freq = 941012500;
+        state->p25_cc_freq = 0;
+        state->lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+        state->last_vc_sync_time = 0;
+        noCarrier(opts, state);
+    }
+    rc |= expect_true("mode metadata preserves redundant return suppression", g_rigctl_setfreq_calls == 1);
+    g_rigctl_setfreq_ok = 0;
+    free_test_runtime(opts, state);
+    return rc;
+}
+
+static int
 test_typed_scan_tune_boundaries(void) {
     dsd_opts* opts = NULL;
     dsd_state* state = NULL;
@@ -2024,6 +2054,7 @@ main(void) {
 
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
     rc |= test_typed_scan_tune_boundaries();
+    rc |= test_trunk_cache_with_mode_metadata();
 #endif
 
     if (rc == 0) {

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -897,6 +897,18 @@ main(void) {
     assert(g_rtl_ted_sps == 20); /* 48000 / 2400 from the stubbed RTL output rate */
     assert(g_rtl_ted_sps_override == 0);
 
+    /* Even stale scanner flags cannot change the trunk coordinator's backend
+     * contract: rigctl owns the frequency and the target owns the profile. */
+    opts->scanner_mode = 1;
+    opts->use_rigctl = 1;
+    g_setfreq_result = true;
+    const int before_stale_scanner = g_rtl_tune_calls;
+    assert(dsd_engine_scan_tune_to_freq(opts, state, 461556250, 20, NULL) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_tune_calls == before_stale_scanner);
+    assert(g_rtl_symbol_rate_hz == 2400 && g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_6K25);
+    opts->scanner_mode = 0;
+    opts->use_rigctl = 0;
+
     /* A parked 4800-class scan target keeps the 12.5 kHz chain. */
     g_trunk_scan_active_gfsk_symbol_rate = 4800;
     g_rtl_symbol_rate_hz = 2400;

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -1503,3 +1503,9 @@ main(void) {
 #if defined(__GNUC__) && !defined(__cplusplus)
 #pragma GCC diagnostic pop
 #endif
+
+void
+dsd_trunk_tuning_request_publish(uint64_t request_id, dsd_trunk_tune_result result) {
+    (void)request_id;
+    (void)result;
+}

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -14,6 +14,7 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/p25_bandplan_export.h>
 #include <dsd-neo/engine/trunk_scan.h>
 #include <dsd-neo/engine/trunk_tuning.h>
@@ -4878,6 +4879,7 @@ test_per_target_modulation_overrides_global_lock(void) {
     static dsd_state state;
     reset_scan_opts_state(&opts, &state);
     opts.mod_cli_lock = 1;
+    opts.trunk_is_tuned = 1;
     opts.mod_qpsk = 1;
     opts.mod_c4fm = 0;
     opts.mod_gfsk = 0;
@@ -4904,7 +4906,7 @@ test_per_target_modulation_overrides_global_lock(void) {
     }
 
     dsd_engine_trunk_scan_shutdown(&opts, &state);
-    if (opts.mod_cli_lock != 1 || opts.mod_qpsk != 1 || opts.mod_gfsk != 0) {
+    if (opts.trunk_is_tuned != 1 || opts.mod_cli_lock != 1 || opts.mod_qpsk != 1 || opts.mod_gfsk != 0) {
         DSD_FPRINTF(stderr, "shutdown did not restore saved modulation opts lock=%d qpsk=%d gfsk=%d\n",
                     opts.mod_cli_lock, opts.mod_qpsk, opts.mod_gfsk);
         test_rc = 1;
@@ -7028,6 +7030,12 @@ main(void) {
     rc |= run_with_default_tune_hook(test_target_p25_bandplan_loads_and_survives_rotation);
     rc |= run_with_default_tune_hook(test_p25_bandplan_export_collects_every_target);
     return rc;
+}
+
+void
+dsd_engine_reset_no_carrier_state(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
 }
 
 /* Coordinator tests stub DSP; acquisition contents are covered by FRAME_SYNC_INTERNAL_HELPERS. */

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -2735,7 +2735,18 @@ run_nxdn_decoder_warning_case(const char* label, const char* target_path, int fr
     char err[256] = {0};
     trunk_scan_test_set_now(0.0);
     int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    if (rc == 0 && (opts.frame_nxdn48 != 1 || opts.frame_nxdn96 != 0 || opts.frame_dmr != 0)) {
+        rc = -1;
+    }
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (rc == 0 && (opts.frame_nxdn48 != 0 || opts.frame_nxdn96 != 1 || opts.frame_p25p1 != 0)) {
+        rc = -1;
+    }
     dsd_engine_trunk_scan_shutdown(&opts, &state);
+    if (opts.frame_nxdn48 != frame_nxdn48 || opts.frame_nxdn96 != frame_nxdn96) {
+        rc = -1;
+    }
     trunk_scan_test_clear_now();
     (void)dsd_test_capture_stderr_end(&cap);
     if (dsd_test_capture_stderr_read(&cap, buf, buf_sz) != 0) {
@@ -2750,7 +2761,7 @@ run_nxdn_decoder_warning_case(const char* label, const char* target_path, int fr
 }
 
 static int
-test_warns_when_nxdn48_decoder_disabled(void) {
+test_target_classes_enable_missing_decoders(void) {
     char dir[DSD_TEST_PATH_MAX];
     char target_path[DSD_TEST_PATH_MAX];
     if (make_runtime_targets("n48,nxdn48-conventional,461556250,,250,,\n"
@@ -2763,22 +2774,13 @@ test_warns_when_nxdn48_decoder_disabled(void) {
     int test_rc = 0;
     char buf[4096];
 
-    /* NXDN96 enabled only: the NXDN48 row is the one that cannot decode. */
-    if (run_nxdn_decoder_warning_case("nxdn48-disabled", target_path, 0, 1, buf, sizeof buf) != 0) {
-        test_rc = 1;
-    } else if (!strstr(buf, "1 trunk scan target(s) have no enabled NXDN48 decoder (first: 'n48')")
-               || !strstr(buf, "use -fi or -fa to decode them") || strstr(buf, "NXDN96 decoder") != NULL) {
-        DSD_FPRINTF(stderr, "nxdn48 disabled warning wrong:\n%s\n", buf);
-        test_rc = 1;
-    }
-
-    /* NXDN48 enabled only: the NXDN96 row is the one that cannot decode. */
-    if (run_nxdn_decoder_warning_case("nxdn96-disabled", target_path, 1, 0, buf, sizeof buf) != 0) {
-        test_rc = 1;
-    } else if (!strstr(buf, "1 trunk scan target(s) have no enabled NXDN96 decoder (first: 'n96')")
-               || !strstr(buf, "use -fn or -fa to decode them") || strstr(buf, "NXDN48 decoder") != NULL) {
-        DSD_FPRINTF(stderr, "nxdn96 disabled warning wrong:\n%s\n", buf);
-        test_rc = 1;
+    /* Either global NXDN variant may be disabled: the target class enables its decoder. */
+    for (int n48 = 0; n48 <= 1; n48++) {
+        if (run_nxdn_decoder_warning_case("target-class", target_path, n48, !n48, buf, sizeof buf) != 0
+            || strstr(buf, "have no enabled") != NULL) {
+            DSD_FPRINTF(stderr, "target class must not require global decoder flags: %s\n", buf);
+            test_rc = 1;
+        }
     }
 
     /* Both enabled (-fa): neither variant warns. */
@@ -6967,7 +6969,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_mixed_target_switch_resets_nxdn_demod_profile);
     rc |= run_with_default_tune_hook(test_nxdn48_target_selects_2400_demod_profile);
     rc |= run_with_default_tune_hook(test_nxdn48_target_uses_rtl_output_rate_for_sps);
-    rc |= run_with_default_tune_hook(test_warns_when_nxdn48_decoder_disabled);
+    rc |= run_with_default_tune_hook(test_target_classes_enable_missing_decoders);
     rc |= run_with_default_tune_hook(test_nxdn_conventional_activity_hold);
     rc |= run_with_default_tune_hook(test_conventional_activity_data_call_respects_tune_data_calls);
     rc |= run_with_default_tune_hook(test_conventional_activity_families_do_not_cross);
@@ -7026,4 +7028,13 @@ main(void) {
     rc |= run_with_default_tune_hook(test_target_p25_bandplan_loads_and_survives_rotation);
     rc |= run_with_default_tune_hook(test_p25_bandplan_export_collects_every_target);
     return rc;
+}
+
+/* Coordinator tests stub DSP; acquisition contents are covered by FRAME_SYNC_INTERNAL_HELPERS. */
+void
+dsd_frame_sync_reset_acquisition(const dsd_opts* opts, dsd_state* state, int forget) {
+    (void)opts;
+    (void)forget;
+    state->profile_proof_valid = 0;
+    state->sps_hunt_counter = 0;
 }

--- a/tests/runtime/test_runtime_config_apply.cpp
+++ b/tests/runtime/test_runtime_config_apply.cpp
@@ -2166,7 +2166,7 @@ test_ui_import_and_dsp_output_commands_report_service_results(void) {
     dsd_app_command_submit(DSD_APP_CMD_IMPORT_CHANNEL_MAP, missing_chan, strlen(missing_chan) + 1U);
     applied = dsd_app_drain_cmds(opts, state);
     rc |= expect_int_eq("channel import command drains", applied, 1);
-    rc |= expect_true("channel import records requested path", strcmp(opts->chan_in_file, missing_chan) == 0);
+    rc |= expect_true("failed channel import preserves configured path", opts->chan_in_file[0] == '\0');
     rc |= expect_true("channel import failure toast", strstr(state->ui_msg, "Failed: Channel map import") != NULL);
 
     const char* missing_group = "./missing-group-list.csv";

--- a/tests/runtime/test_runtime_scan_mode.c
+++ b/tests/runtime/test_runtime_scan_mode.c
@@ -8,9 +8,43 @@
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/scan_mode.h>
 #include <stdlib.h>
 #include <string.h>
+
+static void
+test_p25_modulation_helpers(dsd_opts* opts, dsd_state* state) {
+    assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_P25P2, DSD_DECODE_PRESET_PROFILE_CLI, opts, state) == 0);
+    opts->mod_cli_lock = 1;
+    opts->mod_p25p2_profile_lock = 1;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    assert(dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25) == 0);
+    assert(opts->mod_p25p2_profile_lock && state->samplesPerSymbol == 8);
+    assert(dsd_scan_mode_effective_profile(opts, state).symbol_rate_hz == 6000);
+    assert(dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_DMR) == 0);
+    assert(!opts->mod_p25p2_profile_lock && state->samplesPerSymbol == 10);
+    assert(dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25) == 0);
+    assert(opts->mod_p25p2_profile_lock && state->samplesPerSymbol == 8);
+    dsd_scan_mode_leave(opts, state);
+    opts->mod_p25p2_profile_lock = 0;
+    opts->mod_p25p2_c4fm = 1;
+    opts->mod_c4fm = 1;
+    opts->mod_qpsk = 0;
+    state->rf_mod = 0;
+    state->samplesPerSymbol = 10;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_4;
+    assert(dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25) == 0);
+    assert(opts->mod_p25p2_c4fm && state->samplesPerSymbol == 10 && state->rf_mod == 0);
+    /* An explicit trunk-target modulation still takes precedence over the helper. */
+    dsd_scan_mode_target_modulation(state, 1);
+    assert(dsd_scan_mode_suspend(opts, state));
+    (void)dsd_scan_mode_resume(opts, state);
+    assert(!opts->mod_p25p2_c4fm);
+    dsd_scan_mode_leave(opts, state);
+    assert(opts->mod_p25p2_c4fm && opts->mod_cli_lock);
+}
 
 int
 main(void) {
@@ -98,12 +132,22 @@ main(void) {
     assert(o->frame_p25p1 && !o->frame_ysf);
     dsd_scan_mode_leave(o, s);
     assert(o->frame_ysf && !o->frame_dstar);
+    /* Presets overwrite only the visible label. A different suffix after its NUL
+     * is not an effective setting change and must not interrupt a parked row. */
+    assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_NXDN96, DSD_DECODE_PRESET_PROFILE_CLI, o, s) == 0);
+    assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_P25) == 0);
+    assert(dsd_scan_mode_suspend(o, s));
+    assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_DSTAR, DSD_DECODE_PRESET_PROFILE_CLI, o, s) == 0);
+    assert(dsd_scan_mode_resume(o, s) == 0);
+    dsd_scan_mode_leave(o, s);
+    assert(o->frame_dstar && !o->frame_p25p1);
     dsd_scan_mode parsed;
     assert(dsd_scan_mode_parse("  NxDn48 ", &parsed) == 0 && parsed == DSD_SCAN_MODE_NXDN48);
     assert(dsd_scan_mode_parse("   ", &parsed) == 0 && parsed == DSD_SCAN_MODE_INHERIT);
     assert(dsd_scan_mode_parse("NXDN", &parsed) == -1);
     assert(dsd_scan_mode_parse("analog", &parsed) == -1);
     assert(dsd_scan_mode_parse("p25p1", &parsed) == -1);
+    test_p25_modulation_helpers(o, s);
     dsd_state_ext_free_all(copy);
     dsd_state_ext_free_all(s);
     free(copy);

--- a/tests/runtime/test_runtime_scan_mode.c
+++ b/tests/runtime/test_runtime_scan_mode.c
@@ -38,7 +38,7 @@ test_p25_modulation_helpers(dsd_opts* opts, dsd_state* state) {
     assert(dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25) == 0);
     assert(opts->mod_p25p2_c4fm && state->samplesPerSymbol == 10 && state->rf_mod == 0);
     /* An explicit trunk-target modulation still takes precedence over the helper. */
-    dsd_scan_mode_target_modulation(state, 1);
+    dsd_scan_mode_target_modulation(state, DSD_SCAN_MODULATION_AUTO);
     assert(dsd_scan_mode_suspend(opts, state));
     (void)dsd_scan_mode_resume(opts, state);
     assert(!opts->mod_p25p2_c4fm);
@@ -147,6 +147,23 @@ main(void) {
     assert(dsd_scan_mode_parse("NXDN", &parsed) == -1);
     assert(dsd_scan_mode_parse("analog", &parsed) == -1);
     assert(dsd_scan_mode_parse("p25p1", &parsed) == -1);
+    /* AUTO may be captured on any hunt profile. Leaving a typed row must
+     * publish the restored clock and slicer levels, not AUTO's starting preset. */
+    assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_AUTO, DSD_DECODE_PRESET_PROFILE_CLI, o, s) == 0);
+    const int profile_rates[] = {4800, 2400, 9600, 6000, 4800};
+    const int profile_levels[] = {4, 4, 2, 4, 2};
+    for (int i = 0; i < DSD_FRAME_SYNC_SPS_PROFILE_COUNT; i++) {
+        s->sps_hunt_idx = i;
+        s->samplesPerSymbol = 48000 / profile_rates[i];
+        s->symbolCenter = dsd_opts_symbol_center(s->samplesPerSymbol);
+        assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_DMR) == 0);
+        dsd_scan_mode_leave(o, s);
+        const dsd_decode_mode_profile profile = dsd_scan_mode_effective_profile(o, s);
+        assert(profile.symbol_rate_hz == profile_rates[i]);
+        assert(profile.levels == profile_levels[i]);
+        assert((int)profile.sps_profile_index == i);
+        assert(s->samplesPerSymbol == 48000 / profile.symbol_rate_hz);
+    }
     test_p25_modulation_helpers(o, s);
     assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_AUTO, DSD_DECODE_PRESET_PROFILE_CLI, o, s) == 0);
     dsd_scan_settings_capture(o, s, &baseline);

--- a/tests/runtime/test_runtime_scan_mode.c
+++ b/tests/runtime/test_runtime_scan_mode.c
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <assert.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/dsp/frame_sync.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <stdlib.h>
+#include <string.h>
+
+int
+main(void) {
+    dsd_opts* o = (dsd_opts*)calloc(1, sizeof(*o));
+    dsd_state* s = (dsd_state*)calloc(1, sizeof(*s));
+    dsd_state* copy = (dsd_state*)calloc(1, sizeof(*copy));
+    assert(o && s && copy);
+    o->pulse_digi_out_channels = 1;
+    o->pulse_digi_rate_out = 44100;
+    o->wav_sample_rate = 48000;
+    o->audio_in_type = AUDIO_IN_WAV;
+    o->frame_dstar = 2;
+    o->frame_p25p1 = 1;
+    o->mod_gfsk = 1;
+    o->mod_cli_lock = 1;
+    o->inverted_p2 = 3;
+    o->use_cosine_filter = 1;
+    o->ssize = 47;
+    o->msize = 12;
+    s->rf_mod = 2;
+    s->samplesPerSymbol = 13;
+    s->symbolCenter = 5;
+    dsd_scan_settings baseline;
+    dsd_scan_settings restored;
+    dsd_scan_settings_capture(o, s, &baseline);
+    const int rates[] = {4800, 4800, 4800, 4800, 2400, 2400, 4800, 4800, 4800};
+    for (int m = DSD_SCAN_MODE_P25; m <= DSD_SCAN_MODE_M17; m++) {
+        dsd_scan_mode parsed;
+        assert(dsd_scan_mode_parse(dsd_scan_mode_name((dsd_scan_mode)m), &parsed) == 0 && parsed == (dsd_scan_mode)m);
+        dsd_scan_settings prepared;
+        assert(dsd_scan_mode_prepare(o, s, parsed, &prepared) == 0);
+        assert(dsd_scan_mode_active(s) == DSD_SCAN_MODE_INHERIT);
+        assert(dsd_scan_mode_enter(o, s, parsed) == 0);
+        assert(dsd_scan_mode_active(s) == parsed);
+        assert(dsd_scan_mode_effective_profile(o, s).symbol_rate_hz == rates[m]);
+        assert(dsd_scan_mode_effective_profile(o, s).levels == (m == DSD_SCAN_MODE_DSTAR ? 2 : 4));
+        assert(s->samplesPerSymbol == 48000 / rates[m]);
+        assert(s->rf_mod == 2 && o->mod_gfsk == 1 && o->mod_cli_lock == 1);
+        assert(o->pulse_digi_out_channels == 1 && o->pulse_digi_rate_out == 44100);
+        assert(o->frame_x2tdma == 0 && o->frame_provoice == 0);
+        assert(o->frame_p25p1 == (m == DSD_SCAN_MODE_P25));
+        assert(o->frame_p25p2 == (m == DSD_SCAN_MODE_P25));
+        assert(o->frame_dmr == (m == DSD_SCAN_MODE_DMR));
+        assert(o->frame_nxdn48 == (m == DSD_SCAN_MODE_NXDN48));
+        assert(o->frame_nxdn96 == (m == DSD_SCAN_MODE_NXDN96));
+        assert(o->frame_dpmr == (m == DSD_SCAN_MODE_DPMR));
+        assert(o->frame_dstar == (m == DSD_SCAN_MODE_DSTAR));
+        assert(o->frame_ysf == (m == DSD_SCAN_MODE_YSF));
+        assert(o->frame_m17 == (m == DSD_SCAN_MODE_M17));
+        if (m == DSD_SCAN_MODE_DMR) {
+            assert(o->dmr_stereo == 1 && o->dmr_mono == 0);
+        }
+        if (m == DSD_SCAN_MODE_M17) {
+            assert(o->use_cosine_filter == 0);
+        }
+        dsd_scan_mode_configured(o, s, &restored);
+        assert(memcmp(&baseline, &restored, sizeof(baseline)) == 0);
+        dsd_scan_mode_copy_snapshot(copy, s);
+        assert(copy->state_ext[6] != s->state_ext[6]);
+        dsd_scan_mode_leave(o, s);
+        dsd_scan_settings_capture(o, s, &restored);
+        assert(memcmp(&baseline, &restored, sizeof(baseline)) == 0);
+        assert(dsd_scan_mode_active(copy) == parsed);
+    }
+    assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_M17) == 0);
+    assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_NXDN96) == 0);
+    assert(o->use_cosine_filter == 1 && s->samplesPerSymbol == 10);
+    assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_P25) == 0);
+    s->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_6000_4;
+    assert(dsd_scan_mode_effective_profile(o, s).symbol_rate_hz == 6000);
+    assert(dsd_scan_mode_suspend(o, s));
+    assert(o->frame_dstar == 2 && o->ssize == 47);
+    assert(dsd_scan_mode_resume(o, s) == 0);
+    assert(s->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    assert(dsd_scan_mode_suspend(o, s));
+    o->mod_gfsk = 0;
+    o->mod_qpsk = 1;
+    assert(dsd_scan_mode_resume(o, s) == 1);
+    assert(s->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_6000_4 && s->samplesPerSymbol == 8);
+    assert(s->rf_mod == 1);
+    assert(dsd_scan_mode_suspend(o, s));
+    o->frame_dstar = 0;
+    o->frame_ysf = 1;
+    (void)dsd_scan_mode_resume(o, s);
+    assert(o->frame_p25p1 && !o->frame_ysf);
+    dsd_scan_mode_leave(o, s);
+    assert(o->frame_ysf && !o->frame_dstar);
+    dsd_scan_mode parsed;
+    assert(dsd_scan_mode_parse("  NxDn48 ", &parsed) == 0 && parsed == DSD_SCAN_MODE_NXDN48);
+    assert(dsd_scan_mode_parse("   ", &parsed) == 0 && parsed == DSD_SCAN_MODE_INHERIT);
+    assert(dsd_scan_mode_parse("NXDN", &parsed) == -1);
+    assert(dsd_scan_mode_parse("analog", &parsed) == -1);
+    assert(dsd_scan_mode_parse("p25p1", &parsed) == -1);
+    dsd_state_ext_free_all(copy);
+    dsd_state_ext_free_all(s);
+    free(copy);
+    free(s);
+    free(o);
+    return 0;
+}

--- a/tests/runtime/test_runtime_scan_mode.c
+++ b/tests/runtime/test_runtime_scan_mode.c
@@ -148,6 +148,34 @@ main(void) {
     assert(dsd_scan_mode_parse("analog", &parsed) == -1);
     assert(dsd_scan_mode_parse("p25p1", &parsed) == -1);
     test_p25_modulation_helpers(o, s);
+    assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_AUTO, DSD_DECODE_PRESET_PROFILE_CLI, o, s) == 0);
+    dsd_scan_settings_capture(o, s, &baseline);
+    assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_DMR) == 0);
+    assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_INHERIT) == 0);
+    /* AUTO acquisition on a blank row may move the live clock and modulation. */
+    s->samplesPerSymbol = 20;
+    s->symbolCenter = 9;
+    s->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    s->rf_mod = 2;
+    assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_P25) == 0);
+    dsd_scan_mode_leave(o, s);
+    dsd_scan_settings_capture(o, s, &restored);
+    assert(dsd_scan_settings_equal(&baseline, &restored, 1));
+    /* Persistence must retain custom decoder combinations and the configured
+     * modulation/slot policy without allocating a whole options copy. */
+    o->frame_x2tdma = 0;
+    o->mod_cli_lock = 1;
+    o->mod_c4fm = 0;
+    o->mod_qpsk = 1;
+    o->mod_gfsk = 0;
+    o->dmr_mono = 1;
+    assert(dsd_infer_decode_mode_preset_exact(o) == DSDCFG_MODE_UNSET);
+    assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_DMR) == 0);
+    dsdneoUserConfig config;
+    dsd_snapshot_opts_to_user_config(o, s, &config);
+    assert(config.decode_mode == DSDCFG_MODE_UNSET && config.dmr_mono == 1);
+    assert(config.has_demod && config.demod_path == DSDCFG_DEMOD_QPSK);
+    dsd_scan_mode_leave(o, s);
     dsd_state_ext_free_all(copy);
     dsd_state_ext_free_all(s);
     free(copy);

--- a/tests/test_support/channel_scan_stubs.c
+++ b/tests/test_support/channel_scan_stubs.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/engine/channel_scan.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <stddef.h>
+
+/* Action-only tests have no tuner; exercise the production scoped-settings teardown. */
+void
+dsd_engine_channel_scan_leave(dsd_opts* opts, dsd_state* state) {
+    (void)dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_CHANNEL_SCAN, NULL, NULL);
+    dsd_scan_mode_leave(opts, state);
+}

--- a/tests/test_support/scan_mode_label_stubs.c
+++ b/tests/test_support/scan_mode_label_stubs.c
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/scan_mode.h>
+
+/* Label/picker tests inject preset labels; scoped metadata is covered by runtime and snapshot tests. */
+dsdneoUserDecodeMode
+dsd_scan_mode_configured_preset(const dsd_opts* opts, const dsd_state* state) {
+    (void)state;
+    return dsd_infer_decode_mode_preset(opts);
+}
+
+dsd_scan_mode
+dsd_scan_mode_active(const dsd_state* state) {
+    (void)state;
+    return DSD_SCAN_MODE_INHERIT;
+}
+
+const char*
+dsd_scan_mode_name(dsd_scan_mode mode) {
+    (void)mode;
+    return "";
+}

--- a/tests/test_support/scan_mode_label_stubs.c
+++ b/tests/test_support/scan_mode_label_stubs.c
@@ -16,6 +16,16 @@ static dsd_opts snapshot_opts;
 static dsd_state snapshot_state;
 static int snapshots_available = 1;
 static dsd_scan_mode active_mode;
+static dsd_scan_settings configured_settings;
+static int have_configured;
+
+void
+dsd_test_scan_labels_configured(const dsd_scan_settings* settings) {
+    have_configured = settings != NULL;
+    if (settings) {
+        configured_settings = *settings;
+    }
+}
 
 void
 dsd_test_scan_labels_set(int available, dsd_scan_mode mode) {
@@ -26,7 +36,7 @@ dsd_test_scan_labels_set(int available, dsd_scan_mode mode) {
 const dsd_scan_settings*
 dsd_scan_mode_configured_view(const dsd_state* state) {
     assert(state == &snapshot_state || state == NULL);
-    return NULL;
+    return state && have_configured ? &configured_settings : NULL;
 }
 
 void

--- a/tests/test_support/scan_mode_label_stubs.c
+++ b/tests/test_support/scan_mode_label_stubs.c
@@ -10,9 +10,24 @@
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/scan_mode.h>
 #include <stddef.h>
+#include "scan_mode_label_stubs.h"
 
 static dsd_opts snapshot_opts;
 static dsd_state snapshot_state;
+static int snapshots_available = 1;
+static dsd_scan_mode active_mode;
+
+void
+dsd_test_scan_labels_set(int available, dsd_scan_mode mode) {
+    snapshots_available = available;
+    active_mode = mode;
+}
+
+const dsd_scan_settings*
+dsd_scan_mode_configured_view(const dsd_state* state) {
+    assert(state == &snapshot_state || state == NULL);
+    return NULL;
+}
 
 void
 dsd_app_snapshot_configured_mode(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out) {
@@ -24,12 +39,12 @@ dsd_app_snapshot_configured_mode(const dsd_opts* opts, const dsd_state* state, d
 
 const dsd_opts*
 dsd_app_get_latest_opts_snapshot(void) {
-    return &snapshot_opts;
+    return snapshots_available ? &snapshot_opts : NULL;
 }
 
 const dsd_state*
 dsd_app_get_latest_snapshot(void) {
-    return &snapshot_state;
+    return snapshots_available ? &snapshot_state : NULL;
 }
 
 /* Fail if a label or picker passes the live menu context to an extension reader. */
@@ -43,11 +58,10 @@ dsd_scan_mode_configured_preset(const dsd_opts* opts, const dsd_state* state) {
 dsd_scan_mode
 dsd_scan_mode_active(const dsd_state* state) {
     assert(state == &snapshot_state || state == NULL);
-    return DSD_SCAN_MODE_INHERIT;
+    return state ? active_mode : DSD_SCAN_MODE_INHERIT;
 }
 
 const char*
 dsd_scan_mode_name(dsd_scan_mode mode) {
-    (void)mode;
-    return "";
+    return mode == DSD_SCAN_MODE_P25 ? "p25" : "";
 }

--- a/tests/test_support/scan_mode_label_stubs.c
+++ b/tests/test_support/scan_mode_label_stubs.c
@@ -14,6 +14,14 @@
 static dsd_opts snapshot_opts;
 static dsd_state snapshot_state;
 
+void
+dsd_app_snapshot_configured_mode(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out) {
+    assert(opts == &snapshot_opts);
+    assert(state == &snapshot_state);
+    out->use_cosine_filter = opts->use_cosine_filter;
+    out->monitor_input_audio = opts->monitor_input_audio;
+}
+
 const dsd_opts*
 dsd_app_get_latest_opts_snapshot(void) {
     return &snapshot_opts;

--- a/tests/test_support/scan_mode_label_stubs.c
+++ b/tests/test_support/scan_mode_label_stubs.c
@@ -1,21 +1,40 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 /* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+#include <assert.h>
+#include <dsd-neo/app_control/snapshot.h>
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/scan_mode.h>
+#include <stddef.h>
 
-/* Label/picker tests inject preset labels; scoped metadata is covered by runtime and snapshot tests. */
+static dsd_opts snapshot_opts;
+static dsd_state snapshot_state;
+
+const dsd_opts*
+dsd_app_get_latest_opts_snapshot(void) {
+    return &snapshot_opts;
+}
+
+const dsd_state*
+dsd_app_get_latest_snapshot(void) {
+    return &snapshot_state;
+}
+
+/* Fail if a label or picker passes the live menu context to an extension reader. */
 dsdneoUserDecodeMode
 dsd_scan_mode_configured_preset(const dsd_opts* opts, const dsd_state* state) {
-    (void)state;
+    assert(opts == &snapshot_opts);
+    assert(state == &snapshot_state);
     return dsd_infer_decode_mode_preset(opts);
 }
 
 dsd_scan_mode
 dsd_scan_mode_active(const dsd_state* state) {
-    (void)state;
+    assert(state == &snapshot_state || state == NULL);
     return DSD_SCAN_MODE_INHERIT;
 }
 

--- a/tests/test_support/scan_mode_label_stubs.h
+++ b/tests/test_support/scan_mode_label_stubs.h
@@ -5,5 +5,6 @@
 #include <dsd-neo/runtime/scan_mode.h>
 
 void dsd_test_scan_labels_set(int available, dsd_scan_mode mode);
+void dsd_test_scan_labels_configured(const dsd_scan_settings* settings);
 
 #endif

--- a/tests/test_support/scan_mode_label_stubs.h
+++ b/tests/test_support/scan_mode_label_stubs.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+#ifndef DSD_NEO_TEST_SCAN_MODE_LABEL_STUBS_H
+#define DSD_NEO_TEST_SCAN_MODE_LABEL_STUBS_H
+#include <dsd-neo/runtime/scan_mode.h>
+
+void dsd_test_scan_labels_set(int available, dsd_scan_mode mode);
+
+#endif

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -9,6 +9,7 @@
 
 #include <dsd-neo/app_control/commands.h>
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/enc_lockout.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/init.h>
@@ -955,6 +956,17 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
     rc |= expect_true("accepted RTL frequency timeout reports pending",
                       strstr(state.ui_msg, "Accepted: RTL frequency -> 851500000 Hz (pending)") != NULL);
     rc |= expect_int("accepted RTL frequency timeout tune calls", g_io_control_tune_calls, 1);
+    opts.scanner_mode = 1;
+    post_u32(DSD_APP_CMD_RTL_SET_FREQ, 852000000U);
+    rc |= expect_int("legacy scanner tune drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("legacy manual tune preserves scanner", opts.scanner_mode, 1);
+    rc |= expect_int("typed metadata for manual tune", dsd_channel_mode_set(&state, 0, DSD_SCAN_MODE_DMR), 0);
+    rc |= expect_int("typed mode before manual tune", dsd_scan_mode_enter(&opts, &state, DSD_SCAN_MODE_DMR), 0);
+    post_u32(DSD_APP_CMD_RTL_SET_FREQ, 853000000U);
+    rc |= expect_int("typed scanner tune drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("typed manual tune releases scanner", opts.scanner_mode, 0);
+    rc |= expect_int("typed manual tune releases mode", dsd_scan_mode_active(&state), DSD_SCAN_MODE_INHERIT);
+    rc |= expect_contains("manual tune explains scanner exit", state.ui_msg, "scanner stopped");
     freeState(&state);
 #endif
 
@@ -2118,9 +2130,13 @@ test_scoped_setting_toggles(void) {
     opts->use_cosine_filter = 1;
     opts->monitor_input_audio = 0;
     opts->inverted_dmr = 0;
+    opts->inverted_x2tdma = 0;
+    opts->inverted_dpmr = 0;
+    opts->inverted_m17 = 0;
     rc |= expect_int("enter DMR for toggles", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_DMR), 0);
-    const int commands[] = {DSD_APP_CMD_INVERT_TOGGLE, DSD_APP_CMD_COSINE_FILTER_TOGGLE,
-                            DSD_APP_CMD_INPUT_MONITOR_TOGGLE};
+    const int commands[] = {DSD_APP_CMD_INV_DMR_TOGGLE,       DSD_APP_CMD_INV_X2_TOGGLE,
+                            DSD_APP_CMD_INV_DPMR_TOGGLE,      DSD_APP_CMD_INV_M17_TOGGLE,
+                            DSD_APP_CMD_COSINE_FILTER_TOGGLE, DSD_APP_CMD_INPUT_MONITOR_TOGGLE};
     for (size_t i = 0; i < sizeof(commands) / sizeof(commands[0]); ++i) {
         if (commands[i] == DSD_APP_CMD_INPUT_MONITOR_TOGGLE) {
             const dsd_call_observation call = {.protocol = DSD_SYNC_DMR_BS_VOICE_POS,
@@ -2148,6 +2164,9 @@ test_scoped_setting_toggles(void) {
     rc |= expect_int("hop keeps monitor", opts->monitor_input_audio, 1);
     dsd_scan_mode_leave(opts, state);
     rc |= expect_int("exit keeps invert", opts->inverted_dmr, 1);
+    rc |= expect_int("exit keeps X2 invert", opts->inverted_x2tdma, 1);
+    rc |= expect_int("exit keeps dPMR invert", opts->inverted_dpmr, 1);
+    rc |= expect_int("exit keeps M17 invert", opts->inverted_m17, 1);
     rc |= expect_int("exit keeps filter", opts->use_cosine_filter, 0);
     rc |= expect_int("exit keeps monitor", opts->monitor_input_audio, 1);
     rc |= expect_int("enter P25 for helper toggle", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25), 0);
@@ -2173,6 +2192,10 @@ test_scoped_setting_toggles(void) {
     rc |= expect_int("release drained with target owner", dsd_app_drain_cmds(opts, state), 1);
     rc |= expect_int("release preserves target owner", opts->trunk_scan_enabled, 1);
     rc |= expect_int("release preserves target class", dsd_scan_mode_active(state), DSD_SCAN_MODE_NXDN48);
+    post_empty(DSD_APP_CMD_SCANNER_TOGGLE);
+    rc |= expect_int("scanner toggle during trunk scan drained", dsd_app_drain_cmds(opts, state), 1);
+    rc |= expect_int("trunk scan excludes conventional scanner", opts->scanner_mode, 0);
+    rc |= expect_int("refused scanner preserves target", dsd_scan_mode_active(state), DSD_SCAN_MODE_NXDN48);
     freeState(state);
     free(state);
     free(opts);
@@ -2219,6 +2242,25 @@ test_scoped_mode_commands_and_config(void) {
     rc |= expect_int("exit restores M17 filter", opts->use_cosine_filter, 0);
     rc |= expect_int("exit restores configured timing at live input rate", state->samplesPerSymbol, 20);
     rc |= expect_int("exit restores configured profile", state->sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    opts->scanner_mode = 1;
+    rc |= expect_int("reenter scan P25", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25), 0);
+    dsd_key_set row_keys = {0};
+    row_keys.present = 1;
+    opts->mod_cli_lock = 0;
+    rc |= expect_int("config exit row keys", dsd_scan_keys_enter(state, &row_keys), 1);
+    dsdneoUserConfig cfg = {0};
+    cfg.has_trunking = 1;
+    cfg.trunk_scanner = 0;
+    cfg.has_mode = 1;
+    cfg.decode_mode = DSDCFG_MODE_NXDN48;
+    rc |= expect_int("config exit queued", dsd_app_command_submit(DSD_APP_CMD_CONFIG_APPLY, &cfg, sizeof(cfg)),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("config exit drained", dsd_app_drain_cmds(opts, state), 1);
+    rc |= expect_int("config stops scanner", opts->scanner_mode, 0);
+    rc |= expect_int("config releases scope", dsd_scan_mode_active(state), DSD_SCAN_MODE_INHERIT);
+    rc |= expect_int("config keeps new baseline", opts->frame_nxdn48, 1);
+    rc |= expect_int("config releases P25", opts->frame_p25p1, 0);
+    rc |= expect_int("config releases row keys", state->scan_keys_active_set, 0);
     freeState(state);
     free(state);
     free(opts);

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -2103,6 +2103,66 @@ test_scan_voice_gate_commands(void) {
 }
 
 static int
+test_scoped_setting_toggles(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        return 1;
+    }
+    init_test_context(opts, state);
+    int rc = 0;
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 48000;
+    opts->use_cosine_filter = 1;
+    opts->monitor_input_audio = 0;
+    opts->inverted_dmr = 0;
+    rc |= expect_int("enter DMR for toggles", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_DMR), 0);
+    const int commands[] = {DSD_APP_CMD_INVERT_TOGGLE, DSD_APP_CMD_COSINE_FILTER_TOGGLE,
+                            DSD_APP_CMD_INPUT_MONITOR_TOGGLE};
+    for (size_t i = 0; i < sizeof(commands) / sizeof(commands[0]); ++i) {
+        rc |= expect_int("scoped toggle queued", dsd_app_command_action(commands[i]), DSD_APP_COMMAND_SUBMIT_QUEUED);
+        rc |= expect_int("scoped toggle drained", dsd_app_drain_cmds(opts, state), 1);
+    }
+    rc |= expect_int("hop to NXDN", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_NXDN48), 0);
+    rc |= expect_int("hop keeps invert", opts->inverted_dmr, 1);
+    rc |= expect_int("hop keeps filter", opts->use_cosine_filter, 0);
+    rc |= expect_int("hop keeps monitor", opts->monitor_input_audio, 1);
+    dsd_scan_mode_leave(opts, state);
+    rc |= expect_int("exit keeps invert", opts->inverted_dmr, 1);
+    rc |= expect_int("exit keeps filter", opts->use_cosine_filter, 0);
+    rc |= expect_int("exit keeps monitor", opts->monitor_input_audio, 1);
+    rc |= expect_int("enter P25 for helper toggle", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25), 0);
+    rc |= expect_int("helper toggle queued", dsd_app_command_action(DSD_APP_CMD_MOD_P2_TOGGLE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("helper toggle drained", dsd_app_drain_cmds(opts, state), 1);
+    rc |= expect_int("helper remains on row", opts->mod_p25p2_profile_lock, 1);
+    rc |= expect_int("helper applies 6000 on first press", state->sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    rc |= expect_int("helper applies current input timing", state->samplesPerSymbol, 8);
+    dsd_scan_mode_leave(opts, state);
+    rc |= expect_int("exit keeps helper", opts->mod_p25p2_profile_lock, 1);
+    rc |= expect_int("exit keeps helper profile", state->sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_6000_4);
+    /* These commands leave the trunk-scan owner running. Its decoder scope must
+     * survive until the coordinator switches targets or shuts down. */
+    opts->trunk_scan_enabled = 1;
+    rc |= expect_int("enter target NXDN", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_NXDN48), 0);
+    rc |= expect_int("trunk enable queued", dsd_app_command_set_i32(DSD_APP_CMD_TRUNK_SET, 1),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("trunk enable drained", dsd_app_drain_cmds(opts, state), 1);
+    rc |= expect_int("enable preserves target class", dsd_scan_mode_active(state), DSD_SCAN_MODE_NXDN48);
+    rc |= expect_int("release queued with target owner", dsd_app_command_action(DSD_APP_CMD_TUNER_RELEASE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("release drained with target owner", dsd_app_drain_cmds(opts, state), 1);
+    rc |= expect_int("release preserves target owner", opts->trunk_scan_enabled, 1);
+    rc |= expect_int("release preserves target class", dsd_scan_mode_active(state), DSD_SCAN_MODE_NXDN48);
+    freeState(state);
+    free(state);
+    free(opts);
+    return rc;
+}
+
+static int
 test_scoped_mode_commands_and_config(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
@@ -2151,6 +2211,7 @@ test_scoped_mode_commands_and_config(void) {
 int
 main(void) {
     int rc = 0;
+    rc |= test_scoped_setting_toggles();
     rc |= test_scoped_mode_commands_and_config();
     rc |= test_command_api();
     rc |= test_manual_tune_queue_semantics();

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -20,6 +20,8 @@
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
@@ -613,7 +615,7 @@ test_file_network_and_import_commands(void) {
     post_string(DSD_APP_CMD_IMPORT_KEYS_DEC, missing_csv);
     post_string(DSD_APP_CMD_IMPORT_KEYS_HEX, missing_csv);
     rc |= expect_int("import failure group applied", dsd_app_drain_cmds(&opts, &state), 4);
-    rc |= expect_str("channel import path copied", opts.chan_in_file, missing_csv);
+    rc |= expect_str("failed channel import keeps path", opts.chan_in_file, "");
     rc |= expect_str("group import path copied", opts.group_in_file, missing_csv);
     rc |= expect_str("key import path copied", opts.key_in_file, missing_csv);
     rc |= expect_contains("key import failure toast", state.ui_msg, "Failed: Keys (HEX)");
@@ -2100,9 +2102,56 @@ test_scan_voice_gate_commands(void) {
     return rc;
 }
 
+static int
+test_scoped_mode_commands_and_config(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        return 1;
+    }
+    init_test_context(opts, state);
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 96000;
+    int rc = 0;
+    rc |= expect_int("configured NXDN",
+                     dsd_apply_decode_mode_preset(DSDCFG_MODE_NXDN48, DSD_DECODE_PRESET_PROFILE_CLI, opts, state), 0);
+    opts->scanner_mode = 1;
+    rc |= expect_int("enter scan P25", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25), 0);
+    state->sps_hunt_counter = 17;
+    rc |= expect_int("repeat configured mode queued",
+                     dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, (int32_t)DSDCFG_MODE_NXDN48),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("repeat configured mode drained", dsd_app_drain_cmds(opts, state), 1);
+    rc |= expect_int("repeat keeps row P25", opts->frame_p25p1, 1);
+    rc |= expect_int("repeat keeps dwell", state->sps_hunt_counter, 17);
+    rc |= expect_int("change configured mode queued",
+                     dsd_app_command_set_i32(DSD_APP_CMD_DECODE_MODE_SET, (int32_t)DSDCFG_MODE_M17),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("change configured mode drained", dsd_app_drain_cmds(opts, state), 1);
+    rc |= expect_int("row still P25", opts->frame_p25p1, 1);
+    rc |= expect_int("row excludes M17", opts->frame_m17, 0);
+    dsdneoUserConfig saved;
+    dsd_snapshot_opts_to_user_config(opts, state, &saved);
+    rc |= expect_int("configuration saves baseline M17", saved.decode_mode, DSDCFG_MODE_M17);
+    rc |= expect_int("scanner toggle queued", dsd_app_command_action(DSD_APP_CMD_SCANNER_TOGGLE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("scanner toggle drained", dsd_app_drain_cmds(opts, state), 1);
+    rc |= expect_int("exit restores M17", opts->frame_m17, 1);
+    rc |= expect_int("exit restores M17 filter", opts->use_cosine_filter, 0);
+    rc |= expect_int("exit restores configured timing at live input rate", state->samplesPerSymbol, 20);
+    rc |= expect_int("exit restores configured profile", state->sps_hunt_idx, DSD_FRAME_SYNC_SPS_PROFILE_4800_4);
+    freeState(state);
+    free(state);
+    free(opts);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
+    rc |= test_scoped_mode_commands_and_config();
     rc |= test_command_api();
     rc |= test_manual_tune_queue_semantics();
     rc |= test_setter_coalescing_preserves_fifo_boundaries();

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -2122,9 +2122,26 @@ test_scoped_setting_toggles(void) {
     const int commands[] = {DSD_APP_CMD_INVERT_TOGGLE, DSD_APP_CMD_COSINE_FILTER_TOGGLE,
                             DSD_APP_CMD_INPUT_MONITOR_TOGGLE};
     for (size_t i = 0; i < sizeof(commands) / sizeof(commands[0]); ++i) {
+        if (commands[i] == DSD_APP_CMD_INPUT_MONITOR_TOGGLE) {
+            const dsd_call_observation call = {.protocol = DSD_SYNC_DMR_BS_VOICE_POS,
+                                               .kind = DSD_CALL_KIND_GROUP_VOICE,
+                                               .ota_target_id = 1201,
+                                               .observed_m = 1.0};
+            rc |= expect_int("seed call before monitor toggle",
+                             dsd_call_state_observe(state, &call, DSD_CALL_BOUNDARY_BEGIN), 1);
+            state->synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+            state->rf_mod = 2;
+            state->sps_hunt_counter = 17;
+        }
         rc |= expect_int("scoped toggle queued", dsd_app_command_action(commands[i]), DSD_APP_COMMAND_SUBMIT_QUEUED);
         rc |= expect_int("scoped toggle drained", dsd_app_drain_cmds(opts, state), 1);
     }
+    dsd_call_snapshot call;
+    rc |= expect_int("monitor keeps call", dsd_call_state_get(state, 0, &call), 1);
+    rc |= expect_int("monitor keeps call active", call.phase, DSD_CALL_PHASE_ACTIVE);
+    rc |= expect_int("monitor keeps acquired sync", state->synctype, DSD_SYNC_DMR_BS_VOICE_POS);
+    rc |= expect_int("monitor keeps acquired modulation", state->rf_mod, 2);
+    rc |= expect_int("monitor keeps hunt accounting", state->sps_hunt_counter, 17);
     rc |= expect_int("hop to NXDN", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_NXDN48), 0);
     rc |= expect_int("hop keeps invert", opts->inverted_dmr, 1);
     rc |= expect_int("hop keeps filter", opts->use_cosine_filter, 0);

--- a/tests/ui/test_ui_menu_actions.c
+++ b/tests/ui/test_ui_menu_actions.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <dsd-neo/app_control/commands.h>
 #include <dsd-neo/app_control/frontend.h>
+#include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>
 #include <dsd-neo/core/safe_api.h>
@@ -432,8 +433,8 @@ dsd_user_config_save_atomic(const char* path, const dsdneoUserConfig* cfg) {
 
 void
 dsd_snapshot_opts_to_user_config(const dsd_opts* opts, const dsd_state* state, dsdneoUserConfig* cfg) {
-    (void)opts;
-    (void)state;
+    assert(opts == dsd_app_get_latest_opts_snapshot());
+    assert(state == dsd_app_get_latest_snapshot());
     if (cfg) {
         DSD_MEMSET(cfg, 0, sizeof *cfg);
     }

--- a/tests/ui/test_ui_menu_callbacks.c
+++ b/tests/ui/test_ui_menu_callbacks.c
@@ -13,6 +13,7 @@
 #include <assert.h>
 #include <dsd-neo/app_control/commands.h>
 #include <dsd-neo/app_control/rr_import_apply.h>
+#include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
@@ -300,10 +301,22 @@ dsd_user_config_save_atomic(const char* path, const dsdneoUserConfig* cfg) {
     return g_config_save_rc;
 }
 
+const dsd_opts*
+dsd_app_get_latest_opts_snapshot(void) {
+    static dsd_opts snapshot;
+    return &snapshot;
+}
+
+const dsd_state*
+dsd_app_get_latest_snapshot(void) {
+    static dsd_state snapshot;
+    return &snapshot;
+}
+
 void
 dsd_snapshot_opts_to_user_config(const dsd_opts* opts, const dsd_state* state, dsdneoUserConfig* cfg) {
-    (void)opts;
-    (void)state;
+    assert(opts == dsd_app_get_latest_opts_snapshot());
+    assert(state == dsd_app_get_latest_snapshot());
     if (cfg) {
         DSD_MEMSET(cfg, 0, sizeof *cfg);
     }

--- a/tests/ui/test_ui_menu_labels.c
+++ b/tests/ui/test_ui_menu_labels.c
@@ -22,10 +22,12 @@
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/radioreference.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <sndfile.h>
 #include <stdio.h>
 #include <string.h>
 
+#include "../test_support/scan_mode_label_stubs.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/platform/sockets.h"
@@ -215,6 +217,14 @@ test_decoder_labels(void) {
     rc |= expect_str("decode mode auto", lbl_decode_mode(&ctx, b, sizeof(b)), "Mode... [Auto]");
     g_infer_mode = DSDCFG_MODE_DMR;
     rc |= expect_str("decode mode dmr", lbl_decode_mode(&ctx, b, sizeof(b)), "Mode... [DMR]");
+    dsd_test_scan_labels_set(1, DSD_SCAN_MODE_P25);
+    rc |= expect_str("decode mode with row override", lbl_decode_mode(&ctx, b, sizeof(b)), "Mode... [DMR; scan p25]");
+    dsd_test_scan_labels_set(0, DSD_SCAN_MODE_INHERIT);
+    opts.monitor_input_audio = 1;
+    opts.use_cosine_filter = 1;
+    rc |= expect_str("monitor before snapshots", lbl_monitor(&ctx, b, sizeof(b)), "Source audio monitor [On]");
+    rc |= expect_str("filter before snapshots", lbl_cosine(&ctx, b, sizeof(b)), "Cosine filter [On]");
+    dsd_test_scan_labels_set(1, DSD_SCAN_MODE_INHERIT);
     rc |= expect_str("decode mode null ctx is auto", lbl_decode_mode(NULL, b, sizeof(b)), "Mode... [Auto]");
 
     state.rf_mod = 1;

--- a/tests/ui/test_ui_menu_labels.c
+++ b/tests/ui/test_ui_menu_labels.c
@@ -12,6 +12,7 @@
  */
 
 #include <dsd-neo/app_control/history.h>
+#include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
@@ -250,7 +251,10 @@ test_decoder_labels(void) {
     rc |= expect_str("hpf off", lbl_hpf(&ctx, b, sizeof(b)), "High-pass filter [Off]");
     rc |= expect_str("pbf on", lbl_pbf(&ctx, b, sizeof(b)), "Pulse-shaping band-pass [On]");
     rc |= expect_str("hpf digital off", lbl_hpf_d(&ctx, b, sizeof(b)), "Digital high-pass filter [Off]");
-    opts.use_cosine_filter = 1;
+    /* The M17 row can disable the effective filter while the configured value
+     * shown by this toggle remains enabled. */
+    opts.use_cosine_filter = 0;
+    ((dsd_opts*)dsd_app_get_latest_opts_snapshot())->use_cosine_filter = 1;
     rc |= expect_str("cosine on", lbl_cosine(&ctx, b, sizeof(b)), "Cosine filter [On]");
 
     opts.aggressive_framesync = 0;
@@ -477,7 +481,8 @@ test_input_and_audio_labels(void) {
     rc |= expect_str("output muted", lbl_out_mute(&ctx, b, sizeof(b)), "Mute [On]");
     opts.audio_out = 1;
     rc |= expect_str("output unmuted", lbl_out_mute(&ctx, b, sizeof(b)), "Mute [Off]");
-    opts.monitor_input_audio = 1;
+    opts.monitor_input_audio = 0;
+    ((dsd_opts*)dsd_app_get_latest_opts_snapshot())->monitor_input_audio = 1;
     rc |= expect_str("monitor on", lbl_monitor(&ctx, b, sizeof(b)), "Source audio monitor [On]");
     opts.input_volume_multiplier = 0;
     rc |=

--- a/tests/ui/test_ui_menu_labels.c
+++ b/tests/ui/test_ui_menu_labels.c
@@ -224,7 +224,7 @@ test_decoder_labels(void) {
     opts.use_cosine_filter = 1;
     rc |= expect_str("monitor before snapshots", lbl_monitor(&ctx, b, sizeof(b)), "Source audio monitor [On]");
     rc |= expect_str("filter before snapshots", lbl_cosine(&ctx, b, sizeof(b)), "Cosine filter [On]");
-    dsd_test_scan_labels_set(1, DSD_SCAN_MODE_INHERIT);
+    dsd_test_scan_labels_set(0, DSD_SCAN_MODE_INHERIT);
     rc |= expect_str("decode mode null ctx is auto", lbl_decode_mode(NULL, b, sizeof(b)), "Mode... [Auto]");
 
     state.rf_mod = 1;
@@ -252,6 +252,27 @@ test_decoder_labels(void) {
                      "P25 Phase 2 modulation lock [C4FM]");
     opts.mod_p25p2_c4fm = 0;
     state.rf_mod = 7;
+
+    dsd_test_scan_labels_set(1, DSD_SCAN_MODE_P25);
+    dsd_scan_settings configured = {0};
+    configured.state_rf_mod = 1;
+    configured.mod_qpsk = 1;
+    configured.mod_p25p2_profile_lock = 1;
+    dsd_test_scan_labels_configured(&configured);
+    state.rf_mod = 2;
+    rc |= expect_str("modulation reads configured snapshot", lbl_modulation(&ctx, b, sizeof(b)), "Modulation [QPSK]");
+    rc |= expect_str("p2 lock reads configured snapshot", lbl_p25p2_mod_lock(&ctx, b, sizeof(b)),
+                     "P25 Phase 2 modulation lock [QPSK]");
+    configured.state_rf_mod = 0;
+    configured.mod_p25p2_c4fm = 1;
+    dsd_test_scan_labels_configured(&configured);
+    rc |= expect_str("modulation follows configured toggle", lbl_modulation(&ctx, b, sizeof(b)), "Modulation [C4FM]");
+    rc |= expect_str("configured cli p2 lock", lbl_p25p2_mod_lock(&ctx, b, sizeof(b)),
+                     "P25 Phase 2 modulation lock [C4FM]");
+    dsd_test_scan_labels_configured(NULL);
+    dsd_test_scan_labels_set(1, DSD_SCAN_MODE_INHERIT);
+    ((dsd_state*)dsd_app_get_latest_snapshot())->rf_mod = 1;
+    rc |= expect_str("modulation uses published state", lbl_modulation(&ctx, b, sizeof(b)), "Modulation [QPSK]");
 
     opts.use_lpf = 1;
     opts.use_hpf = 0;

--- a/tests/ui/test_ui_menu_services.c
+++ b/tests/ui/test_ui_menu_services.c
@@ -8,6 +8,7 @@
  */
 
 #include <dsd-neo/core/audio.h>
+#include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/csv_validate.h>
@@ -29,6 +30,7 @@
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/log.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <math.h>
 #include <sndfile.h>
 #include <stdint.h>
@@ -38,7 +40,6 @@
 #include "services.h"
 
 #include "dsd-neo/core/opts_fwd.h"
-#include "dsd-neo/core/state_ext.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "dsd-neo/io/rtl_stream_fwd.h"
 #include "dsd-neo/platform/sockets.h"
@@ -155,6 +156,7 @@ static uint32_t g_chan_import_chan[4];
 static long int g_chan_import_freq[4];
 /* Per-row names, NULL for a row the file leaves unnamed. */
 static const char* g_chan_import_name[4];
+static dsd_scan_mode g_chan_import_mode[4];
 /* Per-row key seed: set entries load a one-slot key set into the row. */
 static int g_chan_import_has_key[4];
 static unsigned long long g_chan_import_key[4];
@@ -177,6 +179,7 @@ csvChanImport(const dsd_opts* opts, dsd_state* state) {
         // Names are positional: the row index is the slot the frequency just took.
         const size_t row = (size_t)state->lcn_freq_count;
         state->trunk_lcn_freq[state->lcn_freq_count++] = g_chan_import_freq[i];
+        (void)dsd_channel_mode_set(state, row, g_chan_import_mode[i]);
         if (g_chan_import_name[i] != NULL) {
             (void)dsd_state_trunk_lcn_name_set(state, row, g_chan_import_name[i]);
         }
@@ -301,13 +304,6 @@ dsd_tg_policy_clear(dsd_state* state) {
     (void)state;
     g_tg_policy_clear_calls++;
     return 0;
-}
-
-/* The throwaway import state may carry module extensions; nothing under test
- * allocates one, so releasing it is a no-op here. */
-void
-dsd_state_ext_free_all(dsd_state* state) {
-    (void)state;
 }
 
 int
@@ -851,7 +847,7 @@ test_file_network_and_import_failure_contracts(void) {
 
     g_chan_import_result = -1;
     rc |= expect_int("channel import failure", svc_import_channel_map(&opts, &state, "channels.csv"), -1);
-    rc |= expect_str("channel import path stored", opts.chan_in_file, "channels.csv");
+    rc |= expect_str("failed channel import keeps path", opts.chan_in_file, "");
     rc |= expect_int("group import failure", svc_import_group_list(&opts, &state, "groups.csv"), -1);
     rc |= expect_str("group import path stored", opts.group_in_file, "groups.csv");
     rc |= expect_int("keys dec import failure", svc_import_keys_dec(&opts, &state, "keys.csv"), -1);
@@ -872,6 +868,7 @@ test_channel_map_reimport_replaces_previous_map(void) {
 
     g_chan_import_result = 0;
     g_chan_import_count = 3;
+    g_chan_import_mode[0] = DSD_SCAN_MODE_NXDN48;
     g_chan_import_chan[0] = 101;
     g_chan_import_freq[0] = 851000000L;
     g_chan_import_chan[1] = 102;
@@ -914,7 +911,7 @@ test_channel_map_reimport_replaces_previous_map(void) {
     rc |= expect_int("failed reimport rc", svc_import_channel_map(&opts, &state, "bad.csv"), -1);
     rc |= expect_int("failed reimport preserves lcn count", state.lcn_freq_count, 2);
     rc |= expect_int("failed reimport preserves chan", (int)state.trunk_chan_map[201], 860000000);
-    rc |= expect_str("failed reimport still stores path", opts.chan_in_file, "bad.csv");
+    rc |= expect_str("failed reimport keeps path", opts.chan_in_file, "b.csv");
 
     // The importer reports success for any file it can open, so a mispicked CSV
     // parses to an empty map. Adopting that would replace the live map with
@@ -960,10 +957,12 @@ test_channel_map_reimport_replaces_previous_map(void) {
     // the names it had, and the imported one is still released exactly once. The count of
     // frees is what ASan checks; a copy instead of a move would read back freed memory here.
     g_chan_import_count = 0;
+    const dsd_scan_mode kept_mode = dsd_channel_mode_get(&state, 0U);
     g_chan_import_name_without_row = "Orphan";
     rc |= expect_int("named empty import refused", svc_import_channel_map(&opts, &state, "empty.csv"), -1);
     rc |= expect_str("refused adopt keeps the live names", dsd_state_trunk_lcn_name_get(&state, 0U), "Repeater 1");
     g_chan_import_name_without_row = NULL;
+    rc |= expect_int("refused adopt keeps mode", dsd_channel_mode_get(&state, 0U), kept_mode);
 
     dsd_state_trunk_lcn_free(&state);
     return rc;
@@ -1029,6 +1028,7 @@ test_clear_services_unload_what_the_importers_loaded(void) {
 
     rc |= expect_int("chan map clear ok", svc_clear_channel_map(&opts, &state), 0);
     rc |= expect_str("chan map clear forgets the path", opts.chan_in_file, "");
+    rc |= expect_int("chan map clear releases modes", dsd_channel_modes_present(&state), 0);
     rc |= expect_int("chan map clear empties the map", (int)state.trunk_chan_map[101], 0);
     rc |= expect_int("chan map clear empties used count", (int)state.trunk_chan_map_used_count, 0);
     rc |= expect_int("chan map clear empties lcn list", state.lcn_freq_count, 0);

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -204,6 +204,18 @@ main(int argc, char** argv) {
     expect("modulation control keeps configured C4FM", model.modulation() == 0);
     dsd_scan_mode_leave(&opts, &state);
 
+    /* Every flag combination must mean the same thing inside a scope. */
+    for (int flags = 0; flags < 8; flags++) {
+        opts.mod_c4fm = (flags & 1) != 0;
+        opts.mod_qpsk = (flags & 2) != 0;
+        opts.mod_gfsk = (flags & 4) != 0;
+        const int expected = dsd_opts_modulation(&opts);
+        expect("enter modulation combination", dsd_scan_mode_enter(&opts, &state, DSD_SCAN_MODE_DMR) == 0);
+        model.refresh(&opts, &state);
+        expect("scoped modulation uses one-flag rule", model.modulation() == expected);
+        dsd_scan_mode_leave(&opts, &state);
+    }
+
     /* Tuner ownership: the gate is the OR, and the two named owners exist only to
      * word a message. All three have to agree. */
     opts.trunk_enable = 1;

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -24,6 +24,7 @@
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/runtime/scan_mode.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -197,6 +198,11 @@ main(int argc, char** argv) {
     opts.mod_c4fm = 1;
     model.refresh(&opts, &state);
     expect("c4fm reads as modulation 0 again", model.modulation() == 0);
+    expect("enter DMR row", dsd_scan_mode_enter(&opts, &state, DSD_SCAN_MODE_DMR) == 0);
+    expect("row selects GFSK", opts.mod_gfsk == 1);
+    model.refresh(&opts, &state);
+    expect("modulation control keeps configured C4FM", model.modulation() == 0);
+    dsd_scan_mode_leave(&opts, &state);
 
     /* Tuner ownership: the gate is the OR, and the two named owners exist only to
      * word a message. All three have to agree. */

--- a/tests/ui/test_ui_snapshot_event_history.c
+++ b/tests/ui/test_ui_snapshot_event_history.c
@@ -9,10 +9,15 @@
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/input_level.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -359,6 +364,24 @@ main(void) {
     assert(dsd_app_notification_get(&notification) == 1);
     assert(strcmp(notification.protocol, "P25p2") == 0);
     assert(notification.cc_freq_hz == 851006250);
+
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    assert(opts);
+    assert(dsd_apply_decode_mode_preset(DSDCFG_MODE_NXDN48, DSD_DECODE_PRESET_PROFILE_CLI, opts, state) == 0);
+    assert(dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_P25) == 0);
+    dsd_app_telemetry_publish_snapshot(state);
+    snap = dsd_app_get_latest_snapshot();
+    assert(dsd_scan_mode_active(snap) == DSD_SCAN_MODE_P25);
+    assert(snap->state_ext[DSD_STATE_EXT_RUNTIME_SCAN_MODE] != state->state_ext[DSD_STATE_EXT_RUNTIME_SCAN_MODE]);
+    dsd_scan_settings settings;
+    dsd_app_snapshot_configured_mode(opts, snap, &settings);
+    assert(settings.frame_nxdn48 == 1 && settings.frame_p25p1 == 0);
+    dsd_scan_mode_leave(opts, state);
+    assert(dsd_scan_mode_active(snap) == DSD_SCAN_MODE_P25);
+    dsd_app_telemetry_publish_snapshot(state);
+    snap = dsd_app_get_latest_snapshot();
+    assert(dsd_scan_mode_active(snap) == DSD_SCAN_MODE_INHERIT);
+    free(opts);
 
     puts("UI_SNAPSHOT_EVENT_HISTORY: OK");
     dsd_state_ext_free_all(state);


### PR DESCRIPTION
## Summary

Channel maps previously shared one global decoder preset, so mixed lists required enabling additional decoders globally. An optional `mode` column now selects each conventional row's decoder class, and trunk-scan target types select their own class. Blank modes inherit the configured settings; P25 includes both phases and excludes DMR/X2-TDMA.

Closes #446.

- Parse named columns in any order beyond the two required fields, including columns beyond 16. Preserve duplicate channel/frequency rows, placeholders, and failed-import rollback.
- Share automatic, manual and avoid stepping with tracked retunes. Stage frontend rate, levels, modulation and filter; commit settings/keys only on successful completion. Pending and partial backend transitions retain frame protection, including inside the synced-frame loop.
- Keep exact global settings in a scoped extension, preserve modulation precedence and the open audio sink, reset stale acquisition state at row changes, and restore configuration on exit/replacement/shutdown.
- Deep-copy scalar scope metadata into frontend snapshots and save configured settings. Update CLI help, operator/architecture/testing docs and a mixed-mode example. Existing dwell and voice-hold defaults remain unchanged. Filter and source-monitor toggles show/edit the configured baseline even when a row preset constrains their effective values; monitoring alone preserves acquisition.

## Validation

- [x] Fresh `dev-debug` configure/clean build, then full CTest: **611 passed**, including 30 I/Q decode tests.
- [x] Radio-disabled preset build/full CTest: **564 passed**.
- [x] Qt frontend/CLI build. Supplemental Qt clang-tidy reproduces the existing `MetricsModel::View` padding diagnostic (38 bytes on both the base and branch); no introduced Qt analysis error was found.
- [x] Thirteen focused ASan/UBSan tests covering metadata lifecycle, scoped settings, actual matcher gates, frontend snapshots, commands, trunk transitions and conventional tune boundaries.
- [x] `tools/preflight_ci.sh`, architecture/CMake checks and `tools/quality_preflight.sh`; full scan-build found no bugs, followed by incremental checks on follow-up fixes; fuzz smoke passed.

The test-only `dsd-neo_test_scan_mode_replay` host parses the real CSV, asserts the production row override, and starts the real engine with scanner retuning disabled (the replay API rejects live retunes). `DECODE_IQ_SCAN_*` checks overrides from global presets that exclude the requested class.

Twelve rotated, realtime pairs per capture, after 12 baseline-against-itself controls, using `tools/replay_ab.sh` and `tools/replay_ab_report.py`:

| Capture | Native / declared voice frames per run | Native / declared errors per voice | Paired difference (95% interval) |
| --- | ---: | ---: | ---: |
| NXDN48 fixture | 47 / 47 | 1.62 / 1.62 | 0.00 ± 0.00 |
| P25 C4FM voice fixture | 5 / 5 | 25.00 / 25.00 | 0.00 ± 0.00 |
| P25 CQPSK voice fixture | 10 / 10 | 4.50 / 4.50 | 0.00 ± 0.00 |
| Reporter `fiNXDN` | 68.8 / 68.8 | 2.39 / 2.41 | +0.02 ± 0.14 |

Fixture payloads and corrected-error pairs match exactly across all repetitions: 2,064 NXDN AMBE, 1,032 C4FM IMBE and 636 CQPSK IMBE frames. The reporter run has 3,288/3,292 codec frames; sequence alignment matches 3,078 payloads and 3,050 associated error pairs. Its self-control matches 3,070 payloads and 3,044 error pairs across 3,262/3,278 codec frames, with errors/voice difference +0.03 ± 0.12. The reporter comparison does not resolve a quality difference; these measurements do not establish scan-speed improvement. Background builds ran during portions of both control and comparison batches, so the reporter intervals include that scheduling variability.

Reporter data SHA-256: `9b4f11941c945996b340594a6786f63af0418d9e63ea214366666380dd41edf4`. Raw logs and summaries are retained locally in `build/446-evidence/`.

## Review and risk

- [x] Reviewed against surrounding ownership, tuning and DSP design; generated changes read and adapted to project conventions.
- [x] Focused tests for parser, allocator, decoder, file/radio input and failure handling; DCO sign-off included.
- [ ] Human review of behavior and ownership boundaries.
- [x] Claude and OMP reviewed after the PR was opened. Verified findings fixed with regressions; both follow-up reviews report no remaining actionable finding.

High-risk areas touched: parser and radio/decoder transitions. No new dependencies, network endpoints, key logging, CLI presets or persisted decode enum values. Untyped lists retain their existing behavior; trunk target types now actively select their decoder class.
