### PR TITLE
feat(engine): support scoped per-row scan options (#382, #446)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -693,6 +693,14 @@ those values for the current CLI run only.
   without writing it to the slot.
 - Select DMR key by talkgroup: `--dmr-tg-key-csv <file>` (per-TG override of the signaled KEY ID;
   rows are `tg_dec,keyid_hex` into the `-K`/`-k` keyring — see `docs/csv-formats.md`)
+- Conflicting outer force switches emit one warning describing the final selection. Existing precedence is retained:
+  long-option ALGID settings are applied before short options, and the last `-4`/`-0` wins. Use per-row settings for
+  mixed scans. `--no-force-key` explicitly disables forcing after those settings; `--strict-crc` similarly disables
+  `-F`. `--no-scan-voice-only` is the inverse of `--scan-voice-only` (the last of these long switches wins).
+- Channel maps and trunk-target lists can combine mode/type with a restricted `options` column, including direct
+  `-1` RC4/DES and `-R` scrambler keys, group files, force settings, CRC policy and conventional voice-gate intervals.
+  See [scoped row options](csv-formats.md#scoped-row-options) for the supported switches and inheritance rules.
+  The outer conventional command remains `-Y -C <file>`; `-Y` does not take a filename argument.
 - Disable DMR Late Entry IDs: `-3` (avoid false ENC)
 
 ## Tools & Extras

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -606,12 +606,17 @@ External dependencies (resolved via CMake):
   configured/active settings. Extension IDs and the main options/state struct layouts are unchanged.
 - The talkgroup policy store supports decoder-thread retain/install/release operations. Profiles retain their own
   context so aliases and session policy changes survive visits; frontend snapshots still clone the effective context.
-  Slot 5 holds the saved global group context and suspend/resume ownership. Clearing metadata restores it first.
+  `dsd_tg_policy_restore()` preserves active calls across temporary suspend/resume; install resets them for target
+  transitions. The CSV importer loads standalone stores through core-private helpers without a decoder-state allocation.
+  Slot 5 holds the saved global group context and suspend/resume ownership. Clearing metadata restores it first;
+  moving metadata unwinds both source and destination scopes before transferring the row definitions.
 - `dsd_scan_key_change_prepare()` allocates the incoming key copy and any needed baseline before a conventional tune;
   commit consumes the change without allocation. Engine checks the map generation and key epoch before committing,
   restaging the tune (and re-preparing against the current globals) when the keyring changed in the window. Both
   coordinators reserve every scope and key allocation before saving the outgoing snapshot, so a failed preparation
-  leaves the receiver, the snapshot and the rotation bookkeeping untouched.
+  leaves the receiver and snapshot untouched. Conventional retries keep the frame gate closed until a row commits,
+  including when a later tune is deferred or rejected; the scanner can still advance to a working row. Separately,
+  trunk-scan failures re-arm dwell or retry timers so memory pressure cannot cause a retry on every tick.
 - `dsd_channel_modes_present()` is true for declared modes and for option-bearing profiles alike, so option-only
   channel maps run the typed scanner. `dsd_scan_settings_equal()` compares acquisition settings only; the row-scoped
   options (forcing, CRC, mutes, voice gate, group file) are folded through `dsd_scan_mode_resume()` without

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -596,3 +596,19 @@ External dependencies (resolved via CMake):
   vocoder (`mbe-neo` 2.x).
 - Terminal frontend: curses (ncursesw/PDCurses), enabled by default with `DSD_ENABLE_TERMINAL_UI=ON`.
 - Optional: RTL‑SDR, SoapySDR >= 0.8.1, CODEC2, libcurl >= 7.56.0.
+
+### Scoped scan options
+
+- Runtime `scan_options` parses the restricted `options` argument grammar into typed values and fixed key/path
+  metadata, validates declared modes, and reports errors without echoing raw arguments. It never runs the CLI parser.
+- Core `scan_profile` merges legacy key columns, resolves and loads companion files, and materializes direct keys.
+  Positional profiles extend the existing channel-mode store in extension slot 5; runtime slot 6 retains nonsecret
+  configured/active settings. Extension IDs and the main options/state struct layouts are unchanged.
+- The talkgroup policy store supports decoder-thread retain/install/release operations. Profiles retain their own
+  context so aliases and session policy changes survive visits; frontend snapshots still clone the effective context.
+  Slot 5 holds the saved global group context and suspend/resume ownership. Clearing metadata restores it first.
+- `dsd_scan_key_change_prepare()` allocates the incoming key copy and any needed baseline before a conventional tune;
+  commit transfers ownership without allocation. Engine checks the map generation and key epoch before committing.
+  Both coordinators restore mode, keys, group policy and scalar overrides together at their protected transitions.
+- App-control scopes force/CRC/voice configuration commands and group imports, while live row policy mutations stay
+  with the active context. Configuration export reads saved group paths and voice settings from the configured scope.

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -608,7 +608,13 @@ External dependencies (resolved via CMake):
   context so aliases and session policy changes survive visits; frontend snapshots still clone the effective context.
   Slot 5 holds the saved global group context and suspend/resume ownership. Clearing metadata restores it first.
 - `dsd_scan_key_change_prepare()` allocates the incoming key copy and any needed baseline before a conventional tune;
-  commit transfers ownership without allocation. Engine checks the map generation and key epoch before committing.
-  Both coordinators restore mode, keys, group policy and scalar overrides together at their protected transitions.
+  commit consumes the change without allocation. Engine checks the map generation and key epoch before committing,
+  restaging the tune (and re-preparing against the current globals) when the keyring changed in the window. Both
+  coordinators reserve every scope and key allocation before saving the outgoing snapshot, so a failed preparation
+  leaves the receiver, the snapshot and the rotation bookkeeping untouched.
+- `dsd_channel_modes_present()` is true for declared modes and for option-bearing profiles alike, so option-only
+  channel maps run the typed scanner. `dsd_scan_settings_equal()` compares acquisition settings only; the row-scoped
+  options (forcing, CRC, mutes, voice gate, group file) are folded through `dsd_scan_mode_resume()` without
+  resetting acquisition. Conventional trunk-scan targets take their voice-gate hold/qualify from the row profile.
 - App-control scopes force/CRC/voice configuration commands and group imports, while live row policy mutations stay
   with the active context. Configuration export reads saved group paths and voice settings from the configured scope.

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -89,7 +89,7 @@ Notes:
   later rows keep their LCN numbers. This is what tells a channel map apart from a decimal key list, which has the same
   `number,number` shape.
 - Optional headers after the two required columns are matched case-insensitively, with surrounding whitespace
-  trimmed: `name`, `mode`, `keys_hex_csv`, `keys_dec_csv`, `single_key_hex`, and `single_key_dec`. They may appear in
+  trimmed: `name`, `mode`, `keys_hex_csv`, `keys_dec_csv`, `single_key_hex`, `single_key_dec`, and `options` (`relevant_CLI_switches`). They may appear in
   any order, including after column 16. Unrecognized columns are ignored. The first `name` column wins; duplicate
   `mode` or key headers reject the file. This preserves legacy free-text note columns, including notes with commas.
 - Channel-map headers and data rows are read in full up to 1 MiB (including the line ending and terminating NUL).
@@ -175,6 +175,63 @@ channel,frequency_hz,name,keys_hex_csv,keys_dec_csv,single_key_dec,single_key_he
 3,462612500,Shared,,,1,0000001F00
 ```
 
+### Scoped row options
+
+Channel maps and trunk-scan targets accept an optional `options` column. `relevant_CLI_switches` is an alias;
+headers match case-insensitively and naming both rejects the file. Combine `mode` and `options` in the same map
+(`examples/conventional_scan_options.csv`); run it with `-Y -C examples/conventional_scan_options.csv`.
+
+Options are parsed once when the list is loaded. They are a restricted argument list, with the following switches:
+
+| Switch | Meaning and accepted modes |
+| --- | --- |
+| `-b <decimal>` | Motorola BP number, `0..255`; DMR. |
+| `-H <hex>` | Hytera/AES key; DMR accepts 10/32/64 digits, P25 32/64, NXDN 64. |
+| `-1 <hex>` | Direct RC4/DES key, 1..16 digits; DMR/P25/NXDN. |
+| `-R <decimal>` | Direct scrambler key, `0..32767`; NXDN/dPMR. |
+| `-k <file>`, `-K <file>` | Decimal/hex key files; DMR/P25/NXDN. |
+| `-G <file>` | Group names and policy for this row or system. |
+| `-4` | Force loaded privacy keys over signalling; DMR/NXDN. |
+| `-0`, `--dmr-force-algid <hex>` | DMR algorithm fallback when identifiers are missing. `-0` means ALGID `21`. |
+| `-F`, `--strict-crc` | Relax CRC checks for DMR/P25/M17, or restore strict checks. |
+| `--no-force-key` | Disable privacy forcing and algorithm fallback for this row. |
+| `--scan-voice-only`, `--no-scan-voice-only` | Enable/disable the conventional voice gate. |
+| `--scan-voice-qualify-ms`, `--scan-voice-hold-ms` | Conventional voice-gate intervals, `100..600000` milliseconds. |
+
+Protocol-specific options require a declared `mode`; trunk targets use their `type`. Trunk-system targets reject
+voice-gate options: their existing `dwell_ms` and `activity_hold_ms` columns retain their roles. Input/output,
+frontend selection, decoder flags and scanner-wide `-t` are not accepted in `options`.
+
+Omitted settings inherit the outer CLI/configuration, including forcing. Use `--no-force-key` on a normal mixed
+clear/BP channel when forcing is configured globally. `-b 1` with normal signalling processes clear and BP calls;
+`-4` deliberately applies loaded privacy keys even to frames marked clear and can corrupt those clear calls.
+There is no automatic choice between forced Motorola and Hytera privacy.
+
+The existing `single_key_dec` and `single_key_hex` columns still mean `-b` and `-H`, respectively. Use `options=-R 1`
+for a direct NXDN scrambler and `options=-1 0123456789` for direct RC4. Loading a key does not itself enable forcing.
+A direct source replaces the row's complete key set; unspecified families and keyring entries are cleared. Explicit
+zero is a supplied value. Direct and file-backed key sources cannot be mixed, including across columns and options.
+Compatible direct families may be combined, but duplicate definitions reject the import.
+
+Within a row, conflicting force settings reject the import. `-0 --dmr-force-algid 21` is accepted because both request
+the same fallback. ALGID `00` disables fallback; `01` and `16` are rejected in this option because they are reserved
+non-algorithm markers internally. Received DMR algorithm/key identifiers retain precedence over algorithm fallback.
+
+Separate switches with whitespace; quote an argument with single or double quotes to retain spaces. Backslashes are
+literal, so `-G "C:\Radio Lists\groups.csv"` works without shell escaping. Hex keys may include an optional `0x`
+prefix and whitespace inside a quoted argument. Long arguments also accept `--name=value`. CSV commas remain field
+separators, including inside quotes. Unknown switches, positional text, malformed quotes and duplicate settings are
+errors. Diagnostics name the row and option without repeating raw option text or key values.
+
+File paths resolve relative to the containing CSV. Keys and group policies are loaded before scanning starts;
+switching rows never reads these files. `-G` replaces the active group policy while parked. Labels and session policy
+edits remain with that row's policy; unconfigured rows use the global policy. Global group imports and scoped setting
+changes from the frontend update the saved baseline beneath the active row. Leaving or replacing the scan restores
+that baseline. Frontend configuration saves preserve configured defaults, not temporary row overrides.
+
+The Qt/Android picker supports embedded values. Companion files named by `-G`, `-k` or `-K` have the same limitation
+as existing key-file columns: the picker does not copy companion files alongside the imported list.
+
 Declared modes use these symbol profiles:
 
 | Mode | Symbols per second | Levels |
@@ -218,6 +275,7 @@ Columns:
 | `keys_dec_csv` | No | Per-target decimal key file (`-k` format), resolved relative to this CSV. Empty uses the global keys. |
 | `single_key_dec` | No | Embedded `-b` Motorola Basic Privacy key number (`0..255`). Explicit `0` is present and overrides the global key. May be combined with `single_key_hex`, but not either key-file column. |
 | `single_key_hex` | No | Embedded `-H` key: optional `0x`, whitespace ignored, exactly 10, 32, or 64 hex digits. May be combined with `single_key_dec`, but not either key-file column. |
+| `options` | No | Scoped switches described above; target `type` determines which protocol options apply. |
 | `p25_bandplan_csv` | No | Per-target [P25 band plan CSV](#p25-band-plan-csv---p25-bandplan-file--trunking-p25_bandplan_csv) for a `p25-trunk` target, resolved relative to this CSV. The rows are parked in the target's snapshot, so one exported multi-system file can be named on every P25 row: each target seeds only the rows that carry its own WACN/SYS (and rows that carry none). |
 
 Validation notes:

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -91,7 +91,8 @@ Notes:
 - Optional headers after the two required columns are matched case-insensitively, with surrounding whitespace
   trimmed: `name`, `mode`, `keys_hex_csv`, `keys_dec_csv`, `single_key_hex`, `single_key_dec`, and `options` (`relevant_CLI_switches`). They may appear in
   any order, including after column 16. Unrecognized columns are ignored. The first `name` column wins; duplicate
-  `mode` or key headers reject the file. This preserves legacy free-text note columns, including notes with commas.
+  `mode`, key, or `options` headers reject the file, including `options` repeated through its
+  `relevant_CLI_switches` alias. This preserves legacy free-text note columns, including notes with commas.
 - Channel-map headers and data rows are read in full up to 1 MiB (including the line ending and terminating NUL).
   Longer rows reject the import with an error; they are never split into additional channels.
 - `mode` accepts `p25`, `dmr`, `nxdn96`, `nxdn48`, `dpmr`, `dstar`, `ysf`, and `m17`, case-insensitively and trimmed.
@@ -193,7 +194,8 @@ Options are parsed once when the list is loaded. They are a restricted argument 
 | `-G <file>` | Group names and policy for this row or system. |
 | `-4` | Force loaded privacy keys over signalling; DMR/NXDN. |
 | `-0`, `--dmr-force-algid <hex>` | DMR algorithm fallback when identifiers are missing. `-0` means ALGID `21`. |
-| `-F`, `--strict-crc` | Relax CRC checks for DMR/P25/M17, or restore strict checks. |
+| `-F` | Relax CRC checks; DMR/P25/M17. |
+| `--strict-crc` | Restore strict CRC checks; all modes, including inherited mode. |
 | `--no-force-key` | Disable privacy forcing and algorithm fallback for this row. |
 | `--scan-voice-only`, `--no-scan-voice-only` | Enable/disable the conventional voice gate. |
 | `--scan-voice-qualify-ms`, `--scan-voice-hold-ms` | Conventional voice-gate intervals, `100..600000` milliseconds. |
@@ -210,33 +212,46 @@ clear/BP channel when forcing is configured globally. `-b 1` with normal signall
 `-4` deliberately applies loaded privacy keys even to frames marked clear and can corrupt those clear calls.
 There is no automatic choice between forced Motorola and Hytera privacy.
 
-The existing `single_key_dec` and `single_key_hex` columns still load the `-b` and `-H` key values, respectively,
-and only that: as before, they never change encrypted-audio muting, whether or not the row also has an `options`
-cell. `-b` and `-H` written in `options` behave like the CLI switches and do decide DMR muting for the row (explicit
-`-b 0` mutes; any key material unmutes); `-1` mutes undecodable P25 audio as the CLI switch does. Use `options=-R 1`
-for a direct NXDN scrambler and `options=-1 0123456789` for direct RC4. Loading a key does not itself enable forcing.
-A direct source replaces the row's complete key set; unspecified families and keyring entries are cleared. Explicit
-zero is a supplied value. Direct and file-backed key sources cannot be mixed, including across columns and options.
-Compatible direct families may be combined, but duplicate definitions reject the import.
+The existing `single_key_dec` and `single_key_hex` columns load the `-b` and `-H` key values, respectively.
+They do not claim an encrypted-audio mute override by themselves. When `options` contains `-b` or `-H`, those
+switches decide DMR muting from all of the row's BP/Hytera material, including the legacy columns: all zero
+mutes, any nonzero material unmutes. For example, `-b 0` mutes by itself, but unmutes alongside a nonzero
+`single_key_hex`. `-1` mutes undecodable P25 audio as the CLI switch does. Use `options=-R 1` for a direct
+NXDN scrambler and `options=-1 0123456789` for direct RC4. Loading a key does not itself enable forcing. A
+direct source replaces the row's complete key set; unspecified families and keyring entries are cleared.
+Explicit zero is a supplied value. Direct and file-backed key sources cannot be mixed, including across
+columns and options. Compatible direct families may be combined, but duplicate definitions reject the import.
 
-Within a row, conflicting force settings reject the import. `-0 --dmr-force-algid 21` is accepted because both request
-the same fallback. ALGID `00` disables fallback; `01` and `16` are rejected in this option because they are reserved
-non-algorithm markers internally. Received DMR algorithm/key identifiers retain precedence over algorithm fallback.
+Within a row, repeated settings reject the import, even with identical values or different switch spellings:
+`-4 -4`, `-b 1 -b 2`, and `-F --strict-crc` are errors. Conflicting force settings also reject the import. The
+only accepted redundancy is one `-0` paired with one `--dmr-force-algid 21`, in either order, because both
+request the same fallback. ALGIDs are hexadecimal, with or without `0x`: `0x00` disables fallback; `0x01` and
+`0x16` are rejected because they are reserved non-algorithm markers internally. Received DMR algorithm/key
+identifiers retain precedence over algorithm fallback.
 
-Separate switches with whitespace; quote an argument with single or double quotes to retain spaces. Backslashes are
-literal, so `-G "C:\Radio Lists\groups.csv"` works without shell escaping. Hex keys may include an optional `0x`
-prefix and whitespace inside a quoted argument. Long arguments also accept `--name=value`. CSV commas remain field
-separators, including inside quotes. Unknown switches, positional text, malformed quotes and duplicate settings are
-errors. Diagnostics name the row and option without repeating raw option text or key values.
+Separate switches with whitespace; quote an argument with single or double quotes to retain spaces.
+Backslashes are literal, so `-G "C:\Radio Lists\groups.csv"` works without shell escaping. Hex keys may
+include an optional `0x` prefix and whitespace inside a quoted argument. Long switches that take an argument
+also accept `--name=value`; argument-free switches reject it (for example, `--scan-voice-only=yes`). An
+argument must not start with `-`; use `./-name.csv` for a filename that starts with a dash. CSV commas remain
+field separators, including inside quotes. Unknown switches, positional text, malformed quotes and duplicate
+settings are errors. Diagnostics name the row and option without repeating raw option text or key values.
 
-File paths resolve relative to the containing CSV. Key-file paths (`-K`, `-k` and the legacy columns) share the
-existing 2047-character limit; a `-G` path is limited to 1023 characters, the same as the global group file it
-replaces. Keys and group policies are loaded before scanning starts; switching rows never reads these files. A
-group file row the importer cannot store is skipped with a warning, exactly as for a global `-G` import. `-G` replaces the active group policy while parked. Labels and session policy
-edits remain with that row's policy; unconfigured rows use the global policy. Global group imports and scoped setting
-changes from the frontend (forcing, CRC policy, mutes, voice gate) update the saved baseline beneath the active row
-and take effect immediately without interrupting the parked row or a call in progress. Leaving or replacing the scan
-restores that baseline. Frontend configuration saves preserve configured defaults, not temporary row overrides.
+File paths resolve relative to the containing CSV. Key-file paths (`-K`, `-k` and the legacy columns) are
+limited to 2047 bytes for channel maps and 1023 bytes for trunk targets, after resolution and excluding the
+terminating NUL. A `-G` path is limited to 1023 bytes, the same as the global group file it replaces.
+Companion paths in a nonempty `options` cell are resolved and loaded even when the row's channel number is
+invalid and takes no scan slot. Keys and group policies are loaded before scanning starts; switching rows
+never reads these files. A group file row the importer cannot store is skipped with a warning, exactly as for
+a global `-G` import. `-G` replaces the active group policy while parked. Labels and session policy edits
+remain with that row's policy; unconfigured rows use the global policy. Global group imports and scoped
+setting changes from the frontend (forcing, CRC policy, mutes, voice gate) update the saved baseline beneath
+the active row. Changes to inherited settings take effect immediately; explicit row overrides continue to
+apply, and temporary suspension preserves active-call priority bookkeeping. Direct-key menu commands keep editing the live keys while their unmute decision updates the saved
+defaults; an explicit row mute still takes precedence. The existing Relaxed CRC checks menu toggle changes
+frame CRC checks only; it preserves the separately configured DMR CSBK CRC default. Leaving or replacing the
+scan restores that baseline. Frontend configuration saves preserve configured defaults, not temporary row
+overrides.
 
 The Qt/Android picker supports embedded values. Companion files named by `-G`, `-k` or `-K` have the same limitation
 as existing key-file columns: the picker does not copy companion files alongside the imported list.

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -198,16 +198,22 @@ Options are parsed once when the list is loaded. They are a restricted argument 
 | `--scan-voice-only`, `--no-scan-voice-only` | Enable/disable the conventional voice gate. |
 | `--scan-voice-qualify-ms`, `--scan-voice-hold-ms` | Conventional voice-gate intervals, `100..600000` milliseconds. |
 
-Protocol-specific options require a declared `mode`; trunk targets use their `type`. Trunk-system targets reject
-voice-gate options: their existing `dwell_ms` and `activity_hold_ms` columns retain their roles. Input/output,
-frontend selection, decoder flags and scanner-wide `-t` are not accepted in `options`.
+Protocol-specific options require a declared `mode`; trunk targets use their `type`. A channel map whose rows carry
+`options` but no `mode` still runs through the typed scanner (blank rows inherit the configured decoder), since the
+legacy `-Y` scanner applies row keys but not row options. Trunk-system targets reject voice-gate options: their
+existing `dwell_ms` and `activity_hold_ms` columns retain their roles, while a conventional target's voice-gate
+intervals replace those two columns while the gate is on (see `docs/trunk-scan.md`). Input/output, frontend
+selection, decoder flags and scanner-wide `-t` are not accepted in `options`.
 
 Omitted settings inherit the outer CLI/configuration, including forcing. Use `--no-force-key` on a normal mixed
 clear/BP channel when forcing is configured globally. `-b 1` with normal signalling processes clear and BP calls;
 `-4` deliberately applies loaded privacy keys even to frames marked clear and can corrupt those clear calls.
 There is no automatic choice between forced Motorola and Hytera privacy.
 
-The existing `single_key_dec` and `single_key_hex` columns still mean `-b` and `-H`, respectively. Use `options=-R 1`
+The existing `single_key_dec` and `single_key_hex` columns still load the `-b` and `-H` key values, respectively,
+and only that: as before, they never change encrypted-audio muting, whether or not the row also has an `options`
+cell. `-b` and `-H` written in `options` behave like the CLI switches and do decide DMR muting for the row (explicit
+`-b 0` mutes; any key material unmutes); `-1` mutes undecodable P25 audio as the CLI switch does. Use `options=-R 1`
 for a direct NXDN scrambler and `options=-1 0123456789` for direct RC4. Loading a key does not itself enable forcing.
 A direct source replaces the row's complete key set; unspecified families and keyring entries are cleared. Explicit
 zero is a supplied value. Direct and file-backed key sources cannot be mixed, including across columns and options.
@@ -223,11 +229,14 @@ prefix and whitespace inside a quoted argument. Long arguments also accept `--na
 separators, including inside quotes. Unknown switches, positional text, malformed quotes and duplicate settings are
 errors. Diagnostics name the row and option without repeating raw option text or key values.
 
-File paths resolve relative to the containing CSV. Keys and group policies are loaded before scanning starts;
-switching rows never reads these files. `-G` replaces the active group policy while parked. Labels and session policy
+File paths resolve relative to the containing CSV. Key-file paths (`-K`, `-k` and the legacy columns) share the
+existing 2047-character limit; a `-G` path is limited to 1023 characters, the same as the global group file it
+replaces. Keys and group policies are loaded before scanning starts; switching rows never reads these files. A
+group file row the importer cannot store is skipped with a warning, exactly as for a global `-G` import. `-G` replaces the active group policy while parked. Labels and session policy
 edits remain with that row's policy; unconfigured rows use the global policy. Global group imports and scoped setting
-changes from the frontend update the saved baseline beneath the active row. Leaving or replacing the scan restores
-that baseline. Frontend configuration saves preserve configured defaults, not temporary row overrides.
+changes from the frontend (forcing, CRC policy, mutes, voice gate) update the saved baseline beneath the active row
+and take effect immediately without interrupting the parked row or a call in progress. Leaving or replacing the scan
+restores that baseline. Frontend configuration saves preserve configured defaults, not temporary row overrides.
 
 The Qt/Android picker supports embedded values. Companion files named by `-G`, `-k` or `-K` have the same limitation
 as existing key-file columns: the picker does not copy companion files alongside the imported list.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -425,6 +425,8 @@ tools/fuzz_smoke.sh
 ```
 
 Scoped scanning options are covered by `RUNTIME_SCAN_OPTIONS` and `CORE_SCAN_PROFILE`, plus conventional/trunk tune
-boundary regressions, CLI conflict/off-switch checks, and terminal loaded-key/redaction tests. The production MBE
+boundary regressions (option-only rows, policy edits beneath a staged tune, keyring changes in the tune window, a
+failed key preparation mid-rotation, per-target voice-gate intervals), CLI conflict/off-switch checks, and terminal
+loaded-key/redaction tests. The production MBE
 regression exercises clear and Motorola BP frames on both slots, with normal signalling and explicit forcing.
 `CORE_SCAN_PROFILE` tests actual group-store ownership; scanner hosts that stub group policy use `scan_group_stubs.c`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -423,3 +423,8 @@ Fuzz-facing changes should run bounded libFuzzer smoke passes:
 ```sh
 tools/fuzz_smoke.sh
 ```
+
+Scoped scanning options are covered by `RUNTIME_SCAN_OPTIONS` and `CORE_SCAN_PROFILE`, plus conventional/trunk tune
+boundary regressions, CLI conflict/off-switch checks, and terminal loaded-key/redaction tests. The production MBE
+regression exercises clear and Motorola BP frames on both slots, with normal signalling and explicit forcing.
+`CORE_SCAN_PROFILE` tests actual group-store ownership; scanner hosts that stub group policy use `scan_group_stubs.c`.

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -308,8 +308,8 @@ from `1` to `49` for manual RTL-family gain in dB.
 
 `row N keys_hex_csv path is too long or invalid` (and `_dec_`)
 
-The key path is resolved relative to the target CSV. Use a path that fits in 1024 bytes and, for a relative
-reference, keep the key file next to (or below) the target CSV.
+The key path is resolved relative to the target CSV. Use a resolved path of at most 1023 bytes (excluding the
+terminating NUL) and, for a relative reference, keep the key file next to (or below) the target CSV.
 
 `failed to import keys for trunk scan target '<id>' from '<file>'`
 
@@ -374,7 +374,7 @@ with trunk scan.
 
 The optional `options` column accepts the same [scoped switches](csv-formats.md#scoped-row-options) as conventional
 channel maps. The target `type` validates protocol-specific switches. A DMR system can use `-K Keys.csv -G Groups.csv
--0 -F --dmr-force-algid 21`; a conventional NXDN target can use `-R 1`. Relative paths refer to the target-list directory.
+-0 -F`; a conventional NXDN target can use `-R 1`. Relative paths refer to the target-list directory.
 Unspecified settings inherit the configured defaults, and `--no-force-key` can disable inherited forcing.
 
 Group policies and keys are preloaded and isolated between targets. Re-parking, failed-tune recovery and shutdown

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -135,9 +135,10 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
 - `--scan-voice-only`: conventional targets hold only from decoded voice media (headers and data no longer hold),
   with the per-target `dwell_ms` as the qualify window in which voice must appear and `activity_hold_ms` as the
   hold after the last voice frame, including when a terminator closes the call before the next scan tick; trunked
-  targets are unchanged (control-only rotates after dwell). The
+  targets are unchanged (control-only rotates after dwell). The scanner-wide
   `--scan-voice-qualify-ms` and `--scan-voice-hold-ms` timings apply to the `-Y` conventional scan only, not to
-  trunk-scan targets.
+  trunk-scan targets; a conventional target can carry its own intervals in its `options` column (see
+  [Per-target options](#per-target-options)).
 
 Each target's `type` selects its decoder class regardless of the configured global preset. P25 targets enable
 both phases and exclude DMR and X2-TDMA; DMR and NXDN targets enable only their declared class and rate. Mixed
@@ -287,7 +288,8 @@ in `[trunk_scan]`.
 
 `trunk scan target CSV header must start with ...`
 
-The first line must begin with `id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes`.
+The first line must begin with `id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes`. Optional column
+names after it are matched case-insensitively.
 
 `row N has invalid frequency_hz`
 
@@ -377,5 +379,12 @@ Unspecified settings inherit the configured defaults, and `--no-force-key` can d
 
 Group policies and keys are preloaded and isolated between targets. Re-parking, failed-tune recovery and shutdown
 restore the associated options with the target. Conventional voice-gate switches are accepted on conventional target
-types only; trunk systems keep their existing activity-hold policy. Row metadata in a target's `chan_csv` is validated
-and discarded; put system options on the target itself.
+types only; trunk systems keep their existing activity-hold policy. While the voice gate is on, a conventional
+target's `--scan-voice-hold-ms` replaces its `activity_hold_ms` as the hold after the last voice frame and
+`--scan-voice-qualify-ms` replaces its `dwell_ms` as the window in which voice must appear; targets without them
+keep the column values. Row metadata in a target's `chan_csv` is validated and discarded; put system options on the
+target itself.
+
+A row that names key material in `options` (`-b`, `-H`, `-1`, `-R`, `-K`, `-k`) may still fill the legacy key
+columns for the other families; the merge rejects a column that duplicates an option. Optional header names,
+including `options` and its `relevant_CLI_switches` alias, match ASCII case-insensitively.

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -367,3 +367,15 @@ To scan multiple systems with one receiver:
 
 `-Y` conventional scanning remains a separate mode for fast conventional sync scanning and is mutually exclusive
 with trunk scan.
+
+### Per-target options
+
+The optional `options` column accepts the same [scoped switches](csv-formats.md#scoped-row-options) as conventional
+channel maps. The target `type` validates protocol-specific switches. A DMR system can use `-K Keys.csv -G Groups.csv
+-0 -F --dmr-force-algid 21`; a conventional NXDN target can use `-R 1`. Relative paths refer to the target-list directory.
+Unspecified settings inherit the configured defaults, and `--no-force-key` can disable inherited forcing.
+
+Group policies and keys are preloaded and isolated between targets. Re-parking, failed-tune recovery and shutdown
+restore the associated options with the target. Conventional voice-gate switches are accepted on conventional target
+types only; trunk systems keep their existing activity-hold policy. Row metadata in a target's `chan_csv` is validated
+and discarded; put system options on the target itself.

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -569,11 +569,13 @@ next channel. The bracketed name is for reading, not for parsing: a channel name
 
 ### Scoped scan controls and loaded keys
 
-The Input/Output pane reports loaded Motorola BP and RC4/DES/scrambler keys even when forcing is disabled, matching
-its existing Hytera indication. “Loaded” does not claim successful decryption. Values remain redacted unless
-`--show-keys` is enabled. Explicit forcing continues to have a separate status.
+The Input/Output pane reports loaded Motorola BP, RC4/DES and NXDN/dPMR scrambler keys while no forcing is active,
+matching its existing Hytera indication (a scrambler value prints in decimal, an RC4/DES key in hex, and the two
+keyring slots print separately when they differ). “Loaded” does not claim successful decryption. Values remain
+redacted unless `--show-keys` is enabled. Explicit forcing (BP, RC4 or TYT) replaces these lines with its own status.
 
-Force, CRC and voice-gate controls edit the configured baseline while a scan row constrains their effective values;
-menu labels show that baseline. Group-file imports also update the baseline, with the parked row's group policy
+Force, CRC, mute and voice-gate controls edit the configured baseline while a scan row constrains their effective
+values; menu labels show that baseline. These edits are policy, not acquisition: they apply at once without ending
+the current call or re-hunting sync. Group-file imports also update the baseline, with the parked row's group policy
 restored afterward. Scalar key entry retains its existing temporary behavior. See the CSV documentation for the
 `options` column and per-row explicit-off switches.

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -566,3 +566,14 @@ row renders, so a call that outlives a scan step keeps the channel it was actual
 call heard on a scan-list row with no name stays unlabelled rather than picking up the name of the
 next channel. The bracketed name is for reading, not for parsing: a channel name may itself contain
 `]`.
+
+### Scoped scan controls and loaded keys
+
+The Input/Output pane reports loaded Motorola BP and RC4/DES/scrambler keys even when forcing is disabled, matching
+its existing Hytera indication. “Loaded” does not claim successful decryption. Values remain redacted unless
+`--show-keys` is enabled. Explicit forcing continues to have a separate status.
+
+Force, CRC and voice-gate controls edit the configured baseline while a scan row constrains their effective values;
+menu labels show that baseline. Group-file imports also update the baseline, with the parked row's group policy
+restored afterward. Scalar key entry retains its existing temporary behavior. See the CSV documentation for the
+`options` column and per-row explicit-off switches.

--- a/examples/conventional_scan_options.csv
+++ b/examples/conventional_scan_options.csv
@@ -1,0 +1,6 @@
+channel,frequency_hz,name,mode,options
+1,143950000,RC4 example,dmr,-1 0123456789 -0 -F
+2,160237500,Hytera forced example,dmr,-H 0123456789 -4 -F --scan-voice-only --scan-voice-hold-ms 4000
+3,164662500,Clear and BP1 example,dmr,-b 1 --no-force-key --strict-crc
+4,472000000,Clear P25 example,p25,--no-force-key --strict-crc
+5,456425000,NXDN scrambler example,nxdn48,-R 1 --no-force-key

--- a/include/dsd-neo/core/channel_mode.h
+++ b/include/dsd-neo/core/channel_mode.h
@@ -16,7 +16,8 @@ dsd_scan_mode dsd_channel_mode_get(const dsd_state* state, size_t row);
 int dsd_channel_mode_set(dsd_state* state, size_t row, dsd_scan_mode mode);
 /** Release all row modes. Does not restore active decoder settings. */
 void dsd_channel_modes_clear(dsd_state* state);
-/** Transfer ownership, replacing destination modes and clearing the source extension. */
+/** Transfer row definitions, replacing destination modes and clearing the source extension.
+ * Restore both states' global group policies first; active/suspended scopes are not moved. */
 void dsd_channel_modes_move(dsd_state* dst, dsd_state* src);
 /** Nonzero if at least one row declares a mode or carries scoped row options (scan_profile.h),
  * i.e. the typed scanner must run the list. */

--- a/include/dsd-neo/core/channel_mode.h
+++ b/include/dsd-neo/core/channel_mode.h
@@ -18,7 +18,8 @@ int dsd_channel_mode_set(dsd_state* state, size_t row, dsd_scan_mode mode);
 void dsd_channel_modes_clear(dsd_state* state);
 /** Transfer ownership, replacing destination modes and clearing the source extension. */
 void dsd_channel_modes_move(dsd_state* dst, dsd_state* src);
-/** Nonzero if at least one row declares a mode. */
+/** Nonzero if at least one row declares a mode or carries scoped row options (scan_profile.h),
+ * i.e. the typed scanner must run the list. */
 int dsd_channel_modes_present(const dsd_state* state);
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/core/csv_import.h
+++ b/include/dsd-neo/core/csv_import.h
@@ -23,7 +23,14 @@ struct p25_bandplan_row;
 extern "C" {
 #endif
 
+/**
+ * Import a group list (docs/csv-formats.md, "Group List CSV") into the state's talkgroup
+ * policy. Malformed rows are skipped with a warning, as are rows dropped for an allocation
+ * failure, and the import still returns 0 with whatever loaded. Returns -1 when the file
+ * cannot be opened or a read error interrupts it.
+ */
 int csvGroupImport(const dsd_opts* opts, dsd_state* state);
+/** csvGroupImport() on an explicit path. */
 int csvGroupImportPath(const char* group_file_path, dsd_state* state);
 int csvChanImport(const dsd_opts* opts, dsd_state* state);
 int csvKeyImportDec(const dsd_opts* opts, dsd_state* state);

--- a/include/dsd-neo/core/key_set.h
+++ b/include/dsd-neo/core/key_set.h
@@ -139,19 +139,41 @@ int dsd_key_set_load_csv(dsd_key_set* out, const char* hex_path, const char* dec
  */
 dsd_key_direct_result dsd_key_set_load_direct(dsd_key_set* out, const char* single_hex, const char* single_dec);
 
-/** Prepared key transition owns all allocations needed at commit; zero-initialize before use. */
+/**
+ * Prepared key transition: owns every allocation the commit needs, so the commit itself
+ * cannot fail. Zero-initialize before the first prepare. Lifecycle:
+ *  - dsd_scan_key_change_prepare() fills it (or, on failure, leaves it empty: no partial
+ *    ownership, `prepared` clear);
+ *  - dsd_scan_key_change_commit() consumes it, moving the sets into the state's scan
+ *    swap and clearing the object, so a commit followed by a clear is safe and a change
+ *    can be re-prepared in place;
+ *  - dsd_scan_key_change_clear() discards a prepared-but-uncommitted change (rollback).
+ * Every path wipes the key material. The baseline is captured at prepare time; it is
+ * the caller's job to re-prepare when the keyring may have changed in between (the
+ * conventional scanner restages on a lockout key-epoch change for that reason).
+ */
 typedef struct {
     dsd_key_set baseline;
     dsd_key_set active;
     int capture_baseline;
     int keyed;
     int changed;
+    int prepared;
 } dsd_scan_key_change;
 
+/** Release everything the change owns and zero it. Safe on an empty or NULL change. */
 void dsd_scan_key_change_clear(dsd_scan_key_change* change);
-/** Prepare without changing live keys. NULL/absent row means restore globals. */
+/**
+ * Prepare without changing live keys. A NULL row, or one with `present == 0`, means the
+ * commit restores the globals. Any prior content of @p change is released first. Returns
+ * 0 on success, -1 on a bad argument or allocation failure with @p change left empty.
+ */
 int dsd_scan_key_change_prepare(const dsd_state* state, const dsd_key_set* row, dsd_scan_key_change* change);
-/** Install without allocation. Returns nonzero if effective key identity changed. */
+/**
+ * Install the prepared transition without allocating and consume @p change. Returns
+ * nonzero when the effective key identity changed. A change that was never prepared, or
+ * whose prepare failed, is a no-op that returns 0.
+ */
 int dsd_scan_key_change_commit(dsd_state* state, dsd_scan_key_change* change);
 
 /**

--- a/include/dsd-neo/core/key_set.h
+++ b/include/dsd-neo/core/key_set.h
@@ -139,6 +139,21 @@ int dsd_key_set_load_csv(dsd_key_set* out, const char* hex_path, const char* dec
  */
 dsd_key_direct_result dsd_key_set_load_direct(dsd_key_set* out, const char* single_hex, const char* single_dec);
 
+/** Prepared key transition owns all allocations needed at commit; zero-initialize before use. */
+typedef struct {
+    dsd_key_set baseline;
+    dsd_key_set active;
+    int capture_baseline;
+    int keyed;
+    int changed;
+} dsd_scan_key_change;
+
+void dsd_scan_key_change_clear(dsd_scan_key_change* change);
+/** Prepare without changing live keys. NULL/absent row means restore globals. */
+int dsd_scan_key_change_prepare(const dsd_state* state, const dsd_key_set* row, dsd_scan_key_change* change);
+/** Install without allocation. Returns nonzero if effective key identity changed. */
+int dsd_scan_key_change_commit(dsd_state* state, dsd_scan_key_change* change);
+
 /**
  * Enter the scan swap: capture the baseline from live state when no set is
  * active, copy @p row_set into the active slot, install it. Returns 1 when

--- a/include/dsd-neo/core/scan_profile.h
+++ b/include/dsd-neo/core/scan_profile.h
@@ -13,23 +13,37 @@
 extern "C" {
 #endif
 
+/** One row's materialized options. `groups` is an owned policy reference (one retain), or NULL
+ * when the row names no group file. */
 typedef struct {
     dsd_scan_option_values values;
     dsd_tg_policy_store* groups;
 } dsd_scan_row_profile;
 
-/** Parsed key values replace the entire key set; out remains unchanged on failure. */
+/** Materialize the direct key values (`-b`, `-H`, `-1`, `-R`, or the merged legacy columns) into
+ * @p out, releasing whatever @p out held. `present` is set only when a direct source exists.
+ * Returns -1 on a bad argument with @p out untouched. */
 int dsd_scan_options_keys(const dsd_scan_options* options, dsd_key_set* out);
-/** Merge legacy key columns into parsed options without changing their legacy mode semantics.
- * Reject duplicate definitions/source-family conflicts. No files are opened. */
+/** Merge the legacy key columns into parsed options. The columns keep their key-only meaning:
+ * they never change encrypted-audio muting (only the option text's own `-b`/`-H` do). Rejects a
+ * column that duplicates an option or mixes direct keys with key files. No files are opened;
+ * on failure @p options is untouched. */
 int dsd_scan_options_merge_keys(dsd_scan_options* options, const char* hex_file, const char* dec_file,
                                 const char* single_hex, const char* single_dec, char* error, size_t error_size);
-/** Resolve paths relative to the list. On failure the caller discards the import object. */
+/** Resolve the key and group paths relative to the list file @p base, each within its own field
+ * capacity. On failure @p options is untouched and the caller discards the import object. */
 int dsd_scan_options_resolve(dsd_scan_options* options, const char* base, char* error, size_t error_size);
-/** Build one profile and key set. Failure leaves outputs untouched. */
+/**
+ * Build one profile and key set, reading the group and key files named in @p options.
+ * On success `*profile` is overwritten with a new heap profile (pass NULL or a pointer whose
+ * previous value the caller has already freed or still owns elsewhere; it is not released
+ * here) and `*keys` is released and replaced. On failure both outputs are untouched.
+ * Returns 0 on success, -1 otherwise.
+ */
 int dsd_scan_profile_load(const dsd_scan_options* options, int show_keys, dsd_scan_row_profile** profile,
                           dsd_key_set* keys);
 
+/** Release a profile and its group reference. NULL, and a profile with NULL groups, are fine. */
 static inline void
 dsd_scan_profile_free(dsd_scan_row_profile* profile) {
     if (!profile) {
@@ -39,17 +53,28 @@ dsd_scan_profile_free(dsd_scan_row_profile* profile) {
     free(profile);
 }
 
-/** Conventional profile by positional scan slot; borrowed until list replacement. */
+/** Conventional profile by positional scan slot; borrowed until list replacement. NULL when
+ * the row carries no options. */
 const dsd_scan_row_profile* dsd_channel_profile_get(const dsd_state* state, size_t row);
-/** Transfer profile ownership on success. */
+/**
+ * Store a row profile, taking ownership of @p profile on success (the slot's previous
+ * profile is freed; NULL clears the slot). Returns -1 on allocation failure, in which case
+ * the caller still owns @p profile and the slot is unchanged. A stored profile with any
+ * option present makes dsd_channel_modes_present() true, so the typed scanner runs it.
+ */
 int dsd_channel_profile_set(dsd_state* state, size_t row, dsd_scan_row_profile* profile);
-/** Reserve group scope before a tune. */
+/** Reserve group scope before a tune. Returns -1 on allocation failure, 0 otherwise. */
 int dsd_scan_groups_begin(dsd_state* state);
-/** Apply/restore the preloaded policy without allocating. Scope must have been reserved. */
+/** Install the row's preloaded policy (the global policy is retained as the baseline on the first
+ * entry), or restore the baseline for a profile without groups. No allocation; the scope must
+ * have been reserved with dsd_scan_groups_begin(). */
 void dsd_scan_groups_enter(dsd_state* state, const dsd_scan_row_profile* profile);
+/** Restore the baseline policy and drop the scope. Safe when no scope is active. */
 void dsd_scan_groups_leave(dsd_state* state);
-/** Group imports update the global policy beneath a parked row. */
+/** Park the row policy so a group import edits the global baseline beneath it. Returns 1 when
+ * parked (resume is then owed), 0 when no row policy is active. */
 int dsd_scan_groups_suspend(dsd_state* state);
+/** Adopt the edited global policy as the new baseline and reinstall the parked row policy. */
 void dsd_scan_groups_resume(dsd_state* state);
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/core/scan_profile.h
+++ b/include/dsd-neo/core/scan_profile.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+/** @file @brief Materialized row options; companion files are read only at import. */
+#ifndef DSD_NEO_CORE_SCAN_PROFILE_H
+#define DSD_NEO_CORE_SCAN_PROFILE_H
+#include <dsd-neo/core/key_set.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/runtime/scan_options.h>
+#include <stdlib.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    dsd_scan_option_values values;
+    dsd_tg_policy_store* groups;
+} dsd_scan_row_profile;
+
+/** Parsed key values replace the entire key set; out remains unchanged on failure. */
+int dsd_scan_options_keys(const dsd_scan_options* options, dsd_key_set* out);
+/** Merge legacy key columns into parsed options without changing their legacy mode semantics.
+ * Reject duplicate definitions/source-family conflicts. No files are opened. */
+int dsd_scan_options_merge_keys(dsd_scan_options* options, const char* hex_file, const char* dec_file,
+                                const char* single_hex, const char* single_dec, char* error, size_t error_size);
+/** Resolve paths relative to the list. On failure the caller discards the import object. */
+int dsd_scan_options_resolve(dsd_scan_options* options, const char* base, char* error, size_t error_size);
+/** Build one profile and key set. Failure leaves outputs untouched. */
+int dsd_scan_profile_load(const dsd_scan_options* options, int show_keys, dsd_scan_row_profile** profile,
+                          dsd_key_set* keys);
+
+static inline void
+dsd_scan_profile_free(dsd_scan_row_profile* profile) {
+    if (!profile) {
+        return;
+    }
+    dsd_tg_policy_release(profile->groups);
+    free(profile);
+}
+
+/** Conventional profile by positional scan slot; borrowed until list replacement. */
+const dsd_scan_row_profile* dsd_channel_profile_get(const dsd_state* state, size_t row);
+/** Transfer profile ownership on success. */
+int dsd_channel_profile_set(dsd_state* state, size_t row, dsd_scan_row_profile* profile);
+/** Reserve group scope before a tune. */
+int dsd_scan_groups_begin(dsd_state* state);
+/** Apply/restore the preloaded policy without allocating. Scope must have been reserved. */
+void dsd_scan_groups_enter(dsd_state* state, const dsd_scan_row_profile* profile);
+void dsd_scan_groups_leave(dsd_state* state);
+/** Group imports update the global policy beneath a parked row. */
+int dsd_scan_groups_suspend(dsd_state* state);
+void dsd_scan_groups_resume(dsd_state* state);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/dsd-neo/core/scan_profile.h
+++ b/include/dsd-neo/core/scan_profile.h
@@ -24,8 +24,8 @@ typedef struct {
  * @p out, releasing whatever @p out held. `present` is set only when a direct source exists.
  * Returns -1 on a bad argument with @p out untouched. */
 int dsd_scan_options_keys(const dsd_scan_options* options, dsd_key_set* out);
-/** Merge the legacy key columns into parsed options. The columns keep their key-only meaning:
- * they never change encrypted-audio muting (only the option text's own `-b`/`-H` do). Rejects a
+/** Merge legacy key columns into parsed options. Columns alone do not claim a mute override;
+ * when option text contains `-b`/`-H`, all merged BP/Hytera material decides DMR muting. Rejects a
  * column that duplicates an option or mixes direct keys with key files. No files are opened;
  * on failure @p options is untouched. */
 int dsd_scan_options_merge_keys(dsd_scan_options* options, const char* hex_file, const char* dec_file,
@@ -74,7 +74,7 @@ void dsd_scan_groups_leave(dsd_state* state);
 /** Park the row policy so a group import edits the global baseline beneath it. Returns 1 when
  * parked (resume is then owed), 0 when no row policy is active. */
 int dsd_scan_groups_suspend(dsd_state* state);
-/** Adopt the edited global policy as the new baseline and reinstall the parked row policy. */
+/** Adopt the edited global baseline and restore the parked policy with active calls intact. */
 void dsd_scan_groups_resume(dsd_state* state);
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/core/talkgroup_policy.h
+++ b/include/dsd-neo/core/talkgroup_policy.h
@@ -156,6 +156,17 @@ int dsd_tg_policy_reload_group_file(const dsd_opts* opts, dsd_state* state);
  */
 int dsd_tg_policy_clear(dsd_state* state);
 
+/** Decoder-thread owned policy context. References preserve row-local aliases and lockouts.
+ * Frontend snapshots still deep-copy their effective context. */
+typedef struct dsd_tg_policy_store dsd_tg_policy_store;
+/** Retain the effective context; NULL represents an empty policy. */
+dsd_tg_policy_store* dsd_tg_policy_retain(const dsd_state* state);
+void dsd_tg_policy_release(dsd_tg_policy_store* store);
+/** Install a retained context without allocating, ending its old active-call bookkeeping. */
+void dsd_tg_policy_install(dsd_state* state, dsd_tg_policy_store* store);
+/** Load a standalone policy. On failure leave out untouched. */
+int dsd_tg_policy_load(const char* path, dsd_tg_policy_store** out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsd-neo/core/talkgroup_policy.h
+++ b/include/dsd-neo/core/talkgroup_policy.h
@@ -156,15 +156,33 @@ int dsd_tg_policy_reload_group_file(const dsd_opts* opts, dsd_state* state);
  */
 int dsd_tg_policy_clear(dsd_state* state);
 
-/** Decoder-thread owned policy context. References preserve row-local aliases and lockouts.
- * Frontend snapshots still deep-copy their effective context. */
+/**
+ * Decoder-thread owned, reference-counted policy context. References preserve row-local
+ * aliases and lockouts across scan visits. Frontend snapshots still deep-copy their
+ * effective context. Ownership protocol: every dsd_tg_policy_retain()/dsd_tg_policy_load()
+ * result is one reference the caller must eventually dsd_tg_policy_release(); the state's
+ * own extension slot holds its own reference, so installing a store never transfers the
+ * caller's.
+ */
 typedef struct dsd_tg_policy_store dsd_tg_policy_store;
-/** Retain the effective context; NULL represents an empty policy. */
+/** Take one reference on the state's effective context. NULL (no context) represents an
+ * empty policy and needs no release. */
 dsd_tg_policy_store* dsd_tg_policy_retain(const dsd_state* state);
+/** Drop one reference; the context is freed with the last one. NULL is ignored. */
 void dsd_tg_policy_release(dsd_tg_policy_store* store);
-/** Install a retained context without allocating, ending its old active-call bookkeeping. */
+/**
+ * Make @p store the state's effective context without allocating: the state takes its own
+ * reference (the caller keeps and still owns theirs), the previously installed context is
+ * released, and the installed store's active-call bookkeeping restarts. NULL installs an
+ * empty policy. Reinstalling the current context only restarts the bookkeeping.
+ */
 void dsd_tg_policy_install(dsd_state* state, dsd_tg_policy_store* store);
-/** Load a standalone policy. On failure leave out untouched. */
+/**
+ * Load a standalone policy from a group file, with csvGroupImportPath() semantics (rows the
+ * importer cannot store are skipped with a warning). On success `*out` is overwritten with a
+ * new reference, so release any reference it held first. On failure `*out` is untouched.
+ * Returns 0 on success, -1 otherwise.
+ */
 int dsd_tg_policy_load(const char* path, dsd_tg_policy_store** out);
 
 #ifdef __cplusplus

--- a/include/dsd-neo/core/talkgroup_policy.h
+++ b/include/dsd-neo/core/talkgroup_policy.h
@@ -178,6 +178,12 @@ void dsd_tg_policy_release(dsd_tg_policy_store* store);
  */
 void dsd_tg_policy_install(dsd_state* state, dsd_tg_policy_store* store);
 /**
+ * Restore a retained context after a temporary suspension, preserving active calls and
+ * preemption cooldowns. Reference ownership is the same as dsd_tg_policy_install().
+ * Use install instead for a target transition that must restart call bookkeeping.
+ */
+void dsd_tg_policy_restore(dsd_state* state, dsd_tg_policy_store* store);
+/**
  * Load a standalone policy from a group file, with csvGroupImportPath() semantics (rows the
  * importer cannot store are skipped with a warning). On success `*out` is overwritten with a
  * new reference, so release any reference it held first. On failure `*out` is untouched.

--- a/include/dsd-neo/engine/channel_scan.h
+++ b/include/dsd-neo/engine/channel_scan.h
@@ -18,7 +18,9 @@ int dsd_engine_channel_scan_waiting(const dsd_state* state);
 /** Resolve an outstanding request before reading samples. Returns 1 while unsettled. */
 int dsd_engine_channel_scan_pending(dsd_opts* opts, dsd_state* state);
 /** Service a row transaction before dispatch/next sync search. Returns 1 when ready;
- * servicing any outstanding transaction clears synctype and returns 0 for a fresh hunt. */
+ * servicing any outstanding transaction clears synctype and returns 0 for a fresh hunt.
+ * A completed tune without a row commit keeps decoding gated even when a subsequent
+ * retry is rejected or deferred; ordinary scanning may still advance to recover. */
 int dsd_engine_channel_scan_service_sync(dsd_opts* opts, dsd_state* state);
 /** Cancel row ownership and restore configured settings. Late completions cannot adopt a row. */
 void dsd_engine_channel_scan_leave(dsd_opts* opts, dsd_state* state);

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -15,6 +15,7 @@
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -76,6 +77,8 @@ typedef struct {
      * text never survives parsing or reaches a diagnostic. */
     dsd_key_scalars single_key_scalars;
     uint8_t single_keys_present;
+    /** Nonsecret, validated per-target overrides. Group path is relative-resolved at import. */
+    dsd_scan_option_values row_options;
     /* Per-target P25 band plan CSV (trunk targets only), resolved relative to the targets CSV at
      * parse time and loaded into the target's own band-plan store at init; empty means none. */
     char p25_bandplan_csv[1024];

--- a/include/dsd-neo/runtime/scan_mode.h
+++ b/include/dsd-neo/runtime/scan_mode.h
@@ -34,7 +34,9 @@ typedef enum {
     DSD_SCAN_MODULATION_GFSK
 } dsd_scan_modulation;
 
-/** Scalar snapshot of the exact configured decoder settings; owns no pointers. */
+/** Scalar snapshot of the exact configured decoder settings; owns no pointers.
+ * The leading block holds the row-scoped nonsecret options (see scan_options.h); they are
+ * captured and restored with the rest but excluded from dsd_scan_settings_equal(). */
 typedef struct {
     int force_key;
     int aggressive_framesync;
@@ -93,7 +95,9 @@ dsd_scan_mode dsd_scan_mode_active(const dsd_state* state);
 /** Capture/restore effective fields for a staged tune; no pointers or audio sink fields are changed. */
 void dsd_scan_settings_capture(const dsd_opts* opts, const dsd_state* state, dsd_scan_settings* out);
 void dsd_scan_settings_restore(const dsd_scan_settings* saved, dsd_opts* opts, dsd_state* state);
-/** Compare setting values, ignoring unused label bytes; optionally include live timing/modulation. */
+/** Compare the acquisition-relevant settings (decoder set, modulation, inversion, slot policy, output
+ * name), ignoring unused label bytes and the row-scoped option fields; optionally include live
+ * timing/modulation. A difference means a staged tune or parked row must be re-acquired. */
 int dsd_scan_settings_equal(const dsd_scan_settings* a, const dsd_scan_settings* b, int include_timing);
 /** Prepare production row settings without committing the row or baseline. */
 int dsd_scan_mode_prepare(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode, dsd_scan_settings* out);
@@ -107,14 +111,18 @@ dsdneoUserDecodeMode dsd_scan_mode_configured_preset_exact(const dsd_opts* opts,
  * INHERIT restores the baseline for a blank row while retaining scan ownership. */
 int dsd_scan_mode_enter(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode);
 /** Install nonsecret row overrides after mode entry; NULL restores baseline row options.
- * No allocation. The caller must already own a scan scope. Reapplied after operator updates. */
-void dsd_scan_mode_options(dsd_opts* opts, dsd_state* state, const dsd_scan_option_values* values);
+ * No allocation. Returns -1 without touching anything when no scan scope is owned (call
+ * dsd_scan_mode_enter()/dsd_scan_mode_begin() first), else 0. While the scope is suspended the
+ * values are only recorded and take effect at dsd_scan_mode_resume(); they are reapplied over the
+ * refreshed baseline after every operator update. */
+int dsd_scan_mode_options(dsd_opts* opts, dsd_state* state, const dsd_scan_option_values* values);
 /** Restore the exact configured baseline and release the scope. */
 void dsd_scan_mode_leave(dsd_opts* opts, dsd_state* state);
 /** Temporarily restore configuration for an operator update, retaining the row constraint. */
 int dsd_scan_mode_suspend(dsd_opts* opts, dsd_state* state);
 /** Save updated configuration and reapply the constraint. Return nonzero when decoder
- * settings changed and acquisition must reset; audio-routing-only updates return zero. */
+ * settings changed and acquisition must reset; audio-routing and row-scoped option updates
+ * (forcing, CRC policy, mutes, voice gate, group file) return zero and simply take effect. */
 int dsd_scan_mode_resume(dsd_opts* opts, dsd_state* state);
 /** Nonzero between suspend and resume; side effects must wait until effective settings are known. */
 int dsd_scan_mode_updating(const dsd_state* state);

--- a/include/dsd-neo/runtime/scan_mode.h
+++ b/include/dsd-neo/runtime/scan_mode.h
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/state_fwd.h>
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -35,6 +36,16 @@ typedef enum {
 
 /** Scalar snapshot of the exact configured decoder settings; owns no pointers. */
 typedef struct {
+    int force_key;
+    int aggressive_framesync;
+    int dmr_crc_relaxed_default;
+    int scan_voice_only;
+    int scan_voice_qualify_ms;
+    int scan_voice_hold_ms;
+    int dmr_mute_encL;
+    int dmr_mute_encR;
+    int unmute_encrypted_p25;
+    char group_in_file[1024];
     int frame_dstar;
     int frame_x2tdma;
     int frame_p25p1;
@@ -95,6 +106,9 @@ dsdneoUserDecodeMode dsd_scan_mode_configured_preset_exact(const dsd_opts* opts,
 /** Select a row from the saved baseline, keeping the open audio sink layout fixed.
  * INHERIT restores the baseline for a blank row while retaining scan ownership. */
 int dsd_scan_mode_enter(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode);
+/** Install nonsecret row overrides after mode entry; NULL restores baseline row options.
+ * No allocation. The caller must already own a scan scope. Reapplied after operator updates. */
+void dsd_scan_mode_options(dsd_opts* opts, dsd_state* state, const dsd_scan_option_values* values);
 /** Restore the exact configured baseline and release the scope. */
 void dsd_scan_mode_leave(dsd_opts* opts, dsd_state* state);
 /** Temporarily restore configuration for an operator update, retaining the row constraint. */

--- a/include/dsd-neo/runtime/scan_options.h
+++ b/include/dsd-neo/runtime/scan_options.h
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+/** @file @brief Import-time scanner options. This is a restricted argument grammar, never a command. */
+#ifndef DSD_NEO_RUNTIME_SCAN_OPTIONS_H
+#define DSD_NEO_RUNTIME_SCAN_OPTIONS_H
+#include <stddef.h>
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    DSD_SCAN_OPT_FORCE = 1U << 0,
+    DSD_SCAN_OPT_CRC = 1U << 1,
+    DSD_SCAN_OPT_VOICE = 1U << 2,
+    DSD_SCAN_OPT_QUALIFY = 1U << 3,
+    DSD_SCAN_OPT_HOLD = 1U << 4,
+    DSD_SCAN_OPT_BP = 1U << 5,
+    DSD_SCAN_OPT_HYTERA = 1U << 6,
+    DSD_SCAN_OPT_SCALAR = 1U << 7,
+    DSD_SCAN_OPT_SCRAMBLER = 1U << 8,
+    DSD_SCAN_OPT_HEX_FILE = 1U << 9,
+    DSD_SCAN_OPT_DEC_FILE = 1U << 10,
+    DSD_SCAN_OPT_GROUP = 1U << 11,
+    DSD_SCAN_OPT_DIRECT = DSD_SCAN_OPT_BP | DSD_SCAN_OPT_HYTERA | DSD_SCAN_OPT_SCALAR | DSD_SCAN_OPT_SCRAMBLER,
+    DSD_SCAN_OPT_FILES = DSD_SCAN_OPT_HEX_FILE | DSD_SCAN_OPT_DEC_FILE
+};
+
+/** Nonsecret overrides copied into runtime/frontend scan scopes. */
+typedef struct {
+    uint32_t present;
+    int force;
+    int strict_crc;
+    int voice_only;
+    int qualify_ms;
+    int hold_ms;
+    int mute_dmr;
+    int unmute_p25;
+    char group_file[1024];
+} dsd_scan_option_values;
+
+/** Parsed import metadata. Wipe after materializing; never publish this object to a frontend. */
+typedef struct {
+    dsd_scan_option_values values;
+    uint64_t bp;
+    uint64_t scalar;
+    uint64_t hytera[4];
+    unsigned int hytera_digits;
+    char hex_file[1024];
+    char dec_file[1024];
+} dsd_scan_options;
+
+/** Parse and validate against a dsd_scan_mode value and conventional/trunk context.
+ * Empty text inherits everything. Protocol-specific options require a declared mode.
+ * On failure out is unchanged; error contains only fixed option names and explanations.
+ * Single/double quotes group arguments; backslashes are literal. No CSV comma escaping. */
+int dsd_scan_options_parse(const char* text, unsigned int mode, int conventional, dsd_scan_options* out, char* error,
+                           size_t error_size);
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/include/dsd-neo/runtime/scan_options.h
+++ b/include/dsd-neo/runtime/scan_options.h
@@ -23,11 +23,21 @@ enum {
     DSD_SCAN_OPT_HEX_FILE = 1U << 9,
     DSD_SCAN_OPT_DEC_FILE = 1U << 10,
     DSD_SCAN_OPT_GROUP = 1U << 11,
+    /** The row decides DMR encrypted-audio muting. Set only by the `-b`/`-H` switches in the option text,
+     * so legacy single_key_dec/single_key_hex columns keep their key-only meaning. */
+    DSD_SCAN_OPT_MUTE_DMR = 1U << 12,
     DSD_SCAN_OPT_DIRECT = DSD_SCAN_OPT_BP | DSD_SCAN_OPT_HYTERA | DSD_SCAN_OPT_SCALAR | DSD_SCAN_OPT_SCRAMBLER,
     DSD_SCAN_OPT_FILES = DSD_SCAN_OPT_HEX_FILE | DSD_SCAN_OPT_DEC_FILE
 };
 
-/** Nonsecret overrides copied into runtime/frontend scan scopes. */
+/** Key-file path capacity, matching the legacy keys_hex_csv/keys_dec_csv column limit (CSV_IMPORT_PATH_MAX). */
+#define DSD_SCAN_OPTIONS_KEY_PATH_MAX   2048
+/** Group-file path capacity; must equal the capacity of dsd_opts::group_in_file, which it overrides. */
+#define DSD_SCAN_OPTIONS_GROUP_PATH_MAX 1024
+
+/** Nonsecret overrides copied into runtime/frontend scan scopes. A field is meaningful only when its
+ * DSD_SCAN_OPT_* bit is set in `present`. `-1` (DSD_SCAN_OPT_SCALAR) always mutes undecodable P25 audio,
+ * as the CLI switch does, so it carries no value here. */
 typedef struct {
     uint32_t present;
     int force;
@@ -36,8 +46,7 @@ typedef struct {
     int qualify_ms;
     int hold_ms;
     int mute_dmr;
-    int unmute_p25;
-    char group_file[1024];
+    char group_file[DSD_SCAN_OPTIONS_GROUP_PATH_MAX];
 } dsd_scan_option_values;
 
 /** Parsed import metadata. Wipe after materializing; never publish this object to a frontend. */
@@ -47,8 +56,8 @@ typedef struct {
     uint64_t scalar;
     uint64_t hytera[4];
     unsigned int hytera_digits;
-    char hex_file[1024];
-    char dec_file[1024];
+    char hex_file[DSD_SCAN_OPTIONS_KEY_PATH_MAX];
+    char dec_file[DSD_SCAN_OPTIONS_KEY_PATH_MAX];
 } dsd_scan_options;
 
 /** Parse and validate against a dsd_scan_mode value and conventional/trunk context.

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -366,7 +366,12 @@ ui_cmd_reset_key_mute_state(dsd_opts* opts, dsd_state* state) {
     }
     state->keyloader = 0;
     state->payload_keyid = state->payload_keyidR = 0;
+    /* Key ownership stays live; only the mute decision updates configured defaults. */
+    const int scoped = dsd_scan_mode_suspend(opts, state);
     opts->dmr_mute_encL = opts->dmr_mute_encR = 0;
+    if (scoped) {
+        (void)dsd_scan_mode_resume(opts, state);
+    }
     // Every direct key mutation funnels through here: invalidate the
     // encrypted-target lockout ledger so each locked target re-verifies once
     // against the new key material.
@@ -2985,7 +2990,6 @@ ui_cmd_handle_aggr_sync_toggle(dsd_opts* opts, dsd_state* state, const struct ds
     (void)state;
     (void)c;
     opts->aggressive_framesync = opts->aggressive_framesync ? 0 : 1;
-    opts->dmr_crc_relaxed_default = (uint8_t)!opts->aggressive_framesync;
     return 1;
 }
 

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -21,6 +21,7 @@
 #include <dsd-neo/core/frontend_types.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/power.h>
+#include <dsd-neo/core/scan_profile.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/talkgroup_policy.h>
@@ -2984,6 +2985,7 @@ ui_cmd_handle_aggr_sync_toggle(dsd_opts* opts, dsd_state* state, const struct ds
     (void)state;
     (void)c;
     opts->aggressive_framesync = opts->aggressive_framesync ? 0 : 1;
+    opts->dmr_crc_relaxed_default = (uint8_t)!opts->aggressive_framesync;
     return 1;
 }
 
@@ -4224,12 +4226,27 @@ command_updates_scan_mode(const struct dsd_app_command* c) {
      * Live controls must continue to inspect the effective row, so suspending
      * every command and diffing afterward would change their behavior. */
     static const int commands[] = {
-        DSD_APP_CMD_DECODE_MODE_SET,      DSD_APP_CMD_MOD_SET,
-        DSD_APP_CMD_MOD_TOGGLE,           DSD_APP_CMD_MOD_P2_TOGGLE,
-        DSD_APP_CMD_INVERT_TOGGLE,        DSD_APP_CMD_COSINE_FILTER_TOGGLE,
-        DSD_APP_CMD_INV_X2_TOGGLE,        DSD_APP_CMD_INV_DMR_TOGGLE,
-        DSD_APP_CMD_INV_DPMR_TOGGLE,      DSD_APP_CMD_INV_M17_TOGGLE,
-        DSD_APP_CMD_INPUT_MONITOR_TOGGLE, DSD_APP_CMD_CONFIG_APPLY,
+        DSD_APP_CMD_ALL_MUTES_TOGGLE,
+        DSD_APP_CMD_FORCE_PRIV_TOGGLE,
+        DSD_APP_CMD_FORCE_RC4_TOGGLE,
+        DSD_APP_CMD_AGGR_SYNC_TOGGLE,
+        DSD_APP_CMD_SCAN_VOICE_ONLY_SET,
+        DSD_APP_CMD_SCAN_VOICE_QUALIFY_MS_SET,
+        DSD_APP_CMD_SCAN_VOICE_HOLD_MS_SET,
+        DSD_APP_CMD_IMPORT_GROUP_LIST,
+        DSD_APP_CMD_IMPORT_GROUP_LIST_CLEAR,
+        DSD_APP_CMD_DECODE_MODE_SET,
+        DSD_APP_CMD_MOD_SET,
+        DSD_APP_CMD_MOD_TOGGLE,
+        DSD_APP_CMD_MOD_P2_TOGGLE,
+        DSD_APP_CMD_INVERT_TOGGLE,
+        DSD_APP_CMD_COSINE_FILTER_TOGGLE,
+        DSD_APP_CMD_INV_X2_TOGGLE,
+        DSD_APP_CMD_INV_DMR_TOGGLE,
+        DSD_APP_CMD_INV_DPMR_TOGGLE,
+        DSD_APP_CMD_INV_M17_TOGGLE,
+        DSD_APP_CMD_INPUT_MONITOR_TOGGLE,
+        DSD_APP_CMD_CONFIG_APPLY,
     };
     if (!c) {
         return 0;
@@ -4247,7 +4264,14 @@ apply_cmd(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     const int mode_update = command_updates_scan_mode(c);
     const int was_scanner = opts && opts->scanner_mode == 1;
     const int scoped = mode_update && opts && state && dsd_scan_mode_suspend(opts, state);
+    const int group_update = c
+                             && (c->id == DSD_APP_CMD_IMPORT_GROUP_LIST || c->id == DSD_APP_CMD_IMPORT_GROUP_LIST_CLEAR
+                                 || c->id == DSD_APP_CMD_CONFIG_APPLY);
+    const int groups_suspended = group_update && dsd_scan_groups_suspend(state);
     const int result = apply_cmd_unscoped(opts, state, c);
+    if (groups_suspended) {
+        dsd_scan_groups_resume(state);
+    }
     if (was_scanner && opts->scanner_mode != 1 && opts->trunk_scan_enabled != 1) {
         /* A suspended scope leaves the newly applied configuration in place. */
         dsd_engine_channel_scan_leave(opts, state);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(
         util/dsd_state_trunk_lcn.c
         util/dsd_state_p25_bandplan.c
         util/key_set.c
+        util/scan_profile.c
         util/channel_label.c
         util/enc_lockout.c
         util/dsd_events.c

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "../util/key_set_internal.h"
+#include "../util/talkgroup_policy_internal.h"
 #include "csv_parse_internal.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -375,14 +376,16 @@ group_apply_policy_fields(const group_policy_header* header, const char* filenam
 }
 
 static int
-group_commit_entry(dsd_state* state, const dsd_tg_policy_entry* entry, int is_range, const char* filename,
-                   unsigned int row_count, size_t* dropped_policy_alloc_rows) {
+group_commit_entry(dsd_state* state, dsd_tg_policy_store* store, const dsd_tg_policy_entry* entry, int is_range,
+                   const char* filename, unsigned int row_count, size_t* dropped_policy_alloc_rows) {
     int rc = 0;
-    if (!state || !entry || !filename || !dropped_policy_alloc_rows) {
+    if ((!state && !store) || !entry || !filename || !dropped_policy_alloc_rows) {
         return -1;
     }
 
-    rc = is_range ? dsd_tg_policy_add_range_entry(state, entry) : dsd_tg_policy_append_exact(state, entry);
+    rc = store      ? dsd_tg_policy_store_append(store, entry)
+         : is_range ? dsd_tg_policy_add_range_entry(state, entry)
+                    : dsd_tg_policy_append_exact(state, entry);
     if (rc == -1) {
         (*dropped_policy_alloc_rows)++;
         return rc;
@@ -399,8 +402,8 @@ group_commit_entry(dsd_state* state, const dsd_tg_policy_entry* entry, int is_ra
 
 /** @brief Parse and commit one group data row. @return 0 when the row loaded. */
 static int
-group_import_row(dsd_state* state, const char* filename, unsigned int row_count, char* buffer,
-                 const group_policy_header* header, size_t* dropped_policy_alloc_rows) {
+group_import_row(dsd_state* state, dsd_tg_policy_store* store, const char* filename, unsigned int row_count,
+                 char* buffer, const group_policy_header* header, size_t* dropped_policy_alloc_rows) {
     char* fields[32];
     size_t field_count = 0;
     uint32_t id_start = 0;
@@ -426,7 +429,7 @@ group_import_row(dsd_state* state, const char* filename, unsigned int row_count,
     name_field = fields[2];
     group_entry_init(&entry, id_start, id_end, is_range, mode_field, name_field, row_count, &mode_blocking);
     group_apply_policy_fields(header, filename, row_count, field_count, fields, &entry, mode_blocking);
-    return group_commit_entry(state, &entry, is_range, filename, row_count, dropped_policy_alloc_rows);
+    return group_commit_entry(state, store, &entry, is_range, filename, row_count, dropped_policy_alloc_rows);
 }
 
 /* Rows dropped for want of memory are a warning, as they always were: the import keeps
@@ -445,7 +448,8 @@ group_import_finish(FILE* fp, const char* filename, size_t dropped_policy_alloc_
 
 /* stats may be NULL; when set, counts data rows so a dry run can report them. */
 static int
-group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_validation* stats) {
+group_import_path(const char* group_file_path, dsd_state* state, dsd_tg_policy_store* store,
+                  dsd_csv_validation* stats) {
     char filename[CSV_IMPORT_PATH_MAX] = "filename.csv";
     char buffer[BSIZE];
     FILE* fp = NULL;
@@ -453,7 +457,7 @@ group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_v
     size_t dropped_policy_alloc_rows = 0;
     group_policy_header header = {0, 0, 0};
 
-    if (!group_file_path || group_file_path[0] == '\0' || !state) {
+    if (!group_file_path || group_file_path[0] == '\0' || (!state && !store)) {
         return -1;
     }
 
@@ -485,12 +489,35 @@ group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_v
         if (stats) {
             stats->total++;
         }
-        if (group_import_row(state, filename, row_count, buffer, &header, &dropped_policy_alloc_rows) == 0 && stats) {
+        if (group_import_row(state, store, filename, row_count, buffer, &header, &dropped_policy_alloc_rows) == 0
+            && stats) {
             stats->accepted++;
         }
     }
 
     return group_import_finish(fp, filename, dropped_policy_alloc_rows);
+}
+
+static int
+group_import_path_stats(const char* path, dsd_state* state, dsd_csv_validation* stats) {
+    return group_import_path(path, state, NULL, stats);
+}
+
+int
+dsd_tg_policy_load(const char* path, dsd_tg_policy_store** out) {
+    if (!out) {
+        return -1;
+    }
+    dsd_tg_policy_store* store = dsd_tg_policy_store_create();
+    if (!store) {
+        return -1;
+    }
+    if (group_import_path(path, NULL, store, NULL) != 0) {
+        dsd_tg_policy_release(store);
+        return -1;
+    }
+    *out = store;
+    return 0;
 }
 
 int
@@ -903,10 +930,10 @@ chan_import_options(dsd_state* state, char** fields, dsd_scan_mode mode, const c
     }
     dsd_scan_row_profile* profile = NULL;
     dsd_key_set keys = {0};
-    if (!rc && store) {
+    if (!rc) {
         rc = dsd_scan_options_resolve(&parsed, base_path, error, sizeof(error));
     }
-    if (!rc && store) {
+    if (!rc) {
         rc = dsd_scan_profile_load(&parsed, show_keys, &profile, &keys);
     }
     if (!rc && store && keys.present) {

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -429,6 +429,8 @@ group_import_row(dsd_state* state, const char* filename, unsigned int row_count,
     return group_commit_entry(state, &entry, is_range, filename, row_count, dropped_policy_alloc_rows);
 }
 
+/* Rows dropped for want of memory are a warning, as they always were: the import keeps
+ * what it could load. A read error is a failure, since the file was not fully read. */
 static int
 group_import_finish(FILE* fp, const char* filename, size_t dropped_policy_alloc_rows) {
     if (dropped_policy_alloc_rows > 0) {
@@ -436,7 +438,7 @@ group_import_finish(FILE* fp, const char* filename, size_t dropped_policy_alloc_
                  dropped_policy_alloc_rows);
     }
 
-    int rc = dropped_policy_alloc_rows || ferror(fp) ? -1 : 0;
+    const int rc = ferror(fp) ? -1 : 0;
     fclose(fp);
     return rc;
 }

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -6,6 +6,7 @@
 #include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/keyring.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/scan_profile.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
@@ -14,6 +15,7 @@
 #include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/path_policy.h>
 #include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -427,6 +429,18 @@ group_import_row(dsd_state* state, const char* filename, unsigned int row_count,
     return group_commit_entry(state, &entry, is_range, filename, row_count, dropped_policy_alloc_rows);
 }
 
+static int
+group_import_finish(FILE* fp, const char* filename, size_t dropped_policy_alloc_rows) {
+    if (dropped_policy_alloc_rows > 0) {
+        LOG_WARN("WARNING: Group file '%s' skipped %zu rows due to policy allocation failure.\n", filename,
+                 dropped_policy_alloc_rows);
+    }
+
+    int rc = dropped_policy_alloc_rows || ferror(fp) ? -1 : 0;
+    fclose(fp);
+    return rc;
+}
+
 /* stats may be NULL; when set, counts data rows so a dry run can report them. */
 static int
 group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_validation* stats) {
@@ -474,13 +488,7 @@ group_import_path_stats(const char* group_file_path, dsd_state* state, dsd_csv_v
         }
     }
 
-    if (dropped_policy_alloc_rows > 0) {
-        LOG_WARN("WARNING: Group file '%s' skipped %zu rows due to policy allocation failure.\n", filename,
-                 dropped_policy_alloc_rows);
-    }
-
-    fclose(fp);
-    return 0;
+    return group_import_finish(fp, filename, dropped_policy_alloc_rows);
 }
 
 int
@@ -681,6 +689,7 @@ enum {
     CHAN_KEYS_DEC,
     CHAN_SINGLE_HEX,
     CHAN_SINGLE_DEC,
+    CHAN_OPTIONS,
     CHAN_FIELD_COUNT
 };
 
@@ -742,7 +751,7 @@ chan_resolve_key_cell(const char* base_path, const char* cell, char* out, size_t
 static int
 chan_parse_header(char* header_line, chan_header_cols* out) {
     static const char* const names[CHAN_FIELD_COUNT] = {
-        "", "", "name", "mode", "keys_hex_csv", "keys_dec_csv", "single_key_hex", "single_key_dec"};
+        "", "", "name", "mode", "keys_hex_csv", "keys_dec_csv", "single_key_hex", "single_key_dec", "options"};
     for (int i = 0; i < CHAN_FIELD_COUNT; i++) {
         out->index[i] = i < 2 ? i : -1;
     }
@@ -754,6 +763,9 @@ chan_parse_header(char* header_line, chan_header_cols* out) {
             *next++ = '\0';
         }
         const char* name = trim_ws(cell);
+        if (csv_ascii_casecmp(name, "relevant_CLI_switches") == 0) {
+            name = "options";
+        }
         for (int i = CHAN_NAME; index >= 2 && i < CHAN_FIELD_COUNT; i++) {
             if (csv_ascii_casecmp(name, names[i]) != 0) {
                 continue;
@@ -874,6 +886,45 @@ chan_import_row_keys(dsd_state* state, char** fields, size_t field_count, const 
     return 0;
 }
 
+static int
+chan_import_options(dsd_state* state, char** fields, dsd_scan_mode mode, const char* base_path, int row_number,
+                    int show_keys, int store, size_t slot) {
+    dsd_scan_options parsed = {0};
+    char error[192] = "could not load options or companion file";
+    int rc = dsd_scan_options_parse(fields[CHAN_OPTIONS], (unsigned int)mode, 1, &parsed, error, sizeof(error));
+    if (!rc) {
+        rc =
+            dsd_scan_options_merge_keys(&parsed, chan_key_cell(fields, CHAN_FIELD_COUNT, CHAN_KEYS_HEX),
+                                        chan_key_cell(fields, CHAN_FIELD_COUNT, CHAN_KEYS_DEC),
+                                        chan_key_cell(fields, CHAN_FIELD_COUNT, CHAN_SINGLE_HEX),
+                                        chan_key_cell(fields, CHAN_FIELD_COUNT, CHAN_SINGLE_DEC), error, sizeof(error));
+    }
+    dsd_scan_row_profile* profile = NULL;
+    dsd_key_set keys = {0};
+    if (!rc && store) {
+        rc = dsd_scan_options_resolve(&parsed, base_path, error, sizeof(error));
+    }
+    if (!rc && store) {
+        rc = dsd_scan_profile_load(&parsed, show_keys, &profile, &keys);
+    }
+    if (!rc && store && keys.present) {
+        rc = dsd_state_trunk_lcn_keys_set(state, slot, &keys);
+    }
+    if (!rc && store) {
+        rc = dsd_channel_profile_set(state, slot, profile);
+        if (!rc) {
+            profile = NULL;
+        }
+    }
+    dsd_scan_profile_free(profile);
+    dsd_key_set_free(&keys);
+    DSD_SECURE_ZERO(&parsed, sizeof(parsed));
+    if (rc) {
+        LOG_ERROR("channel map file '%s' row %d: %s\n", base_path, row_number, error);
+    }
+    return rc;
+}
+
 /**
  * @brief Parse one channel row into @p state.
  *
@@ -915,9 +966,15 @@ chan_import_row(dsd_state* state, char* buffer, const chan_header_cols* cols, co
             return -1;
         }
     }
-    if (chan_import_row_keys(state, fields, CHAN_FIELD_COUNT, base_path, row_number, show_keys, row_has_slot,
-                             row_has_slot ? (size_t)lcn_before : 0U)
-        != 0) {
+    int keys_rc;
+    if (chan_key_cell_present(chan_key_cell(fields, CHAN_FIELD_COUNT, CHAN_OPTIONS))) {
+        keys_rc = chan_import_options(state, fields, mode, base_path, row_number, show_keys, row_has_slot,
+                                      row_has_slot ? (size_t)lcn_before : 0U);
+    } else {
+        keys_rc = chan_import_row_keys(state, fields, CHAN_FIELD_COUNT, base_path, row_number, show_keys, row_has_slot,
+                                       row_has_slot ? (size_t)lcn_before : 0U);
+    }
+    if (keys_rc != 0) {
         return -1;
     }
     *out_field_count = (int)field_count;

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -529,6 +529,7 @@ dsd_channel_modes_move(dsd_state* dst, dsd_state* src) {
         return;
     }
     dsd_scan_groups_leave(dst);
+    dsd_scan_groups_leave(src);
     void* ptr = dsd_state_ext_get(src, DSD_STATE_EXT_CORE_CHANNEL_MODES);
     /* Detach without cleanup before the source's normal teardown. */
     src->state_ext[DSD_STATE_EXT_CORE_CHANNEL_MODES] = NULL;
@@ -630,7 +631,7 @@ dsd_scan_groups_suspend(dsd_state* state) {
         return 0;
     }
     modes->group_suspended_row = dsd_tg_policy_retain(state);
-    dsd_tg_policy_install(state, modes->group_baseline);
+    dsd_tg_policy_restore(state, modes->group_baseline);
     modes->group_suspended = 1;
     return 1;
 }
@@ -643,7 +644,7 @@ dsd_scan_groups_resume(dsd_state* state) {
     }
     dsd_tg_policy_release(modes->group_baseline);
     modes->group_baseline = dsd_tg_policy_retain(state);
-    dsd_tg_policy_install(state, modes->group_suspended_row);
+    dsd_tg_policy_restore(state, modes->group_suspended_row);
     dsd_tg_policy_release(modes->group_suspended_row);
     modes->group_suspended_row = NULL;
     modes->group_suspended = 0;

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -439,6 +439,9 @@ typedef struct {
     dsd_scan_mode* rows;
     dsd_scan_row_profile** profiles;
     size_t profile_capacity;
+    /* Rows whose profile carries at least one option. Like declared_count, a nonzero value
+     * routes the scan through the typed scanner, which is the only path that applies them. */
+    size_t profile_count;
     dsd_tg_policy_store* group_baseline;
     dsd_tg_policy_store* group_suspended_row;
     int group_active;
@@ -467,7 +470,12 @@ dsd_channel_mode_get(const dsd_state* state, size_t row) {
 int
 dsd_channel_modes_present(const dsd_state* state) {
     const channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
-    return modes && modes->declared_count != 0;
+    return modes && (modes->declared_count != 0 || modes->profile_count != 0);
+}
+
+static int
+channel_profile_has_options(const dsd_scan_row_profile* profile) {
+    return profile != NULL && profile->values.present != 0;
 }
 
 int
@@ -575,8 +583,10 @@ dsd_channel_profile_set(dsd_state* state, size_t row, dsd_scan_row_profile* prof
         modes->profiles = profiles;
         modes->profile_capacity = capacity;
     }
+    modes->profile_count -= channel_profile_has_options(modes->profiles[row]);
     dsd_scan_profile_free(modes->profiles[row]);
     modes->profiles[row] = profile;
+    modes->profile_count += channel_profile_has_options(profile);
     return 0;
 }
 

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -15,9 +15,12 @@
 #include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/scan_profile.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -434,11 +437,23 @@ typedef struct {
     size_t capacity;
     size_t declared_count;
     dsd_scan_mode* rows;
+    dsd_scan_row_profile** profiles;
+    size_t profile_capacity;
+    dsd_tg_policy_store* group_baseline;
+    dsd_tg_policy_store* group_suspended_row;
+    int group_active;
+    int group_suspended;
 } channel_modes;
 
 static void
 channel_modes_cleanup(void* ptr) {
     channel_modes* modes = (channel_modes*)ptr;
+    for (size_t i = 0; i < modes->profile_capacity; i++) {
+        dsd_scan_profile_free(modes->profiles[i]);
+    }
+    free((void*)modes->profiles);
+    dsd_tg_policy_release(modes->group_baseline);
+    dsd_tg_policy_release(modes->group_suspended_row);
     free(modes->rows);
     free(modes);
 }
@@ -496,6 +511,7 @@ dsd_channel_mode_set(dsd_state* state, size_t row, dsd_scan_mode mode) {
 
 void
 dsd_channel_modes_clear(dsd_state* state) {
+    dsd_scan_groups_leave(state);
     (void)dsd_state_ext_set(state, DSD_STATE_EXT_CORE_CHANNEL_MODES, NULL, NULL);
 }
 
@@ -504,9 +520,121 @@ dsd_channel_modes_move(dsd_state* dst, dsd_state* src) {
     if (!dst || !src || dst == src) {
         return;
     }
+    dsd_scan_groups_leave(dst);
     void* ptr = dsd_state_ext_get(src, DSD_STATE_EXT_CORE_CHANNEL_MODES);
     /* Detach without cleanup before the source's normal teardown. */
     src->state_ext[DSD_STATE_EXT_CORE_CHANNEL_MODES] = NULL;
     src->state_ext_cleanup[DSD_STATE_EXT_CORE_CHANNEL_MODES] = NULL;
     (void)dsd_state_ext_set(dst, DSD_STATE_EXT_CORE_CHANNEL_MODES, ptr, channel_modes_cleanup);
+}
+
+int
+dsd_scan_groups_begin(dsd_state* state) {
+    if (!state) {
+        return -1;
+    }
+    channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    if (modes) {
+        return 0;
+    }
+    modes = (channel_modes*)calloc(1, sizeof(*modes));
+    if (!modes) {
+        return -1;
+    }
+    (void)dsd_state_ext_set(state, DSD_STATE_EXT_CORE_CHANNEL_MODES, modes, channel_modes_cleanup);
+    return 0;
+}
+
+const dsd_scan_row_profile*
+dsd_channel_profile_get(const dsd_state* state, size_t row) {
+    const channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    return modes && row < modes->profile_capacity ? modes->profiles[row] : NULL;
+}
+
+int
+dsd_channel_profile_set(dsd_state* state, size_t row, dsd_scan_row_profile* profile) {
+    if (row >= SIZE_MAX / sizeof(dsd_scan_row_profile*) || dsd_scan_groups_begin(state)) {
+        return -1;
+    }
+    channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    if (!modes) {
+        return -1;
+    }
+    if (row >= modes->profile_capacity) {
+        size_t capacity = trunk_lcn_grown_capacity(modes->profile_capacity, row + 1, sizeof(*modes->profiles));
+        if (!capacity) {
+            return -1;
+        }
+        dsd_scan_row_profile** profiles =
+            (dsd_scan_row_profile**)realloc((void*)modes->profiles, capacity * sizeof(*profiles));
+        if (!profiles) {
+            return -1;
+        }
+        DSD_MEMSET((void*)(profiles + modes->profile_capacity), 0,
+                   (capacity - modes->profile_capacity) * sizeof(*profiles));
+        modes->profiles = profiles;
+        modes->profile_capacity = capacity;
+    }
+    dsd_scan_profile_free(modes->profiles[row]);
+    modes->profiles[row] = profile;
+    return 0;
+}
+
+void
+dsd_scan_groups_leave(dsd_state* state) {
+    channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    if (!modes || !modes->group_active) {
+        return;
+    }
+    if (!modes->group_suspended) {
+        dsd_tg_policy_install(state, modes->group_baseline);
+    }
+    dsd_tg_policy_release(modes->group_baseline);
+    dsd_tg_policy_release(modes->group_suspended_row);
+    modes->group_baseline = NULL;
+    modes->group_suspended_row = NULL;
+    modes->group_active = modes->group_suspended = 0;
+}
+
+void
+dsd_scan_groups_enter(dsd_state* state, const dsd_scan_row_profile* profile) {
+    channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    if (!modes) {
+        return;
+    }
+    if (!profile || !(profile->values.present & DSD_SCAN_OPT_GROUP)) {
+        dsd_scan_groups_leave(state);
+        return;
+    }
+    if (!modes->group_active) {
+        modes->group_baseline = dsd_tg_policy_retain(state);
+        modes->group_active = 1;
+    }
+    dsd_tg_policy_install(state, profile->groups);
+}
+
+int
+dsd_scan_groups_suspend(dsd_state* state) {
+    channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    if (!modes || !modes->group_active || modes->group_suspended) {
+        return 0;
+    }
+    modes->group_suspended_row = dsd_tg_policy_retain(state);
+    dsd_tg_policy_install(state, modes->group_baseline);
+    modes->group_suspended = 1;
+    return 1;
+}
+
+void
+dsd_scan_groups_resume(dsd_state* state) {
+    channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    if (!modes || !modes->group_suspended) {
+        return;
+    }
+    dsd_tg_policy_release(modes->group_baseline);
+    modes->group_baseline = dsd_tg_policy_retain(state);
+    dsd_tg_policy_install(state, modes->group_suspended_row);
+    dsd_tg_policy_release(modes->group_suspended_row);
+    modes->group_suspended_row = NULL;
+    modes->group_suspended = 0;
 }

--- a/src/core/util/key_set.c
+++ b/src/core/util/key_set.c
@@ -378,6 +378,19 @@ key_set_parse_direct_hex(const char* text, dsd_key_scalars* scalars) {
         }
     }
 
+    dsd_key_scalars_store_direct_hex(scalars, segments, nhex);
+
+    DSD_SECURE_ZERO(segments, sizeof(segments));
+    DSD_SECURE_ZERO(hex, sizeof(hex));
+    return 0;
+}
+
+void
+dsd_key_scalars_store_direct_hex(dsd_key_scalars* scalars, const uint64_t segments[4], size_t nhex) {
+    if (scalars == NULL || segments == NULL || !key_set_direct_hex_width_valid(nhex)) {
+        return;
+    }
+    const size_t segment_count = nhex == 10U ? 1U : nhex / 16U;
     scalars->H = segments[0];
     scalars->K1 = segments[0];
     scalars->K2 = segments[1];
@@ -392,10 +405,6 @@ key_set_parse_direct_hex(const char* text, dsd_key_scalars* scalars) {
         scalars->aes_key_loaded[0] = scalars->aes_key_loaded[1] = any_nonzero;
         scalars->aes_key_segments[0] = scalars->aes_key_segments[1] = (uint8_t)segment_count;
     }
-
-    DSD_SECURE_ZERO(segments, sizeof(segments));
-    DSD_SECURE_ZERO(hex, sizeof(hex));
-    return 0;
 }
 
 dsd_key_direct_result
@@ -506,6 +515,7 @@ dsd_scan_key_change_prepare(const dsd_state* state, const dsd_key_set* row, dsd_
     change->changed = change->keyed ? !state->scan_keys_active_set || !dsd_key_set_equal(&state->scan_keys_active, row)
                                     : state->scan_keys_active_set != 0;
     if (!change->keyed) {
+        change->prepared = 1;
         return 0;
     }
     /* Own the globals as well as the row: rollback may cross an unkeyed target,
@@ -518,12 +528,18 @@ dsd_scan_key_change_prepare(const dsd_state* state, const dsd_key_set* row, dsd_
         dsd_scan_key_change_clear(change);
         return -1;
     }
+    change->prepared = 1;
     return 0;
 }
 
 int
 dsd_scan_key_change_commit(dsd_state* state, dsd_scan_key_change* change) {
     if (!state || !change) {
+        return 0;
+    }
+    if (!change->prepared) {
+        /* A failed or never-run prepare owns nothing and must not touch the live keyring. */
+        dsd_scan_key_change_clear(change);
         return 0;
     }
     const int changed = change->changed;

--- a/src/core/util/key_set.c
+++ b/src/core/util/key_set.c
@@ -19,6 +19,29 @@
 #include "dsd-neo/core/state_fwd.h"
 #include "key_set_internal.h"
 
+#ifdef DSD_NEO_TEST_HOOKS
+static long key_set_alloc_fail_after = -1;
+void dsd_key_set_test_alloc_fail_after(long count);
+
+void
+dsd_key_set_test_alloc_fail_after(long count) {
+    key_set_alloc_fail_after = count;
+}
+#endif
+
+static dsd_key_set_entry*
+key_set_alloc_entries(size_t count) {
+#ifdef DSD_NEO_TEST_HOOKS
+    if (key_set_alloc_fail_after == 0) {
+        return NULL;
+    }
+    if (key_set_alloc_fail_after > 0) {
+        key_set_alloc_fail_after--;
+    }
+#endif
+    return (dsd_key_set_entry*)calloc(count, sizeof(dsd_key_set_entry));
+}
+
 static size_t
 key_set_capacity(void) {
     return sizeof(((dsd_state*)0)->rkey_array) / sizeof(((dsd_state*)0)->rkey_array[0]);
@@ -100,7 +123,7 @@ dsd_key_set_capture(dsd_key_set* out, const dsd_state* state) {
     }
     dsd_key_set_entry* entries = NULL;
     if (count > 0) {
-        entries = (dsd_key_set_entry*)calloc(count, sizeof(*entries));
+        entries = key_set_alloc_entries(count);
         if (entries == NULL) {
             dsd_key_set_free(out);
             return -1;
@@ -159,7 +182,7 @@ dsd_key_set_copy(dsd_key_set* dst, const dsd_key_set* src) {
         if (src->entries == NULL) {
             return -1;
         }
-        entries = (dsd_key_set_entry*)calloc(src->count, sizeof(*entries));
+        entries = key_set_alloc_entries(src->count);
         if (entries == NULL) {
             return -1;
         }
@@ -461,6 +484,65 @@ dsd_key_set_load_csv(dsd_key_set* out, const char* hex_path, const char* dec_pat
     *out = loaded;
     DSD_SECURE_ZERO(&loaded, sizeof(loaded));
     return 0;
+}
+
+void
+dsd_scan_key_change_clear(dsd_scan_key_change* change) {
+    if (!change) {
+        return;
+    }
+    dsd_key_set_free(&change->baseline);
+    dsd_key_set_free(&change->active);
+    DSD_SECURE_ZERO(change, sizeof(*change));
+}
+
+int
+dsd_scan_key_change_prepare(const dsd_state* state, const dsd_key_set* row, dsd_scan_key_change* change) {
+    if (!state || !change) {
+        return -1;
+    }
+    dsd_scan_key_change_clear(change);
+    change->keyed = row && row->present;
+    change->changed = change->keyed ? !state->scan_keys_active_set || !dsd_key_set_equal(&state->scan_keys_active, row)
+                                    : state->scan_keys_active_set != 0;
+    if (!change->keyed) {
+        return 0;
+    }
+    /* Own the globals as well as the row: rollback may cross an unkeyed target,
+     * whose leave releases the current baseline before this change commits. */
+    change->capture_baseline = 1;
+    const int baseline_rc = state->scan_keys_active_set
+                                ? dsd_key_set_copy(&change->baseline, &state->scan_keys_baseline)
+                                : dsd_key_set_capture(&change->baseline, state);
+    if (baseline_rc || dsd_key_set_copy(&change->active, row)) {
+        dsd_scan_key_change_clear(change);
+        return -1;
+    }
+    return 0;
+}
+
+int
+dsd_scan_key_change_commit(dsd_state* state, dsd_scan_key_change* change) {
+    if (!state || !change) {
+        return 0;
+    }
+    const int changed = change->changed;
+    if (!change->keyed) {
+        dsd_scan_keys_leave(state);
+    } else {
+        if (change->capture_baseline) {
+            dsd_key_set_free(&state->scan_keys_baseline);
+            state->scan_keys_baseline = change->baseline;
+            DSD_MEMSET(&change->baseline, 0, sizeof(change->baseline));
+        }
+        dsd_key_set_free(&state->scan_keys_active);
+        state->scan_keys_active = change->active;
+        DSD_MEMSET(&change->active, 0, sizeof(change->active));
+        state->scan_keys_active_set = 1;
+        dsd_key_set_install(state, &state->scan_keys_active);
+    }
+    dsd_scan_key_change_clear(change);
+    return changed;
 }
 
 int

--- a/src/core/util/key_set.c
+++ b/src/core/util/key_set.c
@@ -356,7 +356,7 @@ key_set_direct_segments_nonzero(const uint64_t segments[4], size_t count) {
 }
 
 static int
-key_set_parse_direct_hex(const char* text, dsd_key_scalars* scalars) {
+key_set_parse_direct_hex(const char* text, dsd_key_scalars* scalars, size_t* digits) {
     char hex[65];
     DSD_MEMSET(hex, 0, sizeof(hex));
     size_t nhex = 0U;
@@ -379,6 +379,7 @@ key_set_parse_direct_hex(const char* text, dsd_key_scalars* scalars) {
     }
 
     dsd_key_scalars_store_direct_hex(scalars, segments, nhex);
+    *digits = nhex;
 
     DSD_SECURE_ZERO(segments, sizeof(segments));
     DSD_SECURE_ZERO(hex, sizeof(hex));
@@ -408,7 +409,7 @@ dsd_key_scalars_store_direct_hex(dsd_key_scalars* scalars, const uint64_t segmen
 }
 
 dsd_key_direct_result
-dsd_key_set_load_direct(dsd_key_set* out, const char* single_hex, const char* single_dec) {
+dsd_key_set_load_direct_width(dsd_key_set* out, const char* single_hex, const char* single_dec, size_t* hex_digits) {
     const int have_hex = key_set_text_present(single_hex);
     const int have_dec = key_set_text_present(single_dec);
     if (out == NULL || (!have_hex && !have_dec)) {
@@ -423,15 +424,24 @@ dsd_key_set_load_direct(dsd_key_set* out, const char* single_hex, const char* si
         dsd_key_set_free(&loaded);
         return DSD_KEY_DIRECT_INVALID_DEC;
     }
-    if (have_hex && key_set_parse_direct_hex(single_hex, &loaded.scalars) != 0) {
+    size_t digits = 0;
+    if (have_hex && key_set_parse_direct_hex(single_hex, &loaded.scalars, &digits) != 0) {
         dsd_key_set_free(&loaded);
         return DSD_KEY_DIRECT_INVALID_HEX;
     }
 
     dsd_key_set_free(out);
     *out = loaded;
+    if (hex_digits) {
+        *hex_digits = digits;
+    }
     DSD_SECURE_ZERO(&loaded, sizeof(loaded));
     return DSD_KEY_DIRECT_OK;
+}
+
+dsd_key_direct_result
+dsd_key_set_load_direct(dsd_key_set* out, const char* single_hex, const char* single_dec) {
+    return dsd_key_set_load_direct_width(out, single_hex, single_dec, NULL);
 }
 
 static void

--- a/src/core/util/key_set_internal.h
+++ b/src/core/util/key_set_internal.h
@@ -14,6 +14,11 @@
 /* Compiler-resistant wipe of the inline key material held by a state. */
 void dsd_key_state_secure_wipe(dsd_state* state);
 
+/* Like the public direct loader, additionally returning the validated hex width (zero
+ * when absent). Both outputs are unchanged on failure; hex_digits may be NULL. */
+dsd_key_direct_result dsd_key_set_load_direct_width(dsd_key_set* out, const char* single_hex, const char* single_dec,
+                                                    size_t* hex_digits);
+
 /*
  * Store already-parsed direct `-H` segments (10, 32 or 64 hex digits, big-endian 64-bit
  * words, unused words zero) into the scalar block: H/K1..K4, the Hytera segment count and,

--- a/src/core/util/key_set_internal.h
+++ b/src/core/util/key_set_internal.h
@@ -6,9 +6,20 @@
 #ifndef DSD_NEO_SRC_CORE_UTIL_KEY_SET_INTERNAL_H_
 #define DSD_NEO_SRC_CORE_UTIL_KEY_SET_INTERNAL_H_
 
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <stddef.h>
+#include <stdint.h>
 
 /* Compiler-resistant wipe of the inline key material held by a state. */
 void dsd_key_state_secure_wipe(dsd_state* state);
+
+/*
+ * Store already-parsed direct `-H` segments (10, 32 or 64 hex digits, big-endian 64-bit
+ * words, unused words zero) into the scalar block: H/K1..K4, the Hytera segment count and,
+ * for multi-segment keys, the AES slots. The single owner of that mapping; the CSV column
+ * parser and the scoped-options materializer both route through it. Ignores other widths.
+ */
+void dsd_key_scalars_store_direct_hex(dsd_key_scalars* scalars, const uint64_t segments[4], size_t nhex);
 
 #endif /* DSD_NEO_SRC_CORE_UTIL_KEY_SET_INTERNAL_H_ */

--- a/src/core/util/scan_profile.c
+++ b/src/core/util/scan_profile.c
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <dsd-neo/core/key_set.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/scan_profile.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/runtime/path_policy.h>
+#include <dsd-neo/runtime/scan_options.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int
+profile_error(char* error, size_t size, const char* field, const char* reason) {
+    if (error && size) {
+        DSD_SNPRINTF(error, size, "%s: %s", field, reason);
+    }
+    return -1;
+}
+
+int
+dsd_scan_options_keys(const dsd_scan_options* options, dsd_key_set* out) {
+    if (!options || !out) {
+        return -1;
+    }
+    dsd_key_set keys = {0};
+    const uint32_t present = options->values.present;
+    keys.present = (present & DSD_SCAN_OPT_DIRECT) != 0;
+    keys.scalars.K = options->bp;
+    if (present & (DSD_SCAN_OPT_SCALAR | DSD_SCAN_OPT_SCRAMBLER)) {
+        keys.scalars.R = options->scalar;
+    }
+    if (present & DSD_SCAN_OPT_SCALAR) {
+        keys.scalars.RR = options->scalar;
+    }
+    if (present & DSD_SCAN_OPT_HYTERA) {
+        keys.scalars.H = keys.scalars.K1 = options->hytera[0];
+        keys.scalars.K2 = options->hytera[1];
+        keys.scalars.K3 = options->hytera[2];
+        keys.scalars.K4 = options->hytera[3];
+        unsigned int count = options->hytera_digits == 10 ? 1U : options->hytera_digits / 16U;
+        int nonzero = options->hytera[0] || options->hytera[1] || options->hytera[2] || options->hytera[3];
+        keys.scalars.hytera_key_segments = nonzero ? (uint8_t)count : 0;
+        if (count > 1) {
+            unsigned long long* slots[] = {keys.scalars.A1, keys.scalars.A2, keys.scalars.A3, keys.scalars.A4};
+            for (unsigned int i = 0; i < count; i++) {
+                slots[i][0] = slots[i][1] = options->hytera[i];
+                for (unsigned int j = 0; j < 8; j++) {
+                    keys.scalars.aes_key[i * 8 + j] = (uint8_t)(options->hytera[i] >> (56 - j * 8));
+                }
+            }
+            keys.scalars.aes_key_loaded[0] = keys.scalars.aes_key_loaded[1] = nonzero;
+            keys.scalars.aes_key_segments[0] = keys.scalars.aes_key_segments[1] = (uint8_t)count;
+        }
+    }
+    dsd_key_set_free(out);
+    *out = keys;
+    DSD_SECURE_ZERO(&keys, sizeof(keys));
+    return 0;
+}
+
+static int
+profile_text_present(const char* text) {
+    if (!text) {
+        return 0;
+    }
+    return strspn(text, " \t\r\n\v\f") != strlen(text);
+}
+
+static uint32_t
+profile_legacy_fields(const char* hex_file, const char* dec_file, const char* single_hex, const char* single_dec) {
+    return (profile_text_present(hex_file) ? DSD_SCAN_OPT_HEX_FILE : 0U)
+           | (profile_text_present(dec_file) ? DSD_SCAN_OPT_DEC_FILE : 0U)
+           | (profile_text_present(single_hex) ? DSD_SCAN_OPT_HYTERA : 0U)
+           | (profile_text_present(single_dec) ? DSD_SCAN_OPT_BP : 0U);
+}
+
+static unsigned int
+profile_hex_digits(const char* text) {
+    unsigned int digits = 0;
+    const char* p = text + strspn(text, " \t\r\n\v\f");
+    if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) {
+        p += 2;
+    }
+    for (; *p; p++) {
+        if (!strchr(" \t\r\n\v\f", *p)) {
+            digits++;
+        }
+    }
+    return digits;
+}
+
+static int
+profile_legacy_direct(dsd_scan_options* options, uint32_t legacy, const char* hex, const char* dec) {
+    if (!(legacy & DSD_SCAN_OPT_DIRECT)) {
+        return 0;
+    }
+    dsd_key_set direct = {0};
+    if (dsd_key_set_load_direct(&direct, hex, dec) != DSD_KEY_DIRECT_OK) {
+        return -1;
+    }
+    if (legacy & DSD_SCAN_OPT_HYTERA) {
+        options->hytera[0] = direct.scalars.K1;
+        options->hytera[1] = direct.scalars.K2;
+        options->hytera[2] = direct.scalars.K3;
+        options->hytera[3] = direct.scalars.K4;
+        options->hytera_digits = profile_hex_digits(hex);
+    }
+    if (legacy & DSD_SCAN_OPT_BP) {
+        options->bp = direct.scalars.K;
+    }
+    dsd_key_set_free(&direct);
+    return 0;
+}
+
+static int
+profile_copy_path(char* dest, size_t capacity, const char* path) {
+    if (!profile_text_present(path)) {
+        return 0;
+    }
+    if (strlen(path) >= capacity) {
+        return -1;
+    }
+    DSD_SNPRINTF(dest, capacity, "%s", path);
+    return 0;
+}
+
+static int
+profile_mute_dmr(const dsd_scan_options* options) {
+    return !(options->bp || options->hytera[0] || options->hytera[1] || options->hytera[2] || options->hytera[3]);
+}
+
+int
+dsd_scan_options_merge_keys(dsd_scan_options* options, const char* hex_file, const char* dec_file,
+                            const char* single_hex, const char* single_dec, char* error, size_t error_size) {
+    if (!options) {
+        return -1;
+    }
+    const uint32_t legacy = profile_legacy_fields(hex_file, dec_file, single_hex, single_dec);
+    if (legacy & options->values.present) {
+        return profile_error(error, error_size, "options", "duplicate key source");
+    }
+    const uint32_t combined = legacy | options->values.present;
+    if ((combined & DSD_SCAN_OPT_DIRECT) && (combined & DSD_SCAN_OPT_FILES)) {
+        return profile_error(error, error_size, "options", "direct keys cannot be combined with key files");
+    }
+    if (profile_legacy_direct(options, legacy, single_hex, single_dec)) {
+        return profile_error(error, error_size, "single_key_hex/single_key_dec", "invalid value");
+    }
+    if (profile_copy_path(options->hex_file, sizeof(options->hex_file), hex_file)) {
+        return profile_error(error, error_size, "keys_hex_csv", "path too long");
+    }
+    if (profile_copy_path(options->dec_file, sizeof(options->dec_file), dec_file)) {
+        return profile_error(error, error_size, "keys_dec_csv", "path too long");
+    }
+    options->values.present = combined;
+    options->values.mute_dmr = profile_mute_dmr(options);
+    return 0;
+}
+
+int
+dsd_scan_options_resolve(dsd_scan_options* options, const char* base, char* error, size_t error_size) {
+    if (!options) {
+        return profile_error(error, error_size, "options", "invalid argument");
+    }
+    const char* paths[] = {options->hex_file, options->dec_file, options->values.group_file};
+    char resolved[3][1024] = {{0}};
+    const char* names[] = {"keys_hex_csv/-K", "keys_dec_csv/-k", "-G"};
+    for (size_t i = 0; i < sizeof(paths) / sizeof(paths[0]); i++) {
+        if (!paths[i][0]) {
+            continue;
+        }
+        if (dsd_path_resolve_relative_to_file(base, paths[i], resolved[i], sizeof(resolved[i]))) {
+            return profile_error(error, error_size, names[i], "invalid or oversized path");
+        }
+    }
+    DSD_MEMCPY(options->hex_file, resolved[0], sizeof(options->hex_file));
+    DSD_MEMCPY(options->dec_file, resolved[1], sizeof(options->dec_file));
+    DSD_MEMCPY(options->values.group_file, resolved[2], sizeof(options->values.group_file));
+    return 0;
+}
+
+int
+dsd_scan_profile_load(const dsd_scan_options* options, int show_keys, dsd_scan_row_profile** profile,
+                      dsd_key_set* keys) {
+    if (!options || !profile || !keys) {
+        return -1;
+    }
+    dsd_scan_row_profile* loaded = (dsd_scan_row_profile*)calloc(1, sizeof(*loaded));
+    if (!loaded) {
+        return -1;
+    }
+    loaded->values = options->values;
+    int rc = 0;
+    if (options->values.present & DSD_SCAN_OPT_GROUP) {
+        rc = dsd_tg_policy_load(options->values.group_file, &loaded->groups);
+    }
+    dsd_key_set loaded_keys = {0};
+    if (!rc && (options->values.present & DSD_SCAN_OPT_FILES)) {
+        rc = dsd_key_set_load_csv(&loaded_keys, options->hex_file, options->dec_file, show_keys);
+    } else if (!rc) {
+        rc = dsd_scan_options_keys(options, &loaded_keys);
+    }
+    if (rc) {
+        dsd_scan_profile_free(loaded);
+        dsd_key_set_free(&loaded_keys);
+        return -1;
+    }
+    *profile = loaded;
+    dsd_key_set_free(keys);
+    *keys = loaded_keys;
+    DSD_SECURE_ZERO(&loaded_keys, sizeof(loaded_keys));
+    return 0;
+}

--- a/src/core/util/scan_profile.c
+++ b/src/core/util/scan_profile.c
@@ -11,6 +11,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "key_set_internal.h"
+
 static int
 profile_error(char* error, size_t size, const char* field, const char* reason) {
     if (error && size) {
@@ -35,24 +37,7 @@ dsd_scan_options_keys(const dsd_scan_options* options, dsd_key_set* out) {
         keys.scalars.RR = options->scalar;
     }
     if (present & DSD_SCAN_OPT_HYTERA) {
-        keys.scalars.H = keys.scalars.K1 = options->hytera[0];
-        keys.scalars.K2 = options->hytera[1];
-        keys.scalars.K3 = options->hytera[2];
-        keys.scalars.K4 = options->hytera[3];
-        unsigned int count = options->hytera_digits == 10 ? 1U : options->hytera_digits / 16U;
-        int nonzero = options->hytera[0] || options->hytera[1] || options->hytera[2] || options->hytera[3];
-        keys.scalars.hytera_key_segments = nonzero ? (uint8_t)count : 0;
-        if (count > 1) {
-            unsigned long long* slots[] = {keys.scalars.A1, keys.scalars.A2, keys.scalars.A3, keys.scalars.A4};
-            for (unsigned int i = 0; i < count; i++) {
-                slots[i][0] = slots[i][1] = options->hytera[i];
-                for (unsigned int j = 0; j < 8; j++) {
-                    keys.scalars.aes_key[i * 8 + j] = (uint8_t)(options->hytera[i] >> (56 - j * 8));
-                }
-            }
-            keys.scalars.aes_key_loaded[0] = keys.scalars.aes_key_loaded[1] = nonzero;
-            keys.scalars.aes_key_segments[0] = keys.scalars.aes_key_segments[1] = (uint8_t)count;
-        }
+        dsd_key_scalars_store_direct_hex(&keys.scalars, options->hytera, options->hytera_digits);
     }
     dsd_key_set_free(out);
     *out = keys;
@@ -145,17 +130,40 @@ dsd_scan_options_merge_keys(dsd_scan_options* options, const char* hex_file, con
     if ((combined & DSD_SCAN_OPT_DIRECT) && (combined & DSD_SCAN_OPT_FILES)) {
         return profile_error(error, error_size, "options", "direct keys cannot be combined with key files");
     }
-    if (profile_legacy_direct(options, legacy, single_hex, single_dec)) {
-        return profile_error(error, error_size, "single_key_hex/single_key_dec", "invalid value");
+    /* Merge into a copy so a rejected column leaves the caller's object exactly as it was. */
+    dsd_scan_options merged = *options;
+    int rc = 0;
+    if (profile_legacy_direct(&merged, legacy, single_hex, single_dec)) {
+        rc = profile_error(error, error_size, "single_key_hex/single_key_dec", "invalid value");
+    } else if (profile_copy_path(merged.hex_file, sizeof(merged.hex_file), hex_file)) {
+        rc = profile_error(error, error_size, "keys_hex_csv", "path too long");
+    } else if (profile_copy_path(merged.dec_file, sizeof(merged.dec_file), dec_file)) {
+        rc = profile_error(error, error_size, "keys_dec_csv", "path too long");
     }
-    if (profile_copy_path(options->hex_file, sizeof(options->hex_file), hex_file)) {
-        return profile_error(error, error_size, "keys_hex_csv", "path too long");
+    if (rc == 0) {
+        merged.values.present = combined;
+        /* Legacy columns only load keys. Only the option text's own `-b`/`-H` decide muting, and
+         * then from all of the row's privacy material, as the CLI switches do. */
+        if (combined & DSD_SCAN_OPT_MUTE_DMR) {
+            merged.values.mute_dmr = profile_mute_dmr(&merged);
+        }
+        *options = merged;
     }
-    if (profile_copy_path(options->dec_file, sizeof(options->dec_file), dec_file)) {
-        return profile_error(error, error_size, "keys_dec_csv", "path too long");
+    DSD_SECURE_ZERO(&merged, sizeof(merged));
+    return rc;
+}
+
+static int
+profile_resolve_path(const char* base, char* path, size_t capacity) {
+    if (!path[0]) {
+        return 0;
     }
-    options->values.present = combined;
-    options->values.mute_dmr = profile_mute_dmr(options);
+    char resolved[DSD_SCAN_OPTIONS_KEY_PATH_MAX] = {0};
+    const size_t limit = capacity < sizeof(resolved) ? capacity : sizeof(resolved);
+    if (dsd_path_resolve_relative_to_file(base, path, resolved, limit)) {
+        return -1;
+    }
+    DSD_MEMCPY(path, resolved, capacity);
     return 0;
 }
 
@@ -164,21 +172,30 @@ dsd_scan_options_resolve(dsd_scan_options* options, const char* base, char* erro
     if (!options) {
         return profile_error(error, error_size, "options", "invalid argument");
     }
-    const char* paths[] = {options->hex_file, options->dec_file, options->values.group_file};
-    char resolved[3][1024] = {{0}};
-    const char* names[] = {"keys_hex_csv/-K", "keys_dec_csv/-k", "-G"};
-    for (size_t i = 0; i < sizeof(paths) / sizeof(paths[0]); i++) {
-        if (!paths[i][0]) {
-            continue;
-        }
-        if (dsd_path_resolve_relative_to_file(base, paths[i], resolved[i], sizeof(resolved[i]))) {
-            return profile_error(error, error_size, names[i], "invalid or oversized path");
+    /* Resolve into a copy so a failure leaves the caller's object exactly as it was. */
+    dsd_scan_options resolved = *options;
+
+    const struct {
+        char* path;
+        size_t capacity;
+        const char* name;
+    } paths[] = {
+        {resolved.hex_file, sizeof(resolved.hex_file), "keys_hex_csv/-K"},
+        {resolved.dec_file, sizeof(resolved.dec_file), "keys_dec_csv/-k"},
+        {resolved.values.group_file, sizeof(resolved.values.group_file), "-G"},
+    };
+
+    int rc = 0;
+    for (size_t i = 0; rc == 0 && i < sizeof(paths) / sizeof(paths[0]); i++) {
+        if (profile_resolve_path(base, paths[i].path, paths[i].capacity)) {
+            rc = profile_error(error, error_size, paths[i].name, "invalid or oversized path");
         }
     }
-    DSD_MEMCPY(options->hex_file, resolved[0], sizeof(options->hex_file));
-    DSD_MEMCPY(options->dec_file, resolved[1], sizeof(options->dec_file));
-    DSD_MEMCPY(options->values.group_file, resolved[2], sizeof(options->values.group_file));
-    return 0;
+    if (rc == 0) {
+        *options = resolved;
+    }
+    DSD_SECURE_ZERO(&resolved, sizeof(resolved));
+    return rc;
 }
 
 int

--- a/src/core/util/scan_profile.c
+++ b/src/core/util/scan_profile.c
@@ -61,28 +61,14 @@ profile_legacy_fields(const char* hex_file, const char* dec_file, const char* si
            | (profile_text_present(single_dec) ? DSD_SCAN_OPT_BP : 0U);
 }
 
-static unsigned int
-profile_hex_digits(const char* text) {
-    unsigned int digits = 0;
-    const char* p = text + strspn(text, " \t\r\n\v\f");
-    if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) {
-        p += 2;
-    }
-    for (; *p; p++) {
-        if (!strchr(" \t\r\n\v\f", *p)) {
-            digits++;
-        }
-    }
-    return digits;
-}
-
 static int
 profile_legacy_direct(dsd_scan_options* options, uint32_t legacy, const char* hex, const char* dec) {
     if (!(legacy & DSD_SCAN_OPT_DIRECT)) {
         return 0;
     }
     dsd_key_set direct = {0};
-    if (dsd_key_set_load_direct(&direct, hex, dec) != DSD_KEY_DIRECT_OK) {
+    size_t hex_digits = 0;
+    if (dsd_key_set_load_direct_width(&direct, hex, dec, &hex_digits) != DSD_KEY_DIRECT_OK) {
         return -1;
     }
     if (legacy & DSD_SCAN_OPT_HYTERA) {
@@ -90,7 +76,7 @@ profile_legacy_direct(dsd_scan_options* options, uint32_t legacy, const char* he
         options->hytera[1] = direct.scalars.K2;
         options->hytera[2] = direct.scalars.K3;
         options->hytera[3] = direct.scalars.K4;
-        options->hytera_digits = profile_hex_digits(hex);
+        options->hytera_digits = (unsigned int)hex_digits;
     }
     if (legacy & DSD_SCAN_OPT_BP) {
         options->bp = direct.scalars.K;

--- a/src/core/util/talkgroup_policy.c
+++ b/src/core/util/talkgroup_policy.c
@@ -21,6 +21,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
+#include "talkgroup_policy_internal.h"
 
 typedef struct {
     dsd_tg_policy_entry* entries;
@@ -432,57 +433,40 @@ dsd_tg_policy_make_exact_entry(uint32_t id, const char* mode, const char* name, 
 }
 
 int
-dsd_tg_policy_add_range_entry(dsd_state* state, const dsd_tg_policy_entry* entry) {
-    dsd_tg_policy_context* ctx = NULL;
+dsd_tg_policy_store_append(dsd_tg_policy_store* store, const dsd_tg_policy_entry* entry) {
+    if (!store || !entry
+        || !(entry->is_range ? tg_policy_entry_valid_range(entry) : tg_policy_entry_valid_exact(entry))) {
+        return 1;
+    }
     dsd_tg_policy_entry normalized;
-    if (!state || !entry) {
-        return 1;
-    }
-    if (!tg_policy_entry_valid_range(entry)) {
-        return 1;
-    }
-
     tg_policy_copy_entry_normalized(&normalized, entry);
-
-    ctx = tg_policy_ctx_get_mut(state, 1);
-    if (!ctx) {
+    if (!entry->is_range) {
+        normalized.id_end = normalized.id_start;
+    }
+    if (tg_policy_table_reserve(store, store->table.count + 1) != 0) {
         return -1;
     }
-    if (tg_policy_table_reserve(ctx, ctx->table.count + 1) != 0) {
-        return -1;
-    }
-
-    ctx->table.entries[ctx->table.count++] = normalized;
-    tg_policy_table_note_mutation(ctx);
+    store->table.entries[store->table.count++] = normalized;
+    tg_policy_table_note_mutation(store);
     return 0;
 }
 
 int
+dsd_tg_policy_add_range_entry(dsd_state* state, const dsd_tg_policy_entry* entry) {
+    if (!state || !entry || !tg_policy_entry_valid_range(entry)) {
+        return 1;
+    }
+    dsd_tg_policy_context* ctx = tg_policy_ctx_get_mut(state, 1);
+    return ctx ? dsd_tg_policy_store_append(ctx, entry) : -1;
+}
+
+int
 dsd_tg_policy_append_exact(dsd_state* state, const dsd_tg_policy_entry* entry) {
-    dsd_tg_policy_context* ctx = NULL;
-    dsd_tg_policy_entry normalized;
-    if (!state || !entry) {
+    if (!state || !entry || !tg_policy_entry_valid_exact(entry)) {
         return 1;
     }
-    if (!tg_policy_entry_valid_exact(entry)) {
-        return 1;
-    }
-
-    tg_policy_copy_entry_normalized(&normalized, entry);
-    normalized.is_range = 0;
-    normalized.id_end = normalized.id_start;
-
-    ctx = tg_policy_ctx_get_mut(state, 1);
-    if (!ctx) {
-        return -1;
-    }
-    if (tg_policy_table_reserve(ctx, ctx->table.count + 1) != 0) {
-        return -1;
-    }
-
-    ctx->table.entries[ctx->table.count++] = normalized;
-    tg_policy_table_note_mutation(ctx);
-    return 0;
+    dsd_tg_policy_context* ctx = tg_policy_ctx_get_mut(state, 1);
+    return ctx ? dsd_tg_policy_store_append(ctx, entry) : -1;
 }
 
 int
@@ -1651,7 +1635,7 @@ dsd_tg_policy_release(dsd_tg_policy_store* store) {
 }
 
 void
-dsd_tg_policy_install(dsd_state* state, dsd_tg_policy_store* store) {
+dsd_tg_policy_restore(dsd_state* state, dsd_tg_policy_store* store) {
     if (!state) {
         return;
     }
@@ -1659,28 +1643,19 @@ dsd_tg_policy_install(dsd_state* state, dsd_tg_policy_store* store) {
         if (store != tg_policy_ctx_get_const(state)) {
             store->references++;
         }
-        DSD_MEMSET(&store->active, 0, sizeof(store->active));
     }
     (void)dsd_state_ext_set(state, DSD_STATE_EXT_CORE_TG_POLICY, store, tg_policy_context_free);
 }
 
-int
-dsd_tg_policy_load(const char* path, dsd_tg_policy_store** out) {
-    if (!out) {
-        return -1;
+void
+dsd_tg_policy_install(dsd_state* state, dsd_tg_policy_store* store) {
+    if (state && store) {
+        DSD_MEMSET(&store->active, 0, sizeof(store->active));
     }
-    dsd_state* scratch = (dsd_state*)calloc(1, sizeof(*scratch));
-    if (!scratch) {
-        return -1;
-    }
-    int rc = csvGroupImportPath(path, scratch);
-    if (rc == 0 && !tg_policy_ctx_get_mut(scratch, 1)) {
-        rc = -1;
-    }
-    if (rc == 0) {
-        *out = dsd_tg_policy_retain(scratch);
-    }
-    dsd_state_ext_free_all(scratch);
-    free(scratch);
-    return rc;
+    dsd_tg_policy_restore(state, store);
+}
+
+dsd_tg_policy_store*
+dsd_tg_policy_store_create(void) {
+    return tg_policy_context_alloc();
 }

--- a/src/core/util/talkgroup_policy.c
+++ b/src/core/util/talkgroup_policy.c
@@ -86,12 +86,14 @@ typedef struct {
     unsigned int generation;
 } dsd_tg_policy_active_table;
 
-typedef struct {
+struct dsd_tg_policy_store {
     dsd_tg_policy_table table;
+    size_t references;
     dsd_tg_policy_active_table active;
     uint64_t context_id;
     uint64_t snapshot_source_context_id;
-} dsd_tg_policy_context;
+};
+typedef struct dsd_tg_policy_store dsd_tg_policy_context;
 
 #ifdef DSD_NEO_TEST_HOOKS
 static long s_alloc_fail_after = -1;
@@ -288,6 +290,7 @@ tg_policy_context_alloc(void) {
     if (!ctx) {
         return NULL;
     }
+    ctx->references = 1;
     ctx->context_id = tg_policy_next_context_id();
     ctx->snapshot_source_context_id = ctx->context_id;
     return ctx;
@@ -297,6 +300,9 @@ static void
 tg_policy_context_free(void* ptr) {
     dsd_tg_policy_context* ctx = (dsd_tg_policy_context*)ptr;
     if (!ctx) {
+        return;
+    }
+    if (--ctx->references != 0) {
         return;
     }
     free(ctx->table.entries);
@@ -1628,4 +1634,53 @@ dsd_tg_policy_clear(dsd_state* state) {
         return -1;
     }
     return 0;
+}
+
+dsd_tg_policy_store*
+dsd_tg_policy_retain(const dsd_state* state) {
+    dsd_tg_policy_context* ctx = (dsd_tg_policy_context*)tg_policy_ctx_get_const(state);
+    if (ctx) {
+        ctx->references++;
+    }
+    return ctx;
+}
+
+void
+dsd_tg_policy_release(dsd_tg_policy_store* store) {
+    tg_policy_context_free(store);
+}
+
+void
+dsd_tg_policy_install(dsd_state* state, dsd_tg_policy_store* store) {
+    if (!state) {
+        return;
+    }
+    if (store) {
+        if (store != tg_policy_ctx_get_const(state)) {
+            store->references++;
+        }
+        DSD_MEMSET(&store->active, 0, sizeof(store->active));
+    }
+    (void)dsd_state_ext_set(state, DSD_STATE_EXT_CORE_TG_POLICY, store, tg_policy_context_free);
+}
+
+int
+dsd_tg_policy_load(const char* path, dsd_tg_policy_store** out) {
+    if (!out) {
+        return -1;
+    }
+    dsd_state* scratch = (dsd_state*)calloc(1, sizeof(*scratch));
+    if (!scratch) {
+        return -1;
+    }
+    int rc = csvGroupImportPath(path, scratch);
+    if (rc == 0 && !tg_policy_ctx_get_mut(scratch, 1)) {
+        rc = -1;
+    }
+    if (rc == 0) {
+        *out = dsd_tg_policy_retain(scratch);
+    }
+    dsd_state_ext_free_all(scratch);
+    free(scratch);
+    return rc;
 }

--- a/src/core/util/talkgroup_policy_internal.h
+++ b/src/core/util/talkgroup_policy_internal.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#ifndef DSD_NEO_SRC_CORE_UTIL_TALKGROUP_POLICY_INTERNAL_H_
+#define DSD_NEO_SRC_CORE_UTIL_TALKGROUP_POLICY_INTERNAL_H_
+
+#include <dsd-neo/core/talkgroup_policy.h>
+
+/* Standalone CSV imports need only a policy store, not a decoder state. The created
+ * reference is released with dsd_tg_policy_release(). Append has the public exact/range
+ * insertion return convention: 0 stored, 1 invalid, -1 allocation failure. */
+dsd_tg_policy_store* dsd_tg_policy_store_create(void);
+int dsd_tg_policy_store_append(dsd_tg_policy_store* store, const dsd_tg_policy_entry* entry);
+
+#endif

--- a/src/engine/channel_scan.c
+++ b/src/engine/channel_scan.c
@@ -4,10 +4,12 @@
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/enc_lockout.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/scan_profile.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/state_fwd.h>
@@ -33,7 +35,19 @@ typedef struct {
     int retry;
     dsd_scan_mode mode;
     dsd_scan_settings configured;
+    dsd_scan_key_change keys;
+    uint64_t key_epoch;
 } channel_scan;
+
+static void
+channel_scan_free(void* ptr) {
+    channel_scan* scan = (channel_scan*)ptr;
+    if (!scan) {
+        return;
+    }
+    dsd_scan_key_change_clear(&scan->keys);
+    free(scan);
+}
 
 static channel_scan*
 channel_scan_get(const dsd_state* state) {
@@ -69,13 +83,14 @@ static int
 channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
     dsd_scan_settings latest;
     dsd_scan_mode_configured(opts, state, &latest);
-    if (!dsd_scan_settings_equal(&latest, &scan->configured, 1)) {
+    if (!dsd_scan_settings_equal(&latest, &scan->configured, 1) || scan->key_epoch != state->enc_lockout_key_epoch) {
         /* A configured setting changed while tuning. Stage the new effective
          * profile in a fresh request before any frame can use it. */
         scan->request = 0;
         scan->retry = 1;
         return 0;
     }
+    const int outgoing_force = state->M;
     /* End calls with the outgoing row's keys and label still installed. */
     channel_scan_end_calls(opts, state);
     dsd_engine_reset_no_carrier_state(opts, state);
@@ -83,7 +98,13 @@ channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
         return -1;
     }
     state->lcn_freq_roll = scan->row + 1;
-    (void)dsd_scan_row_keys_apply(state, scan->row);
+    const dsd_scan_row_profile* profile = dsd_channel_profile_get(state, (size_t)scan->row);
+    dsd_scan_mode_options(opts, state, profile ? &profile->values : NULL);
+    dsd_scan_groups_enter(state, profile);
+    const int keys_changed = dsd_scan_key_change_commit(state, &scan->keys);
+    if (keys_changed || outgoing_force != state->M) {
+        dsd_enc_lockout_bump_key_epoch(state);
+    }
     dsd_frame_sync_reset_acquisition(opts, state, 1);
     state->last_cc_sync_time = time(NULL);
     state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
@@ -175,7 +196,7 @@ channel_scan_start_row(dsd_opts* opts, dsd_state* state, int row) {
         if (!scan) {
             return -1;
         }
-        (void)dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_CHANNEL_SCAN, scan, free);
+        (void)dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_CHANNEL_SCAN, scan, channel_scan_free);
     }
     scan->row = row;
     scan->mode = dsd_channel_mode_get(state, (size_t)row);
@@ -187,6 +208,11 @@ channel_scan_start_row(dsd_opts* opts, dsd_state* state, int row) {
         return -1;
     }
     dsd_scan_mode_configured(opts, state, &scan->configured);
+    if (dsd_scan_groups_begin(state)
+        || dsd_scan_key_change_prepare(state, dsd_state_trunk_lcn_keys_get(state, (size_t)row), &scan->keys)) {
+        return -1;
+    }
+    scan->key_epoch = state->enc_lockout_key_epoch;
     dsd_scan_settings_restore(&next, opts, state);
     const dsd_trunk_tune_result result =
         dsd_engine_scan_tune_to_freq(opts, state, freq, state->samplesPerSymbol, &scan->request);
@@ -259,6 +285,7 @@ dsd_engine_channel_scan_leave(dsd_opts* opts, dsd_state* state) {
         channel_scan_end_calls(opts, state);
     }
     (void)dsd_state_ext_set(state, DSD_STATE_EXT_ENGINE_CHANNEL_SCAN, NULL, NULL);
+    dsd_scan_groups_leave(state);
     dsd_scan_mode_leave(opts, state);
     if (active) {
         dsd_frame_sync_reset_acquisition(opts, state, opts->trunk_scan_enabled != 1);

--- a/src/engine/channel_scan.c
+++ b/src/engine/channel_scan.c
@@ -99,7 +99,7 @@ channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
     }
     state->lcn_freq_roll = scan->row + 1;
     const dsd_scan_row_profile* profile = dsd_channel_profile_get(state, (size_t)scan->row);
-    dsd_scan_mode_options(opts, state, profile ? &profile->values : NULL);
+    (void)dsd_scan_mode_options(opts, state, profile ? &profile->values : NULL);
     dsd_scan_groups_enter(state, profile);
     const int keys_changed = dsd_scan_key_change_commit(state, &scan->keys);
     if (keys_changed || outgoing_force != state->M) {

--- a/src/engine/channel_scan.c
+++ b/src/engine/channel_scan.c
@@ -33,6 +33,7 @@ typedef struct {
     uint64_t map_sequence;
     int row;
     int retry;
+    int needs_commit;
     dsd_scan_mode mode;
     dsd_scan_settings configured;
     dsd_scan_key_change keys;
@@ -81,6 +82,9 @@ channel_scan_end_calls(dsd_opts* opts, dsd_state* state) {
 
 static int
 channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
+    /* Hardware has moved. Even if a later retry rolls back, frames cannot use
+     * the outgoing profile until a row is successfully committed. */
+    scan->needs_commit = 1;
     dsd_scan_settings latest;
     dsd_scan_mode_configured(opts, state, &latest);
     if (!dsd_scan_settings_equal(&latest, &scan->configured, 1) || scan->key_epoch != state->enc_lockout_key_epoch) {
@@ -95,6 +99,7 @@ channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
     channel_scan_end_calls(opts, state);
     dsd_engine_reset_no_carrier_state(opts, state);
     if (dsd_scan_mode_enter(opts, state, scan->mode) != 0) {
+        scan->retry = 1;
         return -1;
     }
     state->lcn_freq_roll = scan->row + 1;
@@ -111,6 +116,7 @@ channel_scan_commit(dsd_opts* opts, dsd_state* state, channel_scan* scan) {
     state->nxdn_last_ran = -1;
     dsd_scan_voice_gate_note_retune(state, state->last_cc_sync_time_m);
     scan->request = 0;
+    scan->needs_commit = 0;
     return 1;
 }
 
@@ -124,9 +130,10 @@ dsd_engine_channel_scan_pending(dsd_opts* opts, dsd_state* state) {
         return 0;
     }
     if (scan->retry) {
-        scan->retry = 0;
         if (channel_scan_row_is_current(opts, state, scan)) {
             (void)channel_scan_start_row(opts, state, scan->row);
+        } else {
+            scan->retry = 0;
         }
         return dsd_engine_channel_scan_waiting(state);
     }
@@ -156,7 +163,7 @@ dsd_engine_channel_scan_service_sync(dsd_opts* opts, dsd_state* state) {
         return 0;
     }
     const channel_scan* scan = channel_scan_get(state);
-    if (!scan || (!scan->request && !scan->retry)) {
+    if (!scan || (!scan->request && !scan->retry && !scan->needs_commit)) {
         return 1;
     }
     (void)dsd_engine_channel_scan_pending(opts, state);
@@ -213,6 +220,9 @@ channel_scan_start_row(dsd_opts* opts, dsd_state* state, int row) {
         return -1;
     }
     scan->key_epoch = state->enc_lockout_key_epoch;
+    /* A completed tune may already have moved the receiver. Keep its retry gate
+     * closed through preparation failures; the new request takes over below. */
+    scan->retry = 0;
     dsd_scan_settings_restore(&next, opts, state);
     const dsd_trunk_tune_result result =
         dsd_engine_scan_tune_to_freq(opts, state, freq, state->samplesPerSymbol, &scan->request);

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/scan_profile.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
@@ -18,6 +19,7 @@
 #include <dsd-neo/engine/scan_voice_gate.h>
 #include <dsd-neo/engine/trunk_scan.h>
 #include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
 #ifdef USE_RADIO
 #include <dsd-neo/io/rtl_stream_c.h>
 #endif
@@ -205,6 +207,7 @@ typedef struct {
     /* Static per-target key configuration, loaded at init. Not part of the
      * snapshot: the switch applies it through the scan key swap instead. */
     dsd_key_set keys;
+    dsd_scan_row_profile* profile;
     p25_sm_ctx_t p25_ctx;
     dmr_sm_ctx_t dmr_ctx;
     double parked_since_m;
@@ -521,6 +524,7 @@ typedef struct {
     int single_key_hex_idx;
     int single_key_dec_idx;
     int p25_bandplan_idx;
+    int options_idx;
     unsigned int row;
     char* err;
     size_t err_sz;
@@ -760,6 +764,46 @@ scan_parse_target_direct_keys(dsd_trunk_scan_target* target, const dsd_trunk_sca
     return 0;
 }
 
+static dsd_scan_mode trunk_scan_target_mode(dsd_trunk_scan_target_type type);
+
+static int
+scan_parse_target_options(dsd_trunk_scan_target* target, char** fields, size_t count,
+                          const dsd_trunk_scan_row_parse* parse) {
+    const char* text = scan_optional_field(fields, count, parse->options_idx);
+    if (!text[0]) {
+        return 0;
+    }
+    dsd_scan_options options = {0};
+    char error[192] = "invalid row options";
+    int rc = dsd_scan_options_parse(text, (unsigned int)trunk_scan_target_mode(target->type),
+                                    trunk_scan_type_is_conventional(target->type), &options, error, sizeof(error));
+    if (!rc) {
+        rc = dsd_scan_options_merge_keys(&options, scan_optional_field(fields, count, parse->keys_hex_idx),
+                                         scan_optional_field(fields, count, parse->keys_dec_idx),
+                                         scan_optional_field(fields, count, parse->single_key_hex_idx),
+                                         scan_optional_field(fields, count, parse->single_key_dec_idx), error,
+                                         sizeof(error));
+    }
+    if (!rc) {
+        rc = dsd_scan_options_resolve(&options, parse->resolved_path, error, sizeof(error));
+    }
+    if (!rc) {
+        dsd_key_set keys = {0};
+        (void)dsd_scan_options_keys(&options, &keys);
+        target->single_key_scalars = keys.scalars;
+        target->single_keys_present = keys.present;
+        dsd_key_set_free(&keys);
+        DSD_MEMCPY(target->keys_hex_csv, options.hex_file, sizeof(target->keys_hex_csv));
+        DSD_MEMCPY(target->keys_dec_csv, options.dec_file, sizeof(target->keys_dec_csv));
+        target->row_options = options.values;
+    }
+    DSD_SECURE_ZERO(&options, sizeof(options));
+    if (rc) {
+        scan_set_error(parse->err, parse->err_sz, "row %u: %s", parse->row, error);
+    }
+    return rc;
+}
+
 static int
 scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_trunk_scan_row_parse* parse) {
     char* fields[DSD_TRUNK_SCAN_MAX_CSV_FIELDS] = {0};
@@ -825,6 +869,10 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
     if (scan_parse_target_direct_keys(&target, parse, single_hex_s, single_dec_s) != 0) {
         return -1;
     }
+    if (scan_parse_target_options(&target, fields, field_count, parse) != 0) {
+        DSD_SECURE_ZERO(&target.single_key_scalars, sizeof(target.single_key_scalars));
+        return -1;
+    }
     parsed->targets[parsed->count++] = target;
     DSD_SECURE_ZERO(&target.single_key_scalars, sizeof(target.single_key_scalars));
     return 0;
@@ -840,11 +888,20 @@ scan_match_optional_header(dsd_trunk_scan_row_parse* parse, const char* name, si
         {"modulation", &parse->modulation_idx},         {"rtl_gain", &parse->rtl_gain_idx},
         {"keys_hex_csv", &parse->keys_hex_idx},         {"keys_dec_csv", &parse->keys_dec_idx},
         {"single_key_hex", &parse->single_key_hex_idx}, {"single_key_dec", &parse->single_key_dec_idx},
-        {"p25_bandplan_csv", &parse->p25_bandplan_idx},
+        {"p25_bandplan_csv", &parse->p25_bandplan_idx}, {"options", &parse->options_idx},
+        {"relevant_CLI_switches", &parse->options_idx},
     };
 
     for (size_t k = 0; k < sizeof cols / sizeof cols[0]; k++) {
-        if (strcmp(name, cols[k].name) != 0) {
+        int matches = strcmp(name, cols[k].name) == 0;
+        if (cols[k].idx == &parse->options_idx) {
+            size_t n = strlen(name);
+            matches = n == strlen(cols[k].name);
+            for (size_t j = 0; matches && j < n; j++) {
+                matches = tolower((unsigned char)name[j]) == tolower((unsigned char)cols[k].name[j]);
+            }
+        }
+        if (!matches) {
             continue;
         }
         if (*cols[k].idx >= 0) {
@@ -893,6 +950,7 @@ scan_read_target_csv_header(FILE* fp, char* line, size_t line_sz, dsd_trunk_scan
     parse->single_key_hex_idx = -1;
     parse->single_key_dec_idx = -1;
     parse->p25_bandplan_idx = -1;
+    parse->options_idx = -1;
     for (size_t i = DSD_TRUNK_SCAN_REQUIRED_CSV_FIELDS; i < field_count; i++) {
         if (scan_match_optional_header(parse, scan_unquote(fields[i]), i) != 0) {
             return -1;
@@ -2052,6 +2110,25 @@ trunk_scan_import_target_p25_bandplan(dsd_state* state, const dsd_trunk_scan_tar
 }
 
 static int
+trunk_scan_load_profile(dsd_trunk_scan_target_runtime* rt, char* error, size_t error_size) {
+    if (!rt->target.row_options.present) {
+        return 0;
+    }
+    rt->profile = (dsd_scan_row_profile*)calloc(1, sizeof(*rt->profile));
+    if (!rt->profile) {
+        scan_set_error(error, error_size, "out of memory loading target options");
+        return -1;
+    }
+    rt->profile->values = rt->target.row_options;
+    if ((rt->profile->values.present & DSD_SCAN_OPT_GROUP)
+        && dsd_tg_policy_load(rt->profile->values.group_file, &rt->profile->groups)) {
+        scan_set_error(error, error_size, "failed to load group policy for target '%s'", rt->target.id);
+        return -1;
+    }
+    return 0;
+}
+
+static int
 trunk_scan_build_target_runtime(dsd_trunk_scan_coord* coord, dsd_opts* opts, dsd_state* state,
                                 const dsd_trunk_scan_target_list* list, char* err, size_t err_sz) {
     dsd_trunk_scan_snapshot* empty_snapshot = &coord->scratch_snapshot;
@@ -2064,6 +2141,9 @@ trunk_scan_build_target_runtime(dsd_trunk_scan_coord* coord, dsd_opts* opts, dsd
     for (size_t i = 0; i < build_count; i++) {
         dsd_trunk_scan_target_runtime* rt = &coord->targets[i];
         rt->target = list->targets[i];
+        if (trunk_scan_load_profile(rt, err, err_sz)) {
+            return -1;
+        }
         const int have_key_files = rt->target.keys_hex_csv[0] != '\0' || rt->target.keys_dec_csv[0] != '\0';
         if (rt->target.single_keys_present != 0U && have_key_files) {
             scan_set_error(err, err_sz, "trunk scan target '%s' combines direct keys with key CSV files",
@@ -2165,24 +2245,6 @@ trunk_scan_retune_active(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_target
 }
 
 /*
- * Per-target keys ride the scan key swap: a keyed target installs its set, an
- * unkeyed one hands the foreground keyring back to the globals. Trunk scan
- * never bumps the lockout key epoch -- every target carries its own lockout
- * ledger snapshot, so no global invalidation is owed on a switch.
- */
-static void
-trunk_scan_apply_target_keys(dsd_state* state, const dsd_trunk_scan_target_runtime* rt) {
-    if (!state || !rt) {
-        return;
-    }
-    if (rt->keys.present) {
-        (void)dsd_scan_keys_enter(state, &rt->keys);
-    } else {
-        dsd_scan_keys_leave(state);
-    }
-}
-
-/*
  * Peer IDEN sharing (#402). Two scan targets that are sites of one P25 system (same WACN/SYS)
  * announce the same IDEN_UP tables, so an identifier one target has already learned is a valid
  * seed for the other. Copy only into empty live slots, only from a parked peer's snapshot entry
@@ -2260,10 +2322,30 @@ trunk_scan_target_mode(dsd_trunk_scan_target_type type) {
     return DSD_SCAN_MODE_INHERIT;
 }
 
+/*
+ * Per-target keys ride the scan key swap: a keyed target installs its set, an
+ * unkeyed one hands the foreground keyring back to the globals. Trunk scan
+ * never bumps the lockout key epoch -- every target carries its own lockout
+ * ledger snapshot, so no global invalidation is owed on a switch.
+ */
+static int
+trunk_scan_prepare_keys(dsd_state* state, const dsd_key_set* keys, dsd_scan_key_change* change) {
+    if (dsd_scan_groups_begin(state)) {
+        return -1;
+    }
+    return dsd_scan_key_change_prepare(state, keys, change);
+}
+
+enum { TRUNK_SCAN_PREPARE_FAILED = -2 };
+
 static int
 trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord, size_t next, int save_current) {
     if (!coord || next >= coord->count) {
         return -1;
+    }
+    dsd_scan_key_change key_change = {0};
+    if (trunk_scan_prepare_keys(state, &coord->targets[next].keys, &key_change)) {
+        return TRUNK_SCAN_PREPARE_FAILED;
     }
     if (save_current && coord->active < coord->count) {
         trunk_scan_save_target_snapshot(coord, state, &coord->targets[coord->active]);
@@ -2275,13 +2357,16 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     trunk_scan_publish_active_target(state, coord);
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
     if (dsd_scan_mode_enter(opts, state, trunk_scan_target_mode(rt->target.type)) != 0) {
-        return -1;
+        dsd_scan_key_change_clear(&key_change);
+        return TRUNK_SCAN_PREPARE_FAILED;
     }
     trunk_scan_restore_target_snapshot(coord, state, rt);
     trunk_scan_share_peer_idens(coord, state, rt);
     trunk_scan_apply_target_opts(opts, coord, &rt->target);
     dsd_scan_mode_target_modulation(state, (dsd_scan_modulation)rt->target.modulation);
-    trunk_scan_apply_target_keys(state, rt);
+    (void)dsd_scan_key_change_commit(state, &key_change);
+    dsd_scan_mode_options(opts, state, rt->profile ? &rt->profile->values : NULL);
+    dsd_scan_groups_enter(state, rt->profile);
     trunk_scan_apply_target_demod(opts, state, &rt->target);
     trunk_scan_sync_active_sm_mode(state, rt);
     dsd_frame_sync_reset_acquisition(opts, state, 0);
@@ -2333,6 +2418,11 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
     if (!coord || coord->count < 2) {
         return;
     }
+    /* Reserve rollback keys before the first switch can change the foreground. */
+    dsd_scan_key_change rollback = {0};
+    if (dsd_scan_key_change_prepare(state, &coord->targets[coord->active].keys, &rollback)) {
+        return;
+    }
     double now_m = trunk_scan_now_m();
     dsd_trunk_scan_snapshot* original_snapshot = &coord->scratch_snapshot;
     trunk_scan_save_snapshot(state, original_snapshot);
@@ -2357,6 +2447,7 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
         }
         tried = 1;
         if (trunk_scan_switch_to(opts, state, coord, next, save_current) == 0) {
+            dsd_scan_key_change_clear(&rollback);
             return;
         }
         if (next != original_active) {
@@ -2372,6 +2463,7 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
          * re-running this walk on every tick until something changes. */
         coord->targets[original_active].idle_since_m = now_m;
         trunk_scan_publish_active_target(state, coord);
+        dsd_scan_key_change_clear(&rollback);
         return;
     }
     /* The loop above published every target it tried, and the last one it tried is not
@@ -2382,7 +2474,10 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
     trunk_scan_restore_snapshot(state, original_snapshot);
     trunk_scan_apply_target_opts(opts, coord, &coord->targets[coord->active].target);
     dsd_scan_mode_target_modulation(state, (dsd_scan_modulation)coord->targets[coord->active].target.modulation);
-    trunk_scan_apply_target_keys(state, &coord->targets[coord->active]);
+    (void)dsd_scan_key_change_commit(state, &rollback);
+    const dsd_scan_row_profile* restored_profile = coord->targets[coord->active].profile;
+    dsd_scan_mode_options(opts, state, restored_profile ? &restored_profile->values : NULL);
+    dsd_scan_groups_enter(state, restored_profile);
     trunk_scan_apply_target_demod(opts, state, &coord->targets[coord->active].target);
     trunk_scan_sync_active_sm_mode(state, &coord->targets[coord->active]);
 }
@@ -2831,6 +2926,7 @@ trunk_scan_coord_free(dsd_trunk_scan_coord* coord) {
         free(coord->targets[i].snapshot.chan_map_chan);
         free(coord->targets[i].snapshot.chan_map_freq);
         dsd_key_set_free(&coord->targets[i].keys);
+        dsd_scan_profile_free(coord->targets[i].profile);
         DSD_SECURE_ZERO(&coord->targets[i].target.single_key_scalars,
                         sizeof(coord->targets[i].target.single_key_scalars));
     }
@@ -2929,6 +3025,7 @@ trunk_scan_init_release(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* 
                         dsd_trunk_scan_target_list* list) {
     dsd_engine_channel_scan_leave(opts, state);
     trunk_scan_restore_saved_opts(opts, coord);
+    dsd_scan_groups_leave(state);
     dsd_scan_keys_leave(state);
     trunk_scan_coord_free(coord);
     dsd_trunk_scan_target_list_reset(list);
@@ -2968,7 +3065,13 @@ dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size_t e
     }
     dsd_trunk_scan_target_list_reset(&list);
     trunk_scan_install_runtime_hooks(coord);
-    if (trunk_scan_switch_to(opts, state, coord, 0, 0) != 0 && coord->count > 1) {
+    const int switch_rc = trunk_scan_switch_to(opts, state, coord, 0, 0);
+    if (switch_rc == TRUNK_SCAN_PREPARE_FAILED) {
+        dsd_engine_trunk_scan_shutdown(opts, state);
+        scan_set_error(err, err_sz, "unable to prepare initial trunk scan key/policy scope");
+        return -1;
+    }
+    if (switch_rc != 0 && coord->count > 1) {
         trunk_scan_advance(opts, state, coord);
     }
     LOG_INFO("NOTICE: Trunk scan enabled with %zu targets\n", coord->count);
@@ -3004,6 +3107,7 @@ dsd_engine_trunk_scan_shutdown(dsd_opts* opts, dsd_state* state) {
     trunk_scan_log_nxdn_diag_summaries(coord, state);
     dsd_engine_channel_scan_leave(opts, state);
     trunk_scan_restore_saved_opts(opts, coord);
+    dsd_scan_groups_leave(state);
     dsd_scan_keys_leave(state);
     trunk_scan_uninstall_runtime_hooks(coord);
     trunk_scan_clear_published_target(state);

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -2454,6 +2454,7 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
     /* Reserve rollback keys before the first switch can change the foreground. */
     dsd_scan_key_change rollback = {0};
     if (dsd_scan_key_change_prepare(state, &coord->targets[coord->active].keys, &rollback)) {
+        coord->targets[coord->active].idle_since_m = trunk_scan_now_m();
         return;
     }
     double now_m = trunk_scan_now_m();
@@ -2530,11 +2531,13 @@ trunk_scan_retry_active_if_due(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_
     if (coord->count != 1 && !coord->hold_active) {
         return;
     }
-    const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
     if (rt->retry_until_m <= 0.0 || rt->retry_until_m > now_m) {
         return;
     }
-    (void)trunk_scan_switch_to(opts, state, coord, coord->active, 0);
+    if (trunk_scan_switch_to(opts, state, coord, coord->active, 0) == TRUNK_SCAN_PREPARE_FAILED) {
+        rt->retry_until_m = now_m + 2.0;
+    }
 }
 
 /*

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -18,6 +18,7 @@
 #include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
 #include <dsd-neo/engine/trunk_scan.h>
+#include <dsd-neo/platform/posix_compat.h>
 #include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/scan_options.h>
 #ifdef USE_RADIO
@@ -767,12 +768,22 @@ scan_parse_target_direct_keys(dsd_trunk_scan_target* target, const dsd_trunk_sca
 static dsd_scan_mode trunk_scan_target_mode(dsd_trunk_scan_target_type type);
 
 static int
-scan_parse_target_options(dsd_trunk_scan_target* target, char** fields, size_t count,
-                          const dsd_trunk_scan_row_parse* parse) {
-    const char* text = scan_optional_field(fields, count, parse->options_idx);
-    if (!text[0]) {
-        return 0;
+scan_copy_target_key_path(char* dest, size_t capacity, const char* resolved) {
+    if (strlen(resolved) >= capacity) {
+        return -1;
     }
+    DSD_SNPRINTF(dest, capacity, "%s", resolved);
+    return 0;
+}
+
+/*
+ * A row with an `options` cell hands every key cell to the scoped-options merge, which
+ * validates, resolves and materializes them once; the legacy key-cell parsers are skipped
+ * for that row so nothing is derived twice or overwritten.
+ */
+static int
+scan_parse_target_options(dsd_trunk_scan_target* target, const char* text, char** fields, size_t count,
+                          const dsd_trunk_scan_row_parse* parse) {
     dsd_scan_options options = {0};
     char error[192] = "invalid row options";
     int rc = dsd_scan_options_parse(text, (unsigned int)trunk_scan_target_mode(target->type),
@@ -787,14 +798,18 @@ scan_parse_target_options(dsd_trunk_scan_target* target, char** fields, size_t c
     if (!rc) {
         rc = dsd_scan_options_resolve(&options, parse->resolved_path, error, sizeof(error));
     }
+    if (!rc
+        && (scan_copy_target_key_path(target->keys_hex_csv, sizeof(target->keys_hex_csv), options.hex_file)
+            || scan_copy_target_key_path(target->keys_dec_csv, sizeof(target->keys_dec_csv), options.dec_file))) {
+        rc = -1;
+        DSD_SNPRINTF(error, sizeof(error), "%s", "keys_hex_csv/keys_dec_csv: path too long");
+    }
     if (!rc) {
         dsd_key_set keys = {0};
         (void)dsd_scan_options_keys(&options, &keys);
         target->single_key_scalars = keys.scalars;
         target->single_keys_present = keys.present;
         dsd_key_set_free(&keys);
-        DSD_MEMCPY(target->keys_hex_csv, options.hex_file, sizeof(target->keys_hex_csv));
-        DSD_MEMCPY(target->keys_dec_csv, options.dec_file, sizeof(target->keys_dec_csv));
         target->row_options = options.values;
     }
     DSD_SECURE_ZERO(&options, sizeof(options));
@@ -802,6 +817,38 @@ scan_parse_target_options(dsd_trunk_scan_target* target, char** fields, size_t c
         scan_set_error(parse->err, parse->err_sz, "row %u: %s", parse->row, error);
     }
     return rc;
+}
+
+/*
+ * Non-secret path work for one row. A row with an `options` cell hands its key cells to
+ * the scoped-options merge later (scan_parse_target_secrets), so only the legacy row
+ * validates and resolves them here.
+ */
+static int
+scan_parse_target_key_paths(dsd_trunk_scan_target* target, char** fields, size_t count,
+                            const dsd_trunk_scan_row_parse* parse, const char* chan_csv, int have_options) {
+    const char* keys_hex_s = have_options ? "" : scan_optional_field(fields, count, parse->keys_hex_idx);
+    const char* keys_dec_s = have_options ? "" : scan_optional_field(fields, count, parse->keys_dec_idx);
+    const char* single_hex_s = scan_optional_field(fields, count, parse->single_key_hex_idx);
+    const char* single_dec_s = scan_optional_field(fields, count, parse->single_key_dec_idx);
+    const char* p25_bandplan_s = scan_optional_field(fields, count, parse->p25_bandplan_idx);
+    if (!have_options
+        && scan_validate_target_key_sources(parse, keys_hex_s, keys_dec_s, single_hex_s, single_dec_s) != 0) {
+        return -1;
+    }
+    return scan_parse_target_paths(target, parse, chan_csv, keys_hex_s, keys_dec_s, p25_bandplan_s);
+}
+
+/* Secrets are parsed after every fallible non-secret row check. Once accepted, the
+ * list owns the only surviving copy. */
+static int
+scan_parse_target_secrets(dsd_trunk_scan_target* target, char** fields, size_t count,
+                          const dsd_trunk_scan_row_parse* parse, const char* options_s) {
+    if (options_s[0] != '\0') {
+        return scan_parse_target_options(target, options_s, fields, count, parse);
+    }
+    return scan_parse_target_direct_keys(target, parse, scan_optional_field(fields, count, parse->single_key_hex_idx),
+                                         scan_optional_field(fields, count, parse->single_key_dec_idx));
 }
 
 static int
@@ -819,11 +866,7 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
 
     const char* modulation_s = scan_optional_field(fields, field_count, parse->modulation_idx);
     const char* rtl_gain_s = scan_optional_field(fields, field_count, parse->rtl_gain_idx);
-    const char* keys_hex_s = scan_optional_field(fields, field_count, parse->keys_hex_idx);
-    const char* keys_dec_s = scan_optional_field(fields, field_count, parse->keys_dec_idx);
-    const char* single_hex_s = scan_optional_field(fields, field_count, parse->single_key_hex_idx);
-    const char* single_dec_s = scan_optional_field(fields, field_count, parse->single_key_dec_idx);
-    const char* p25_bandplan_s = scan_optional_field(fields, field_count, parse->p25_bandplan_idx);
+    const char* options_s = scan_optional_field(fields, field_count, parse->options_idx);
 
     dsd_trunk_scan_target target;
     DSD_MEMSET(&target, 0, sizeof(target));
@@ -838,9 +881,7 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
         scan_set_error(parse->err, parse->err_sz, "row %u duplicates target type/frequency", parse->row);
         return -1;
     }
-
-    if (scan_validate_target_key_sources(parse, keys_hex_s, keys_dec_s, single_hex_s, single_dec_s) != 0
-        || scan_parse_target_paths(&target, parse, chan_csv, keys_hex_s, keys_dec_s, p25_bandplan_s) != 0) {
+    if (scan_parse_target_key_paths(&target, fields, field_count, parse, chan_csv, options_s[0] != '\0') != 0) {
         return -1;
     }
     if (scan_parse_ms_field(dwell_s, parse->default_dwell_ms, &target.dwell_ms) != 0) {
@@ -864,12 +905,7 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
         scan_set_error(parse->err, parse->err_sz, "out of memory loading trunk scan targets");
         return -1;
     }
-    /* Parse secrets after every fallible non-secret row check. Once accepted,
-     * the list owns the only surviving copy. */
-    if (scan_parse_target_direct_keys(&target, parse, single_hex_s, single_dec_s) != 0) {
-        return -1;
-    }
-    if (scan_parse_target_options(&target, fields, field_count, parse) != 0) {
+    if (scan_parse_target_secrets(&target, fields, field_count, parse, options_s) != 0) {
         DSD_SECURE_ZERO(&target.single_key_scalars, sizeof(target.single_key_scalars));
         return -1;
     }
@@ -878,7 +914,8 @@ scan_parse_target_row(char* line, dsd_trunk_scan_target_list* parsed, const dsd_
     return 0;
 }
 
-/* Optional columns are matched by header name; naming one twice rejects the file. */
+/* Optional columns are matched by header name, ASCII case-insensitively as the channel-map
+ * importer does; naming one twice (including through an alias) rejects the file. */
 static int
 scan_match_optional_header(dsd_trunk_scan_row_parse* parse, const char* name, size_t index) {
     const struct {
@@ -893,15 +930,7 @@ scan_match_optional_header(dsd_trunk_scan_row_parse* parse, const char* name, si
     };
 
     for (size_t k = 0; k < sizeof cols / sizeof cols[0]; k++) {
-        int matches = strcmp(name, cols[k].name) == 0;
-        if (cols[k].idx == &parse->options_idx) {
-            size_t n = strlen(name);
-            matches = n == strlen(cols[k].name);
-            for (size_t j = 0; matches && j < n; j++) {
-                matches = tolower((unsigned char)name[j]) == tolower((unsigned char)cols[k].name[j]);
-            }
-        }
-        if (!matches) {
+        if (dsd_strcasecmp(name, cols[k].name) != 0) {
             continue;
         }
         if (*cols[k].idx >= 0) {
@@ -2327,15 +2356,21 @@ trunk_scan_target_mode(dsd_trunk_scan_target_type type) {
  * unkeyed one hands the foreground keyring back to the globals. Trunk scan
  * never bumps the lockout key epoch -- every target carries its own lockout
  * ledger snapshot, so no global invalidation is owed on a switch.
+ *
+ * Every allocation a switch needs (scan-mode scope, group scope, key copies) happens here,
+ * before the outgoing target's snapshot is saved or anything else moves, so a failure
+ * leaves the receiver exactly where it was and the caller can simply try another target.
  */
 static int
-trunk_scan_prepare_keys(dsd_state* state, const dsd_key_set* keys, dsd_scan_key_change* change) {
-    if (dsd_scan_groups_begin(state)) {
+trunk_scan_prepare_switch(const dsd_opts* opts, dsd_state* state, const dsd_key_set* keys,
+                          dsd_scan_key_change* change) {
+    if (dsd_scan_mode_begin(opts, state) || dsd_scan_groups_begin(state)) {
         return -1;
     }
     return dsd_scan_key_change_prepare(state, keys, change);
 }
 
+/* The receiver never left the active target; nothing was saved, published or retuned. */
 enum { TRUNK_SCAN_PREPARE_FAILED = -2 };
 
 static int
@@ -2344,7 +2379,7 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
         return -1;
     }
     dsd_scan_key_change key_change = {0};
-    if (trunk_scan_prepare_keys(state, &coord->targets[next].keys, &key_change)) {
+    if (trunk_scan_prepare_switch(opts, state, &coord->targets[next].keys, &key_change)) {
         return TRUNK_SCAN_PREPARE_FAILED;
     }
     if (save_current && coord->active < coord->count) {
@@ -2356,16 +2391,14 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
      * here until the caller decides otherwise, and the label has to say so. */
     trunk_scan_publish_active_target(state, coord);
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
-    if (dsd_scan_mode_enter(opts, state, trunk_scan_target_mode(rt->target.type)) != 0) {
-        dsd_scan_key_change_clear(&key_change);
-        return TRUNK_SCAN_PREPARE_FAILED;
-    }
+    /* The scope was reserved above and every target type maps to a valid mode. */
+    (void)dsd_scan_mode_enter(opts, state, trunk_scan_target_mode(rt->target.type));
     trunk_scan_restore_target_snapshot(coord, state, rt);
     trunk_scan_share_peer_idens(coord, state, rt);
     trunk_scan_apply_target_opts(opts, coord, &rt->target);
     dsd_scan_mode_target_modulation(state, (dsd_scan_modulation)rt->target.modulation);
     (void)dsd_scan_key_change_commit(state, &key_change);
-    dsd_scan_mode_options(opts, state, rt->profile ? &rt->profile->values : NULL);
+    (void)dsd_scan_mode_options(opts, state, rt->profile ? &rt->profile->values : NULL);
     dsd_scan_groups_enter(state, rt->profile);
     trunk_scan_apply_target_demod(opts, state, &rt->target);
     trunk_scan_sync_active_sm_mode(state, rt);
@@ -2445,11 +2478,16 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
         if (coord->targets[next].avoided && next != original_active) {
             continue;
         }
-        tried = 1;
-        if (trunk_scan_switch_to(opts, state, coord, next, save_current) == 0) {
+        const int switch_rc = trunk_scan_switch_to(opts, state, coord, next, save_current);
+        if (switch_rc == 0) {
             dsd_scan_key_change_clear(&rollback);
             return;
         }
+        if (switch_rc == TRUNK_SCAN_PREPARE_FAILED) {
+            /* Nothing moved: the outgoing snapshot is still owed to the next real attempt. */
+            continue;
+        }
+        tried = 1;
         if (next != original_active) {
             attempted_alternate_retune = 1;
         }
@@ -2476,7 +2514,7 @@ trunk_scan_advance(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord
     dsd_scan_mode_target_modulation(state, (dsd_scan_modulation)coord->targets[coord->active].target.modulation);
     (void)dsd_scan_key_change_commit(state, &rollback);
     const dsd_scan_row_profile* restored_profile = coord->targets[coord->active].profile;
-    dsd_scan_mode_options(opts, state, restored_profile ? &restored_profile->values : NULL);
+    (void)dsd_scan_mode_options(opts, state, restored_profile ? &restored_profile->values : NULL);
     dsd_scan_groups_enter(state, restored_profile);
     trunk_scan_apply_target_demod(opts, state, &coord->targets[coord->active].target);
     trunk_scan_sync_active_sm_mode(state, &coord->targets[coord->active]);
@@ -2499,6 +2537,28 @@ trunk_scan_retry_active_if_due(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_
     (void)trunk_scan_switch_to(opts, state, coord, coord->active, 0);
 }
 
+/*
+ * Conventional voice-gate intervals. The target list's dwell_ms/activity_hold_ms play the
+ * qualify/hold roles, and a target's own `--scan-voice-qualify-ms`/`--scan-voice-hold-ms`
+ * options replace them while the gate is on. The scanner-wide `-Y` timings never apply
+ * here (docs/trunk-scan.md).
+ */
+static int
+trunk_scan_target_hold_ms(const dsd_opts* opts, const dsd_trunk_scan_target_runtime* rt) {
+    if (opts->scan_voice_only == 1 && rt->profile && (rt->profile->values.present & DSD_SCAN_OPT_HOLD)) {
+        return rt->profile->values.hold_ms;
+    }
+    return rt->target.activity_hold_ms;
+}
+
+static int
+trunk_scan_target_dwell_ms(const dsd_opts* opts, const dsd_trunk_scan_target_runtime* rt) {
+    if (opts->scan_voice_only == 1 && rt->profile && (rt->profile->values.present & DSD_SCAN_OPT_QUALIFY)) {
+        return rt->profile->values.qualify_ms;
+    }
+    return rt->target.dwell_ms;
+}
+
 static int
 trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coord, double now_m) {
     const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
@@ -2515,7 +2575,7 @@ trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coor
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
         return opts->trunk_is_tuned == 1;
     }
-    double hold_s = (double)rt->target.activity_hold_ms / 1000.0;
+    double hold_s = (double)trunk_scan_target_hold_ms(opts, rt) / 1000.0;
     return rt->last_allowed_activity_m > 0.0 && (now_m - rt->last_allowed_activity_m) < hold_s;
 }
 
@@ -2659,7 +2719,7 @@ trunk_scan_refresh_voice_media_hold(const dsd_opts* opts, dsd_state* state, dsd_
         state->scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_OFF;
         return;
     }
-    const double hold_s = (double)rt->target.activity_hold_ms / 1000.0;
+    const double hold_s = (double)trunk_scan_target_hold_ms(opts, rt) / 1000.0;
     dsd_scan_voice_probe_result media;
     const int probe_rc = dsd_scan_voice_probe(opts, state, &media);
     if (probe_rc > 0 && media.retained_media_m > rt->last_allowed_activity_m) {
@@ -2710,7 +2770,7 @@ trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* c
         rt->idle_since_m = now_m;
         return;
     }
-    double dwell_s = (double)rt->target.dwell_ms / 1000.0;
+    double dwell_s = (double)trunk_scan_target_dwell_ms(opts, rt) / 1000.0;
     if ((now_m - rt->idle_since_m) >= dwell_s) {
         trunk_scan_advance(opts, state, coord);
     }

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(
         config_schema.c
         decode_mode.c
         scan_mode.c
+        scan_options.c
         config_expand.c
         control_pump.c
         freq_parse.c

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -47,7 +47,7 @@
 
 // Local helpers --------------------------------------------------------------
 static int dsd_parse_short_opts(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out_exit_rc,
-                                int* out_chan_csv_cli_seen);
+                                int* out_chan_csv_cli_seen, unsigned int* out_force_choices);
 extern int optind;
 extern char* optarg;
 
@@ -88,6 +88,21 @@ cli_collect_hex_digits(const char* in, char* out, size_t out_cap, size_t* out_le
         *out_len = w;
     }
     return 1;
+}
+
+static int
+cli_parse_force_algid(const char* text, uint64_t* algid) {
+    char hex[3];
+    size_t digits = 0;
+    return cli_collect_hex_digits(text, hex, sizeof(hex), &digits) && digits > 0
+           && dsd_parse_hex_u64_n(hex, digits, algid) == 0;
+}
+
+static int
+cli_force_algid_changed(const char* previous, const char* next) {
+    uint64_t old_value = 0, new_value = 0;
+    return previous && cli_parse_force_algid(previous, &old_value) && cli_parse_force_algid(next, &new_value)
+           && old_value != new_value;
 }
 
 static int
@@ -862,6 +877,18 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
             }                                                                                                          \
             continue;                                                                                                  \
         }                                                                                                              \
+        if (strcmp(argv[i], "--no-force-key") == 0) {                                                                  \
+            no_force_key_cli = 1;                                                                                      \
+            continue;                                                                                                  \
+        }                                                                                                              \
+        if (strcmp(argv[i], "--strict-crc") == 0) {                                                                    \
+            strict_crc_cli = 1;                                                                                        \
+            continue;                                                                                                  \
+        }                                                                                                              \
+        if (strcmp(argv[i], "--no-scan-voice-only") == 0) {                                                            \
+            opts->scan_voice_only = 0;                                                                                 \
+            continue;                                                                                                  \
+        }                                                                                                              \
         if (strcmp(argv[i], "--scan-voice-only") == 0) {                                                               \
             opts->scan_voice_only = 1;                                                                                 \
             continue;                                                                                                  \
@@ -1062,10 +1089,13 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
                 cli_set_exit_rc(out_exit_rc, 1);                                                                       \
                 return DSD_PARSE_ERROR;                                                                                \
             }                                                                                                          \
-            dmr_force_algid_cli = DSD_PARSE_ARGS_NEXT_ARG();                                                           \
+            const char* value = DSD_PARSE_ARGS_NEXT_ARG();                                                             \
+            long_force_conflict_cli |= cli_force_algid_changed(dmr_force_algid_cli, value);                            \
+            dmr_force_algid_cli = value;                                                                               \
             continue;                                                                                                  \
         }                                                                                                              \
         if (strncmp(argv[i], "--dmr-force-algid=", 18) == 0) {                                                         \
+            long_force_conflict_cli |= cli_force_algid_changed(dmr_force_algid_cli, argv[i] + 18);                     \
             dmr_force_algid_cli = argv[i] + 18;                                                                        \
             continue;                                                                                                  \
         }                                                                                                              \
@@ -1571,11 +1601,8 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
         LOG_INFO("NOTICE: P25 band plan export file: %s\n", opts->p25_bandplan_export_file);                           \
     }                                                                                                                  \
     if (dmr_force_algid_cli) {                                                                                         \
-        char hex[3];                                                                                                   \
-        size_t nhex = 0;                                                                                               \
         uint64_t alg = 0U;                                                                                             \
-        if (!cli_collect_hex_digits(dmr_force_algid_cli, hex, sizeof hex, &nhex) || nhex == 0 || nhex > 2              \
-            || dsd_parse_hex_u64_n(hex, nhex, &alg) != 0) {                                                            \
+        if (!cli_parse_force_algid(dmr_force_algid_cli, &alg)) {                                                       \
             LOG_ERROR("Invalid --dmr-force-algid value\n");                                                            \
             cli_set_exit_rc(out_exit_rc, 1);                                                                           \
             return DSD_PARSE_ERROR;                                                                                    \
@@ -1599,6 +1626,45 @@ cli_next_arg(char** argv, int i, int* arg_advance) {
         state->m17_signature_verification_status = 0U;                                                                 \
         LOG_INFO("NOTICE: M17 signature public key loaded for secp256r1 verification\n");                              \
     }
+
+static void
+cli_finish_force_options(dsd_opts* opts, dsd_state* state, unsigned int choices, int long_force, int have_long,
+                         int clear_force, int strict_crc, int long_conflict) {
+    if (clear_force) {
+        state->M = 0;
+    }
+    if (strict_crc) {
+        opts->aggressive_framesync = 1;
+        opts->dmr_crc_relaxed_default = 0;
+    }
+    int conflict = choices == 3U || long_conflict;
+    if (have_long) {
+        conflict |= (choices & 1U) && long_force != 1;
+        conflict |= (choices & 2U) && long_force != 0x21;
+    }
+    conflict |= clear_force && (choices || (have_long && long_force != 0));
+    if (conflict) {
+        LOG_WARN("WARNING: Conflicting force options; effective force mode is 0x%02X. "
+                 "Use per-row options for mixed scans.\n",
+                 state->M);
+    }
+}
+
+static void
+cli_reset_getopt(void) {
+    // Reset getopt index and parse short options here (migrated)
+    // NOTE: We invoke getopt() multiple times (unit tests, bootstrap flows).
+    // Linux getopt supports optind=0 full reset; BSD variants use optreset.
+#if defined(__linux__)
+    optind = 0;
+#else
+    optind = 1;
+#endif
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+    extern int optreset;
+    optreset = 1;
+#endif
+}
 
 int
 dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out_argc, int* out_exit_rc) {
@@ -1631,6 +1697,9 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
     const char* p25_bandplan_cli = NULL;
     const char* p25_bandplan_export_cli = NULL;
     const char* dmr_force_algid_cli = NULL;
+    int long_force_conflict_cli = 0;
+    int no_force_key_cli = 0;
+    int strict_crc_cli = 0;
     const char* m17_signature_public_key_cli = NULL;
     const char* iq_capture_cli = NULL;
     const char* iq_capture_format_cli = NULL;
@@ -1664,21 +1733,14 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
     DSD_PARSE_ARGS_TRAILING_BLOCK();
 
     int new_argc = dsd_cli_compact_args(argc, argv);
-    // Reset getopt index and parse short options here (migrated)
-    // NOTE: We invoke getopt() multiple times (unit tests, bootstrap flows).
-    // Linux getopt supports optind=0 full reset; BSD variants use optreset.
-#if defined(__linux__)
-    optind = 0;
-#else
-    optind = 1;
-#endif
-#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
-    extern int optreset;
-    optreset = 1;
-#endif
+    cli_reset_getopt();
 
-    int parse_rc = dsd_parse_short_opts(new_argc, argv, opts, state, out_exit_rc, &chan_csv_cli_seen);
+    unsigned int force_choices = 0U;
+    const int long_force = state->M;
+    int parse_rc = dsd_parse_short_opts(new_argc, argv, opts, state, out_exit_rc, &chan_csv_cli_seen, &force_choices);
     if (parse_rc == DSD_PARSE_CONTINUE) {
+        cli_finish_force_options(opts, state, force_choices, long_force, dmr_force_algid_cli != NULL, no_force_key_cli,
+                                 strict_crc_cli, long_force_conflict_cli);
         parse_rc = cli_validate_trunk_scan_runtime_args(opts, trunk_scan_cli_seen, chan_csv_cli_seen,
                                                         p25_bandplan_cli_seen, config_one_shot_cli_seen, out_exit_rc);
     }
@@ -1740,6 +1802,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
             break;                                                                                                     \
         case '0':                                                                                                      \
             state->M = 0x21;                                                                                           \
+            *out_force_choices |= 2U;                                                                                 \
             LOG_INFO("NOTICE: Force RC4 Key over Missing PI header/LE Encryption Identifiers (DMR)\n");                \
             break;                                                                                                     \
         case '1':                                                                                                      \
@@ -2773,6 +2836,7 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
         case '4':                                                                                                      \
             /* Force Privacy Key over Encryption Identifiers */                                                        \
             state->M = 1;                                                                                              \
+            *out_force_choices |= 1U;                                                                                 \
             LOG_INFO("NOTICE: Force Privacy Key priority enabled\n");                                                  \
             break;                                                                                                     \
         default:                                                                                                       \
@@ -2804,7 +2868,7 @@ dsd_warn_ineffective_short_opts(const dsd_opts* opts, const dsd_state* state) {
 
 static int
 dsd_parse_short_opts(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out_exit_rc,
-                     int* out_chan_csv_cli_seen) {
+                     int* out_chan_csv_cli_seen, unsigned int* out_force_choices) {
 
     int c;
     dsd_stat_t st = {0};

--- a/src/runtime/cli/compact.c
+++ b/src/runtime/cli/compact.c
@@ -56,10 +56,25 @@ compact_copy_terminator_tail_or_stop(int start, int argc, char** argv, int* out_
 }
 
 static const char* const k_skip_exact_no_arg[] = {
-    "--auto-ppm",          "--rtltcp-autotune",      "--iq-loop",       "--rdio-api-delete-after-upload",
-    "--enc-lockout",       "--enc-follow",           "--no-config",     "--print-config",
-    "--interactive-setup", "--dump-config-template", "--strict-config", "--list-profiles",
-    "--dmr-debug-burst",   "--dmr-debug-unsynced",   "--show-keys",     "--scan-voice-only",
+    "--auto-ppm",
+    "--rtltcp-autotune",
+    "--iq-loop",
+    "--rdio-api-delete-after-upload",
+    "--enc-lockout",
+    "--enc-follow",
+    "--no-config",
+    "--print-config",
+    "--interactive-setup",
+    "--dump-config-template",
+    "--strict-config",
+    "--list-profiles",
+    "--no-force-key",
+    "--strict-crc",
+    "--no-scan-voice-only",
+    "--dmr-debug-burst",
+    "--dmr-debug-unsynced",
+    "--show-keys",
+    "--scan-voice-only",
 };
 
 static const char* const k_skip_exact_next_any[] = {

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -293,6 +293,9 @@ dsd_cli_usage_section_advanced_decoder_options(void) {
 
 static void
 dsd_cli_usage_section_advanced_key_options(void) {
+    printf("  --no-force-key Disable privacy/scrambler forcing and DMR algorithm fallback.\n");
+    printf("  --strict-crc   Disable -F CRC relaxation.\n");
+    printf("  --no-scan-voice-only Disable conventional voice-only scanning.\n");
     printf("  -b <dec>      Manually Enter Basic Privacy Key (Decimal Value of Key Number)\n");
     printf("\n");
     printf("  -H <hex>      Manually Enter Hytera 10/32/64 Char Basic Privacy Hex Key (see example below)\n");

--- a/src/runtime/config_user.cpp
+++ b/src/runtime/config_user.cpp
@@ -1756,12 +1756,14 @@ snapshot_demod_config(const dsd_opts* opts, const dsd_state* state, dsdneoUserCo
 }
 
 static void
-snapshot_trunking_config(const dsd_opts* opts, dsdneoUserConfig* cfg) {
+snapshot_trunking_config(const dsd_opts* opts, const dsd_state* state, dsdneoUserConfig* cfg) {
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(state);
     cfg->has_trunking = 1;
     cfg->trunk_enabled = (opts->trunk_enable) ? 1 : 0;
     DSD_SNPRINTF(cfg->trunk_chan_csv, sizeof cfg->trunk_chan_csv, "%s", opts->chan_in_file);
     cfg->trunk_chan_csv[sizeof cfg->trunk_chan_csv - 1] = '\0';
-    DSD_SNPRINTF(cfg->trunk_group_csv, sizeof cfg->trunk_group_csv, "%s", opts->group_in_file);
+    DSD_SNPRINTF(cfg->trunk_group_csv, sizeof cfg->trunk_group_csv, "%s",
+                 configured ? configured->group_in_file : opts->group_in_file);
     cfg->trunk_group_csv[sizeof cfg->trunk_group_csv - 1] = '\0';
     DSD_SNPRINTF(cfg->trunk_p25_bandplan_csv, sizeof cfg->trunk_p25_bandplan_csv, "%s", opts->p25_bandplan_in_file);
     cfg->trunk_p25_bandplan_csv[sizeof cfg->trunk_p25_bandplan_csv - 1] = '\0';
@@ -1772,9 +1774,9 @@ snapshot_trunking_config(const dsd_opts* opts, dsdneoUserConfig* cfg) {
     cfg->trunk_tune_enc_calls = opts->trunk_tune_enc_calls ? 1 : 0;
     cfg->trunk_scanner = opts->scanner_mode ? 1 : 0;
     cfg->trunk_p25_prefer_candidates = opts->p25_prefer_candidates ? 1 : 0;
-    cfg->trunk_scan_voice_only = opts->scan_voice_only ? 1 : 0;
-    cfg->trunk_scan_voice_qualify_ms = opts->scan_voice_qualify_ms;
-    cfg->trunk_scan_voice_hold_ms = opts->scan_voice_hold_ms;
+    cfg->trunk_scan_voice_only = (configured ? configured->scan_voice_only : opts->scan_voice_only) ? 1 : 0;
+    cfg->trunk_scan_voice_qualify_ms = configured ? configured->scan_voice_qualify_ms : opts->scan_voice_qualify_ms;
+    cfg->trunk_scan_voice_hold_ms = configured ? configured->scan_voice_hold_ms : opts->scan_voice_hold_ms;
 }
 
 static void
@@ -1862,7 +1864,7 @@ dsd_snapshot_opts_to_user_config(const dsd_opts* opts, const dsd_state* state, d
     snapshot_output_config(opts, cfg);
     snapshot_mode_config(opts, state, cfg);
     snapshot_demod_config(opts, state, cfg);
-    snapshot_trunking_config(opts, cfg);
+    snapshot_trunking_config(opts, state, cfg);
     snapshot_radioreference_config(opts, cfg);
     snapshot_trunk_scan_config(opts, cfg);
     snapshot_logging_config(opts, cfg);

--- a/src/runtime/scan_mode.c
+++ b/src/runtime/scan_mode.c
@@ -130,6 +130,11 @@ dsd_scan_settings_capture(const dsd_opts* opts, const dsd_state* state, dsd_scan
     out->state_sps_hunt_idx = state->sps_hunt_idx;
 }
 
+_Static_assert(sizeof(((dsd_scan_option_values*)0)->group_file) == sizeof(((dsd_opts*)0)->group_in_file),
+               "row group paths are copied verbatim over dsd_opts::group_in_file");
+_Static_assert(sizeof(((dsd_scan_settings*)0)->group_in_file) == sizeof(((dsd_opts*)0)->group_in_file),
+               "scan settings snapshot dsd_opts::group_in_file verbatim");
+
 static void
 scan_settings_restore_row_opts(const dsd_scan_settings* saved, dsd_opts* opts) {
     opts->aggressive_framesync = saved->aggressive_framesync;
@@ -141,6 +146,22 @@ scan_settings_restore_row_opts(const dsd_scan_settings* saved, dsd_opts* opts) {
     opts->dmr_mute_encR = saved->dmr_mute_encR;
     opts->unmute_encrypted_p25 = saved->unmute_encrypted_p25;
     DSD_MEMCPY(opts->group_in_file, saved->group_in_file, sizeof(opts->group_in_file));
+}
+
+/* Row-scoped nonsecret options are policy, not acquisition: they never restage a tune
+ * or interrupt a parked row, so they travel beside the comparison, not through it. */
+static void
+scan_settings_copy_row_opts(dsd_scan_settings* dst, const dsd_scan_settings* src) {
+    dst->force_key = src->force_key;
+    dst->aggressive_framesync = src->aggressive_framesync;
+    dst->dmr_crc_relaxed_default = src->dmr_crc_relaxed_default;
+    dst->scan_voice_only = src->scan_voice_only;
+    dst->scan_voice_qualify_ms = src->scan_voice_qualify_ms;
+    dst->scan_voice_hold_ms = src->scan_voice_hold_ms;
+    dst->dmr_mute_encL = src->dmr_mute_encL;
+    dst->dmr_mute_encR = src->dmr_mute_encR;
+    dst->unmute_encrypted_p25 = src->unmute_encrypted_p25;
+    DSD_MEMCPY(dst->group_in_file, src->group_in_file, sizeof(dst->group_in_file));
 }
 
 static void
@@ -209,15 +230,6 @@ int
 dsd_scan_settings_equal(const dsd_scan_settings* a, const dsd_scan_settings* b, int include_timing) {
     /* Explicit membership, independent of struct order and padding. */
     static const size_t options[] = {
-        offsetof(dsd_scan_settings, force_key),
-        offsetof(dsd_scan_settings, aggressive_framesync),
-        offsetof(dsd_scan_settings, dmr_crc_relaxed_default),
-        offsetof(dsd_scan_settings, scan_voice_only),
-        offsetof(dsd_scan_settings, scan_voice_qualify_ms),
-        offsetof(dsd_scan_settings, scan_voice_hold_ms),
-        offsetof(dsd_scan_settings, dmr_mute_encL),
-        offsetof(dsd_scan_settings, dmr_mute_encR),
-        offsetof(dsd_scan_settings, unmute_encrypted_p25),
         offsetof(dsd_scan_settings, frame_dstar),
         offsetof(dsd_scan_settings, frame_x2tdma),
         offsetof(dsd_scan_settings, frame_p25p1),
@@ -259,7 +271,6 @@ dsd_scan_settings_equal(const dsd_scan_settings* a, const dsd_scan_settings* b, 
     }
     return scan_settings_fields_equal(a, b, options, sizeof(options) / sizeof(options[0]))
            && strncmp(a->output_name, b->output_name, sizeof(a->output_name)) == 0
-           && strncmp(a->group_in_file, b->group_in_file, sizeof(a->group_in_file)) == 0
            && (!include_timing || scan_settings_fields_equal(a, b, timing, sizeof(timing) / sizeof(timing[0])));
 }
 
@@ -348,12 +359,13 @@ scan_options_apply(dsd_opts* opts, dsd_state* state, const dsd_scan_option_value
     if (present & DSD_SCAN_OPT_HOLD) {
         opts->scan_voice_hold_ms = values->hold_ms;
     }
-    if (present & (DSD_SCAN_OPT_BP | DSD_SCAN_OPT_HYTERA)) {
+    if (present & DSD_SCAN_OPT_MUTE_DMR) {
         opts->dmr_mute_encL = values->mute_dmr;
         opts->dmr_mute_encR = values->mute_dmr;
     }
     if (present & DSD_SCAN_OPT_SCALAR) {
-        opts->unmute_encrypted_p25 = values->unmute_p25;
+        /* `-1` loads a key for decryption; undecodable P25 audio stays muted, as on the CLI. */
+        opts->unmute_encrypted_p25 = 0;
     }
     if (present & DSD_SCAN_OPT_GROUP) {
         DSD_MEMCPY(opts->group_in_file, values->group_file, sizeof(opts->group_in_file));
@@ -366,11 +378,11 @@ scan_scope_apply(dsd_opts* opts, dsd_state* state, const scan_scope* scope) {
     scan_options_apply(opts, state, &scope->options);
 }
 
-void
+int
 dsd_scan_mode_options(dsd_opts* opts, dsd_state* state, const dsd_scan_option_values* values) {
     scan_scope* scope = scan_scope_get(state);
     if (!scope || !opts) {
-        return;
+        return -1;
     }
     DSD_MEMSET(&scope->options, 0, sizeof(scope->options));
     if (values) {
@@ -381,6 +393,7 @@ dsd_scan_mode_options(dsd_opts* opts, dsd_state* state, const dsd_scan_option_va
         state->M = scope->configured.force_key;
         scan_options_apply(opts, state, &scope->options);
     }
+    return 0;
 }
 
 int
@@ -485,9 +498,11 @@ dsd_scan_mode_resume(dsd_opts* opts, dsd_state* state) {
     }
     dsd_scan_settings effective;
     dsd_scan_settings_capture(opts, state, &effective);
-    /* Monitoring is audio routing. Fold it into the restored effective values
-     * without treating it as an acquisition change or replacing live timing. */
+    /* Monitoring is audio routing, and the row-scoped options are policy (forcing, CRC,
+     * mutes, voice gate, group file). Fold both into the restored effective values
+     * without treating them as an acquisition change or replacing live timing. */
     scope->effective.monitor_input_audio = opts->monitor_input_audio;
+    scan_settings_copy_row_opts(&scope->effective, &effective);
     if (dsd_scan_settings_equal(&scope->effective, &effective, 0)) {
         dsd_scan_settings_restore(&scope->effective, opts, state);
         return 0;

--- a/src/runtime/scan_mode.c
+++ b/src/runtime/scan_mode.c
@@ -13,7 +13,9 @@
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -24,6 +26,7 @@ typedef struct {
     dsd_scan_mode mode;
     dsdneoUserDecodeMode configured_mode;
     int suspended;
+    dsd_scan_option_values options;
 } scan_scope;
 
 static const char* const mode_names[] = {"", "p25", "dmr", "nxdn96", "nxdn48", "dpmr", "dstar", "ysf", "m17"};
@@ -79,6 +82,16 @@ dsd_scan_settings_capture(const dsd_opts* opts, const dsd_state* state, dsd_scan
         return;
     }
     DSD_MEMSET(out, 0, sizeof(*out));
+    out->force_key = state->M;
+    out->aggressive_framesync = opts->aggressive_framesync;
+    out->dmr_crc_relaxed_default = opts->dmr_crc_relaxed_default;
+    out->scan_voice_only = opts->scan_voice_only;
+    out->scan_voice_qualify_ms = opts->scan_voice_qualify_ms;
+    out->scan_voice_hold_ms = opts->scan_voice_hold_ms;
+    out->dmr_mute_encL = opts->dmr_mute_encL;
+    out->dmr_mute_encR = opts->dmr_mute_encR;
+    out->unmute_encrypted_p25 = opts->unmute_encrypted_p25;
+    DSD_MEMCPY(out->group_in_file, opts->group_in_file, sizeof(out->group_in_file));
     out->frame_dstar = opts->frame_dstar;
     out->frame_x2tdma = opts->frame_x2tdma;
     out->frame_p25p1 = opts->frame_p25p1;
@@ -118,7 +131,21 @@ dsd_scan_settings_capture(const dsd_opts* opts, const dsd_state* state, dsd_scan
 }
 
 static void
+scan_settings_restore_row_opts(const dsd_scan_settings* saved, dsd_opts* opts) {
+    opts->aggressive_framesync = saved->aggressive_framesync;
+    opts->dmr_crc_relaxed_default = saved->dmr_crc_relaxed_default;
+    opts->scan_voice_only = saved->scan_voice_only;
+    opts->scan_voice_qualify_ms = saved->scan_voice_qualify_ms;
+    opts->scan_voice_hold_ms = saved->scan_voice_hold_ms;
+    opts->dmr_mute_encL = saved->dmr_mute_encL;
+    opts->dmr_mute_encR = saved->dmr_mute_encR;
+    opts->unmute_encrypted_p25 = saved->unmute_encrypted_p25;
+    DSD_MEMCPY(opts->group_in_file, saved->group_in_file, sizeof(opts->group_in_file));
+}
+
+static void
 scan_settings_restore_opts(const dsd_scan_settings* saved, dsd_opts* opts) {
+    scan_settings_restore_row_opts(saved, opts);
     opts->frame_dstar = saved->frame_dstar;
     opts->frame_x2tdma = saved->frame_x2tdma;
     opts->frame_p25p1 = saved->frame_p25p1;
@@ -158,6 +185,7 @@ dsd_scan_settings_restore(const dsd_scan_settings* saved, dsd_opts* opts, dsd_st
         return;
     }
     scan_settings_restore_opts(saved, opts);
+    state->M = saved->force_key;
     state->rf_mod = saved->state_rf_mod;
     state->samplesPerSymbol = saved->state_samplesPerSymbol;
     state->symbolCenter = saved->state_symbolCenter;
@@ -181,6 +209,15 @@ int
 dsd_scan_settings_equal(const dsd_scan_settings* a, const dsd_scan_settings* b, int include_timing) {
     /* Explicit membership, independent of struct order and padding. */
     static const size_t options[] = {
+        offsetof(dsd_scan_settings, force_key),
+        offsetof(dsd_scan_settings, aggressive_framesync),
+        offsetof(dsd_scan_settings, dmr_crc_relaxed_default),
+        offsetof(dsd_scan_settings, scan_voice_only),
+        offsetof(dsd_scan_settings, scan_voice_qualify_ms),
+        offsetof(dsd_scan_settings, scan_voice_hold_ms),
+        offsetof(dsd_scan_settings, dmr_mute_encL),
+        offsetof(dsd_scan_settings, dmr_mute_encR),
+        offsetof(dsd_scan_settings, unmute_encrypted_p25),
         offsetof(dsd_scan_settings, frame_dstar),
         offsetof(dsd_scan_settings, frame_x2tdma),
         offsetof(dsd_scan_settings, frame_p25p1),
@@ -222,6 +259,7 @@ dsd_scan_settings_equal(const dsd_scan_settings* a, const dsd_scan_settings* b, 
     }
     return scan_settings_fields_equal(a, b, options, sizeof(options) / sizeof(options[0]))
            && strncmp(a->output_name, b->output_name, sizeof(a->output_name)) == 0
+           && strncmp(a->group_in_file, b->group_in_file, sizeof(a->group_in_file)) == 0
            && (!include_timing || scan_settings_fields_equal(a, b, timing, sizeof(timing) / sizeof(timing[0])));
 }
 
@@ -252,7 +290,7 @@ scan_scope_apply_timing(const dsd_opts* opts, dsd_state* state, dsd_decode_mode_
 }
 
 static void
-scan_scope_apply(dsd_opts* opts, dsd_state* state, const scan_scope* scope) {
+scan_scope_apply_decoder(dsd_opts* opts, dsd_state* state, const scan_scope* scope) {
     dsd_scan_settings_restore(&scope->configured, opts, state);
     if (scope->mode == DSD_SCAN_MODE_INHERIT) {
         return;
@@ -291,6 +329,60 @@ scan_scope_apply(dsd_opts* opts, dsd_state* state, const scan_scope* scope) {
     scan_scope_apply_timing(opts, state, profile);
 }
 
+static void
+scan_options_apply(dsd_opts* opts, dsd_state* state, const dsd_scan_option_values* values) {
+    const uint32_t present = values->present;
+    if (present & DSD_SCAN_OPT_FORCE) {
+        state->M = values->force;
+    }
+    if (present & DSD_SCAN_OPT_CRC) {
+        opts->aggressive_framesync = (short)values->strict_crc;
+        opts->dmr_crc_relaxed_default = (uint8_t)!values->strict_crc;
+    }
+    if (present & DSD_SCAN_OPT_VOICE) {
+        opts->scan_voice_only = values->voice_only;
+    }
+    if (present & DSD_SCAN_OPT_QUALIFY) {
+        opts->scan_voice_qualify_ms = values->qualify_ms;
+    }
+    if (present & DSD_SCAN_OPT_HOLD) {
+        opts->scan_voice_hold_ms = values->hold_ms;
+    }
+    if (present & (DSD_SCAN_OPT_BP | DSD_SCAN_OPT_HYTERA)) {
+        opts->dmr_mute_encL = values->mute_dmr;
+        opts->dmr_mute_encR = values->mute_dmr;
+    }
+    if (present & DSD_SCAN_OPT_SCALAR) {
+        opts->unmute_encrypted_p25 = values->unmute_p25;
+    }
+    if (present & DSD_SCAN_OPT_GROUP) {
+        DSD_MEMCPY(opts->group_in_file, values->group_file, sizeof(opts->group_in_file));
+    }
+}
+
+static void
+scan_scope_apply(dsd_opts* opts, dsd_state* state, const scan_scope* scope) {
+    scan_scope_apply_decoder(opts, state, scope);
+    scan_options_apply(opts, state, &scope->options);
+}
+
+void
+dsd_scan_mode_options(dsd_opts* opts, dsd_state* state, const dsd_scan_option_values* values) {
+    scan_scope* scope = scan_scope_get(state);
+    if (!scope || !opts) {
+        return;
+    }
+    DSD_MEMSET(&scope->options, 0, sizeof(scope->options));
+    if (values) {
+        scope->options = *values;
+    }
+    if (!scope->suspended) {
+        scan_settings_restore_row_opts(&scope->configured, opts);
+        state->M = scope->configured.force_key;
+        scan_options_apply(opts, state, &scope->options);
+    }
+}
+
 int
 dsd_scan_mode_begin(const dsd_opts* opts, dsd_state* state) {
     if (!opts || !state) {
@@ -321,6 +413,7 @@ dsd_scan_mode_enter(dsd_opts* opts, dsd_state* state, dsd_scan_mode mode) {
     if (!scope) {
         return -1;
     }
+    DSD_MEMSET(&scope->options, 0, sizeof(scope->options));
     scope->modulation = 0;
     scope->mode = mode;
     scope->suspended = 0;
@@ -469,6 +562,7 @@ dsd_scan_mode_copy_snapshot(dsd_state* dst, const dsd_state* src) {
         (void)dsd_state_ext_set(dst, DSD_STATE_EXT_RUNTIME_SCAN_MODE, copy, free);
     }
     copy->configured = source->configured;
+    copy->options = source->options;
     copy->modulation = source->modulation;
     copy->mode = source->mode;
     copy->configured_mode = source->configured_mode;

--- a/src/runtime/scan_options.c
+++ b/src/runtime/scan_options.c
@@ -195,7 +195,6 @@ option_set_hex(const scan_option_spec* spec, const char* argument, unsigned int 
             rc = -1;
         } else {
             parsed->scalar = words[0];
-            parsed->values.unmute_p25 = 0;
         }
     } else if (rc == 0) {
         if (digits > 2 || words[0] == 1 || words[0] == 0x16) {
@@ -219,7 +218,6 @@ option_set_number(const scan_option_spec* spec, const char* argument, dsd_scan_o
             }
             if (spec->field == DSD_SCAN_OPT_BP) {
                 parsed->bp = number;
-                parsed->values.mute_dmr = number == 0;
             } else {
                 parsed->scalar = number;
             }
@@ -258,13 +256,19 @@ option_set(const scan_option_spec* spec, const char* argument, unsigned int mode
         case DSD_SCAN_OPT_VOICE: parsed->values.voice_only = spec->value; return 0;
         default: break;
     }
-    char* path = spec->field == DSD_SCAN_OPT_HEX_FILE   ? parsed->hex_file
-                 : spec->field == DSD_SCAN_OPT_DEC_FILE ? parsed->dec_file
-                                                        : parsed->values.group_file;
-    if (!argument[0] || strlen(argument) >= sizeof(parsed->hex_file)) {
+    char* path = parsed->values.group_file;
+    size_t capacity = sizeof(parsed->values.group_file);
+    if (spec->field == DSD_SCAN_OPT_HEX_FILE) {
+        path = parsed->hex_file;
+        capacity = sizeof(parsed->hex_file);
+    } else if (spec->field == DSD_SCAN_OPT_DEC_FILE) {
+        path = parsed->dec_file;
+        capacity = sizeof(parsed->dec_file);
+    }
+    if (!argument[0] || strlen(argument) >= capacity) {
         return -1;
     }
-    DSD_SNPRINTF(path, sizeof(parsed->hex_file), "%s", argument);
+    DSD_SNPRINTF(path, capacity, "%s", argument);
     return 0;
 }
 
@@ -297,7 +301,7 @@ static int
 option_read(const char** cursor, unsigned int mode, int conventional, dsd_scan_options* parsed,
             unsigned int* force_sources, char* error, size_t error_size) {
     char token[1024] = {0};
-    char argument[1024] = {0};
+    char argument[DSD_SCAN_OPTIONS_KEY_PATH_MAX] = {0};
     int rc = option_token(cursor, token, sizeof(token));
     if (rc <= 0) {
         if (rc < 0) {
@@ -362,7 +366,10 @@ dsd_scan_options_parse(const char* text, unsigned int mode, int conventional, ds
         rc = option_sources_valid(parsed.values.present, error, error_size);
     }
     if (rc == 0) {
+        /* The CLI `-b`/`-H` switches decide DMR encrypted-audio muting from whether any privacy
+         * material was supplied; explicit zero mutes. Only the option text claims that decision. */
         if (parsed.values.present & (DSD_SCAN_OPT_BP | DSD_SCAN_OPT_HYTERA)) {
+            parsed.values.present |= DSD_SCAN_OPT_MUTE_DMR;
             parsed.values.mute_dmr = !option_has_privacy_material(&parsed);
         }
         *out = parsed;

--- a/src/runtime/scan_options.c
+++ b/src/runtime/scan_options.c
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <dsd-neo/core/parse.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MODE_BIT(m) (1U << (m))
+#define DMR         MODE_BIT(DSD_SCAN_MODE_DMR)
+#define P25         MODE_BIT(DSD_SCAN_MODE_P25)
+#define NXDN        (MODE_BIT(DSD_SCAN_MODE_NXDN48) | MODE_BIT(DSD_SCAN_MODE_NXDN96))
+#define DPMR        MODE_BIT(DSD_SCAN_MODE_DPMR)
+#define ALL_MODES   0x1FFU
+
+typedef struct {
+    const char* name;
+    uint32_t field;
+    unsigned int modes;
+    int argument;
+    int conventional;
+    int value;
+} scan_option_spec;
+
+static const scan_option_spec specifications[] = {
+    {"-b", DSD_SCAN_OPT_BP, DMR, 1, 0, 0},
+    {"-H", DSD_SCAN_OPT_HYTERA, DMR | P25 | NXDN, 1, 0, 0},
+    {"-1", DSD_SCAN_OPT_SCALAR, DMR | P25 | NXDN, 1, 0, 0},
+    {"-R", DSD_SCAN_OPT_SCRAMBLER, NXDN | DPMR, 1, 0, 0},
+    {"-K", DSD_SCAN_OPT_HEX_FILE, DMR | P25 | NXDN, 1, 0, 0},
+    {"-k", DSD_SCAN_OPT_DEC_FILE, DMR | P25 | NXDN, 1, 0, 0},
+    {"-G", DSD_SCAN_OPT_GROUP, ALL_MODES, 1, 0, 0},
+    {"-4", DSD_SCAN_OPT_FORCE, DMR | NXDN, 0, 0, 1},
+    {"-0", DSD_SCAN_OPT_FORCE, DMR, 0, 0, 0x21},
+    {"--dmr-force-algid", DSD_SCAN_OPT_FORCE, DMR, 1, 0, 0},
+    {"--no-force-key", DSD_SCAN_OPT_FORCE, ALL_MODES, 0, 0, 0},
+    {"-F", DSD_SCAN_OPT_CRC, DMR | P25 | MODE_BIT(DSD_SCAN_MODE_M17), 0, 0, 0},
+    {"--strict-crc", DSD_SCAN_OPT_CRC, ALL_MODES, 0, 0, 1},
+    {"--scan-voice-only", DSD_SCAN_OPT_VOICE, ALL_MODES, 0, 1, 1},
+    {"--no-scan-voice-only", DSD_SCAN_OPT_VOICE, ALL_MODES, 0, 1, 0},
+    {"--scan-voice-qualify-ms", DSD_SCAN_OPT_QUALIFY, ALL_MODES, 1, 1, 0},
+    {"--scan-voice-hold-ms", DSD_SCAN_OPT_HOLD, ALL_MODES, 1, 1, 0},
+};
+
+static int
+option_error(char* error, size_t size, const char* name, const char* reason) {
+    if (error && size) {
+        DSD_SNPRINTF(error, size, "%s: %s", name, reason);
+    }
+    return -1;
+}
+
+static int
+option_space(unsigned char c) {
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '\v' || c == '\f';
+}
+
+/* Copy one argument, removing grouping quotes without interpreting escapes. */
+static int
+option_token(const char** cursor, char* out, size_t size) {
+    const char* p = *cursor;
+    while (option_space((unsigned char)*p)) {
+        p++;
+    }
+    if (!*p) {
+        *cursor = p;
+        return 0;
+    }
+    size_t used = 0;
+    char quote = 0;
+    while (*p && (quote || !option_space((unsigned char)*p))) {
+        char c = *p++;
+        if (c == quote) {
+            quote = 0;
+            continue;
+        }
+        if (!quote && (c == '\'' || c == '"')) {
+            quote = c;
+            continue;
+        }
+        if (used + 1 >= size) {
+            return -1;
+        }
+        out[used++] = c;
+    }
+    if (quote) {
+        return -1;
+    }
+    out[used] = '\0';
+    *cursor = p;
+    return 1;
+}
+
+static const scan_option_spec*
+option_find(const char* name) {
+    for (size_t i = 0; i < sizeof(specifications) / sizeof(specifications[0]); i++) {
+        if (strcmp(name, specifications[i].name) == 0) {
+            return &specifications[i];
+        }
+    }
+    return NULL;
+}
+
+static int
+option_decimal(const char* text, unsigned long max, unsigned long* out) {
+    if (!text || !*text) {
+        return -1;
+    }
+    for (const char* p = text; *p; p++) {
+        if (*p < '0' || *p > '9') {
+            return -1;
+        }
+    }
+    errno = 0;
+    char* end = NULL;
+    unsigned long value = strtoul(text, &end, 10);
+    if (errno || !end || *end || value > max) {
+        return -1;
+    }
+    *out = value;
+    return 0;
+}
+
+static int
+option_hex(const char* text, uint64_t words[4], unsigned int* digits) {
+    char hex[65] = {0};
+    size_t n = 0;
+    while (option_space((unsigned char)*text)) {
+        text++;
+    }
+    if (text[0] == '0' && (text[1] == 'x' || text[1] == 'X')) {
+        text += 2;
+    }
+    int rc = -1;
+    for (; *text; text++) {
+        if (option_space((unsigned char)*text)) {
+            continue;
+        }
+        if (n == sizeof(hex) - 1) {
+            goto done;
+        }
+        hex[n++] = *text;
+    }
+    if (!n) {
+        goto done;
+    }
+    for (size_t offset = 0; offset < n; offset += 16) {
+        size_t width = n - offset < 16 ? n - offset : 16;
+        if (dsd_parse_hex_u64_n(hex + offset, width, &words[offset / 16]) != 0) {
+            goto done;
+        }
+    }
+    *digits = (unsigned int)n;
+    rc = 0;
+done:
+    DSD_SECURE_ZERO(hex, sizeof(hex));
+    return rc;
+}
+
+static int
+option_hytera_width(unsigned int digits, unsigned int mode) {
+    if (digits != 10 && digits != 32 && digits != 64) {
+        return 0;
+    }
+    if (mode == DSD_SCAN_MODE_P25 && digits == 10) {
+        return 0;
+    }
+    return !(MODE_BIT(mode) & NXDN) || digits == 64;
+}
+
+static int
+option_has_privacy_material(const dsd_scan_options* parsed) {
+    return parsed->bp || parsed->hytera[0] || parsed->hytera[1] || parsed->hytera[2] || parsed->hytera[3];
+}
+
+static int
+option_set_hex(const scan_option_spec* spec, const char* argument, unsigned int mode, dsd_scan_options* parsed) {
+    uint64_t words[4] = {0};
+    unsigned int digits = 0;
+    int rc = option_hex(argument, words, &digits);
+    if (rc == 0 && spec->field == DSD_SCAN_OPT_HYTERA) {
+        if (!option_hytera_width(digits, mode)) {
+            rc = -1;
+        }
+        if (rc == 0) {
+            DSD_MEMCPY(parsed->hytera, words, sizeof(words));
+            parsed->hytera_digits = digits;
+        }
+    } else if (rc == 0 && spec->field == DSD_SCAN_OPT_SCALAR) {
+        if (digits > 16) {
+            rc = -1;
+        } else {
+            parsed->scalar = words[0];
+            parsed->values.unmute_p25 = 0;
+        }
+    } else if (rc == 0) {
+        if (digits > 2 || words[0] == 1 || words[0] == 0x16) {
+            rc = -1;
+        } else {
+            parsed->values.force = (int)words[0];
+        }
+    }
+    DSD_SECURE_ZERO(words, sizeof(words));
+    return rc;
+}
+
+static int
+option_set_number(const scan_option_spec* spec, const char* argument, dsd_scan_options* parsed) {
+    unsigned long number = 0;
+    switch (spec->field) {
+        case DSD_SCAN_OPT_BP:
+        case DSD_SCAN_OPT_SCRAMBLER:
+            if (option_decimal(argument, spec->field == DSD_SCAN_OPT_BP ? 255UL : 32767UL, &number)) {
+                return -1;
+            }
+            if (spec->field == DSD_SCAN_OPT_BP) {
+                parsed->bp = number;
+                parsed->values.mute_dmr = number == 0;
+            } else {
+                parsed->scalar = number;
+            }
+            return 0;
+        case DSD_SCAN_OPT_QUALIFY:
+        case DSD_SCAN_OPT_HOLD:
+            if (option_decimal(argument, 600000UL, &number) || number < 100) {
+                return -1;
+            }
+            if (spec->field == DSD_SCAN_OPT_QUALIFY) {
+                parsed->values.qualify_ms = (int)number;
+            } else {
+                parsed->values.hold_ms = (int)number;
+            }
+            return 0;
+        default: return -1;
+    }
+}
+
+static int
+option_set(const scan_option_spec* spec, const char* argument, unsigned int mode, dsd_scan_options* parsed) {
+    switch (spec->field) {
+        case DSD_SCAN_OPT_FORCE:
+            if (spec->argument) {
+                return option_set_hex(spec, argument, mode, parsed);
+            }
+            parsed->values.force = spec->value;
+            return 0;
+        case DSD_SCAN_OPT_HYTERA:
+        case DSD_SCAN_OPT_SCALAR: return option_set_hex(spec, argument, mode, parsed);
+        case DSD_SCAN_OPT_BP:
+        case DSD_SCAN_OPT_SCRAMBLER:
+        case DSD_SCAN_OPT_QUALIFY:
+        case DSD_SCAN_OPT_HOLD: return option_set_number(spec, argument, parsed);
+        case DSD_SCAN_OPT_CRC: parsed->values.strict_crc = spec->value; return 0;
+        case DSD_SCAN_OPT_VOICE: parsed->values.voice_only = spec->value; return 0;
+        default: break;
+    }
+    char* path = spec->field == DSD_SCAN_OPT_HEX_FILE   ? parsed->hex_file
+                 : spec->field == DSD_SCAN_OPT_DEC_FILE ? parsed->dec_file
+                                                        : parsed->values.group_file;
+    if (!argument[0] || strlen(argument) >= sizeof(parsed->hex_file)) {
+        return -1;
+    }
+    DSD_SNPRINTF(path, sizeof(parsed->hex_file), "%s", argument);
+    return 0;
+}
+
+static int
+option_apply(const scan_option_spec* spec, const char* argument, unsigned int mode, dsd_scan_options* parsed,
+             unsigned int* force_sources, char* error, size_t error_size) {
+    const int old_force = parsed->values.force;
+    if ((parsed->values.present & spec->field) && spec->field != DSD_SCAN_OPT_FORCE) {
+        return option_error(error, error_size, spec->name, "duplicate option");
+    }
+    if (option_set(spec, argument, mode, parsed)) {
+        return option_error(error, error_size, spec->name, "invalid value");
+    }
+    if ((parsed->values.present & DSD_SCAN_OPT_FORCE) && spec->field == DSD_SCAN_OPT_FORCE
+        && old_force != parsed->values.force) {
+        return option_error(error, error_size, spec->name, "conflicting force settings");
+    }
+    if (spec->field == DSD_SCAN_OPT_FORCE) {
+        const unsigned int source = spec->argument ? 1U : spec->value == 0x21 ? 2U : 4U;
+        if (*force_sources && ((*force_sources & source) || parsed->values.force != 0x21)) {
+            return option_error(error, error_size, spec->name, "duplicate force setting");
+        }
+        *force_sources |= source;
+    }
+    parsed->values.present |= spec->field;
+    return 1;
+}
+
+static int
+option_read(const char** cursor, unsigned int mode, int conventional, dsd_scan_options* parsed,
+            unsigned int* force_sources, char* error, size_t error_size) {
+    char token[1024] = {0};
+    char argument[1024] = {0};
+    int rc = option_token(cursor, token, sizeof(token));
+    if (rc <= 0) {
+        if (rc < 0) {
+            option_error(error, error_size, "options", "invalid quoting or oversized argument");
+        }
+        goto done;
+    }
+    char* equals = strncmp(token, "--", 2) == 0 ? strchr(token, '=') : NULL;
+    if (equals) {
+        *equals++ = '\0';
+    }
+    const scan_option_spec* spec = option_find(token);
+    rc = -1;
+    if (!spec) {
+        option_error(error, error_size, "options", "unsupported switch or positional argument");
+        goto done;
+    }
+    if (!(spec->modes & MODE_BIT(mode)) || (spec->conventional && !conventional)) {
+        option_error(error, error_size, spec->name, "not supported for this mode/target");
+        goto done;
+    }
+    if (equals && !spec->argument) {
+        option_error(error, error_size, spec->name, "takes no argument");
+        goto done;
+    }
+    if (spec->argument && !equals && option_token(cursor, argument, sizeof(argument)) != 1) {
+        option_error(error, error_size, spec->name, "requires a valid argument");
+        goto done;
+    }
+    rc = option_apply(spec, equals ? equals : argument, mode, parsed, force_sources, error, error_size);
+done:
+    DSD_SECURE_ZERO(token, sizeof(token));
+    DSD_SECURE_ZERO(argument, sizeof(argument));
+    return rc;
+}
+
+static int
+option_sources_valid(uint32_t present, char* error, size_t size) {
+    if ((present & DSD_SCAN_OPT_DIRECT) && (present & DSD_SCAN_OPT_FILES)) {
+        return option_error(error, size, "options", "direct keys cannot be combined with key files");
+    }
+    if ((present & DSD_SCAN_OPT_SCALAR) && (present & DSD_SCAN_OPT_SCRAMBLER)) {
+        return option_error(error, size, "options", "scalar key families conflict");
+    }
+    return 0;
+}
+
+int
+dsd_scan_options_parse(const char* text, unsigned int mode, int conventional, dsd_scan_options* out, char* error,
+                       size_t error_size) {
+    if (!out || mode > DSD_SCAN_MODE_M17) {
+        return option_error(error, error_size, "options", "invalid argument");
+    }
+    dsd_scan_options parsed = {0};
+    const char* cursor = text ? text : "";
+    int rc;
+    unsigned int force_sources = 0;
+    do {
+        rc = option_read(&cursor, mode, conventional, &parsed, &force_sources, error, error_size);
+    } while (rc > 0);
+    if (rc == 0) {
+        rc = option_sources_valid(parsed.values.present, error, error_size);
+    }
+    if (rc == 0) {
+        if (parsed.values.present & (DSD_SCAN_OPT_BP | DSD_SCAN_OPT_HYTERA)) {
+            parsed.values.mute_dmr = !option_has_privacy_material(&parsed);
+        }
+        *out = parsed;
+    }
+    DSD_SECURE_ZERO(&parsed, sizeof(parsed));
+    return rc;
+}

--- a/src/runtime/scan_options.c
+++ b/src/runtime/scan_options.c
@@ -272,9 +272,22 @@ option_set(const scan_option_spec* spec, const char* argument, unsigned int mode
     return 0;
 }
 
+typedef struct {
+    const scan_option_spec* first;
+    int alias_used;
+} scan_force_options;
+
+/* The only redundant spelling allowed is -0 paired once with --dmr-force-algid 21. */
+static int
+option_force_alias(const scan_option_spec* first, const scan_option_spec* next, int force) {
+    return force == 0x21
+           && ((strcmp(first->name, "-0") == 0 && strcmp(next->name, "--dmr-force-algid") == 0)
+               || (strcmp(first->name, "--dmr-force-algid") == 0 && strcmp(next->name, "-0") == 0));
+}
+
 static int
 option_apply(const scan_option_spec* spec, const char* argument, unsigned int mode, dsd_scan_options* parsed,
-             unsigned int* force_sources, char* error, size_t error_size) {
+             scan_force_options* forces, char* error, size_t error_size) {
     const int old_force = parsed->values.force;
     if ((parsed->values.present & spec->field) && spec->field != DSD_SCAN_OPT_FORCE) {
         return option_error(error, error_size, spec->name, "duplicate option");
@@ -287,19 +300,28 @@ option_apply(const scan_option_spec* spec, const char* argument, unsigned int mo
         return option_error(error, error_size, spec->name, "conflicting force settings");
     }
     if (spec->field == DSD_SCAN_OPT_FORCE) {
-        const unsigned int source = spec->argument ? 1U : spec->value == 0x21 ? 2U : 4U;
-        if (*force_sources && ((*force_sources & source) || parsed->values.force != 0x21)) {
-            return option_error(error, error_size, spec->name, "duplicate force setting");
+        if (forces->first) {
+            if (forces->alias_used || !option_force_alias(forces->first, spec, parsed->values.force)) {
+                return option_error(error, error_size, spec->name, "duplicate force setting");
+            }
+            forces->alias_used = 1;
+        } else {
+            forces->first = spec;
         }
-        *force_sources |= source;
     }
     parsed->values.present |= spec->field;
     return 1;
 }
 
+/* A missing value cannot consume the following switch as a file path. */
+static int
+option_argument(const char** cursor, char* argument, size_t size) {
+    return option_token(cursor, argument, size) == 1 && argument[0] != '-';
+}
+
 static int
 option_read(const char** cursor, unsigned int mode, int conventional, dsd_scan_options* parsed,
-            unsigned int* force_sources, char* error, size_t error_size) {
+            scan_force_options* forces, char* error, size_t error_size) {
     char token[1024] = {0};
     char argument[DSD_SCAN_OPTIONS_KEY_PATH_MAX] = {0};
     int rc = option_token(cursor, token, sizeof(token));
@@ -327,11 +349,11 @@ option_read(const char** cursor, unsigned int mode, int conventional, dsd_scan_o
         option_error(error, error_size, spec->name, "takes no argument");
         goto done;
     }
-    if (spec->argument && !equals && option_token(cursor, argument, sizeof(argument)) != 1) {
+    if (spec->argument && !equals && !option_argument(cursor, argument, sizeof(argument))) {
         option_error(error, error_size, spec->name, "requires a valid argument");
         goto done;
     }
-    rc = option_apply(spec, equals ? equals : argument, mode, parsed, force_sources, error, error_size);
+    rc = option_apply(spec, equals ? equals : argument, mode, parsed, forces, error, error_size);
 done:
     DSD_SECURE_ZERO(token, sizeof(token));
     DSD_SECURE_ZERO(argument, sizeof(argument));
@@ -358,9 +380,9 @@ dsd_scan_options_parse(const char* text, unsigned int mode, int conventional, ds
     dsd_scan_options parsed = {0};
     const char* cursor = text ? text : "";
     int rc;
-    unsigned int force_sources = 0;
+    scan_force_options forces = {0};
     do {
-        rc = option_read(&cursor, mode, conventional, &parsed, &force_sources, error, error_size);
+        rc = option_read(&cursor, mode, conventional, &parsed, &forces, error, error_size);
     } while (rc > 0);
     if (rc == 0) {
         rc = option_sources_valid(parsed.values.present, error, error_size);

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -832,11 +832,28 @@ ui_render_forced_key_status_tyt(const dsd_state* state, int show_keys) {
 }
 
 static void
+ui_render_loaded_scalar_keys(const dsd_state* state, int show_keys) {
+    if (state->M != 1 && state->K != 0) {
+        char key_text[16];
+        printw("| Moto BP Key Loaded (not forced): %s \n",
+               dsd_secret_format_decimal(key_text, sizeof(key_text), show_keys, state->K, 3U));
+    }
+    if (state->M != 1 && state->M != 0x21 && (state->R != 0 || state->RR != 0)) {
+        char left[17];
+        char right[17];
+        printw("| RC4/DES or scrambler key loaded (not forced): %s / %s \n",
+               dsd_secret_format_hex(left, sizeof(left), show_keys, state->R, 16U, 0),
+               dsd_secret_format_hex(right, sizeof(right), show_keys, state->RR, 16U, 0));
+    }
+}
+
+static void
 ui_render_forced_key_status(const dsd_state* state, int show_keys) {
     if (state == NULL) {
         return;
     }
 
+    ui_render_loaded_scalar_keys(state, show_keys);
     if (state->M != 1 && state->tyt_bp == 0 && ui_hytera_key_segment_count(state) != 0U) {
         ui_render_hytera_loaded_key_status(state, show_keys);
     }

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -831,17 +831,35 @@ ui_render_forced_key_status_tyt(const dsd_state* state, int show_keys) {
            dsd_secret_format_hex(key_text, sizeof key_text, show_keys, state->H, 4U, 0));
 }
 
+/*
+ * Loaded-but-not-forced scalar keys, beside the Hytera line that already exists for the same
+ * purpose. Nothing prints while any forcing is active (BP, RC4, TYT or the -2 TYT key).
+ * `R` is shared: `-R` stores a 15-bit NXDN/dPMR scrambler value in it alone, while `-1`, the
+ * key menu and the keyring store 64-bit RC4/DES keys in R (slot 1) and RR (slot 2).
+ */
 static void
 ui_render_loaded_scalar_keys(const dsd_state* state, int show_keys) {
-    if (state->M != 1 && state->K != 0) {
+    if (state->M == 1 || state->M == 0x21 || state->M == 0x16 || state->tyt_bp != 0) {
+        return;
+    }
+    if (state->K != 0) {
         char key_text[16];
         printw("| Moto BP Key Loaded (not forced): %s \n",
                dsd_secret_format_decimal(key_text, sizeof(key_text), show_keys, state->K, 3U));
     }
-    if (state->M != 1 && state->M != 0x21 && (state->R != 0 || state->RR != 0)) {
+    const int scrambler = state->R != 0 && state->R <= 0x7FFFULL && state->RR != state->R;
+    if (scrambler) {
+        char key_text[16];
+        printw("| NXDN/dPMR Scrambler Key Loaded (not forced): %s \n",
+               dsd_secret_format_decimal(key_text, sizeof(key_text), show_keys, state->R, 5U));
+    } else if (state->R == state->RR && state->R != 0) {
+        char key_text[17];
+        printw("| RC4/DES Key Loaded (not forced): %s \n",
+               dsd_secret_format_hex(key_text, sizeof(key_text), show_keys, state->R, 16U, 0));
+    } else if (state->R != 0 || state->RR != 0) {
         char left[17];
         char right[17];
-        printw("| RC4/DES or scrambler key loaded (not forced): %s / %s \n",
+        printw("| RC4/DES Keys Loaded (not forced): %s / %s \n",
                dsd_secret_format_hex(left, sizeof(left), show_keys, state->R, 16U, 0),
                dsd_secret_format_hex(right, sizeof(right), show_keys, state->RR, 16U, 0));
     }

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -839,7 +839,7 @@ ui_render_forced_key_status_tyt(const dsd_state* state, int show_keys) {
  */
 static void
 ui_render_loaded_scalar_keys(const dsd_state* state, int show_keys) {
-    if (state->M == 1 || state->M == 0x21 || state->M == 0x16 || state->tyt_bp != 0) {
+    if (state->M != 0 || state->tyt_bp != 0) {
         return;
     }
     if (state->K != 0) {

--- a/src/ui/terminal/menu_actions.c
+++ b/src/ui/terminal/menu_actions.c
@@ -445,20 +445,26 @@ act_hangtime(void* v) {
 void
 act_scan_voice_only(void* v) {
     UiCtx* c = (UiCtx*)v;
-    int32_t on = (c && c->opts && c->opts->scan_voice_only) ? 0 : 1;
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(dsd_app_get_latest_snapshot());
+    const int active = configured ? configured->scan_voice_only : (c && c->opts && c->opts->scan_voice_only);
+    int32_t on = active ? 0 : 1;
     (void)dsd_app_command_set_i32(DSD_APP_CMD_SCAN_VOICE_ONLY_SET, on);
 }
 
 void
 act_scan_voice_qualify(void* v) {
     UiCtx* c = (UiCtx*)v;
-    ui_prompt_open_int_async("Voice qualify (ms)", c->opts->scan_voice_qualify_ms, cb_scan_voice_qualify, c);
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(dsd_app_get_latest_snapshot());
+    const int ms = configured ? configured->scan_voice_qualify_ms : c->opts->scan_voice_qualify_ms;
+    ui_prompt_open_int_async("Voice qualify (ms)", ms, cb_scan_voice_qualify, c);
 }
 
 void
 act_scan_voice_hold(void* v) {
     UiCtx* c = (UiCtx*)v;
-    ui_prompt_open_int_async("Voice hold (ms)", c->opts->scan_voice_hold_ms, cb_scan_voice_hold, c);
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(dsd_app_get_latest_snapshot());
+    const int ms = configured ? configured->scan_voice_hold_ms : c->opts->scan_voice_hold_ms;
+    ui_prompt_open_int_async("Voice hold (ms)", ms, cb_scan_voice_hold, c);
 }
 
 void

--- a/src/ui/terminal/menu_labels.c
+++ b/src/ui/terminal/menu_labels.c
@@ -32,6 +32,11 @@
 #include "menu_internal.h"
 #include "ui_key_status.h"
 
+static const dsd_scan_settings*
+menu_configured_scan_settings(void) {
+    return dsd_scan_mode_configured_view(dsd_app_get_latest_snapshot());
+}
+
 static const char*
 onoff(int on) {
     return on ? "On" : "Off";
@@ -320,7 +325,8 @@ lbl_hpf_d(const void* v, char* b, size_t n) {
 const char*
 lbl_crc_relax(const void* v, char* b, size_t n) {
     const UiCtx* c = (const UiCtx*)v;
-    int relaxed = (c->opts->aggressive_framesync == 0);
+    const dsd_scan_settings* configured = menu_configured_scan_settings();
+    int relaxed = ((configured ? configured->aggressive_framesync : c->opts->aggressive_framesync) == 0);
     DSD_SNPRINTF(b, n, "Relaxed CRC checks [%s]", onoff(relaxed));
     return b;
 }
@@ -489,14 +495,17 @@ lbl_hangtime(const void* v, char* b, size_t n) {
 const char*
 lbl_scan_voice_only(const void* v, char* b, size_t n) {
     const UiCtx* c = (const UiCtx*)v;
-    DSD_SNPRINTF(b, n, "Voice-only scan [%s]", onoff(c && c->opts && c->opts->scan_voice_only));
+    const dsd_scan_settings* configured = menu_configured_scan_settings();
+    DSD_SNPRINTF(b, n, "Voice-only scan [%s]",
+                 onoff(configured ? configured->scan_voice_only : c && c->opts && c->opts->scan_voice_only));
     return b;
 }
 
 const char*
 lbl_scan_voice_qualify(const void* v, char* b, size_t n) {
     const UiCtx* c = (const UiCtx*)v;
-    const int ms = (c && c->opts) ? c->opts->scan_voice_qualify_ms : 0;
+    const dsd_scan_settings* configured = menu_configured_scan_settings();
+    const int ms = configured ? configured->scan_voice_qualify_ms : (c && c->opts) ? c->opts->scan_voice_qualify_ms : 0;
     DSD_SNPRINTF(b, n, "Voice qualify... [%d ms]", ms);
     return b;
 }
@@ -504,7 +513,8 @@ lbl_scan_voice_qualify(const void* v, char* b, size_t n) {
 const char*
 lbl_scan_voice_hold(const void* v, char* b, size_t n) {
     const UiCtx* c = (const UiCtx*)v;
-    const int ms = (c && c->opts) ? c->opts->scan_voice_hold_ms : 0;
+    const dsd_scan_settings* configured = menu_configured_scan_settings();
+    const int ms = configured ? configured->scan_voice_hold_ms : (c && c->opts) ? c->opts->scan_voice_hold_ms : 0;
     DSD_SNPRINTF(b, n, "Voice hold... [%d ms]", ms);
     return b;
 }
@@ -604,8 +614,11 @@ lbl_p25_p1_err_sec(const void* v, char* b, size_t n) {
 const char*
 lbl_muting(const void* v, char* b, size_t n) {
     const UiCtx* c = (const UiCtx*)v;
-    int dmr = (c->opts->dmr_mute_encL == 1 && c->opts->dmr_mute_encR == 1);
-    int p25 = (c->opts->unmute_encrypted_p25 == 0);
+    const dsd_scan_settings* configured = menu_configured_scan_settings();
+    const int left = configured ? configured->dmr_mute_encL : c->opts->dmr_mute_encL;
+    const int right = configured ? configured->dmr_mute_encR : c->opts->dmr_mute_encR;
+    const int dmr = left == 1 && right == 1;
+    const int p25 = (configured ? configured->unmute_encrypted_p25 : c->opts->unmute_encrypted_p25) == 0;
     DSD_SNPRINTF(b, n, "Mute encrypted audio [%s]", onoff(dmr && p25));
     return b;
 }
@@ -651,7 +664,8 @@ lbl_enc_lockout_clear(const void* v, char* b, size_t n) {
 const char*
 lbl_key_force_bp(const void* v, char* b, size_t n) {
     const UiCtx* c = (const UiCtx*)v;
-    const int on = (c && c->state && c->state->M == 1);
+    const dsd_scan_settings* configured = menu_configured_scan_settings();
+    const int on = configured ? configured->force_key == 1 : (c && c->state && c->state->M == 1);
     DSD_SNPRINTF(b, n, "Force basic/scrambler key [%s]", onoff(on));
     return b;
 }
@@ -659,7 +673,8 @@ lbl_key_force_bp(const void* v, char* b, size_t n) {
 const char*
 lbl_key_force_rc4(const void* v, char* b, size_t n) {
     const UiCtx* c = (const UiCtx*)v;
-    const int on = (c && c->state && c->state->M == 0x21);
+    const dsd_scan_settings* configured = menu_configured_scan_settings();
+    const int on = configured ? configured->force_key == 0x21 : (c && c->state && c->state->M == 0x21);
     DSD_SNPRINTF(b, n, "Force RC4 key [%s]", onoff(on));
     return b;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4540,6 +4540,10 @@ target_link_libraries(
     dsd-neo_test_engine_channel_scan
     PRIVATE dsd-neo_runtime dsd-neo_test_call_state_support dsd-neo_test_support
 )
+target_compile_definitions(
+    dsd-neo_test_engine_channel_scan
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
 add_test(NAME ENGINE_CHANNEL_SCAN COMMAND dsd-neo_test_engine_channel_scan)
 
 add_executable(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3788,13 +3788,6 @@ target_link_libraries(
 )
 add_test(NAME CORE_SCAN_PROFILE COMMAND dsd-neo_test_core_scan_profile)
 
-add_executable(
-    dsd-neo_test_runtime_scan_options
-    runtime/test_runtime_scan_options.c
-)
-target_link_libraries(dsd-neo_test_runtime_scan_options PRIVATE dsd-neo_runtime)
-add_test(NAME RUNTIME_SCAN_OPTIONS COMMAND dsd-neo_test_runtime_scan_options)
-
 add_executable(dsd-neo_test_core_csv_validate core/test_core_csv_validate.c)
 target_include_directories(
     dsd-neo_test_core_csv_validate
@@ -4628,6 +4621,13 @@ add_test(NAME RUNTIME_RR_PROVENANCE COMMAND dsd-neo_test_runtime_rr_provenance)
 add_executable(dsd-neo_test_runtime_scan_mode runtime/test_runtime_scan_mode.c)
 target_link_libraries(dsd-neo_test_runtime_scan_mode PRIVATE dsd-neo_runtime)
 add_test(NAME RUNTIME_SCAN_MODE COMMAND dsd-neo_test_runtime_scan_mode)
+
+add_executable(
+    dsd-neo_test_runtime_scan_options
+    runtime/test_runtime_scan_options.c
+)
+target_link_libraries(dsd-neo_test_runtime_scan_options PRIVATE dsd-neo_runtime)
+add_test(NAME RUNTIME_SCAN_OPTIONS COMMAND dsd-neo_test_runtime_scan_options)
 
 add_executable(dsd-neo_test_scan_mode_replay engine/scan_mode_replay.c)
 target_link_libraries(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1638,6 +1638,7 @@ endif()
 
 add_executable(
     dsd-neo_test_app_control_actions
+    test_support/scan_group_stubs.c
     ui/test_ui_cmd_actions.c
     ${PROJECT_SOURCE_DIR}/src/app_control/actions/actions_audio.c
     ${PROJECT_SOURCE_DIR}/src/app_control/actions/actions_radio.c
@@ -1697,6 +1698,7 @@ add_test(
 
 add_executable(
     dsd-neo_test_ui_menu_services
+    test_support/scan_group_stubs.c
     ui/test_ui_menu_services.c
     ${PROJECT_SOURCE_DIR}/src/app_control/menu_services.c
     # svc_clear_keys() drops the DMR TG->key ID map through keyring_dmr_tg_map_reset().
@@ -3771,6 +3773,28 @@ target_link_libraries(
 )
 add_test(NAME CORE_KEY_SET COMMAND dsd-neo_test_core_key_set)
 
+add_executable(
+    dsd-neo_test_core_scan_profile
+    core/test_core_scan_profile.c
+    ../src/core/util/talkgroup_policy.c
+)
+target_compile_definitions(
+    dsd-neo_test_core_scan_profile
+    PRIVATE DSD_NEO_TEST_HOOKS
+)
+target_link_libraries(
+    dsd-neo_test_core_scan_profile
+    PRIVATE dsd-neo_core dsd-neo_proto_dmr dsd-neo_test_support
+)
+add_test(NAME CORE_SCAN_PROFILE COMMAND dsd-neo_test_core_scan_profile)
+
+add_executable(
+    dsd-neo_test_runtime_scan_options
+    runtime/test_runtime_scan_options.c
+)
+target_link_libraries(dsd-neo_test_runtime_scan_options PRIVATE dsd-neo_runtime)
+add_test(NAME RUNTIME_SCAN_OPTIONS COMMAND dsd-neo_test_runtime_scan_options)
+
 add_executable(dsd-neo_test_core_csv_validate core/test_core_csv_validate.c)
 target_include_directories(
     dsd-neo_test_core_csv_validate
@@ -3810,6 +3834,7 @@ add_test(NAME CORE_CHANNEL_LABEL COMMAND dsd-neo_test_core_channel_label)
 
 add_executable(
     dsd-neo_test_core_state_trunk_lcn_avoid
+    test_support/scan_group_stubs.c
     core/test_core_state_trunk_lcn_avoid.c
     ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
 )
@@ -4511,6 +4536,7 @@ add_test(
 
 add_executable(
     dsd-neo_test_engine_channel_scan
+    test_support/scan_group_stubs.c
     engine/test_engine_channel_scan.c
     ${PROJECT_SOURCE_DIR}/src/engine/channel_scan.c
     ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
@@ -4525,6 +4551,8 @@ add_test(NAME ENGINE_CHANNEL_SCAN COMMAND dsd-neo_test_engine_channel_scan)
 
 add_executable(
     dsd-neo_test_engine_trunk_scan
+    ${PROJECT_SOURCE_DIR}/src/core/util/scan_profile.c
+    test_support/scan_group_stubs.c
     engine/test_engine_trunk_scan.c
     ${PROJECT_SOURCE_DIR}/src/engine/channel_scan.c
     ${PROJECT_SOURCE_DIR}/src/engine/trunk_scan.c
@@ -4543,7 +4571,7 @@ target_include_directories(
 )
 target_compile_definitions(
     dsd-neo_test_engine_trunk_scan
-    PRIVATE DSD_TRUNK_SCAN_TEST_CLOCK=1
+    PRIVATE DSD_TRUNK_SCAN_TEST_CLOCK=1 DSD_NEO_TEST_HOOKS
 )
 target_link_libraries(
     dsd-neo_test_engine_trunk_scan

--- a/tests/core/test_core_mbe_transform_context.c
+++ b/tests/core/test_core_mbe_transform_context.c
@@ -26,6 +26,7 @@
 #include <sndfile.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "dsd-neo/core/opts_fwd.h"
@@ -1940,6 +1941,68 @@ test_process_mbe_frame_dmr_rc4_transforms_left_and_right_slots(void) {
     return rc;
 }
 
+/* Ordinary BP follows signalling; forced BP also transforms frames marked clear.
+ * Exercise the production voice path in both slots with the same decoded fixture. */
+static int
+test_process_mbe_frame_mixed_clear_and_bp(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        return 1;
+    }
+    mbe_parms cur, prev, enhanced, cur2, prev2, enhanced2;
+    mbe_parms expected_cur, expected_prev, expected_enhanced;
+    char imbe[8][23] = {{0}}, ambe[4][24] = {{0}}, imbe7100[7][24] = {{0}};
+    int rc = 0;
+    for (int slot = 0; slot < 2; slot++) {
+        for (int scenario = 0; scenario < 3; scenario++) {
+            char decoded[49], expected[49];
+            int errs = 0, errs2 = 0;
+            mbe_process_result result;
+            rc |= prepare_active_ambe2450_fixture(ambe, decoded, &errs, &errs2, &result);
+            DSD_MEMCPY(expected, decoded, sizeof(expected));
+            if (scenario != 0) {
+                rc |= dmr_basic_privacy_apply_frame49(1, expected) != 1;
+            }
+            (void)dsd_mbe_strip_ambe_context_if_changed(decoded, expected, &result);
+            float expected_audio[160];
+            char expected_error[96];
+            mbe_initMbeParms(&expected_cur, &expected_prev, &expected_enhanced);
+            int ret = mbe_processAmbe2450Dataf(expected_audio, &result, expected, &expected_cur, &expected_prev,
+                                               &expected_enhanced);
+            store_expected_process_status(ret, expected_audio, &errs, &errs2, expected_error, sizeof(expected_error),
+                                          &result);
+            init_mbe_state(state, &cur, &prev, &enhanced, &cur2, &prev2, &enhanced2);
+            opts->floating_point = 1;
+            opts->dmr_stereo = 1;
+            state->synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+            state->currentslot = slot;
+            state->K = 1;
+            state->M = scenario == 2;
+            state->dmr_fid = state->dmr_fidR = 0x10;
+            state->dmr_so = state->dmr_soR = scenario == 1 ? 0x40 : 0;
+            processMbeFrame(opts, state, imbe, ambe, imbe7100);
+            const float* actual = slot ? state->audio_out_temp_bufR : state->audio_out_temp_buf;
+            for (int sample = 0; sample < 160; sample++) {
+                float difference = actual[sample] - expected_audio[sample];
+                if (!(difference >= -0.000001f && difference <= 0.000001f)) {
+                    rc = 1;
+                }
+            }
+            rc |= (slot ? state->dmr_encR : state->dmr_encL) != 0;
+        }
+    }
+    if (rc) {
+        DSD_FPRINTF(stderr, "mixed clear/BP production processing regression\n");
+    }
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+    return rc;
+}
+
 static int
 test_process_mbe_frame_dmr_reverse_mute_preserves_p25_override(void) {
     int rc = 0;
@@ -2824,6 +2887,7 @@ main(void) {
     rc |= test_process_mbe_frame_hard_dmr_left_stages_audio();
     rc |= test_process_mbe_frame_trunked_mono_bs_fallback_gates_to_granted_slot();
     rc |= test_process_mbe_frame_dmr_rc4_transforms_left_and_right_slots();
+    rc |= test_process_mbe_frame_mixed_clear_and_bp();
     rc |= test_process_mbe_frame_dmr_reverse_mute_preserves_p25_override();
     rc |= test_process_mbe_frame_dmr_missing_alg_key_unmutes_slots();
     rc |= test_process_mbe_frame_dmr_post_decode_gates_override_enc_flags();

--- a/tests/core/test_core_mbe_transform_context.c
+++ b/tests/core/test_core_mbe_transform_context.c
@@ -1984,10 +1984,17 @@ test_process_mbe_frame_mixed_clear_and_bp(void) {
             state->dmr_fid = state->dmr_fidR = 0x10;
             state->dmr_so = state->dmr_soR = scenario == 1 ? 0x40 : 0;
             processMbeFrame(opts, state, imbe, ambe, imbe7100);
+            rc |= expect_eq_int("mixed clear/BP errs", slot ? state->errsR : state->errs, errs);
+            rc |= expect_eq_int("mixed clear/BP errs2", slot ? state->errs2R : state->errs2, errs2);
+            rc |= expect_eq_int("mixed clear/BP status",
+                                strcmp(slot ? state->err_strR : state->err_str, expected_error), 0);
+            const float* staged = slot ? state->f_r : state->f_l;
             const float* actual = slot ? state->audio_out_temp_bufR : state->audio_out_temp_buf;
             for (int sample = 0; sample < 160; sample++) {
                 float difference = actual[sample] - expected_audio[sample];
-                if (!(difference >= -0.000001f && difference <= 0.000001f)) {
+                float staged_difference = staged[sample] - expected_audio[sample];
+                if (!(difference >= -0.000001f && difference <= 0.000001f)
+                    || !(staged_difference >= -0.000001f && staged_difference <= 0.000001f)) {
                     rc = 1;
                 }
             }

--- a/tests/core/test_core_scan_profile.c
+++ b/tests/core/test_core_scan_profile.c
@@ -180,9 +180,101 @@ test_csv_import(void) {
     assert(dsd_state_trunk_lcn_keys_get(state, 1)->scalars.R == 1);
     dsd_state_trunk_lcn_free(state);
     dsd_state_ext_free_all(state);
+
+    /* A map whose rows carry options but no mode still has to run through the typed
+     * scanner, since the legacy scanner applies keys but never row options. */
+    write_file(path, "channel,frequency_hz,options\n"
+                     "1,150000000,--scan-voice-hold-ms 4000\n"
+                     "2,150000001,\n");
+    DSD_MEMSET(state, 0, sizeof(*state));
+    assert(csvChanImport(opts, state) == 0);
+    assert(state->lcn_freq_count == 2);
+    assert(dsd_channel_mode_get(state, 0) == DSD_SCAN_MODE_INHERIT);
+    assert(dsd_channel_modes_present(state));
+    assert(dsd_channel_profile_get(state, 0)->values.hold_ms == 4000);
+    assert(dsd_channel_profile_get(state, 1) == NULL);
+    /* Replacing the only option-bearing profile with an empty one releases the gate. */
+    dsd_scan_row_profile* blank = (dsd_scan_row_profile*)calloc(1, sizeof(*blank));
+    assert(blank);
+    assert(dsd_channel_profile_set(state, 0, blank) == 0);
+    assert(!dsd_channel_modes_present(state));
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+
+    /* Legacy key columns beside an options cell keep their key-only meaning: they never
+     * decide encrypted-audio muting, while the option text's own `-b` does. */
+    write_file(path, "channel,frequency_hz,mode,single_key_dec,options\n"
+                     "1,150000000,dmr,5,--no-force-key\n"
+                     "2,150000001,dmr,,-b 5\n"
+                     "3,150000002,dmr,,-b 0\n");
+    DSD_MEMSET(state, 0, sizeof(*state));
+    assert(csvChanImport(opts, state) == 0);
+    assert(state->lcn_freq_count == 3);
+    assert(dsd_state_trunk_lcn_keys_get(state, 0)->scalars.K == 5);
+    assert(dsd_state_trunk_lcn_keys_get(state, 1)->scalars.K == 5);
+    assert(!(dsd_channel_profile_get(state, 0)->values.present & DSD_SCAN_OPT_MUTE_DMR));
+    assert((dsd_channel_profile_get(state, 1)->values.present & DSD_SCAN_OPT_MUTE_DMR)
+           && dsd_channel_profile_get(state, 1)->values.mute_dmr == 0);
+    assert((dsd_channel_profile_get(state, 2)->values.present & DSD_SCAN_OPT_MUTE_DMR)
+           && dsd_channel_profile_get(state, 2)->values.mute_dmr == 1);
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
     free(state);
     free(opts);
     assert(remove(path) == 0);
+}
+
+/* Option-bearing rows with no declared mode: the scope applies the row's policy over the
+ * baseline exactly as a declared row would, and the legacy columns leave muting alone. */
+static void
+test_legacy_columns_do_not_mute(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts && state);
+    opts->wav_sample_rate = 48000;
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->dmr_mute_encL = opts->dmr_mute_encR = 1;
+    dsd_scan_options parsed = {0};
+    char error[192];
+    assert(dsd_scan_options_parse("--no-force-key", DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error)) == 0);
+    assert(dsd_scan_options_merge_keys(&parsed, "", "", "0000001f00", "5", error, sizeof(error)) == 0);
+    assert(parsed.bp == 5 && parsed.hytera[0] == 0x1f00 && parsed.hytera_digits == 10);
+    assert(!(parsed.values.present & DSD_SCAN_OPT_MUTE_DMR));
+    dsd_key_set keys = {0};
+    dsd_scan_row_profile* profile = NULL;
+    assert(dsd_scan_profile_load(&parsed, 0, &profile, &keys) == 0);
+    assert(keys.present && keys.scalars.K == 5 && keys.scalars.K1 == 0x1f00 && keys.scalars.hytera_key_segments == 1);
+    assert(dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_INHERIT) == 0);
+    assert(dsd_scan_mode_options(opts, state, &profile->values) == 0);
+    assert(opts->dmr_mute_encL == 1 && opts->dmr_mute_encR == 1);
+    dsd_scan_profile_free(profile);
+    profile = NULL;
+    /* A rejected column leaves the options exactly as parsed. */
+    unsigned char before_merge[sizeof(parsed)];
+    unsigned char after_merge[sizeof(parsed)];
+    DSD_MEMCPY(before_merge, &parsed, sizeof(before_merge));
+    assert(dsd_scan_options_merge_keys(&parsed, "", "", "zz", "", error, sizeof(error)) != 0);
+    DSD_MEMCPY(after_merge, &parsed, sizeof(after_merge));
+    assert(memcmp(before_merge, after_merge, sizeof(after_merge)) == 0);
+    DSD_SECURE_ZERO(before_merge, sizeof(before_merge));
+    DSD_SECURE_ZERO(after_merge, sizeof(after_merge));
+    /* `-b` in the option text decides muting from all of the row's material. */
+    DSD_SECURE_ZERO(&parsed, sizeof(parsed));
+    assert(dsd_scan_options_parse("-b 0", DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error)) == 0);
+    assert((parsed.values.present & DSD_SCAN_OPT_MUTE_DMR) && parsed.values.mute_dmr == 1);
+    assert(dsd_scan_options_merge_keys(&parsed, "", "", "0000001f00", "", error, sizeof(error)) == 0);
+    assert((parsed.values.present & DSD_SCAN_OPT_MUTE_DMR) && parsed.values.mute_dmr == 0);
+    assert(dsd_scan_profile_load(&parsed, 0, &profile, &keys) == 0);
+    assert(dsd_scan_mode_options(opts, state, &profile->values) == 0);
+    assert(opts->dmr_mute_encL == 0 && opts->dmr_mute_encR == 0);
+    dsd_scan_mode_leave(opts, state);
+    assert(opts->dmr_mute_encL == 1);
+    dsd_scan_profile_free(profile);
+    dsd_key_set_free(&keys);
+    DSD_SECURE_ZERO(&parsed, sizeof(parsed));
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
 }
 
 static void
@@ -220,13 +312,29 @@ test_group_load_failure(void) {
     write_file(path, "id,mode,name\n123,A,Expected row\n");
     dsd_tg_policy_store* original = NULL;
     assert(dsd_tg_policy_load(path, &original) == 0);
-    for (long fail = 0; fail < 2; fail++) {
-        dsd_tg_policy_store* out = original;
-        dsd_tg_policy_test_alloc_fail_after(fail);
-        assert(dsd_tg_policy_load(path, &out) != 0);
-        assert(out == original);
-        dsd_tg_policy_test_alloc_reset();
-    }
+    /* No context at all is a failure that leaves the output alone. */
+    dsd_tg_policy_store* out = original;
+    dsd_tg_policy_test_alloc_fail_after(0);
+    assert(dsd_tg_policy_load(path, &out) != 0);
+    assert(out == original);
+    dsd_tg_policy_test_alloc_reset();
+    /* A row the importer could not store is skipped with a warning, as the global `-G`
+     * import has always done, and the load still yields a (here empty) policy. */
+    dsd_tg_policy_store* partial = NULL;
+    dsd_tg_policy_test_alloc_fail_after(1);
+    assert(dsd_tg_policy_load(path, &partial) == 0);
+    dsd_tg_policy_test_alloc_reset();
+    assert(partial != NULL && partial != original);
+    dsd_state* probe = (dsd_state*)calloc(1, sizeof(*probe));
+    assert(probe);
+    dsd_tg_policy_install(probe, partial);
+    char name[64];
+    assert(!dsd_tg_policy_lookup_label(probe, 123, NULL, 0, name, sizeof(name)));
+    dsd_tg_policy_install(probe, original);
+    assert(dsd_tg_policy_lookup_label(probe, 123, NULL, 0, name, sizeof(name)) && strcmp(name, "Expected row") == 0);
+    dsd_state_ext_free_all(probe);
+    free(probe);
+    dsd_tg_policy_release(partial);
     dsd_tg_policy_release(original);
     assert(remove(path) == 0);
 }
@@ -269,6 +377,26 @@ test_relative_paths(void) {
     assert(strcmp(options.values.group_file, "lists/group list.csv") == 0);
     assert(strcmp(options.hex_file, "lists/hex keys.csv") == 0);
     assert(strcmp(options.dec_file, "lists/decimal.csv") == 0);
+    /* Each path resolves within its own capacity: a key path may use the legacy column limit,
+     * while a group path is bounded by the option field it overrides. A failure leaves the
+     * object untouched. */
+    char base[DSD_SCAN_OPTIONS_GROUP_PATH_MAX];
+    DSD_MEMSET(base, 'b', sizeof(base) - 1);
+    base[sizeof(base) - 1] = '\0';
+    base[sizeof(base) - 5] = '/';
+    unsigned char before_resolve[sizeof(options)];
+    unsigned char after_resolve[sizeof(options)];
+    DSD_MEMCPY(before_resolve, &options, sizeof(before_resolve));
+    assert(dsd_scan_options_resolve(&options, base, error, sizeof(error)) != 0);
+    DSD_MEMCPY(after_resolve, &options, sizeof(after_resolve));
+    assert(memcmp(before_resolve, after_resolve, sizeof(after_resolve)) == 0);
+    DSD_SECURE_ZERO(before_resolve, sizeof(before_resolve));
+    DSD_SECURE_ZERO(after_resolve, sizeof(after_resolve));
+    options.values.present &= ~(uint32_t)DSD_SCAN_OPT_GROUP;
+    options.values.group_file[0] = '\0';
+    assert(dsd_scan_options_resolve(&options, base, error, sizeof(error)) == 0);
+    assert(strlen(options.hex_file) > DSD_SCAN_OPTIONS_GROUP_PATH_MAX);
+    assert(strlen(options.dec_file) > DSD_SCAN_OPTIONS_GROUP_PATH_MAX);
     DSD_SECURE_ZERO(&options, sizeof(options));
 }
 
@@ -281,5 +409,6 @@ main(void) {
     test_relative_paths();
     test_group_ownership();
     test_csv_import();
+    test_legacy_columns_do_not_mute();
     return 0;
 }

--- a/tests/core/test_core_scan_profile.c
+++ b/tests/core/test_core_scan_profile.c
@@ -137,15 +137,29 @@ test_group_ownership(void) {
     expect_label(state, "Global");
     dsd_scan_groups_enter(state, row);
     expect_label(state, "Row edit");
+    dsd_tg_policy_call_route active = {
+        .target_id = 123, .source_id = 1, .freq_hz = 851000000, .channel = 10, .slot = 0};
+    dsd_tg_policy_call_route candidate = active;
+    candidate.target_id = 456;
+    dsd_tg_policy_decision decision = {.priority = 10, .tune_allowed = 1, .preempt_requested = 1};
+    assert(dsd_tg_policy_note_active_call(state, &active, &decision, 1.0) == 0);
+    decision.priority = 20;
+    assert(dsd_tg_policy_should_preempt(NULL, state, &candidate, &decision, 100.0));
     assert(dsd_scan_groups_suspend(state));
     expect_label(state, "Global");
     assert(dsd_tg_policy_make_exact_entry(123, "A", "New global", DSD_TG_POLICY_SOURCE_IMPORTED, &entry) == 0);
     assert(dsd_tg_policy_upsert_exact(state, &entry, DSD_TG_POLICY_UPSERT_REPLACE_FIRST) == 0);
     dsd_scan_groups_resume(state);
     expect_label(state, "Row edit");
+    assert(dsd_tg_policy_should_preempt(NULL, state, &candidate, &decision, 100.0));
+    /* A plain suspend/resume must also retain the same active route. */
+    assert(dsd_scan_groups_suspend(state));
+    dsd_scan_groups_resume(state);
+    assert(dsd_tg_policy_should_preempt(NULL, state, &candidate, &decision, 100.0));
     for (int i = 0; i < 10; i++) {
         dsd_scan_groups_enter(state, row);
     }
+    assert(!dsd_tg_policy_should_preempt(NULL, state, &candidate, &decision, 100.0));
     dsd_scan_groups_leave(state);
     expect_label(state, "New global");
     dsd_scan_profile_free(row);
@@ -400,8 +414,104 @@ test_relative_paths(void) {
     DSD_SECURE_ZERO(&options, sizeof(options));
 }
 
+static void
+test_move_unwinds_both_group_scopes(void) {
+    for (int suspended = 0; suspended < 2; suspended++) {
+        dsd_state* src = (dsd_state*)calloc(1, sizeof(*src));
+        dsd_state* dst = (dsd_state*)calloc(1, sizeof(*dst));
+        assert(src && dst);
+        dsd_tg_policy_entry entry;
+        assert(dsd_tg_policy_make_exact_entry(123, "A", "Source global", DSD_TG_POLICY_SOURCE_IMPORTED, &entry) == 0);
+        assert(dsd_tg_policy_append_exact(src, &entry) == 0);
+        assert(dsd_tg_policy_make_exact_entry(123, "A", "Destination global", DSD_TG_POLICY_SOURCE_IMPORTED, &entry)
+               == 0);
+        assert(dsd_tg_policy_append_exact(dst, &entry) == 0);
+        dsd_scan_row_profile* row = (dsd_scan_row_profile*)calloc(1, sizeof(*row));
+        assert(row);
+        row->values.present = DSD_SCAN_OPT_GROUP;
+        /* An empty row policy still owns a scope and must not carry its source baseline. */
+        assert(dsd_channel_profile_set(src, 0, row) == 0);
+        assert(dsd_scan_groups_begin(dst) == 0);
+        dsd_scan_groups_enter(src, row);
+        dsd_scan_groups_enter(dst, row);
+        if (suspended) {
+            assert(dsd_scan_groups_suspend(src));
+            assert(dsd_scan_groups_suspend(dst));
+        }
+        dsd_channel_modes_move(dst, src);
+        expect_label(src, "Source global");
+        expect_label(dst, "Destination global");
+        assert(dsd_channel_profile_get(src, 0) == NULL);
+        assert(dsd_channel_profile_get(dst, 0) == row);
+        assert(!dsd_scan_groups_suspend(dst));
+        dsd_scan_groups_enter(dst, row);
+        dsd_scan_groups_leave(dst);
+        expect_label(dst, "Destination global");
+        dsd_state_ext_free_all(src);
+        dsd_state_ext_free_all(dst);
+        free(src);
+        free(dst);
+    }
+}
+
+static void
+test_slotless_options_validate_files(void) {
+    char path[1024];
+    int fd = dsd_test_mkstemp(path, sizeof(path), "dsd_slotless_options");
+    assert(fd >= 0);
+    dsd_close(fd);
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    assert(state && opts);
+    DSD_SNPRINTF(opts->chan_in_file, sizeof(opts->chan_in_file), "%s", path);
+    const char* switches[] = {"-G", "-K", "-k"};
+    for (size_t i = 0; i < sizeof(switches) / sizeof(switches[0]); i++) {
+        char csv[2048];
+        DSD_SNPRINTF(csv, sizeof(csv),
+                     "channel,frequency_hz,mode,options\n"
+                     "invalid,150000000,dmr,%s '%s.missing'\n",
+                     switches[i], path);
+        write_file(path, csv);
+        assert(csvChanImport(opts, state) != 0);
+        assert(state->lcn_freq_count == 0);
+    }
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+    assert(remove(path) == 0);
+}
+
+/* The column parser supplies the width even for prefixed, spaced and all-zero keys. */
+static void
+test_legacy_hex_widths(void) {
+    const char* values[] = {" 0X00 0000 0000 ", "00000000000000000000000000000000",
+                            "0x00000000000000000000000000000000 00000000000000000000000000000001"};
+    const unsigned int widths[] = {10, 32, 64};
+    for (size_t i = 0; i < sizeof(widths) / sizeof(widths[0]); i++) {
+        dsd_scan_options options = {0};
+        dsd_key_set keys = {0};
+        char error[192];
+        assert(dsd_scan_options_merge_keys(&options, "", "", values[i], "", error, sizeof(error)) == 0);
+        assert(options.hytera_digits == widths[i]);
+        assert(dsd_scan_options_keys(&options, &keys) == 0);
+        assert(keys.present);
+        if (i > 0) {
+            assert(keys.scalars.aes_key_segments[0] == widths[i] / 16);
+        }
+        if (i == 2) {
+            assert(keys.scalars.K4 == 1 && keys.scalars.aes_key_loaded[0]);
+        }
+        dsd_key_set_free(&keys);
+        DSD_SECURE_ZERO(&options, sizeof(options));
+    }
+}
+
 int
 main(void) {
+    test_move_unwinds_both_group_scopes();
+    test_slotless_options_validate_files();
+    test_legacy_hex_widths();
     test_keys_and_scope();
     test_prepared_key_rollback();
     test_group_load_failure();

--- a/tests/core/test_core_scan_profile.c
+++ b/tests/core/test_core_scan_profile.c
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <assert.h>
+#include <dsd-neo/core/channel_mode.h>
+#include <dsd-neo/core/csv_import.h>
+#include <dsd-neo/core/key_set.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/scan_profile.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "test_support.h"
+
+void dsd_tg_policy_test_alloc_reset(void);
+void dsd_tg_policy_test_alloc_fail_after(long fail_after);
+
+static void
+write_file(const char* path, const char* contents) {
+    FILE* fp = dsd_fopen_private(path, "w");
+    assert(fp);
+    assert(fputs(contents, fp) >= 0);
+    assert(fclose(fp) == 0);
+}
+
+static void
+expect_label(const dsd_state* state, const char* label) {
+    char name[64];
+    assert(dsd_tg_policy_lookup_label(state, 123, NULL, 0, name, sizeof(name)));
+    assert(strcmp(name, label) == 0);
+}
+
+static void
+test_keys_and_scope(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts && state);
+    opts->frame_dstar = 1;
+    opts->wav_sample_rate = 48000;
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->scan_voice_hold_ms = 2000;
+    opts->aggressive_framesync = 1;
+    state->R = 999;
+    state->M = 1;
+
+    const struct {
+        const char* text;
+        uint64_t r;
+        uint64_t rr;
+        uint64_t k;
+        unsigned int mode;
+        int force;
+    } rows[] = {{"-1 0123456789 -0 -F --scan-voice-only --scan-voice-hold-ms 4000", 0x123456789ULL, 0x123456789ULL, 0,
+                 DSD_SCAN_MODE_DMR, 0x21},
+                {"-H 0000001f00 -4", 0, 0, 0, DSD_SCAN_MODE_DMR, 1},
+                {"-b 1 --no-force-key --strict-crc --no-scan-voice-only", 0, 0, 1, DSD_SCAN_MODE_DMR, 0},
+                {"-R 1 --no-force-key", 1, 0, 0, DSD_SCAN_MODE_NXDN48, 0}};
+
+    for (size_t i = 0; i < sizeof(rows) / sizeof(rows[0]); i++) {
+        dsd_scan_options parsed = {0};
+        char error[192];
+        dsd_key_set keys = {0};
+        dsd_scan_row_profile* profile = NULL;
+        assert(dsd_scan_options_parse(rows[i].text, rows[i].mode, 1, &parsed, error, sizeof(error)) == 0);
+        assert(dsd_scan_profile_load(&parsed, 0, &profile, &keys) == 0);
+        dsd_scan_key_change change = {0};
+        const uint64_t old_r = state->R;
+        assert(dsd_scan_key_change_prepare(state, &keys, &change) == 0);
+        assert(state->R == old_r);
+        assert(dsd_scan_mode_enter(opts, state, (dsd_scan_mode)rows[i].mode) == 0);
+        dsd_scan_mode_options(opts, state, &profile->values);
+        assert(dsd_scan_key_change_commit(state, &change));
+        assert(state->R == rows[i].r && state->RR == rows[i].rr && state->K == rows[i].k && state->M == rows[i].force);
+        assert(state->keyloader == 0);
+        if (i == 0) {
+            assert(opts->scan_voice_hold_ms == 4000 && opts->scan_voice_only == 1 && opts->dmr_crc_relaxed_default);
+        }
+        if (i == 1) {
+            assert(state->K1 == 0x1f00 && opts->scan_voice_hold_ms == 2000 && !opts->scan_voice_only);
+        }
+        if (i == 2) {
+            assert(opts->aggressive_framesync == 1 && !opts->dmr_crc_relaxed_default && opts->dmr_mute_encL == 0);
+        }
+        dsd_scan_profile_free(profile);
+        dsd_key_set_free(&keys);
+        DSD_SECURE_ZERO(&parsed, sizeof(parsed));
+    }
+    dsd_scan_key_change restore = {0};
+    assert(dsd_scan_key_change_prepare(state, NULL, &restore) == 0);
+    assert(dsd_scan_key_change_commit(state, &restore));
+    dsd_scan_mode_leave(opts, state);
+    assert(state->R == 999 && state->M == 1 && opts->frame_dstar && opts->scan_voice_hold_ms == 2000);
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+}
+
+static void
+test_group_ownership(void) {
+    char path[1024];
+    int fd = dsd_test_mkstemp(path, sizeof(path), "dsd_scan_groups");
+    assert(fd >= 0);
+    dsd_close(fd);
+    write_file(path, "id,mode,name\n123,B,Row group\n");
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    dsd_state* snapshot = (dsd_state*)calloc(1, sizeof(*snapshot));
+    assert(state && snapshot);
+    dsd_tg_policy_entry entry;
+    assert(dsd_tg_policy_make_exact_entry(123, "A", "Global", DSD_TG_POLICY_SOURCE_IMPORTED, &entry) == 0);
+    assert(dsd_tg_policy_append_exact(state, &entry) == 0);
+    dsd_scan_options parsed = {0};
+    parsed.values.present = DSD_SCAN_OPT_GROUP;
+    DSD_SNPRINTF(parsed.values.group_file, sizeof(parsed.values.group_file), "%s", path);
+    dsd_key_set keys = {0};
+    dsd_scan_row_profile* row = NULL;
+    assert(dsd_scan_profile_load(&parsed, 0, &row, &keys) == 0);
+    assert(remove(path) == 0); /* Entry must never reopen its file. */
+    assert(dsd_scan_groups_begin(state) == 0);
+    dsd_scan_groups_enter(state, row);
+    expect_label(state, "Row group");
+    assert(dsd_tg_policy_copy_snapshot(snapshot, state) == 0);
+    assert(dsd_tg_policy_make_exact_entry(123, "A", "Row edit", DSD_TG_POLICY_SOURCE_USER_LOCKOUT, &entry) == 0);
+    assert(dsd_tg_policy_upsert_exact(state, &entry, DSD_TG_POLICY_UPSERT_REPLACE_FIRST) == 0);
+    expect_label(snapshot, "Row group");
+    dsd_scan_groups_enter(state, NULL);
+    expect_label(state, "Global");
+    dsd_scan_groups_enter(state, row);
+    expect_label(state, "Row edit");
+    assert(dsd_scan_groups_suspend(state));
+    expect_label(state, "Global");
+    assert(dsd_tg_policy_make_exact_entry(123, "A", "New global", DSD_TG_POLICY_SOURCE_IMPORTED, &entry) == 0);
+    assert(dsd_tg_policy_upsert_exact(state, &entry, DSD_TG_POLICY_UPSERT_REPLACE_FIRST) == 0);
+    dsd_scan_groups_resume(state);
+    expect_label(state, "Row edit");
+    for (int i = 0; i < 10; i++) {
+        dsd_scan_groups_enter(state, row);
+    }
+    dsd_scan_groups_leave(state);
+    expect_label(state, "New global");
+    dsd_scan_profile_free(row);
+    dsd_key_set_free(&keys);
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    dsd_state_ext_free_all(snapshot);
+    free(state);
+    free(snapshot);
+}
+
+static void
+test_csv_import(void) {
+    char path[1024];
+    int fd = dsd_test_mkstemp(path, sizeof(path), "dsd_scan_map");
+    assert(fd >= 0);
+    dsd_close(fd);
+    write_file(path, "channel,frequency_hz,relevant_CLI_switches,mode,name\n"
+                     "1,150000000,-1 0123456789 -0 -F,dmr,RC4\n"
+                     "1,150000000,-R 1,nxdn48,NXDN\n"
+                     "2,0,-b 1,dmr,Placeholder\n");
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts && state);
+    DSD_SNPRINTF(opts->chan_in_file, sizeof(opts->chan_in_file), "%s", path);
+    assert(csvChanImport(opts, state) == 0);
+    assert(state->lcn_freq_count == 3);
+    assert(dsd_channel_mode_get(state, 0) == DSD_SCAN_MODE_DMR);
+    assert(dsd_channel_mode_get(state, 1) == DSD_SCAN_MODE_NXDN48);
+    assert(dsd_channel_profile_get(state, 0)->values.force == 0x21);
+    assert(dsd_state_trunk_lcn_keys_get(state, 0)->scalars.R == 0x123456789ULL);
+    assert(dsd_state_trunk_lcn_keys_get(state, 1)->scalars.R == 1);
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+    assert(remove(path) == 0);
+}
+
+static void
+test_prepared_key_rollback(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(state);
+    state->rkey_array[7] = 123;
+    state->rkey_array_loaded[7] = 1;
+    state->keyloader = 1;
+    state->R = 99;
+    dsd_key_set row = {0};
+    row.present = 1;
+    row.scalars.R = 1;
+    assert(dsd_scan_keys_enter(state, &row));
+    dsd_scan_key_change rollback = {0};
+    assert(dsd_scan_key_change_prepare(state, &row, &rollback) == 0);
+    dsd_scan_keys_leave(state);
+    assert(state->rkey_array[7] == 123 && state->R == 99);
+    row.scalars.R = 2;
+    assert(dsd_scan_keys_enter(state, &row));
+    (void)dsd_scan_key_change_commit(state, &rollback);
+    assert(state->R == 1 && state->keyloader == 0 && !state->rkey_array_loaded[7]);
+    dsd_scan_keys_leave(state);
+    assert(state->R == 99 && state->keyloader == 1 && state->rkey_array_loaded[7] && state->rkey_array[7] == 123);
+    dsd_key_set_free(&row);
+    free(state);
+}
+
+static void
+test_group_load_failure(void) {
+    char path[1024];
+    int fd = dsd_test_mkstemp(path, sizeof(path), "dsd_scan_group_fail");
+    assert(fd >= 0);
+    dsd_close(fd);
+    write_file(path, "id,mode,name\n123,A,Expected row\n");
+    dsd_tg_policy_store* original = NULL;
+    assert(dsd_tg_policy_load(path, &original) == 0);
+    for (long fail = 0; fail < 2; fail++) {
+        dsd_tg_policy_store* out = original;
+        dsd_tg_policy_test_alloc_fail_after(fail);
+        assert(dsd_tg_policy_load(path, &out) != 0);
+        assert(out == original);
+        dsd_tg_policy_test_alloc_reset();
+    }
+    dsd_tg_policy_release(original);
+    assert(remove(path) == 0);
+}
+
+static void
+test_source_conflicts(void) {
+    const struct {
+        const char* text;
+        const char* hex_file;
+        const char* dec_file;
+        const char* hex;
+        const char* dec;
+    } rows[] = {
+        {"-1 12345", "keys.csv", "", "", ""},        {"-R 1", "", "keys.csv", "", ""},
+        {"-K keys.csv", "keys.csv", "", "", ""},     {"-K keys.csv", "", "", "", "1"},
+        {"-k keys.csv", "", "", "0000000001", ""},   {"-b 1", "", "", "", "1"},
+        {"-H 0000000001", "", "", "0000000001", ""},
+    };
+
+    for (size_t i = 0; i < sizeof(rows) / sizeof(rows[0]); i++) {
+        dsd_scan_options options = {0};
+        char error[192];
+        const unsigned mode = i == 1 ? DSD_SCAN_MODE_NXDN48 : DSD_SCAN_MODE_DMR;
+        assert(dsd_scan_options_parse(rows[i].text, mode, 1, &options, error, sizeof(error)) == 0);
+        assert(dsd_scan_options_merge_keys(&options, rows[i].hex_file, rows[i].dec_file, rows[i].hex, rows[i].dec,
+                                           error, sizeof(error))
+               != 0);
+        DSD_SECURE_ZERO(&options, sizeof(options));
+    }
+}
+
+static void
+test_relative_paths(void) {
+    dsd_scan_options options = {0};
+    char error[192];
+    assert(dsd_scan_options_parse("-G 'group list.csv' -K 'hex keys.csv' -k decimal.csv", DSD_SCAN_MODE_DMR, 1,
+                                  &options, error, sizeof(error))
+           == 0);
+    assert(dsd_scan_options_resolve(&options, "lists/channels.csv", error, sizeof(error)) == 0);
+    assert(strcmp(options.values.group_file, "lists/group list.csv") == 0);
+    assert(strcmp(options.hex_file, "lists/hex keys.csv") == 0);
+    assert(strcmp(options.dec_file, "lists/decimal.csv") == 0);
+    DSD_SECURE_ZERO(&options, sizeof(options));
+}
+
+int
+main(void) {
+    test_keys_and_scope();
+    test_prepared_key_rollback();
+    test_group_load_failure();
+    test_source_conflicts();
+    test_relative_paths();
+    test_group_ownership();
+    test_csv_import();
+    return 0;
+}

--- a/tests/engine/test_engine_channel_scan.c
+++ b/tests/engine/test_engine_channel_scan.c
@@ -29,6 +29,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+void dsd_key_set_test_alloc_fail_after(long count);
+
 static dsd_trunk_tune_result tune_result;
 static uint64_t request;
 static int tunes;
@@ -218,9 +220,34 @@ test_option_only_rows_and_policy_edits(void) {
     dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
     assert(dsd_engine_channel_scan_pending(opts, state) == 1);
     assert(tunes == before_key_edit && state->R == 0);
-    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    /* The receiver moved, but its outgoing profile must remain gated if restaging
+     * runs out of memory. Repeated sync service passes cannot bypass that gate. */
+    dsd_key_set_test_alloc_fail_after(0);
+    for (int i = 0; i < 3; i++) {
+        assert(dsd_engine_channel_scan_pending(opts, state) == 1);
+        state->synctype = DSD_SYNC_DMR_BS_VOICE_POS;
+        assert(dsd_engine_channel_scan_service_sync(opts, state) == 0);
+        assert(state->synctype == DSD_SYNC_NONE);
+        assert(dsd_engine_channel_scan_waiting(state));
+        assert(tunes == before_key_edit && state->R == 0);
+    }
+    dsd_key_set_test_alloc_fail_after(-1);
+    /* A deferred or rejected retry can retire its tune-ledger gate, but the
+     * receiver is still on an uncommitted row. Keep decoding closed and allow
+     * ordinary scanning to recover instead of trapping it on the failed row. */
+    tune_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
     assert(dsd_engine_channel_scan_pending(opts, state) == 0);
-    assert(tunes == before_key_edit + 1 && state->R == 0x55 && state->scan_keys_active_set);
+    assert(!dsd_engine_channel_scan_waiting(state));
+    assert(dsd_trunk_tuning_frame_is_dispatchable(dsd_trunk_tuning_generation(), 1));
+    assert(!dsd_engine_channel_scan_service_sync(opts, state));
+    tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    assert(dsd_engine_channel_scan_step(opts, state) == -1);
+    assert(!dsd_engine_channel_scan_waiting(state));
+    assert(!dsd_engine_channel_scan_service_sync(opts, state));
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    assert(dsd_engine_channel_scan_step(opts, state) == 1);
+    assert(dsd_engine_channel_scan_service_sync(opts, state) == 1);
+    assert(tunes == before_key_edit + 3 && state->R == 0x55 && state->scan_keys_active_set);
     assert(state->rkey_array[3] == 0 && !state->rkey_array_loaded[3]);
     dsd_engine_channel_scan_leave(opts, state);
     dsd_scan_keys_leave(state);

--- a/tests/engine/test_engine_channel_scan.c
+++ b/tests/engine/test_engine_channel_scan.c
@@ -6,8 +6,10 @@
 #include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/csv_validate.h>
+#include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/scan_profile.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/state_fwd.h>
@@ -21,6 +23,7 @@
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -96,8 +99,60 @@ dsd_scan_voice_gate_note_retune(dsd_state* state, double now) {
     state->last_cc_sync_time_m = now;
 }
 
+static void
+test_option_commit_boundary(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts && state);
+    opts->scanner_mode = 1;
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 48000;
+    opts->frame_dstar = 1;
+    opts->aggressive_framesync = 1;
+    opts->scan_voice_hold_ms = 2000;
+    state->samplesPerSymbol = 10;
+    state->R = 999;
+    state->lcn_freq_count = 2;
+    *dsd_state_trunk_lcn_slot(state, 0) = *dsd_state_trunk_lcn_slot(state, 1) = 150000000;
+    assert(dsd_channel_mode_set(state, 0, DSD_SCAN_MODE_DMR) == 0);
+    dsd_scan_row_profile* profile = (dsd_scan_row_profile*)calloc(1, sizeof(*profile));
+    assert(profile);
+    profile->values.present = DSD_SCAN_OPT_FORCE | DSD_SCAN_OPT_CRC | DSD_SCAN_OPT_HOLD;
+    profile->values.force = 0x21;
+    profile->values.hold_ms = 4000;
+    assert(dsd_channel_profile_set(state, 0, profile) == 0);
+    dsd_key_set keys = {0};
+    keys.present = 1;
+    keys.scalars.R = keys.scalars.RR = 0x123456789ULL;
+    assert(dsd_state_trunk_lcn_keys_set(state, 0, &keys) == 0);
+    expected_nxdn = 0;
+    tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    assert(dsd_engine_channel_scan_step(opts, state) == 0);
+    assert(state->R == 999 && state->M == 0 && opts->scan_voice_hold_ms == 2000);
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_FAILED);
+    assert(!dsd_engine_channel_scan_pending(opts, state));
+    assert(state->R == 999 && state->M == 0 && opts->aggressive_framesync == 1);
+    state->lcn_freq_roll = 0;
+    assert(dsd_engine_channel_scan_step(opts, state) == 0);
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(!dsd_engine_channel_scan_pending(opts, state));
+    assert(state->R == 0x123456789ULL && state->RR == state->R && state->M == 0x21);
+    assert(opts->scan_voice_hold_ms == 4000 && !opts->aggressive_framesync && opts->dmr_crc_relaxed_default);
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    assert(dsd_engine_channel_scan_step_manual(opts, state) == 1);
+    assert(state->R == 999 && state->M == 0 && opts->scan_voice_hold_ms == 2000 && opts->aggressive_framesync == 1);
+    dsd_engine_channel_scan_leave(opts, state);
+    dsd_scan_keys_leave(state);
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+    tunes = reset_count = 0;
+}
+
 int
 main(void) {
+    test_option_commit_boundary();
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
     assert(opts && state);

--- a/tests/engine/test_engine_channel_scan.c
+++ b/tests/engine/test_engine_channel_scan.c
@@ -6,6 +6,7 @@
 #include <dsd-neo/core/channel_mode.h>
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/csv_validate.h>
+#include <dsd-neo/core/enc_lockout.h>
 #include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
@@ -150,9 +151,92 @@ test_option_commit_boundary(void) {
     tunes = reset_count = 0;
 }
 
+/* Rows that carry options but declare no mode still belong to the typed scanner: the legacy
+ * scanner applies keys but never row options. Edits to the row-scoped policy (mutes, voice
+ * gate) beneath a staged tune take effect without restaging it, whereas a keyring change
+ * during the tune window restages so the commit re-prepares against the current globals. */
+static void
+test_option_only_rows_and_policy_edits(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts && state);
+    opts->scanner_mode = 1;
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 48000;
+    opts->frame_dstar = 1;
+    opts->dmr_mute_encL = opts->dmr_mute_encR = 1;
+    opts->scan_voice_hold_ms = 2000;
+    opts->scan_voice_qualify_ms = 1000;
+    state->samplesPerSymbol = 10;
+    state->lcn_freq_count = 1;
+    *dsd_state_trunk_lcn_slot(state, 0) = 150000000;
+    assert(!dsd_channel_modes_present(state));
+    dsd_scan_row_profile* profile = (dsd_scan_row_profile*)calloc(1, sizeof(*profile));
+    assert(profile);
+    profile->values.present = DSD_SCAN_OPT_HOLD | DSD_SCAN_OPT_MUTE_DMR;
+    profile->values.hold_ms = 4000;
+    profile->values.mute_dmr = 0;
+    assert(dsd_channel_profile_set(state, 0, profile) == 0);
+    assert(dsd_channel_modes_present(state) && dsd_channel_mode_get(state, 0) == DSD_SCAN_MODE_INHERIT);
+
+    expected_nxdn = 0;
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    assert(dsd_engine_channel_scan_step(opts, state) == 1);
+    assert(opts->scan_voice_hold_ms == 4000 && opts->dmr_mute_encL == 0 && opts->dmr_mute_encR == 0);
+    assert(opts->frame_dstar == 1);
+
+    /* A policy edit during an outstanding request: the commit proceeds without a retry. */
+    state->lcn_freq_roll = 0;
+    tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    assert(dsd_engine_channel_scan_step(opts, state) == 0);
+    assert(dsd_scan_mode_suspend(opts, state));
+    assert(opts->scan_voice_hold_ms == 2000 && opts->dmr_mute_encL == 1);
+    opts->scan_voice_qualify_ms = 1500;
+    opts->unmute_encrypted_p25 = 1;
+    assert(dsd_scan_mode_resume(opts, state) == 0);
+    assert(opts->scan_voice_hold_ms == 4000 && opts->dmr_mute_encL == 0 && opts->scan_voice_qualify_ms == 1500);
+    const int before_policy_edit = tunes;
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_engine_channel_scan_pending(opts, state) == 0);
+    assert(tunes == before_policy_edit && opts->scan_voice_qualify_ms == 1500 && opts->unmute_encrypted_p25 == 1);
+
+    /* A keyring change during an outstanding request restages, and the eventual leave hands
+     * back the globals as edited rather than the copy prepared before the edit. */
+    dsd_key_set keys = {0};
+    keys.present = 1;
+    keys.scalars.R = keys.scalars.RR = 0x55;
+    assert(dsd_state_trunk_lcn_keys_set(state, 0, &keys) == 0);
+    state->lcn_freq_roll = 0;
+    tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    assert(dsd_engine_channel_scan_step(opts, state) == 0);
+    dsd_scan_keys_suspend(state);
+    state->rkey_array[3] = 777;
+    state->rkey_array_loaded[3] = 1;
+    dsd_scan_keys_resume(state);
+    dsd_enc_lockout_bump_key_epoch(state);
+    const int before_key_edit = tunes;
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
+    assert(dsd_engine_channel_scan_pending(opts, state) == 1);
+    assert(tunes == before_key_edit && state->R == 0);
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    assert(dsd_engine_channel_scan_pending(opts, state) == 0);
+    assert(tunes == before_key_edit + 1 && state->R == 0x55 && state->scan_keys_active_set);
+    assert(state->rkey_array[3] == 0 && !state->rkey_array_loaded[3]);
+    dsd_engine_channel_scan_leave(opts, state);
+    dsd_scan_keys_leave(state);
+    assert(state->R == 0 && state->rkey_array[3] == 777 && state->rkey_array_loaded[3]);
+    assert(opts->scan_voice_hold_ms == 2000 && opts->dmr_mute_encL == 1 && opts->scan_voice_qualify_ms == 1500);
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+    tunes = reset_count = 0;
+}
+
 int
 main(void) {
     test_option_commit_boundary();
+    test_option_only_rows_and_policy_edits();
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
     assert(opts && state);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -6931,6 +6931,122 @@ run_with_default_tune_hook(int (*test_fn)(void)) {
     return rc;
 }
 
+void dsd_key_set_test_alloc_fail_after(long count);
+
+static int
+test_initial_key_allocation_failure(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char path[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof(dir))) {
+        return 1;
+    }
+    if (write_targets_file_with_header(dir, "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,options\n",
+                                       "a,dmr-conventional,461000000,,250,,,-b 1 -4\n", path, sizeof(path))) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        cleanup_paths(dir, path, NULL);
+        return 1;
+    }
+    reset_scan_opts_state(opts, state);
+    state->R = 99;
+    state->rkey_array_loaded[7] = 1;
+    state->rkey_array[7] = 123;
+    DSD_SNPRINTF(opts->trunk_scan_targets_csv, sizeof(opts->trunk_scan_targets_csv), "%s", path);
+    dsd_key_set_test_alloc_fail_after(0);
+    char error[256];
+    int rc = dsd_engine_trunk_scan_init(opts, state, error, sizeof(error)) == 0;
+    dsd_key_set_test_alloc_fail_after(-1);
+    rc |= dsd_engine_trunk_scan_active_index(state) != (size_t)-1;
+    rc |= state->R != 99 || state->rkey_array[7] != 123 || !state->rkey_array_loaded[7];
+    rc |= state->scan_keys_active_set || state->M != 0;
+    if (rc) {
+        DSD_FPRINTF(stderr, "initial key allocation failure did not preserve the baseline and reject startup\n");
+    }
+    dsd_engine_trunk_scan_shutdown(opts, state);
+    dsd_state_ext_free_all(state);
+    dsd_state_trunk_lcn_free(state);
+    free(state);
+    free(opts);
+    cleanup_paths(dir, path, NULL);
+    return rc;
+}
+
+static int
+test_target_options_rotate_and_restore(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char path[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof(dir))) {
+        return 1;
+    }
+    const char* header = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,OPTIONS\n";
+    if (write_targets_file_with_header(
+            dir, header,
+            "a,dmr-conventional,461000000,,250,,rc4,-1 0123456789 -0 -F --scan-voice-hold-ms 4000\n"
+            "b,dmr-conventional,461000001,,250,,hytera,-H 0000001f00 -4\n"
+            "c,dmr-conventional,461000002,,250,,mixed,-b 1 --no-force-key --strict-crc\n"
+            "d,nxdn48-conventional,461000003,,250,,scrambler,-R 1 --no-force-key\n",
+            path, sizeof(path))) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        cleanup_paths(dir, path, NULL);
+        return 1;
+    }
+    reset_scan_opts_state(opts, state);
+    state->R = 999;
+    state->M = 1;
+    opts->aggressive_framesync = 1;
+    opts->scan_voice_hold_ms = 2000;
+    DSD_SNPRINTF(opts->trunk_scan_targets_csv, sizeof(opts->trunk_scan_targets_csv), "%s", path);
+    char error[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(opts, state, error, sizeof(error));
+    int failed = rc != 0;
+    if (rc == 0) {
+        failed |= state->R != 0x123456789ULL || state->RR != state->R || state->M != 0x21
+                  || opts->aggressive_framesync != 0 || opts->scan_voice_hold_ms != 4000;
+        trunk_scan_test_set_now(0.26);
+        dsd_engine_trunk_scan_tick(opts, state);
+        failed |= state->R != 0 || state->K1 != 0x1f00 || state->M != 1 || opts->scan_voice_hold_ms != 2000;
+        trunk_scan_test_set_now(0.52);
+        dsd_engine_trunk_scan_tick(opts, state);
+        failed |= state->K != 1 || state->K1 != 0 || state->M != 0 || !opts->aggressive_framesync;
+        trunk_scan_test_set_now(0.78);
+        dsd_engine_trunk_scan_tick(opts, state);
+        failed |= state->R != 1 || state->RR != 0 || state->K != 0 || state->M != 0 || !opts->frame_nxdn48;
+        dsd_engine_trunk_scan_shutdown(opts, state);
+        failed |= state->R != 999 || state->M != 1 || opts->scan_voice_hold_ms != 2000;
+    }
+    if (failed) {
+        DSD_FPRINTF(stderr, "target options regression: %s\n", error);
+    }
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, path, NULL);
+    failed |= expect_parser_rejects_with_header("options-conflict", header, "a,dmr-conventional,461000000,,,,,-4 -0\n");
+    failed |= expect_parser_rejects_with_header("options-trunk-voice", header,
+                                                "a,p25-trunk,851000000,,,,,--scan-voice-only\n");
+    failed |= expect_parser_rejects_with_header(
+        "options-duplicate-header",
+        "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,options,relevant_CLI_switches\n",
+        "a,dmr-conventional,461000000,,,,,-b 1,-F\n");
+    return failed;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -6950,6 +7066,8 @@ main(void) {
     rc |= run_with_default_tune_hook(test_coordinator_preserves_long_lcn_list_across_rotation);
     rc |= run_with_default_tune_hook(test_target_keys_install_and_restore_across_switches);
     rc |= run_with_default_tune_hook(test_direct_target_keys_install_and_restore_across_switches);
+    rc |= run_with_default_tune_hook(test_initial_key_allocation_failure);
+    rc |= run_with_default_tune_hook(test_target_options_rotate_and_restore);
     rc |= run_with_default_tune_hook(test_target_chan_csv_keys_are_discarded);
     rc |= run_with_default_tune_hook(test_target_keys_survive_failed_alternate_retune);
     rc |= run_with_default_tune_hook(test_coordinator_preserves_large_chan_map_across_rotation);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -7047,6 +7047,217 @@ test_target_options_rotate_and_restore(void) {
     return failed;
 }
 
+/* A target whose key copies cannot be allocated is not an attempt: the receiver never left
+ * the outgoing target, so its snapshot is still owed to the next switch that really happens.
+ * Here B's prepare fails while advancing from A, C is reached instead, and A's learned state
+ * must come back when the rotation returns to it. */
+static int
+test_prepare_failure_keeps_outgoing_snapshot(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char hex_path[DSD_TEST_PATH_MAX];
+    if (dsd_test_path_join(hex_path, sizeof hex_path, dir, "hexkeys.csv") != 0
+        || write_text_file(hex_path, "key id(hex),key value (hex)\n0010,AAAAAAAAAAAAAAAA\n") != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,keys_hex_csv\n";
+    if (write_targets_file_with_header(dir, header,
+                                       "a,p25-trunk,851000000,,250,,plain,\n"
+                                       "b,p25-trunk,852000000,,250,,keyed,hexkeys.csv\n"
+                                       "c,p25-trunk,853000000,,250,,plain,\n",
+                                       target_path, sizeof target_path)
+        != 0) {
+        (void)remove(hex_path);
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0
+        || dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "prepare-failure scan init failed: %s\n", err);
+        test_rc = 1;
+    }
+    state.p25_iden_fdma[1].base_freq = 12345;
+    dsd_state_set_trunk_chan_freq(&state, 99U, 851012500);
+
+    dsd_key_set_test_alloc_fail_after(0);
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    dsd_key_set_test_alloc_fail_after(-1);
+    if (dsd_engine_trunk_scan_active_index(&state) != 2) {
+        DSD_FPRINTF(stderr, "keyed target with failed key allocation was not skipped (active=%zu)\n",
+                    dsd_engine_trunk_scan_active_index(&state));
+        test_rc = 1;
+    }
+    if (state.p25_iden_fdma[1].base_freq == 12345 || state.scan_keys_active_set) {
+        DSD_FPRINTF(stderr, "reached target carried the outgoing target's state or keys\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "scan did not rotate back to the first target (active=%zu)\n",
+                    dsd_engine_trunk_scan_active_index(&state));
+        test_rc = 1;
+    }
+    if (state.p25_iden_fdma[1].base_freq != 12345 || state.trunk_chan_map[99] != 851012500) {
+        DSD_FPRINTF(stderr, "outgoing snapshot was lost across a prepare failure (base=%ld chan=%ld)\n",
+                    state.p25_iden_fdma[1].base_freq, state.trunk_chan_map[99]);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    (void)remove(hex_path);
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* Per-target voice-gate intervals: with the gate on, a conventional target's own
+ * --scan-voice-hold-ms replaces activity_hold_ms as the hold after the last voice frame,
+ * and --scan-voice-qualify-ms replaces dwell_ms as the window in which voice must appear.
+ * Targets without them keep the column values. */
+static int
+run_target_voice_option_case(const char* name, const char* options, double media_hold_until, double expect_rotate_by) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,options\n";
+    char body[512];
+    DSD_SNPRINTF(body, sizeof body,
+                 "a,dmr-conventional,461000000,,250,250,,%s\n"
+                 "b,dmr-conventional,462000000,,250,250,,\n",
+                 options);
+    if (write_targets_file_with_header(dir, header, body, target_path, sizeof target_path) != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.scan_voice_only = 1;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "%s: scan init failed: %s\n", name, err);
+        test_rc = 1;
+    }
+    if (media_hold_until > 0.0) {
+        if (seed_voice_gate_media_epoch(&state, 0.10, 0.25, DSD_CALL_CRYPTO_CLEAR) != 0
+            || dsd_call_state_end_ex(&state, 0U, 0.26, DSD_CALL_END_SYNC_LOSS) != 1) {
+            test_rc = 1;
+        }
+    }
+    /* Walk the clock; the target must still be parked right up to the expected hold or
+     * qualify boundary and gone one dwell after it. */
+    for (int step = 3; step * 0.10 < expect_rotate_by - 0.05; step++) {
+        const double now = step / 10.0;
+        trunk_scan_test_set_now(now);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+            DSD_FPRINTF(stderr, "%s: target rotated early at %.2f\n", name, now);
+            test_rc = 1;
+            break;
+        }
+        if (media_hold_until > 0.0 && now < media_hold_until
+            && state.scan_voice_gate_phase != (uint8_t)DSD_SCAN_VOICE_GATE_TAIL) {
+            DSD_FPRINTF(stderr, "%s: hold not honoured at %.2f (phase %u)\n", name, now,
+                        (unsigned)state.scan_voice_gate_phase);
+            test_rc = 1;
+            break;
+        }
+    }
+    trunk_scan_test_set_now(expect_rotate_by);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1) {
+        DSD_FPRINTF(stderr, "%s: target did not rotate by %.2f\n", name, expect_rotate_by);
+        test_rc = 1;
+    }
+    /* The plain target keeps its 250 ms column dwell. */
+    trunk_scan_test_set_now(expect_rotate_by + 0.30);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0) {
+        DSD_FPRINTF(stderr, "%s: plain target did not keep its column dwell\n", name);
+        test_rc = 1;
+    }
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_state_ext_free_all(&state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_target_voice_gate_options_apply(void) {
+    int rc = 0;
+    /* Media at 0.25 with the column hold would lapse at 0.50 and rotate by ~0.80; the row's
+     * 1000 ms hold keeps the target until 1.25 and rotates one dwell later. */
+    rc |= run_target_voice_option_case("row-hold", "--scan-voice-hold-ms 1000", 1.25, 1.60);
+    rc |= run_target_voice_option_case("column-hold", "", 0.50, 0.80);
+    /* No media at all: the column dwell would rotate at 0.25; the row's 1000 ms qualify window
+     * keeps the target until 1.0. */
+    rc |= run_target_voice_option_case("row-qualify", "--scan-voice-qualify-ms 1000", 0.0, 1.05);
+    return rc;
+}
+
+/* Optional target-list headers match ASCII case-insensitively, as channel-map headers do,
+ * and a duplicate is still a duplicate whatever its case. */
+static int
+test_parser_optional_headers_are_case_insensitive(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    char target_path[DSD_TEST_PATH_MAX];
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,RTL_Gain,Modulation\n";
+    if (write_targets_file_with_header(dir, header, "p25,p25-trunk,851000000,,250,,primary,27,cqpsk\n", target_path,
+                                       sizeof target_path)
+        != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    static dsd_opts opts;
+    DSD_MEMSET(&opts, 0, sizeof opts);
+    opts.trunk_scan_idle_dwell_ms = 3000;
+    opts.trunk_scan_activity_hold_ms = 1200;
+    dsd_trunk_scan_target_list list;
+    DSD_MEMSET(&list, 0, sizeof list);
+    char err[256] = {0};
+    int test_rc = 0;
+    if (dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err) != 0 || list.count != 1
+        || list.targets[0].modulation != DSD_TRUNK_SCAN_MODULATION_CQPSK || list.targets[0].rtl_gain_is_set != 1
+        || list.targets[0].rtl_gain_db != 27) {
+        DSD_FPRINTF(stderr, "mixed-case optional headers were not matched: %s\n", err);
+        test_rc = 1;
+    }
+    dsd_trunk_scan_target_list_reset(&list);
+    cleanup_paths(dir, target_path, NULL);
+    test_rc |= expect_parser_rejects_with_header(
+        "duplicate-header-case",
+        "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,MODULATION\n",
+        "p25,p25-trunk,851000000,,250,,primary,cqpsk,cqpsk\n");
+    return test_rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -7068,6 +7279,9 @@ main(void) {
     rc |= run_with_default_tune_hook(test_direct_target_keys_install_and_restore_across_switches);
     rc |= run_with_default_tune_hook(test_initial_key_allocation_failure);
     rc |= run_with_default_tune_hook(test_target_options_rotate_and_restore);
+    rc |= run_with_default_tune_hook(test_prepare_failure_keeps_outgoing_snapshot);
+    rc |= run_with_default_tune_hook(test_target_voice_gate_options_apply);
+    rc |= run_with_default_tune_hook(test_parser_optional_headers_are_case_insensitive);
     rc |= run_with_default_tune_hook(test_target_chan_csv_keys_are_discarded);
     rc |= run_with_default_tune_hook(test_target_keys_survive_failed_alternate_retune);
     rc |= run_with_default_tune_hook(test_coordinator_preserves_large_chan_map_across_rotation);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -6933,6 +6933,86 @@ run_with_default_tune_hook(int (*test_fn)(void)) {
 
 void dsd_key_set_test_alloc_fail_after(long count);
 
+/* Allocation failures re-arm dwell/retry timers. Recovering memory on the next tick
+ * must not cause an immediate retune, but the next scheduled attempt must succeed. */
+static int
+run_prepare_failure_timer_case(int retry) {
+    char dir[DSD_TEST_PATH_MAX];
+    char path[DSD_TEST_PATH_MAX];
+    char keys[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof(dir))) {
+        return 1;
+    }
+    if (dsd_test_path_join(keys, sizeof(keys), dir, "keys.csv")
+        || write_text_file(keys, "key id(hex),key value (hex)\n0010,AAAAAAAAAAAAAAAA\n")) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    const char* rows = retry ? "a,p25-trunk,851000000,,250,,,-K keys.csv\n"
+                             : "a,p25-trunk,851000000,,250,,,-K keys.csv\n"
+                               "b,p25-trunk,852000000,,250,,,\n";
+    if (write_targets_file_with_header(dir, "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,options\n",
+                                       rows, path, sizeof(path))) {
+        (void)remove(keys);
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        (void)remove(keys);
+        cleanup_paths(dir, path, NULL);
+        return 1;
+    }
+    reset_scan_opts_state(opts, state);
+    DSD_SNPRINTF(opts->trunk_scan_targets_csv, sizeof(opts->trunk_scan_targets_csv), "%s", path);
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_cc_request = counting_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_failures_remaining = retry;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    trunk_scan_test_set_now(0.0);
+    char error[256];
+    int failed = dsd_engine_trunk_scan_init(opts, state, error, sizeof(error)) != 0;
+    failed |= g_counting_tune_to_cc_calls != 1;
+    dsd_key_set_test_alloc_fail_after(0);
+    const double failure_time = retry ? 2.01 : 0.26;
+    trunk_scan_test_set_now(failure_time);
+    dsd_engine_trunk_scan_tick(opts, state);
+    dsd_key_set_test_alloc_fail_after(-1);
+    failed |= g_counting_tune_to_cc_calls != 1;
+    trunk_scan_test_set_now(failure_time + 0.01);
+    dsd_engine_trunk_scan_tick(opts, state);
+    failed |= g_counting_tune_to_cc_calls != 1;
+    failed |= dsd_engine_trunk_scan_active_index(state) != 0;
+    trunk_scan_test_set_now(retry ? 4.02 : 0.52);
+    dsd_engine_trunk_scan_tick(opts, state);
+    failed |= g_counting_tune_to_cc_calls != 2;
+    failed |= dsd_engine_trunk_scan_active_index(state) != (retry ? 0U : 1U);
+    if (failed) {
+        DSD_FPRINTF(stderr, "prepare failure did not re-arm %s timer\n", retry ? "retry" : "dwell");
+    }
+    dsd_engine_trunk_scan_shutdown(opts, state);
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+    trunk_scan_test_clear_now();
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    (void)remove(keys);
+    cleanup_paths(dir, path, NULL);
+    return failed;
+}
+
+static int
+test_prepare_failure_timers(void) {
+    int rc = run_prepare_failure_timer_case(0);
+    return rc | run_prepare_failure_timer_case(1);
+}
+
 static int
 test_initial_key_allocation_failure(void) {
     char dir[DSD_TEST_PATH_MAX];
@@ -7277,6 +7357,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_coordinator_preserves_long_lcn_list_across_rotation);
     rc |= run_with_default_tune_hook(test_target_keys_install_and_restore_across_switches);
     rc |= run_with_default_tune_hook(test_direct_target_keys_install_and_restore_across_switches);
+    rc |= run_with_default_tune_hook(test_prepare_failure_timers);
     rc |= run_with_default_tune_hook(test_initial_key_allocation_failure);
     rc |= run_with_default_tune_hook(test_target_options_rotate_and_restore);
     rc |= run_with_default_tune_hook(test_prepare_failure_keeps_outgoing_snapshot);

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -76,6 +76,7 @@ target_sources(
         ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
         # A channel-map row's key cells load through the key-set helpers.
         ${PROJECT_SOURCE_DIR}/src/core/util/key_set.c
+        ${PROJECT_SOURCE_DIR}/src/core/util/scan_profile.c
         ${PROJECT_SOURCE_DIR}/src/core/util/talkgroup_policy.c
         # csvDmrTgKeyImport() clears the live map through keyring_dmr_tg_map_reset().
         ${PROJECT_SOURCE_DIR}/src/core/vocoder/keyring.c

--- a/tests/fuzz/corpus/core_csv_import/scan_options.csv
+++ b/tests/fuzz/corpus/core_csv_import/scan_options.csv
@@ -1,0 +1,3 @@
+channel,frequency_hz,mode,options
+1,150000000,dmr,-1 0123456789 -0 -F
+2,150000001,nxdn48,-R 1

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -7573,9 +7573,72 @@ test_bootstrap_cli_rate_override_uses_cli_rate_for_headerless_open(void) {
     return test_rc;
 }
 
+static int
+test_force_conflicts_and_explicit_off_options(void) {
+    const struct {
+        const char* first;
+        const char* second;
+        int expected;
+    } cases[] = {{"-4", "-0", 0x21},
+                 {"-0", "-4", 1},
+                 {"-4", "--no-force-key", 0},
+                 {"--dmr-force-algid=21", "--dmr-force-algid=24", 0x24},
+                 {"--dmr-force-algid=24", "-0", 0x21},
+                 {"-0", "--dmr-force-algid=24", 0x21}};
+
+    int failed = 0;
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+        dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+        if (!opts || !state) {
+            free(opts);
+            free(state);
+            return 1;
+        }
+        initOpts(opts);
+        initState(state);
+        char first[32], second[32];
+        DSD_SNPRINTF(first, sizeof(first), "%s", cases[i].first);
+        DSD_SNPRINTF(second, sizeof(second), "%s", cases[i].second);
+        char program[] = "dsd-neo";
+        char* argv[] = {program, first, second, NULL};
+        int argc_effective, exit_rc;
+        char output[4096];
+        int rc = parse_args_capture_stderr(3, argv, opts, state, &argc_effective, &exit_rc, output, sizeof(output));
+        const char* warning = strstr(output, "Conflicting force options");
+        failed |= rc != DSD_PARSE_CONTINUE || state->M != cases[i].expected || !warning;
+        if (warning) {
+            failed |= strstr(warning + 1, "Conflicting force options") != NULL;
+        }
+        freeState(state);
+        free(state);
+        free(opts);
+    }
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        return 1;
+    }
+    initOpts(opts);
+    initState(state);
+    char a0[] = "dsd-neo", a1[] = "-F", a2[] = "--strict-crc", a3[] = "--scan-voice-only",
+         a4[] = "--no-scan-voice-only";
+    char* argv[] = {a0, a1, a2, a3, a4, NULL};
+    int effective, exit_rc;
+    failed |= dsd_parse_args(5, argv, opts, state, &effective, &exit_rc) != DSD_PARSE_CONTINUE;
+    failed |= opts->aggressive_framesync != 1 || opts->dmr_crc_relaxed_default != 0 || opts->scan_voice_only != 0;
+    freeState(state);
+    free(state);
+    free(opts);
+    return failed;
+}
+
 int
 main(void) {
     int rc = 0;
+    rc |= test_force_conflicts_and_explicit_off_options();
     rc |= test_help_returns_one_shot_and_does_not_exit();
     rc |= test_invalid_option_returns_error_and_does_not_exit();
     rc |= test_unknown_option_returns_error_and_does_not_exit();

--- a/tests/runtime/test_runtime_scan_mode.c
+++ b/tests/runtime/test_runtime_scan_mode.c
@@ -4,6 +4,7 @@
 #include <assert.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/state_fwd.h>
@@ -11,6 +12,7 @@
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -46,8 +48,74 @@ test_p25_modulation_helpers(dsd_opts* opts, dsd_state* state) {
     assert(opts->mod_p25p2_c4fm && opts->mod_cli_lock);
 }
 
+/* Row-scoped options are policy, not acquisition. An operator edit to any of them beneath
+ * a parked row must take effect without tearing the row down, and the equality that gates
+ * restaging a tune must ignore them. */
+static void
+test_row_option_edits_are_not_acquisition_changes(void) {
+    dsd_opts* o = (dsd_opts*)calloc(1, sizeof(*o));
+    dsd_state* s = (dsd_state*)calloc(1, sizeof(*s));
+    assert(o && s);
+    o->wav_sample_rate = 48000;
+    o->audio_in_type = AUDIO_IN_WAV;
+    o->frame_dmr = 1;
+    o->dmr_mute_encL = o->dmr_mute_encR = 1;
+    o->aggressive_framesync = 1;
+    o->scan_voice_hold_ms = 2000;
+    DSD_SNPRINTF(o->group_in_file, sizeof(o->group_in_file), "%s", "global.csv");
+    s->M = 0;
+    const dsd_scan_option_values none = {0};
+    assert(dsd_scan_mode_options(o, s, &none) == -1); /* no scope yet: nothing to apply */
+    assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_DMR) == 0);
+    assert(dsd_scan_mode_options(o, s, NULL) == 0);
+    dsd_scan_settings before;
+    dsd_scan_settings_capture(o, s, &before);
+
+    assert(dsd_scan_mode_suspend(o, s));
+    o->dmr_mute_encL = o->dmr_mute_encR = 0;
+    o->aggressive_framesync = 0;
+    o->dmr_crc_relaxed_default = 1;
+    o->scan_voice_only = 1;
+    o->scan_voice_hold_ms = 4000;
+    o->unmute_encrypted_p25 = 1;
+    s->M = 1;
+    DSD_SNPRINTF(o->group_in_file, sizeof(o->group_in_file), "%s", "edited.csv");
+    assert(dsd_scan_mode_resume(o, s) == 0);
+    assert(o->dmr_mute_encL == 0 && o->dmr_mute_encR == 0 && o->aggressive_framesync == 0
+           && o->dmr_crc_relaxed_default == 1 && o->scan_voice_only == 1 && o->scan_voice_hold_ms == 4000
+           && o->unmute_encrypted_p25 == 1 && s->M == 1);
+    assert(strcmp(o->group_in_file, "edited.csv") == 0);
+    dsd_scan_settings after;
+    dsd_scan_settings_capture(o, s, &after);
+    assert(dsd_scan_settings_equal(&before, &after, 1));
+    assert(after.dmr_mute_encL == 0 && after.force_key == 1 && after.scan_voice_hold_ms == 4000);
+
+    /* A row override layered over the edited baseline still yields to a decoder change. */
+    dsd_scan_option_values row = {0};
+    row.present = DSD_SCAN_OPT_HOLD | DSD_SCAN_OPT_MUTE_DMR | DSD_SCAN_OPT_FORCE;
+    row.hold_ms = 3000;
+    row.mute_dmr = 1;
+    row.force = 0x21;
+    assert(dsd_scan_mode_options(o, s, &row) == 0);
+    assert(o->scan_voice_hold_ms == 3000 && o->dmr_mute_encL == 1 && s->M == 0x21);
+    assert(dsd_scan_mode_suspend(o, s));
+    assert(o->scan_voice_hold_ms == 4000 && o->dmr_mute_encL == 0 && s->M == 1);
+    o->scan_voice_hold_ms = 5000;
+    assert(dsd_scan_mode_resume(o, s) == 0);
+    assert(o->scan_voice_hold_ms == 3000 && o->dmr_mute_encL == 1 && s->M == 0x21);
+    assert(dsd_scan_mode_suspend(o, s));
+    o->inverted_dmr = !o->inverted_dmr;
+    assert(dsd_scan_mode_resume(o, s) == 1);
+    dsd_scan_mode_leave(o, s);
+    assert(o->scan_voice_hold_ms == 5000 && o->dmr_mute_encL == 0 && s->M == 1);
+    dsd_state_ext_free_all(s);
+    free(s);
+    free(o);
+}
+
 int
 main(void) {
+    test_row_option_edits_are_not_acquisition_changes();
     dsd_opts* o = (dsd_opts*)calloc(1, sizeof(*o));
     dsd_state* s = (dsd_state*)calloc(1, sizeof(*s));
     dsd_state* copy = (dsd_state*)calloc(1, sizeof(*copy));

--- a/tests/runtime/test_runtime_scan_options.c
+++ b/tests/runtime/test_runtime_scan_options.c
@@ -13,6 +13,11 @@ main(void) {
     char error[192] = {0};
     assert(dsd_scan_options_parse("", DSD_SCAN_MODE_INHERIT, 1, &parsed, error, sizeof(error)) == 0);
     assert(parsed.values.present == 0);
+    assert(
+        dsd_scan_options_parse("--dmr-force-algid 0x21 -0 -G ./-F", DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error))
+        == 0);
+    assert(parsed.values.force == 0x21 && strcmp(parsed.values.group_file, "./-F") == 0);
+    assert(dsd_scan_options_parse("--strict-crc", DSD_SCAN_MODE_DSTAR, 1, &parsed, error, sizeof(error)) == 0);
     assert(dsd_scan_options_parse("-1 '01 23 45 67 89' -0 -F --scan-voice-only --scan-voice-hold-ms=4000",
                                   DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error))
            == 0);
@@ -109,6 +114,11 @@ main(void) {
                    {"-G 'unterminated", DSD_SCAN_MODE_DMR, 1},
                    {"-G", DSD_SCAN_MODE_DMR, 1},
                    {"-G ''", DSD_SCAN_MODE_DMR, 1},
+                   {"-G -F", DSD_SCAN_MODE_DMR, 1},
+                   {"-K --no-force-key", DSD_SCAN_MODE_DMR, 1},
+                   {"-k --not-a-switch-SENSITIVE", DSD_SCAN_MODE_DMR, 1},
+                   {"-F --strict-crc", DSD_SCAN_MODE_DMR, 1},
+                   {"--dmr-force-algid 21 -0 --dmr-force-algid 21", DSD_SCAN_MODE_DMR, 1},
                    {"--scan-voice-only=yes", DSD_SCAN_MODE_DMR, 1},
                    {"-t 0", DSD_SCAN_MODE_DMR, 1},
                    {"-i rtl:0", DSD_SCAN_MODE_DMR, 1},

--- a/tests/runtime/test_runtime_scan_options.c
+++ b/tests/runtime/test_runtime_scan_options.c
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <assert.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
+#include <string.h>
+
+int
+main(void) {
+    dsd_scan_options parsed = {0};
+    char error[192] = {0};
+    assert(dsd_scan_options_parse("", DSD_SCAN_MODE_INHERIT, 1, &parsed, error, sizeof(error)) == 0);
+    assert(parsed.values.present == 0);
+    assert(dsd_scan_options_parse("-1 '01 23 45 67 89' -0 -F --scan-voice-only --scan-voice-hold-ms=4000",
+                                  DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error))
+           == 0);
+    assert(parsed.scalar == 0x0123456789ULL && parsed.values.force == 0x21);
+    assert(parsed.values.voice_only == 1 && parsed.values.hold_ms == 4000 && parsed.values.strict_crc == 0);
+    assert(dsd_scan_options_parse(
+               "-G \"C:\\Radio Lists\\groups.csv\" -K 'relative keys.csv' -k dec.csv -0 --dmr-force-algid 21",
+               DSD_SCAN_MODE_DMR, 0, &parsed, error, sizeof(error))
+           == 0);
+    assert(strcmp(parsed.values.group_file, "C:\\Radio Lists\\groups.csv") == 0);
+    assert(strcmp(parsed.hex_file, "relative keys.csv") == 0 && strcmp(parsed.dec_file, "dec.csv") == 0);
+    assert(dsd_scan_options_parse("-H 0x0000001f00 -4 -F", DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error)) == 0);
+    assert(parsed.hytera_digits == 10 && parsed.hytera[0] == 0x1F00 && parsed.values.force == 1);
+    assert(dsd_scan_options_parse("-b 0 --no-force-key --strict-crc --no-scan-voice-only", DSD_SCAN_MODE_DMR, 1,
+                                  &parsed, error, sizeof(error))
+           == 0);
+    assert(parsed.values.present & DSD_SCAN_OPT_BP);
+    assert(parsed.bp == 0 && parsed.values.force == 0 && parsed.values.strict_crc == 1
+           && parsed.values.voice_only == 0);
+    assert(dsd_scan_options_parse("-R 32767 -4", DSD_SCAN_MODE_NXDN48, 1, &parsed, error, sizeof(error)) == 0);
+    assert(parsed.scalar == 32767 && parsed.values.force == 1);
+    assert(dsd_scan_options_parse("-R 1", DSD_SCAN_MODE_DPMR, 1, &parsed, error, sizeof(error)) == 0);
+    assert(dsd_scan_options_parse("-H 00112233445566778899aabbccddeeff", DSD_SCAN_MODE_P25, 1, &parsed, error,
+                                  sizeof(error))
+           == 0);
+    assert(parsed.hytera_digits == 32 && parsed.hytera[1] == 0x8899aabbccddeeffULL);
+
+    const struct {
+        const char* text;
+        unsigned int mode;
+        int conventional;
+    } invalid[] = {{"-4 -0", DSD_SCAN_MODE_DMR, 1},
+                   {"-0 -4", DSD_SCAN_MODE_DMR, 1},
+                   {"-4 -4", DSD_SCAN_MODE_DMR, 1},
+                   {"-0 -0", DSD_SCAN_MODE_DMR, 1},
+                   {"--no-force-key --no-force-key", DSD_SCAN_MODE_DMR, 1},
+                   {"-0 --dmr-force-algid 21 -0", DSD_SCAN_MODE_DMR, 1},
+                   {"-0 --dmr-force-algid 24", DSD_SCAN_MODE_DMR, 1},
+                   {"--dmr-force-algid 01", DSD_SCAN_MODE_DMR, 1},
+                   {"--dmr-force-algid 16", DSD_SCAN_MODE_DMR, 1},
+                   {"--dmr-force-algid 100", DSD_SCAN_MODE_DMR, 1},
+                   {"-b 256", DSD_SCAN_MODE_DMR, 1},
+                   {"-b -1", DSD_SCAN_MODE_DMR, 1},
+                   {"-b 1x", DSD_SCAN_MODE_DMR, 1},
+                   {"-R 32768", DSD_SCAN_MODE_NXDN48, 1},
+                   {"-R 1 -1 0123", DSD_SCAN_MODE_NXDN48, 1},
+                   {"-1 12345678901234567", DSD_SCAN_MODE_DMR, 1},
+                   {"-H 123", DSD_SCAN_MODE_DMR, 1},
+                   {"-H 0011223344", DSD_SCAN_MODE_P25, 1},
+                   {"-H 00112233445566778899aabbccddeeff", DSD_SCAN_MODE_NXDN48, 1},
+                   {"-b 1 -K keys.csv", DSD_SCAN_MODE_DMR, 1},
+                   {"-K keys.csv -1 0123456789", DSD_SCAN_MODE_DMR, 1},
+                   {"-b 1 -b 2", DSD_SCAN_MODE_DMR, 1},
+                   {"-4", DSD_SCAN_MODE_P25, 1},
+                   {"-b 1", DSD_SCAN_MODE_INHERIT, 1},
+                   {"-0", DSD_SCAN_MODE_NXDN48, 1},
+                   {"-F", DSD_SCAN_MODE_DSTAR, 1},
+                   {"--scan-voice-only", DSD_SCAN_MODE_DMR, 0},
+                   {"--scan-voice-hold-ms 4000", DSD_SCAN_MODE_P25, 0},
+                   {"--scan-voice-hold-ms 99", DSD_SCAN_MODE_DMR, 1},
+                   {"--scan-voice-qualify-ms 600001", DSD_SCAN_MODE_DMR, 1},
+                   {"-G 'unterminated", DSD_SCAN_MODE_DMR, 1},
+                   {"-G", DSD_SCAN_MODE_DMR, 1},
+                   {"-G ''", DSD_SCAN_MODE_DMR, 1},
+                   {"--scan-voice-only=yes", DSD_SCAN_MODE_DMR, 1},
+                   {"-t 0", DSD_SCAN_MODE_DMR, 1},
+                   {"-i rtl:0", DSD_SCAN_MODE_DMR, 1},
+                   {"-f1", DSD_SCAN_MODE_DMR, 1},
+                   {"--frontend terminal", DSD_SCAN_MODE_DMR, 1},
+                   {"--not-a-switch-SENSITIVE", DSD_SCAN_MODE_DMR, 1},
+                   {"-1 SENSITIVE", DSD_SCAN_MODE_DMR, 1},
+                   {"-b 1 ; touch file", DSD_SCAN_MODE_DMR, 1}};
+
+    unsigned char before[sizeof(parsed)];
+    DSD_MEMCPY(before, &parsed, sizeof(before));
+    for (size_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+        assert(dsd_scan_options_parse(invalid[i].text, invalid[i].mode, invalid[i].conventional, &parsed, error,
+                                      sizeof(error))
+               < 0);
+        unsigned char after[sizeof(parsed)];
+        DSD_MEMCPY(after, &parsed, sizeof(after));
+        assert(memcmp(after, before, sizeof(after)) == 0);
+        DSD_SECURE_ZERO(after, sizeof(after));
+        assert(strstr(error, "SENSITIVE") == NULL);
+    }
+    DSD_SECURE_ZERO(&before, sizeof(before));
+    DSD_SECURE_ZERO(&parsed, sizeof(parsed));
+    return 0;
+}

--- a/tests/runtime/test_runtime_scan_options.c
+++ b/tests/runtime/test_runtime_scan_options.c
@@ -32,6 +32,38 @@ main(void) {
     assert(parsed.values.present & DSD_SCAN_OPT_BP);
     assert(parsed.bp == 0 && parsed.values.force == 0 && parsed.values.strict_crc == 1
            && parsed.values.voice_only == 0);
+    /* `-b`/`-H` decide DMR encrypted-audio muting as the CLI switches do: explicit zero mutes,
+     * material unmutes. `-1`/`-R` load keys without claiming that decision. */
+    assert((parsed.values.present & DSD_SCAN_OPT_MUTE_DMR) && parsed.values.mute_dmr == 1);
+    assert(dsd_scan_options_parse("-b 7", DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error)) == 0);
+    assert((parsed.values.present & DSD_SCAN_OPT_MUTE_DMR) && parsed.values.mute_dmr == 0);
+    assert(dsd_scan_options_parse("-H 0000000000", DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error)) == 0);
+    assert((parsed.values.present & DSD_SCAN_OPT_MUTE_DMR) && parsed.values.mute_dmr == 1);
+    assert(dsd_scan_options_parse("-1 0123456789", DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error)) == 0);
+    assert(!(parsed.values.present & DSD_SCAN_OPT_MUTE_DMR));
+    assert(dsd_scan_options_parse("-R 5", DSD_SCAN_MODE_NXDN48, 1, &parsed, error, sizeof(error)) == 0);
+    assert(!(parsed.values.present & DSD_SCAN_OPT_MUTE_DMR));
+    /* Key-file paths share the legacy column limit; the group path is bounded by the option
+     * it overrides, and an oversized argument never leaves a partial result behind. */
+    {
+        char text[DSD_SCAN_OPTIONS_KEY_PATH_MAX + 32];
+        const size_t long_len = DSD_SCAN_OPTIONS_KEY_PATH_MAX - 1;
+        DSD_MEMSET(text, 0, sizeof(text));
+        DSD_MEMCPY(text, "-K ", 3);
+        DSD_MEMSET(text + 3, 'k', long_len);
+        assert(dsd_scan_options_parse(text, DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error)) == 0);
+        assert(strlen(parsed.hex_file) == long_len);
+        text[3 + long_len] = 'k';
+        assert(dsd_scan_options_parse(text, DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error)) < 0);
+        assert(strlen(parsed.hex_file) == long_len);
+        DSD_MEMCPY(text, "-G ", 3);
+        DSD_MEMSET(text + 3, 'g', DSD_SCAN_OPTIONS_GROUP_PATH_MAX);
+        text[3 + DSD_SCAN_OPTIONS_GROUP_PATH_MAX] = '\0';
+        assert(dsd_scan_options_parse(text, DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error)) < 0);
+        text[3 + DSD_SCAN_OPTIONS_GROUP_PATH_MAX - 1] = '\0';
+        assert(dsd_scan_options_parse(text, DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error)) == 0);
+        assert(strlen(parsed.values.group_file) == DSD_SCAN_OPTIONS_GROUP_PATH_MAX - 1);
+    }
     assert(dsd_scan_options_parse("-R 32767 -4", DSD_SCAN_MODE_NXDN48, 1, &parsed, error, sizeof(error)) == 0);
     assert(parsed.scalar == 32767 && parsed.values.force == 1);
     assert(dsd_scan_options_parse("-R 1", DSD_SCAN_MODE_DPMR, 1, &parsed, error, sizeof(error)) == 0);

--- a/tests/test_support/scan_group_stubs.c
+++ b/tests/test_support/scan_group_stubs.c
@@ -24,6 +24,12 @@ dsd_tg_policy_install(dsd_state* state, dsd_tg_policy_store* store) {
     (void)store;
 }
 
+void
+dsd_tg_policy_restore(dsd_state* state, dsd_tg_policy_store* store) {
+    (void)state;
+    (void)store;
+}
+
 int
 dsd_tg_policy_load(const char* path, dsd_tg_policy_store** out) {
     (void)path;

--- a/tests/test_support/scan_group_stubs.c
+++ b/tests/test_support/scan_group_stubs.c
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+/* Hosts that deliberately stub talkgroup policy do not load row group files.
+ * Production ownership and import are exercised by CORE_SCAN_PROFILE. */
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <stddef.h>
+
+dsd_tg_policy_store*
+dsd_tg_policy_retain(const dsd_state* state) {
+    (void)state;
+    return NULL;
+}
+
+void
+dsd_tg_policy_release(dsd_tg_policy_store* store) {
+    (void)store;
+}
+
+void
+dsd_tg_policy_install(dsd_state* state, dsd_tg_policy_store* store) {
+    (void)state;
+    (void)store;
+}
+
+int
+dsd_tg_policy_load(const char* path, dsd_tg_policy_store** out) {
+    (void)path;
+    (void)out;
+    return -1;
+}

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -2311,7 +2311,7 @@ test_scoped_row_option_commands(void) {
     rc |= expect_int("configured force updated", configured.force_key, 1);
     rc |= expect_int("configured mute updated", configured.dmr_mute_encL, 0);
     rc |= expect_int("configured CRC updated", configured.aggressive_framesync, 0);
-    rc |= expect_int("configured CRC default updated", configured.dmr_crc_relaxed_default, 1);
+    rc |= expect_int("configured CSBK CRC default preserved", configured.dmr_crc_relaxed_default, 0);
     dsdneoUserConfig saved;
     dsd_snapshot_opts_to_user_config(opts, state, &saved);
     rc |= expect_int("saved configured hold", saved.trunk_scan_voice_hold_ms, 3000);
@@ -2329,9 +2329,83 @@ test_scoped_row_option_commands(void) {
     return rc;
 }
 
+/* Direct key commands keep their live key ownership while their unmute decision
+ * persists in the configured scope, including beneath an explicit row mute. */
+static int
+test_scoped_direct_key_mutes(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        return 1;
+    }
+    init_test_context(opts, state);
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 48000;
+    const int commands[] = {DSD_APP_CMD_KEY_BASIC_SET, DSD_APP_CMD_KEY_SCRAMBLER_SET, DSD_APP_CMD_KEY_RC4DES_SET,
+                            DSD_APP_CMD_KEY_HYTERA_SET, DSD_APP_CMD_KEY_AES_SET};
+    int rc = 0;
+    for (int row_mutes = 0; row_mutes < 2; row_mutes++) {
+        for (size_t i = 0; i < sizeof(commands) / sizeof(commands[0]); i++) {
+            opts->dmr_mute_encL = opts->dmr_mute_encR = 1;
+            state->R = 99;
+            dsd_key_set keys = {0};
+            keys.present = 1;
+            keys.scalars.R = 55;
+            rc |= expect_true("enter row keys", dsd_scan_keys_enter(state, &keys));
+            rc |= expect_int("enter key command scope", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_DMR), 0);
+            dsd_scan_option_values row = {.present = DSD_SCAN_OPT_MUTE_DMR, .mute_dmr = 1};
+            (void)dsd_scan_mode_options(opts, state, row_mutes ? &row : NULL);
+            uint64_t payload[5] = {7, 8, 9, 10, 11};
+            uint32_t short_key = 7;
+            const void* data = i < 2 ? (const void*)&short_key : (const void*)payload;
+            size_t size = i < 2    ? sizeof(uint32_t)
+                          : i == 2 ? sizeof(uint64_t)
+                          : i == 3 ? sizeof(dsd_app_hytera_key_payload)
+                                   : sizeof(dsd_app_aes_key_payload);
+            rc |= expect_int("post direct key", dsd_app_command_submit(commands[i], data, size),
+                             DSD_APP_COMMAND_SUBMIT_QUEUED);
+            rc |= expect_int("direct key drained", dsd_app_drain_cmds(opts, state), 1);
+            rc |= expect_int("row mute respected left", opts->dmr_mute_encL, row_mutes);
+            rc |= expect_int("row mute respected right", opts->dmr_mute_encR, row_mutes);
+            dsd_scan_settings configured;
+            dsd_scan_mode_configured(opts, state, &configured);
+            rc |= expect_int("direct key saved left unmute", configured.dmr_mute_encL, 0);
+            rc |= expect_int("direct key saved right unmute", configured.dmr_mute_encR, 0);
+            rc |= expect_true("direct key retains row ownership", state->scan_keys_active_set != 0);
+            const uint64_t live[] = {state->K, state->R, state->RR, state->K4, state->A4[0]};
+            const uint64_t expected[] = {7, 7, 7, 11, 10};
+            rc |= expect_true("direct key updates live material", live[i] == expected[i]);
+            post_empty(DSD_APP_CMD_AGGR_SYNC_TOGGLE);
+            (void)dsd_app_drain_cmds(opts, state);
+            rc |= expect_int("CRC toggle preserves row mute", opts->dmr_mute_encL, row_mutes);
+            (void)dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_NXDN48);
+            (void)dsd_scan_mode_options(opts, state, NULL);
+            rc |= expect_int("next row inherits unmute", opts->dmr_mute_encL, 0);
+            dsd_scan_keys_leave(state);
+            rc |= expect_true("leave restores global key", state->R == 99);
+            dsd_scan_mode_leave(opts, state);
+        }
+    }
+    for (int relaxed = 0; relaxed < 2; relaxed++) {
+        opts->dmr_crc_relaxed_default = (uint8_t)relaxed;
+        for (int toggle = 0; toggle < 2; toggle++) {
+            post_empty(DSD_APP_CMD_AGGR_SYNC_TOGGLE);
+            (void)dsd_app_drain_cmds(opts, state);
+            rc |= expect_int("menu CRC toggle preserves CSBK policy", opts->dmr_crc_relaxed_default, relaxed);
+        }
+    }
+    freeState(state);
+    free(state);
+    free(opts);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
+    rc |= test_scoped_direct_key_mutes();
     rc |= test_scoped_row_option_commands();
     rc |= test_scoped_setting_toggles();
     rc |= test_scoped_mode_commands_and_config();

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -23,6 +23,7 @@
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
@@ -2267,9 +2268,68 @@ test_scoped_mode_commands_and_config(void) {
     return rc;
 }
 
+static int
+test_scoped_row_option_commands(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        return 1;
+    }
+    init_test_context(opts, state);
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 48000;
+    opts->scan_voice_only = 0;
+    opts->scan_voice_hold_ms = 2000;
+    opts->aggressive_framesync = 1;
+    opts->dmr_crc_relaxed_default = 0;
+    opts->dmr_mute_encL = opts->dmr_mute_encR = 1;
+    DSD_SNPRINTF(opts->group_in_file, sizeof(opts->group_in_file), "%s", "global.csv");
+    state->M = 0;
+    int rc = expect_int("enter option row", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_DMR), 0);
+    const dsd_scan_option_values row = {.present = DSD_SCAN_OPT_FORCE | DSD_SCAN_OPT_CRC | DSD_SCAN_OPT_VOICE
+                                                   | DSD_SCAN_OPT_HOLD | DSD_SCAN_OPT_GROUP | DSD_SCAN_OPT_BP,
+                                        .force = 0x21,
+                                        .strict_crc = 0,
+                                        .voice_only = 1,
+                                        .hold_ms = 4000,
+                                        .group_file = "row.csv"};
+    dsd_scan_mode_options(opts, state, &row);
+    rc |= expect_int("queue force default", post_empty(DSD_APP_CMD_FORCE_PRIV_TOGGLE), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("queue CRC default", post_empty(DSD_APP_CMD_AGGR_SYNC_TOGGLE), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("queue hold default", dsd_app_command_set_i32(DSD_APP_CMD_SCAN_VOICE_HOLD_MS_SET, 3000),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("queue mute default", post_empty(DSD_APP_CMD_ALL_MUTES_TOGGLE), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("option commands drained", dsd_app_drain_cmds(opts, state), 4);
+    rc |= expect_int("row keeps force", state->M, 0x21);
+    rc |= expect_int("row keeps hold", opts->scan_voice_hold_ms, 4000);
+    dsd_scan_settings configured;
+    dsd_scan_mode_configured(opts, state, &configured);
+    rc |= expect_int("configured force updated", configured.force_key, 1);
+    rc |= expect_int("configured mute updated", configured.dmr_mute_encL, 0);
+    rc |= expect_int("configured CRC updated", configured.aggressive_framesync, 0);
+    rc |= expect_int("configured CRC default updated", configured.dmr_crc_relaxed_default, 1);
+    dsdneoUserConfig saved;
+    dsd_snapshot_opts_to_user_config(opts, state, &saved);
+    rc |= expect_int("saved configured hold", saved.trunk_scan_voice_hold_ms, 3000);
+    rc |= expect_int("saved configured gate", saved.trunk_scan_voice_only, 0);
+    rc |= expect_str("saved configured groups", saved.trunk_group_csv, "global.csv");
+    dsd_scan_mode_options(opts, state, NULL);
+    rc |= expect_int("clear options restores force", state->M, 1);
+    rc |= expect_int("clear options restores hold", opts->scan_voice_hold_ms, 3000);
+    rc |= expect_str("clear options restores groups", opts->group_in_file, "global.csv");
+    dsd_scan_mode_leave(opts, state);
+    freeState(state);
+    free(state);
+    free(opts);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
+    rc |= test_scoped_row_option_commands();
     rc |= test_scoped_setting_toggles();
     rc |= test_scoped_mode_commands_and_config();
     rc |= test_command_api();

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -2289,13 +2289,14 @@ test_scoped_row_option_commands(void) {
     state->M = 0;
     int rc = expect_int("enter option row", dsd_scan_mode_enter(opts, state, DSD_SCAN_MODE_DMR), 0);
     const dsd_scan_option_values row = {.present = DSD_SCAN_OPT_FORCE | DSD_SCAN_OPT_CRC | DSD_SCAN_OPT_VOICE
-                                                   | DSD_SCAN_OPT_HOLD | DSD_SCAN_OPT_GROUP | DSD_SCAN_OPT_BP,
+                                                   | DSD_SCAN_OPT_HOLD | DSD_SCAN_OPT_GROUP | DSD_SCAN_OPT_MUTE_DMR,
                                         .force = 0x21,
                                         .strict_crc = 0,
                                         .voice_only = 1,
                                         .hold_ms = 4000,
+                                        .mute_dmr = 1,
                                         .group_file = "row.csv"};
-    dsd_scan_mode_options(opts, state, &row);
+    rc |= expect_int("install row options", dsd_scan_mode_options(opts, state, &row), 0);
     rc |= expect_int("queue force default", post_empty(DSD_APP_CMD_FORCE_PRIV_TOGGLE), DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("queue CRC default", post_empty(DSD_APP_CMD_AGGR_SYNC_TOGGLE), DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("queue hold default", dsd_app_command_set_i32(DSD_APP_CMD_SCAN_VOICE_HOLD_MS_SET, 3000),
@@ -2304,6 +2305,7 @@ test_scoped_row_option_commands(void) {
     rc |= expect_int("option commands drained", dsd_app_drain_cmds(opts, state), 4);
     rc |= expect_int("row keeps force", state->M, 0x21);
     rc |= expect_int("row keeps hold", opts->scan_voice_hold_ms, 4000);
+    rc |= expect_int("row keeps mute", opts->dmr_mute_encL, 1);
     dsd_scan_settings configured;
     dsd_scan_mode_configured(opts, state, &configured);
     rc |= expect_int("configured force updated", configured.force_key, 1);
@@ -2315,9 +2317,10 @@ test_scoped_row_option_commands(void) {
     rc |= expect_int("saved configured hold", saved.trunk_scan_voice_hold_ms, 3000);
     rc |= expect_int("saved configured gate", saved.trunk_scan_voice_only, 0);
     rc |= expect_str("saved configured groups", saved.trunk_group_csv, "global.csv");
-    dsd_scan_mode_options(opts, state, NULL);
+    rc |= expect_int("clear row options", dsd_scan_mode_options(opts, state, NULL), 0);
     rc |= expect_int("clear options restores force", state->M, 1);
     rc |= expect_int("clear options restores hold", opts->scan_voice_hold_ms, 3000);
+    rc |= expect_int("clear options restores mute", opts->dmr_mute_encL, 0);
     rc |= expect_str("clear options restores groups", opts->group_in_file, "global.csv");
     dsd_scan_mode_leave(opts, state);
     freeState(state);

--- a/tests/ui/test_ui_menu_actions.c
+++ b/tests/ui/test_ui_menu_actions.c
@@ -30,6 +30,8 @@
 #include <string.h>
 #include "command_dispatch.h"
 
+#include <dsd-neo/runtime/scan_mode.h>
+#include "../test_support/scan_mode_label_stubs.h"
 #include "csv_picker.h"
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -1872,6 +1874,19 @@ test_scan_voice_gate_actions(void) {
     rc |= expect_int("voice hold opens int prompt", g_prompt.calls, 1);
     rc |= expect_int("voice hold wires callback", g_prompt.int_cb == cb_scan_voice_hold, 1);
     rc |= expect_int("voice hold posts nothing yet", g_cmd.calls, 0);
+
+    dsd_scan_settings configured = {0};
+    configured.scan_voice_qualify_ms = 1800;
+    configured.scan_voice_hold_ms = 2800;
+    dsd_test_scan_labels_configured(&configured);
+    reset_capture();
+    act_scan_voice_only(&ctx);
+    rc |= expect_int("voice-only toggles configured default", cmd_i32(), 1);
+    act_scan_voice_qualify(&ctx);
+    rc |= expect_int("voice qualify configured initial", g_prompt.initial_int, 1800);
+    act_scan_voice_hold(&ctx);
+    rc |= expect_int("voice hold configured initial", g_prompt.initial_int, 2800);
+    dsd_test_scan_labels_configured(NULL);
 
     return rc;
 }

--- a/tests/ui/test_ui_menu_labels.c
+++ b/tests/ui/test_ui_menu_labels.c
@@ -448,6 +448,20 @@ test_encryption_labels(void) {
     state.M = 0x21;
     rc |= expect_str("force bp off", lbl_key_force_bp(&ctx, b, sizeof(b)), "Force basic/scrambler key [Off]");
     rc |= expect_str("force rc4 on", lbl_key_force_rc4(&ctx, b, sizeof(b)), "Force RC4 key [On]");
+    dsd_scan_settings configured = {0};
+    configured.force_key = 1;
+    configured.dmr_mute_encL = configured.dmr_mute_encR = 1;
+    configured.aggressive_framesync = 1;
+    configured.scan_voice_only = 1;
+    configured.scan_voice_hold_ms = 4000;
+    dsd_test_scan_labels_configured(&configured);
+    rc |= expect_str("muting configured", lbl_muting(&ctx, b, sizeof(b)), "Mute encrypted audio [On]");
+    rc |= expect_str("force BP configured", lbl_key_force_bp(&ctx, b, sizeof(b)), "Force basic/scrambler key [On]");
+    rc |= expect_str("force RC4 configured", lbl_key_force_rc4(&ctx, b, sizeof(b)), "Force RC4 key [Off]");
+    rc |= expect_str("CRC configured", lbl_crc_relax(&ctx, b, sizeof(b)), "Relaxed CRC checks [Off]");
+    rc |= expect_str("voice gate configured", lbl_scan_voice_only(&ctx, b, sizeof(b)), "Voice-only scan [On]");
+    rc |= expect_str("voice hold configured", lbl_scan_voice_hold(&ctx, b, sizeof(b)), "Voice hold... [4000 ms]");
+    dsd_test_scan_labels_configured(NULL);
 
     rc |= expect_str("hytera unset", lbl_key_hytera(&ctx, b, sizeof(b)), "Hytera privacy key (hex)...");
     state.H = 0x1234U;

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -1273,6 +1273,34 @@ test_history_viewport_helpers(void) {
 }
 
 static void
+test_loaded_scalar_key_status(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(state);
+    state->K = 42;
+    state->R = 0x0123456789ULL;
+    reset_printw_capture();
+    ui_render_forced_key_status(state, 0);
+    assert_capture_contains("Moto BP Key Loaded (not forced): [redacted]");
+    assert_capture_contains("RC4/DES or scrambler key loaded");
+    assert(strstr(g_printw_capture, "0123456789") == NULL);
+    assert(strstr(g_printw_capture, "Forcing Key Priority") == NULL);
+    reset_printw_capture();
+    ui_render_forced_key_status(state, 1);
+    assert_capture_contains("042");
+    assert_capture_contains("0000000123456789");
+    state->M = 1;
+    reset_printw_capture();
+    ui_render_forced_key_status(state, 0);
+    assert_capture_contains("Forcing Key Priority -- Moto BP Key");
+    assert(strstr(g_printw_capture, "Moto BP Key Loaded (not forced)") == NULL);
+    state->M = 0x21;
+    reset_printw_capture();
+    ui_render_forced_key_status(state, 0);
+    assert_capture_contains("Forcing Key Priority -- RC4 Key");
+    free(state);
+}
+
+static void
 test_hytera_key_format_helper(void) {
     static dsd_state state;
     char key_text[96];
@@ -1912,6 +1940,7 @@ main(void) {
     test_history_color_pair_policy();
     test_history_viewport_helpers();
     test_hytera_key_format_helper();
+    test_loaded_scalar_key_status();
     test_edacs_tree_update_helpers();
     test_patch_and_slot_helpers();
     test_lock_and_protocol_helpers();

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -1314,6 +1314,12 @@ test_loaded_scalar_key_status(void) {
     ui_render_forced_key_status(state, 0);
     assert_capture_contains("Forcing Key Priority -- RC4 Key");
     assert(strstr(g_printw_capture, "Loaded (not forced)") == NULL);
+    for (int algid = 1; algid <= 0xFF; algid++) {
+        state->M = algid;
+        reset_printw_capture();
+        ui_render_forced_key_status(state, 0);
+        assert(strstr(g_printw_capture, "Loaded (not forced)") == NULL);
+    }
     state->M = 0x16;
     reset_printw_capture();
     ui_render_forced_key_status(state, 0);

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -1277,26 +1277,53 @@ test_loaded_scalar_key_status(void) {
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
     assert(state);
     state->K = 42;
-    state->R = 0x0123456789ULL;
+    state->R = state->RR = 0x0123456789ULL; /* `-1` mirrors the RC4/DES key into both slots */
     reset_printw_capture();
     ui_render_forced_key_status(state, 0);
     assert_capture_contains("Moto BP Key Loaded (not forced): [redacted]");
-    assert_capture_contains("RC4/DES or scrambler key loaded");
+    assert_capture_contains("RC4/DES Key Loaded (not forced): [redacted]");
     assert(strstr(g_printw_capture, "0123456789") == NULL);
     assert(strstr(g_printw_capture, "Forcing Key Priority") == NULL);
+    assert(strstr(g_printw_capture, "Scrambler") == NULL);
     reset_printw_capture();
     ui_render_forced_key_status(state, 1);
     assert_capture_contains("042");
     assert_capture_contains("0000000123456789");
+    /* `-R` stores a 15-bit scrambler value in R alone: decimal, never a hex RC4 line. */
+    state->R = 1;
+    state->RR = 0;
+    reset_printw_capture();
+    ui_render_forced_key_status(state, 1);
+    assert_capture_contains("NXDN/dPMR Scrambler Key Loaded (not forced): 00001");
+    assert(strstr(g_printw_capture, "RC4/DES") == NULL);
+    /* Keyring slots holding two different RC4/DES keys show both. */
+    state->R = 0x0123456789ULL;
+    state->RR = 0x0000000ABCDEULL;
+    reset_printw_capture();
+    ui_render_forced_key_status(state, 1);
+    assert_capture_contains("RC4/DES Keys Loaded (not forced): 0000000123456789 / 00000000000ABCDE");
+    state->RR = state->R;
+    /* Any active forcing (BP, RC4, TYT marker, or the -2 TYT key) hides the loaded lines. */
     state->M = 1;
     reset_printw_capture();
     ui_render_forced_key_status(state, 0);
     assert_capture_contains("Forcing Key Priority -- Moto BP Key");
-    assert(strstr(g_printw_capture, "Moto BP Key Loaded (not forced)") == NULL);
+    assert(strstr(g_printw_capture, "Loaded (not forced)") == NULL);
     state->M = 0x21;
     reset_printw_capture();
     ui_render_forced_key_status(state, 0);
     assert_capture_contains("Forcing Key Priority -- RC4 Key");
+    assert(strstr(g_printw_capture, "Loaded (not forced)") == NULL);
+    state->M = 0x16;
+    reset_printw_capture();
+    ui_render_forced_key_status(state, 0);
+    assert_capture_contains("Forcing Key Priority -- TYT 16-bit Key");
+    assert(strstr(g_printw_capture, "Loaded (not forced)") == NULL);
+    state->M = 0;
+    state->tyt_bp = 1;
+    reset_printw_capture();
+    ui_render_forced_key_status(state, 0);
+    assert(strstr(g_printw_capture, "Loaded (not forced)") == NULL);
     free(state);
 }
 


### PR DESCRIPTION
## Summary

Mixed scans shared global privacy forcing, CRC and voice-gate settings, and the direct-key CSV columns only represented `-b` and `-H`. Add a restricted `options` column to conventional channel maps and trunk-scan targets, with `relevant_CLI_switches` as an alias. Each row can now select its keys and decode policy: for example, `-H ... -4` for forced Hytera, `-1 ... -0` for RC4 fallback, `-b 1 --no-force-key` for mixed clear/BP calls, and `-R 1` for NXDN scrambling.

Addresses @noamlivne's reports on [PR #464](https://github.com/arancormonk/dsd-neo/pull/464#issuecomment-5551326349) and [PR #482](https://github.com/arancormonk/dsd-neo/pull/482#issuecomment-5551319087). Related issues: #382 and #446.

- Validate switches against the declared mode or target type. Keep existing key columns; reject duplicate settings, conflicting force selectors and mixed direct/file key sources. Accept `-0 --dmr-force-algid 21` as equivalent selectors.
- Load key/group files relative to the list at import time. Stage key allocations before tuning, preserve the configured baseline, restore it on exit, and retain row-specific group policy edits across switches. Allocation failures reject startup before decoding with an incomplete profile.
- Scope force, CRC, mute and conventional voice-gate settings. Frontend edits and configuration saves use configured defaults beneath the active row. Omitted options inherit those defaults; `--no-force-key`, `--strict-crc` and `--no-scan-voice-only` provide explicit resets.
- Preserve existing global force precedence and warn about incompatible selectors. Display loaded BP and RC4/DES/scrambler keys in the terminal Input/Output pane using the existing redaction helpers.
- Add operator/API documentation, a mixed-scan example and regressions for parsing, mixed clear/BP calls, tune boundaries, policy ownership, allocation failures, frontend controls and redaction.

## Review

- [x] Changes reviewed against the surrounding module design, ownership boundaries and failure paths.
- [ ] Human review of behavior and ownership boundaries.
- [ ] Second/outside review of this broad parser and key-handling change (pending PR review).
- [x] High-risk areas identified: parser / crypto (key material handling).
- [x] Generated changes read and adapted to project conventions.
- [x] Non-trivial commit includes a DCO sign-off.

## Quality Review

- [x] Focused tests cover parser, file input, key allocation and scanner transition changes.
- [x] Runtime, key-handling and input paths received additional review.
- [x] No new broad static-analysis suppressions, dependencies, subprocess execution or key logging.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j 6` and full CTest: **613 passed**, including 30 I/Q decode cases.
- [x] Full ASan/UBSan CTest: **613 passed**; focused rechecks cover subsequent fixes.
- [x] Radio-off build/full CTest: **566 passed**; focused rechecks cover subsequent fixes.
- [x] Qt build/full CTest: **621 passed**, with focused Qt and scanner rechecks.
- [x] `tools/preflight_ci.sh` passed.
- [x] `DSD_HOOK_SCAN_BUILD_REUSE=1 tools/quality_preflight.sh` passed. A preceding full scan-build found no bugs; incremental analysis rechecked final updates. Fuzz smoke passed.
- [x] Architecture, secret-redaction, formatting, Semgrep, clang-tidy, IWYU, cppcheck and GCC fanalyzer checks passed in preflight. Full-tree CMake/shell/workflow lint, zizmor, OSV and gitleaks passed in the quality run.

The push hook was bypassed at the maintainer's request because preflight had already passed.

## Risk

- Security/dependency impact: adds import-time key/profile storage and retained group contexts. Key material is wiped on release and excluded from frontend scope metadata; diagnostics do not echo raw options or keys. No new dependencies.
- CLI/UI behavior impact: legacy lists and global force precedence remain supported. Omitted row options inherit global forcing, so mixed clear/BP rows should explicitly use `--no-force-key` when forcing is configured globally. The column accepts the documented switch subset; commas remain CSV separators even inside quotes.
- Compatibility/packaging impact: embedded row options work with the Qt/Android picker; companion files still need accessible paths because the picker does not copy them with the list. Validation ran on Linux; Windows and live-radio confirmation remain for the reporter.
