### PR TITLE
feat(engine): support NXDN48 trunk scan targets (#375)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Levels/Audio: `-g 0|1..50`, `-n 0..100`, `-nm`, `-8`, `-V 0|1|2|3`, `-z 0|1|2`, `-y`, `-v 0xF`
 - Modes: `-fa | -fs | -fr | -f1 | -f2 | -fd | -fx | -fy | -fz | -fU | -fi | -fn | -fp | -fh | -fH | -fe | -fE | -fm`
 - Inversions/filtering: `-xx`, `-xr`, `-xd`, `-xz`, `-l`, `-q`
-- Trunking/scan: `-T`, `-Y`, `--trunk-scan targets.csv` (P25/DMR/NXDN96/NXDN48 targets; each type selects its decoder class), `-C chan.csv`, `-G group.csv`, `--src-csv src.csv`, `--p25-bandplan plan.csv`, `--p25-bandplan-export plan.csv`, `-W`, `-E`, `-p`, `-e`, `-I 1234`, `-U 4532`, `-B 12000`, `-t 1`, `--enc-lockout|--enc-follow`, `--scan-voice-only`, `--scan-voice-qualify-ms <ms>`, `--scan-voice-hold-ms <ms>`
+- Trunking/scan: `-T`, `-Y`, `--trunk-scan targets.csv` (P25/DMR/NXDN96/NXDN48 trunk and conventional targets; each type selects its decoder class), `-C chan.csv`, `-G group.csv`, `--src-csv src.csv`, `--p25-bandplan plan.csv`, `--p25-bandplan-export plan.csv`, `-W`, `-E`, `-p`, `-e`, `-I 1234`, `-U 4532`, `-B 12000`, `-t 1`, `--enc-lockout|--enc-follow`, `--scan-voice-only`, `--scan-voice-qualify-ms <ms>`, `--scan-voice-hold-ms <ms>`
 - RTL‑SDR strings: `-i rtl:dev:freq:gain:ppm:bw:sql:vol[:bias=on|off]` or `-i rtltcp:host:port:freq:gain:ppm:bw:sql:vol[:bias=on|off]`
 - Soapy selection: `-i soapy`, `-i soapy:driver=airspy[,serial=...]`, or `-i soapy[:args]:freq[:gain[:ppm[:bw[:sql[:vol]]]]]` (discover args with `SoapySDRUtil --find`)
 - RTL retune control: `--rtl-udp-control <port>` binds to loopback by default; use
@@ -29,7 +29,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Follow DMR trunking (TCP PCM input + rigctl): `dsd-neo -fs -i tcp -U 4532 -T -C dmr_t3_chan.csv -G group.csv --frontend terminal`
 - Follow DMR trunking (RTL‑SDR): `dsd-neo -fs -i rtl:0:450M:26:-2:48:0:2 -T -C connect_plus_chan.csv -G group.csv --frontend terminal`
 - Follow DMR trunking (SoapySDR): `dsd-neo -fs -i soapy:driver=airspy -T -C connect_plus_chan.csv -G group.csv --frontend terminal`
-- Scan several P25/DMR/NXDN targets with one tuner: `dsd-neo -fa -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal` (`-ft` is enough when the list has no NXDN targets; `-fn` for NXDN96-only lists, `-fi` for NXDN48-only lists, `-fa` whenever both NXDN rates appear)
+- Scan several P25/DMR/NXDN targets with one tuner: `dsd-neo -fa -i rtl:0:851.0125M:22:0:48:0:2 --trunk-scan examples/trunk_scan_targets.csv -G examples/group.csv --frontend terminal` (each target selects its own decoder class, so the global preset only matters outside trunk scan)
 - Capture RTL I/Q + metadata: `dsd-neo -i rtl:0:851.375M:22:0:48:0:2 --iq-capture p25-control.iq --frontend terminal`
 - Inspect a capture: `dsd-neo --iq-info p25-control.iq.json`
 - Replay a capture through demod: `dsd-neo --iq-replay p25-control.iq.json -f1 --frontend terminal`
@@ -473,8 +473,9 @@ Notes
   message; legacy untyped scans retain their existing manual-tune behavior. Manual `L` skips zero-frequency placeholders,
   while automatic scanning continues to park on them for the configured dwell.
 - Single-tuner trunk scan mode: `--trunk-scan <targets.csv>`
-  - Rotates one tuner across CSV-defined P25 trunk, DMR trunk, DMR conventional, NXDN trunk, NXDN96 conventional
-    (`nxdn-conventional`) and NXDN48 conventional (`nxdn48-conventional`) targets. Full guide: `docs/trunk-scan.md`.
+  - Rotates one tuner across CSV-defined P25 trunk, DMR trunk, DMR conventional, NXDN trunk (`nxdn-trunk` NXDN96,
+    `nxdn48-trunk` NXDN48), NXDN96 conventional (`nxdn-conventional`) and NXDN48 conventional
+    (`nxdn48-conventional`) targets. Full guide: `docs/trunk-scan.md`.
   - Requires a live retuning path: RTL-family input opened by DSD-neo, or rigctl control such as `-U 4532`.
   - Use per-target `chan_csv` (and `p25_bandplan_csv`) entries in the target CSV; global `-C` and `--p25-bandplan`
     are rejected in this mode. Targets that are sites of one P25 system (same WACN/SYS) share the band plan one of

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -63,7 +63,7 @@ Key public headers:
 ### Single-Tuner Trunk Scan
 
 `src/engine/trunk_scan.c` owns the coordinator that rotates one retunable receiver across the explicit targets of a
-target-list CSV (P25 trunk, DMR trunk, DMR conventional, NXDN trunk, and NXDN96/NXDN48 conventional). Operator-facing
+target-list CSV (P25 trunk, DMR trunk, DMR conventional, NXDN96/NXDN48 trunk, and NXDN96/NXDN48 conventional). Operator-facing
 behavior, the CSV columns, and the CLI/config options live in `docs/trunk-scan.md`;
 `include/dsd-neo/engine/trunk_scan.h` is the whole public surface:
 

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -295,9 +295,9 @@ Columns:
 | Column | Required | Behavior |
 |--------|----------|----------|
 | `id` | Yes | Unique short name shown in the terminal status row and Call Info, as the `[id]` prefix on event-history rows, `-J` log lines and the rdio `talkgroup_tag` fallback, and in log messages. Empty or too-long IDs are rejected. |
-| `type` | Yes | One of `p25-trunk`, `dmr-trunk`, `dmr-conventional`, `nxdn-trunk`, `nxdn-conventional` (NXDN96, 12.5 kHz), or `nxdn48-conventional` (NXDN48, 6.25 kHz). |
+| `type` | Yes | One of `p25-trunk`, `dmr-trunk`, `dmr-conventional`, `nxdn-trunk` (NXDN96, 12.5 kHz), `nxdn48-trunk` (NXDN48, 6.25 kHz), `nxdn-conventional` (NXDN96, 12.5 kHz), or `nxdn48-conventional` (NXDN48, 6.25 kHz). |
 | `frequency_hz` | Yes | Decimal Hz only. Normal 64-bit builds accept `1..4294967295`; 32-bit builds may reject values above `LONG_MAX`. Do not use `K`/`M`/`G` suffixes in CSV. |
-| `chan_csv` | No | Optional channel-map path for trunk targets. Paths are resolved relative to this CSV. Leave empty for conventional DMR and both conventional NXDN types. |
+| `chan_csv` | No | Optional channel-map path for trunk targets (`p25-trunk`, `dmr-trunk`, `nxdn-trunk`, `nxdn48-trunk`). Paths are resolved relative to this CSV. Leave empty for conventional DMR and both conventional NXDN types. |
 | `dwell_ms` | No | Per-target idle dwell (`250..600000`). Empty uses `--trunk-scan-dwell-ms` or `[trunk_scan] idle_dwell_ms`. |
 | `activity_hold_ms` | No | Per-target conventional DMR/NXDN (NXDN96 and NXDN48) activity hold (`250..600000`). Empty uses `--trunk-scan-activity-hold-ms` or `[trunk_scan] activity_hold_ms`. |
 | `notes` | No | Ignored. Use for local notes. |
@@ -315,8 +315,8 @@ Validation notes:
 - No fixed target-count limit. Each parked target reserves a snapshot of decoder state (~80 KB), and the list is
   capped by a 256 MB budget for those snapshots - a few thousand targets. A CSV past the cap is rejected while
   parsing, with an error naming the budget.
-- Duplicate IDs and duplicate `(type, frequency_hz)` rows are rejected. `nxdn-conventional` and
-  `nxdn48-conventional` are distinct types, so one frequency may appear once as each.
+- Duplicate IDs and duplicate `(type, frequency_hz)` rows are rejected. `nxdn-trunk`/`nxdn48-trunk` and
+  `nxdn-conventional`/`nxdn48-conventional` are distinct types, so one frequency may appear once as each.
 - Optional column names are exact-case in this format. Duplicate direct-key headers, malformed direct values, and
   rows that mix a direct value with a key-file path are rejected without echoing the key value.
 - `chan_csv` and `p25_bandplan_csv` on conventional (`dmr-conventional`/`nxdn-conventional`/`nxdn48-conventional`)
@@ -336,6 +336,7 @@ county-p25,p25-trunk,851012500,,3000,,primary P25 control channel,cqpsk,18
 city-dmr,dmr-trunk,452012500,dmr_channels.csv,3000,,DMR Tier III control channel,auto,
 plant,dmr-conventional,461112500,,1500,1200,one-frequency DMR,gfsk,auto
 site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel,auto,
+site-nxdn48,nxdn48-trunk,461556250,nxdn_chan_map.csv,3000,,NXDN48 Type-C control channel (6.25 kHz),gfsk,
 field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,
 field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz) channel,gfsk,
 ```

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -40,6 +40,7 @@ county-p25,p25-trunk,851012500,,3000,,P25 control channel,cqpsk,18
 city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel,auto,
 plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR,gfsk,auto
 site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel,auto,
+site-nxdn48,nxdn48-trunk,461556250,nxdn_chan_map.csv,3000,,NXDN48 Type-C control channel (6.25 kHz),gfsk,
 field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96,gfsk,
 field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz),gfsk,
 ```
@@ -51,7 +52,7 @@ Column behavior:
 | Column | Required | Meaning |
 |--------|----------|---------|
 | `id` | Yes | Unique short name shown in the terminal status row and Call Info, as the `[id]` prefix on event-history rows, `-J` log lines and the rdio `talkgroup_tag` fallback, and in log messages. Keep it under 64 bytes. |
-| `type` | Yes | `p25-trunk`, `dmr-trunk`, `dmr-conventional`, `nxdn-trunk`, `nxdn-conventional` (NXDN96, 12.5 kHz), or `nxdn48-conventional` (NXDN48, 6.25 kHz). |
+| `type` | Yes | `p25-trunk`, `dmr-trunk`, `dmr-conventional`, `nxdn-trunk` (NXDN96, 12.5 kHz), `nxdn48-trunk` (NXDN48, 6.25 kHz), `nxdn-conventional` (NXDN96, 12.5 kHz), or `nxdn48-conventional` (NXDN48, 6.25 kHz). |
 | `frequency_hz` | Yes | Initial park/control frequency in decimal Hz. Suffixes such as `M` are not accepted in CSV. |
 | `chan_csv` | No | Channel map for a trunk target. Paths are resolved relative to the target CSV file. Leave empty for conventional DMR and both conventional NXDN types. |
 | `dwell_ms` | No | Idle dwell for this target. Empty uses the CLI/config default. Valid range: `250..600000`. |
@@ -94,13 +95,14 @@ Target list limits and validation:
 - Duplicate `(type, frequency_hz)` pairs are rejected.
 - A duplicated key header is rejected. An unloadable key path fails the whole import like a bad `-K`/`-k`; a malformed
   direct key or a row mixing direct and file sources also fails, without repeating direct key material in the error.
-- `chan_csv` is only valid for `p25-trunk`, `dmr-trunk`, and `nxdn-trunk` targets; `p25_bandplan_csv` is refused
+- `chan_csv` is only valid for `p25-trunk`, `dmr-trunk`, `nxdn-trunk` and `nxdn48-trunk` targets; `p25_bandplan_csv` is refused
   on conventional targets, a duplicated `p25_bandplan_csv` header is rejected, and a band plan that fails to load
   fails the whole import. A global `--p25-bandplan`/`[trunking] p25_bandplan_csv` is rejected in this mode like
   `-C`.
 - `modulation` values are target-type specific: `cqpsk`/`c4fm` are P25-only, and `gfsk` is valid for DMR and both NXDN
   target rates.
-- `nxdn-conventional` and `nxdn48-conventional` are distinct types, so the same frequency may appear once as each.
+- `nxdn-trunk`/`nxdn48-trunk` and `nxdn-conventional`/`nxdn48-conventional` are distinct types, so the same frequency
+  may appear once as each.
 - `rtl_gain` only affects RTL-family inputs opened by DSD-neo. It is ignored when scan retuning is done through rigctl
   against a non-RTL audio input.
 - The parser is intentionally small. It can handle a quoted `chan_csv` that contains a comma, but it is not a full CSV
@@ -249,7 +251,7 @@ During scanning:
   tuner autogain; `auto` and global-auto targets restore the saved autogain setting.
 - P25, DMR, and NXDN trunk targets stay parked while their trunking state machine is following an active call
   (NXDN stays parked while following an active grant and returns to its control channel at hangtime/release).
-- `nxdn-trunk` targets follow the site-broadcast outbound control channel: when a DFA site announces a control
+- `nxdn-trunk` and `nxdn48-trunk` targets follow the site-broadcast outbound control channel: when a DFA site announces a control
   channel that differs from the target's `frequency_hz`, DSD-neo adopts it (logging
   `NOTICE: NXDN trunking: site control channel is X MHz; following it`) and re-parks that target there from then on.
   A per-target `chan_csv` containing LCN rows pins the control channel instead, so an operator list always wins.
@@ -263,14 +265,25 @@ During scanning:
   `activity_hold_ms` the hold. The terminal status line marks the parked conventional target `Voice: QUALIFY`,
   `VOICE` while a media-bearing call is active, or `TAIL` after it ends while the hold runs. Trunked
   targets are unchanged: control-only traffic rotates after dwell, and they carry no `Voice:` marker.
-- An `nxdn-trunk` target with a `chan_csv` reports channels it was granted but could not map, once per channel while
+- An `nxdn-trunk` or `nxdn48-trunk` target with a `chan_csv` reports channels it was granted but could not map, once per channel while
   it is parked (`NOTICE: NXDN trunking: grant: CH 12 has no frequency mapping in chan_csv (site.csv)`), and a summary
   for each such target at exit. Every target keeps its own list, so one target's gaps are never attributed to another.
-- `nxdn48-conventional` targets park at 2400 sym/s with the 6.25 kHz channel filter; every other GFSK-family target
-  parks at 4800 sym/s with the 12.5 kHz filter. Each target's decoder class keeps the hunt on its allowed
+- `nxdn48-conventional` and `nxdn48-trunk` targets park at 2400 sym/s with the 6.25 kHz channel filter; every other
+  GFSK-family target parks at 4800 sym/s with the 12.5 kHz filter. Each target's decoder class keeps the hunt on its allowed
   symbol profile throughout dead air, including with empty or `auto` modulation. The parked target's type selects the
   symbol rate and channel filter even under a global `-m` modulation lock; the lock still governs symbol slicing, so
   DMR and NXDN rows under `-mc` or `-mq` need `modulation = gfsk` (or `auto`) to decode.
+- NXDN Type-D (distributed trunking, Icom IDAS Type-D; 6.25 kHz only) has no dedicated control channel: an idle
+  home repeater sends an Idle Repeater Message on its SCCH and a busy one carries `Go to Repeater` messages.
+  To follow one, park an `nxdn48-trunk` target on the home repeater's outbound frequency with a `chan_csv` that
+  maps repeater numbers 1-30 to outbound frequencies, plus a row `31` carrying the home repeater's frequency:
+  the home repeater's own row must equal the target's `frequency_hz`, and row `31` is what DSD-neo tunes on a
+  call's termination message and then treats as the control channel (without it the return waits for the DISC
+  message or hangtime, and a `CH 31 has no frequency mapping` notice is logged once). Calls are followed from
+  the SCCH Busy Repeater message; while the site is idle nothing but `dwell_ms` keeps the target parked, so
+  give it a dwell of several seconds. This path is inherited from DSD-FME, which tested it on a two-channel
+  Type-D system; DSD-neo has not verified it against a live Type-D site. An `--iq-capture` of a home repeater
+  spanning an idle period and one call (see `docs/testing.md`) is what would confirm it.
 - When a retune fails, DSD-neo logs a warning, briefly cools that target down, and tries another eligible target.
   While held, a failed retune retries the held target after the cooldown instead of moving on.
 
@@ -346,10 +359,12 @@ rotating across unrelated scan targets.
 
 ## Limitations
 
-- P25 trunk, DMR trunk, DMR conventional, NXDN trunk, NXDN96 conventional, and NXDN48 conventional targets are
-  supported. Trunked NXDN targets are 12.5 kHz NXDN96 only: 6.25 kHz NXDN48 Type-D control channels are not a
-  trunk-scan target type, so an NXDN48 site's control channel cannot be followed. `-Y` with `-fi` remains available
-  for scanning NXDN48 channels outside trunk scan.
+- P25 trunk, DMR trunk, DMR conventional, NXDN trunk at both rates (`nxdn-trunk`, `nxdn48-trunk`), NXDN96
+  conventional, and NXDN48 conventional targets are supported. NXDN Type-C sites use one control-channel
+  format at 4800 and 9600 bps (NXDN TS 1-A), so `nxdn48-trunk` shares every decoding path with `nxdn-trunk`
+  and differs only in symbol rate and channel filter; neither the Type-C nor the Type-D NXDN48 path has been
+  verified against a live NXDN48 trunked site from trunk scan. `-Y` with `-fi` remains available for scanning
+  NXDN48 channels outside trunk scan.
 - There is one active receiver. Traffic on targets that are not currently parked can be missed.
 - Group policy is global across all scan targets.
 - Target CSV files are simple comma-delimited files, not full RFC 4180 CSV.

--- a/examples/trunk_scan_targets.csv
+++ b/examples/trunk_scan_targets.csv
@@ -3,5 +3,6 @@ county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learn
 city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel using examples/dmr_t3_chan.csv,auto,,,,
 plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,,,1,0000001F00
 site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel; channel map optional when the site broadcasts DFA,auto,,,,
+site-nxdn48,nxdn48-trunk,461556250,nxdn_chan_map.csv,3000,,NXDN48 Type-C control channel (6.25 kHz); for a Type-D home repeater map repeater numbers 1-30 and row 31 = the home repeater,gfsk,,,,
 field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,,,,
 field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz) conventional channel,gfsk,,,,

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -54,6 +54,7 @@ typedef enum {
     DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK = 3,
     DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL = 4,
     DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL = 5,
+    DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK = 6,
 } dsd_trunk_scan_target_type;
 
 typedef enum {

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -384,10 +384,27 @@ trunk_scan_type_is_conventional(dsd_trunk_scan_target_type type) {
     switch (type) {
         case DSD_TRUNK_SCAN_TARGET_P25_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK: return 0;
         case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
         case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL:
         case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return 1;
+    }
+    return 0;
+}
+
+/* NXDN trunk targets follow Type-C RCCH grants or Type-D SCCH busy-repeater signalling
+ * and own an nxdn_trunk_diag ledger. */
+static int
+trunk_scan_type_is_nxdn_trunk(dsd_trunk_scan_target_type type) {
+    switch (type) {
+        case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK: return 1;
+        case DSD_TRUNK_SCAN_TARGET_P25_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return 0;
     }
     return 0;
 }
@@ -399,6 +416,7 @@ static int
 trunk_scan_type_anchors_p25_cc_freq(dsd_trunk_scan_target_type type) {
     switch (type) {
         case DSD_TRUNK_SCAN_TARGET_P25_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK: return 1;
         case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
@@ -419,6 +437,7 @@ trunk_scan_type_gfsk_symbol_rate(dsd_trunk_scan_target_type type) {
         case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
         case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL: return 4800;
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return 2400;
     }
     return 0;
@@ -456,6 +475,10 @@ scan_parse_type(const char* s, dsd_trunk_scan_target_type* out) {
     }
     if (strcmp(s, "nxdn48-conventional") == 0) {
         *out = DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL;
+        return 0;
+    }
+    if (strcmp(s, "nxdn48-trunk") == 0) {
+        *out = DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK;
         return 0;
     }
     return -1;
@@ -2044,6 +2067,7 @@ trunk_scan_apply_target_opts(dsd_opts* opts, const dsd_trunk_scan_coord* coord, 
     switch (target->type) {
         case DSD_TRUNK_SCAN_TARGET_P25_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK: opts->trunk_enable = 1; break;
         case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
         case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL:
@@ -2346,6 +2370,7 @@ trunk_scan_target_mode(dsd_trunk_scan_target_type type) {
         case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL: return DSD_SCAN_MODE_DMR;
         case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL: return DSD_SCAN_MODE_NXDN96;
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return DSD_SCAN_MODE_NXDN48;
     }
     return DSD_SCAN_MODE_INHERIT;
@@ -2575,7 +2600,7 @@ trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coor
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
         return (opts->trunk_is_tuned == 1 || dmr_sm_get_state(&rt->dmr_ctx) == DMR_SM_TUNED);
     }
-    if (rt->target.type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
+    if (trunk_scan_type_is_nxdn_trunk(rt->target.type)) {
         return opts->trunk_is_tuned == 1;
     }
     double hold_s = (double)trunk_scan_target_hold_ms(opts, rt) / 1000.0;
@@ -2702,8 +2727,7 @@ trunk_scan_resolve_pending_retune(dsd_state* state, dsd_trunk_scan_target_runtim
 
 static int
 trunk_scan_target_is_trunked(dsd_trunk_scan_target_type type) {
-    return type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK || type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK
-           || type == DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK;
+    return !trunk_scan_type_is_conventional(type);
 }
 
 /* Voice-only scan (issue #381): conventional targets hold only from decoded voice
@@ -2915,6 +2939,7 @@ trunk_scan_type_in_conventional_family(dsd_trunk_scan_target_type type, trunk_sc
     switch (type) {
         case DSD_TRUNK_SCAN_TARGET_P25_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK:
         case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK: return 0;
         case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL: return family == TRUNK_SCAN_CONVENTIONAL_FAMILY_DMR;
         case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL:
@@ -3153,7 +3178,7 @@ trunk_scan_log_nxdn_diag_summaries(dsd_trunk_scan_coord* coord, const dsd_state*
     }
     for (size_t i = 0; i < coord->count; i++) {
         const dsd_trunk_scan_target_runtime* rt = &coord->targets[i];
-        if (rt->target.type != DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK) {
+        if (!trunk_scan_type_is_nxdn_trunk(rt->target.type)) {
             continue;
         }
         nxdn_trunk_diag_log_summary_for(rt->target.chan_csv, &rt->snapshot.nxdn_diag, trunk_scan_snapshot_chan_lookup,

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -133,8 +133,8 @@ static void DSD_ATTR_USED
 dsd_engine_apply_cc_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     // Skipping is safe for the other protocols rather than merely harmless: DMR and NXDN96 are
     // already parked at 4800 sym/s with the four-level profile, and NXDN48/EDACS carry rates
-    // this function cannot express at all. An nxdn48-conventional scan target relies on that
-    // skip: the coordinator seeds its 2400 sym/s timing, and the front end gets the matching
+    // this function cannot express at all. The nxdn48-conventional and nxdn48-trunk scan targets
+    // rely on that skip: the coordinator seeds their 2400 sym/s timing, and the front end gets the matching
     // 6.25 kHz chain from dsd_engine_gfsk_cc_symbol_rate().
     if (!opts || !state || state->p25_cc_freq == 0 || !dsd_engine_cc_is_p25(state)) {
         return;

--- a/tests/engine/test_engine_trunk_retune_regression.c
+++ b/tests/engine/test_engine_trunk_retune_regression.c
@@ -897,6 +897,41 @@ main(void) {
     assert(g_rtl_ted_sps == 20); /* 48000 / 2400 from the stubbed RTL output rate */
     assert(g_rtl_ted_sps_override == 0);
 
+    /* An nxdn48-trunk target anchors p25_cc_freq like nxdn-trunk, so its return to the control channel goes
+     * through dsd_engine_compute_cc_sps(), which only knows P25 rates. The RTL chain must still come back as
+     * 2400 sym/s in 6.25 kHz with TED 20 from the coordinator's rate, not the P25-derived 10. */
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    DSD_MEMSET(state, 0, sizeof(*state));
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_scan_enabled = 1;
+    opts->trunk_enable = 1;
+    opts->trunk_is_tuned = 1;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->rf_mod = 2;
+    state->p25_cc_freq = 461556250;
+    state->trunk_cc_freq = 461556250;
+    state->p25_cc_is_tdma = 2;
+    state->synctype = DSD_SYNC_NXDN_POS;
+    state->lastsynctype = DSD_SYNC_NXDN_POS;
+    state->samplesPerSymbol = 20;
+    state->symbolCenter = 9;
+    state->sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_2400_4;
+    g_trunk_scan_target_count = 2;
+    g_trunk_scan_active_p25_target = 0;
+    g_trunk_scan_active_gfsk_symbol_rate = 2400;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    g_rtl_symbol_rate_hz = 4800;
+    g_rtl_channel_profile = RTL_STREAM_CHANNEL_PROFILE_12K5;
+    g_rtl_ted_sps = 10;
+    g_rtl_pending_active = 0;
+    assert(dsd_engine_return_to_cc_request(opts, state, 0U) == DSD_TRUNK_TUNE_RESULT_OK);
+    assert(g_rtl_symbol_rate_hz == 2400);
+    assert(g_rtl_channel_profile == RTL_STREAM_CHANNEL_PROFILE_6K25);
+    assert(g_rtl_ted_sps == 20);
+    assert(state->rf_mod == 2 && state->samplesPerSymbol == 20 && state->symbolCenter == 9);
+    assert(state->sps_hunt_idx == DSD_FRAME_SYNC_SPS_PROFILE_2400_4);
+    assert(opts->trunk_is_tuned == 0);
+
     /* Even stale scanner flags cannot change the trunk coordinator's backend
      * contract: rigctl owns the frequency and the target owns the profile. */
     opts->scanner_mode = 1;

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -488,7 +488,8 @@ test_parser_accepts_nxdn_targets(void) {
     if (write_targets_file_with_header(dir, header,
                                        "nxdn,nxdn-trunk,461000000,chan.csv,,,site,gfsk\n"
                                        "conv,nxdn-conventional,462000000,,250,500,,auto\n"
-                                       "conv48,nxdn48-conventional,462000000,,250,500,,gfsk\n",
+                                       "conv48,nxdn48-conventional,462000000,,250,500,,gfsk\n"
+                                       "trunk48,nxdn48-trunk,461556250,chan.csv,,,narrow site,gfsk\n",
                                        target_path, sizeof target_path)
         != 0) {
         cleanup_paths(dir, NULL, chan_path);
@@ -505,7 +506,7 @@ test_parser_accepts_nxdn_targets(void) {
     int rc = dsd_trunk_scan_load_targets_csv(target_path, &opts, &list, err, sizeof err);
 
     int test_rc = 0;
-    if (rc != 0 || list.count != 3) {
+    if (rc != 0 || list.count != 4) {
         DSD_FPRINTF(stderr, "parser nxdn rc=%d count=%zu err=%s\n", rc, list.count, err);
         test_rc = 1;
     }
@@ -531,6 +532,13 @@ test_parser_accepts_nxdn_targets(void) {
             || list.targets[2].activity_hold_ms != 500 || list.targets[2].modulation != DSD_TRUNK_SCAN_MODULATION_GFSK
             || list.targets[2].chan_csv[0] != '\0') {
             DSD_FPRINTF(stderr, "parser nxdn48 conventional target 2 mismatch\n");
+            test_rc = 1;
+        }
+        if (list.targets[3].type != DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK || list.targets[3].frequency_hz != 461556250U
+            || list.targets[3].dwell_ms != 3000 || list.targets[3].activity_hold_ms != 1200
+            || list.targets[3].modulation != DSD_TRUNK_SCAN_MODULATION_GFSK
+            || !strstr(list.targets[3].chan_csv, "chan.csv")) {
+            DSD_FPRINTF(stderr, "parser nxdn48 trunk target 3 mismatch\n");
             test_rc = 1;
         }
     }
@@ -739,6 +747,10 @@ test_parser_rejects_invalid_inputs(void) {
     rc |= expect_parser_rejects_with_header(
         "nxdn48-unsupported-modulation", "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n",
         "a,nxdn48-conventional,461556250,,,,,c4fm\n");
+    rc |=
+        expect_parser_rejects_with_header("nxdn48-trunk-unsupported-modulation",
+                                          "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation\n",
+                                          "a,nxdn48-trunk,461556250,,,,,cqpsk\n");
     rc |= expect_parser_rejects_with_header("invalid-rtl-gain",
                                             "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,rtl_gain\n",
                                             "a,p25-trunk,851000000,,,,,50\n");
@@ -3510,13 +3522,12 @@ test_trunked_voice_gate_control_only_unchanged(void) {
 }
 
 static int
-test_nxdn_trunk_target_holds_while_tuned(void) {
+run_nxdn_trunk_hold_case(const char* trunk_row, const char* label) {
     char dir[DSD_TEST_PATH_MAX];
     char target_path[DSD_TEST_PATH_MAX];
-    if (make_runtime_targets("n,nxdn-trunk,461000000,,250,,\n"
-                             "c,dmr-conventional,462000000,,250,,\n",
-                             target_path, sizeof target_path, dir, sizeof dir)
-        != 0) {
+    char rows[256];
+    DSD_SNPRINTF(rows, sizeof rows, "%sc,dmr-conventional,462000000,,250,,\n", trunk_row);
+    if (make_runtime_targets(rows, target_path, sizeof target_path, dir, sizeof dir) != 0) {
         return 1;
     }
 
@@ -3530,7 +3541,7 @@ test_nxdn_trunk_target_holds_while_tuned(void) {
     int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
     int test_rc = 0;
     if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0) {
-        DSD_FPRINTF(stderr, "nxdn hold scan init failed rc=%d err=%s\n", rc, err);
+        DSD_FPRINTF(stderr, "%s hold scan init failed rc=%d err=%s\n", label, rc, err);
         test_rc = 1;
     }
 
@@ -3538,13 +3549,13 @@ test_nxdn_trunk_target_holds_while_tuned(void) {
     trunk_scan_test_set_now(0.26);
     dsd_engine_trunk_scan_tick(&opts, &state);
     if (dsd_engine_trunk_scan_active_index(&state) != 0) {
-        DSD_FPRINTF(stderr, "tuned NXDN trunk target rotated away while tuned\n");
+        DSD_FPRINTF(stderr, "%s trunk target rotated away while tuned\n", label);
         test_rc = 1;
     }
     trunk_scan_test_set_now(0.52);
     dsd_engine_trunk_scan_tick(&opts, &state);
     if (dsd_engine_trunk_scan_active_index(&state) != 0) {
-        DSD_FPRINTF(stderr, "tuned NXDN trunk target rotated away on second tick\n");
+        DSD_FPRINTF(stderr, "%s trunk target rotated away on second tick\n", label);
         test_rc = 1;
     }
 
@@ -3552,13 +3563,13 @@ test_nxdn_trunk_target_holds_while_tuned(void) {
     trunk_scan_test_set_now(0.78);
     dsd_engine_trunk_scan_tick(&opts, &state);
     if (dsd_engine_trunk_scan_active_index(&state) != 0) {
-        DSD_FPRINTF(stderr, "NXDN trunk target rotated on idle clock restart tick\n");
+        DSD_FPRINTF(stderr, "%s trunk target rotated on idle clock restart tick\n", label);
         test_rc = 1;
     }
     trunk_scan_test_set_now(1.04);
     dsd_engine_trunk_scan_tick(&opts, &state);
     if (dsd_engine_trunk_scan_active_index(&state) != 1) {
-        DSD_FPRINTF(stderr, "NXDN trunk target did not rotate after release and dwell\n");
+        DSD_FPRINTF(stderr, "%s trunk target did not rotate after release and dwell\n", label);
         test_rc = 1;
     }
 
@@ -3566,6 +3577,13 @@ test_nxdn_trunk_target_holds_while_tuned(void) {
     trunk_scan_test_clear_now();
     cleanup_paths(dir, target_path, NULL);
     return test_rc;
+}
+
+static int
+test_nxdn_trunk_target_holds_while_tuned(void) {
+    int rc = run_nxdn_trunk_hold_case("n,nxdn-trunk,461000000,,250,,\n", "NXDN96");
+    rc |= run_nxdn_trunk_hold_case("n,nxdn48-trunk,461556250,,250,,\n", "NXDN48");
+    return rc;
 }
 
 static int
@@ -3640,7 +3658,7 @@ test_nxdn_trunk_diag_isolated_per_target(void) {
     char target_path[DSD_TEST_PATH_MAX];
     if (write_targets_file(dir,
                            "a,nxdn-trunk,461000000,chan.csv,250,,\n"
-                           "b,nxdn-trunk,462000000,,250,,\n",
+                           "b,nxdn48-trunk,462000000,,250,,\n",
                            target_path, sizeof target_path)
         != 0) {
         cleanup_paths(dir, NULL, chan_path);
@@ -3933,6 +3951,92 @@ counting_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps
         state->trunk_cc_freq = freq;
     }
     return g_counting_tune_to_cc_result;
+}
+
+static int
+test_nxdn48_trunk_target_parks_on_2400_control_channel(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("n96,nxdn-trunk,461000000,,250,,\n"
+                             "n48,nxdn48-trunk,461556250,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_cc_request = counting_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_failures_remaining = 0;
+    g_counting_tune_to_cc_ted_sps = 0;
+    g_counting_tune_to_cc_freq = 0;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int rc = dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err);
+    int test_rc = 0;
+    if (rc != 0 || dsd_engine_trunk_scan_active_index(&state) != 0 || g_counting_tune_to_cc_ted_sps != 10
+        || opts.frame_nxdn96 != 1 || opts.frame_nxdn48 != 0) {
+        DSD_FPRINTF(stderr, "nxdn96 trunk park failed rc=%d active=%zu ted=%d n96=%d n48=%d err=%s\n", rc,
+                    dsd_engine_trunk_scan_active_index(&state), g_counting_tune_to_cc_ted_sps, opts.frame_nxdn96,
+                    opts.frame_nxdn48, err);
+        test_rc = 1;
+    }
+
+    /* Parking an NXDN48 trunk target must replace stale timing and select the narrow decoder. */
+    state.sps_hunt_idx = DSD_FRAME_SYNC_SPS_PROFILE_4800_2;
+    state.sps_hunt_counter = 17;
+    state.samplesPerSymbol = 8;
+    state.symbolCenter = 3;
+    state.rf_mod = 0;
+    g_counting_tune_to_cc_ted_sps = 0;
+    g_counting_tune_to_cc_freq = 0;
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 1 || opts.trunk_enable != 1 || opts.frame_nxdn48 != 1
+        || opts.frame_nxdn96 != 0 || state.p25_cc_freq != 461556250L || state.trunk_cc_freq != 461556250L
+        || state.trunk_lcn_freq[0] != 461556250L || state.lcn_freq_count < 1) {
+        DSD_FPRINTF(stderr,
+                    "nxdn48 trunk park wrong active=%zu trunk=%d n48=%d n96=%d p25=%ld cc=%ld lcn=%ld count=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), opts.trunk_enable, opts.frame_nxdn48, opts.frame_nxdn96,
+                    state.p25_cc_freq, state.trunk_cc_freq, state.trunk_lcn_freq[0], state.lcn_freq_count);
+        test_rc = 1;
+    }
+    if (state.sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_2400_4 || state.sps_hunt_counter != 0
+        || state.samplesPerSymbol != 20 || state.symbolCenter != 9 || state.rf_mod != 2
+        || g_counting_tune_to_cc_ted_sps != 20 || g_counting_tune_to_cc_freq != 461556250L) {
+        DSD_FPRINTF(stderr, "nxdn48 trunk timing wrong idx=%d counter=%d sps=%d center=%d rf_mod=%d ted=%d freq=%ld\n",
+                    state.sps_hunt_idx, state.sps_hunt_counter, state.samplesPerSymbol, state.symbolCenter,
+                    state.rf_mod, g_counting_tune_to_cc_ted_sps, g_counting_tune_to_cc_freq);
+        test_rc = 1;
+    }
+
+    /* The return to NXDN96 must restore both decoder selection and 4800-symbol timing. */
+    g_counting_tune_to_cc_ted_sps = 0;
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_engine_trunk_scan_active_index(&state) != 0 || state.sps_hunt_idx != DSD_FRAME_SYNC_SPS_PROFILE_4800_4
+        || state.samplesPerSymbol != 10 || state.symbolCenter != 4 || state.rf_mod != 2 || opts.frame_nxdn96 != 1
+        || opts.frame_nxdn48 != 0 || g_counting_tune_to_cc_ted_sps != 10) {
+        DSD_FPRINTF(stderr, "nxdn96 trunk inherited narrow profile active=%zu idx=%d sps=%d center=%d ted=%d\n",
+                    dsd_engine_trunk_scan_active_index(&state), state.sps_hunt_idx, state.samplesPerSymbol,
+                    state.symbolCenter, g_counting_tune_to_cc_ted_sps);
+        test_rc = 1;
+    }
+
+    DSD_MEMSET(&hooks, 0, sizeof hooks);
+    dsd_trunk_tuning_hooks_set(hooks);
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
 }
 
 static int
@@ -6002,7 +6106,8 @@ test_parser_accepts_target_key_columns(void) {
                                        "c,nxdn-conventional,461000000,,250,,conv,hexkeys.csv,\n"
                                        "d,nxdn-trunk,461037500,,250,,type-c,,deckeys.csv\n"
                                        "e,dmr-conventional,461112500,,250,,plant,hexkeys.csv,deckeys.csv\n"
-                                       "f,nxdn48-conventional,461556250,,250,,narrow,hexkeys.csv,\n",
+                                       "f,nxdn48-conventional,461556250,,250,,narrow,hexkeys.csv,\n"
+                                       "g,nxdn48-trunk,461556250,,250,,narrow type-c,,deckeys.csv\n",
                                        target_path, sizeof target_path)
         != 0) {
         cleanup_paths(dir, NULL, NULL);
@@ -6021,7 +6126,7 @@ test_parser_accepts_target_key_columns(void) {
     int test_rc = 0;
     char want_hex[DSD_TEST_PATH_MAX] = {0};
     char want_dec[DSD_TEST_PATH_MAX] = {0};
-    if (rc != 0 || list.count != 6 || dsd_test_path_join(want_hex, sizeof want_hex, dir, "hexkeys.csv") != 0
+    if (rc != 0 || list.count != 7 || dsd_test_path_join(want_hex, sizeof want_hex, dir, "hexkeys.csv") != 0
         || dsd_test_path_join(want_dec, sizeof want_dec, dir, "deckeys.csv") != 0) {
         DSD_FPRINTF(stderr, "target keys parser rc=%d count=%zu err=%s\n", rc, list.count, err);
         test_rc = 1;
@@ -6053,6 +6158,10 @@ test_parser_accepts_target_key_columns(void) {
         }
         if (strcmp(list.targets[5].keys_hex_csv, want_hex) != 0 || list.targets[5].keys_dec_csv[0] != '\0') {
             DSD_FPRINTF(stderr, "nxdn48-conventional target key paths mismatch\n");
+            test_rc = 1;
+        }
+        if (list.targets[6].keys_hex_csv[0] != '\0' || strcmp(list.targets[6].keys_dec_csv, want_dec) != 0) {
+            DSD_FPRINTF(stderr, "nxdn48-trunk target key paths mismatch\n");
             test_rc = 1;
         }
     }
@@ -7383,6 +7492,7 @@ main(void) {
     rc |= run_with_default_tune_hook(test_nxdn_trunk_target_seeds_control_channel);
     rc |= run_with_default_tune_hook(test_mixed_target_switch_resets_nxdn_demod_profile);
     rc |= run_with_default_tune_hook(test_nxdn48_target_selects_2400_demod_profile);
+    rc |= run_with_default_tune_hook(test_nxdn48_trunk_target_parks_on_2400_control_channel);
     rc |= run_with_default_tune_hook(test_nxdn48_target_uses_rtl_output_rate_for_sps);
     rc |= run_with_default_tune_hook(test_target_classes_enable_missing_decoders);
     rc |= run_with_default_tune_hook(test_nxdn_conventional_activity_hold);


### PR DESCRIPTION
## Summary

Closes #375.

- Add `nxdn48-trunk` for NXDN48 trunk scanning at 2400 sym/s with the 6.25 kHz channel profile, mirroring the existing NXDN96 trunk target.
- Preserve channel-map handling, control-channel anchors, tuned-call hold, decoder selection, and per-target diagnostic isolation across both NXDN rates.
- Add parser, mixed-rate parking, hold, diagnostic isolation, and return-to-control-channel regression coverage.
- Update operator docs and examples, distinguish Type-C from Type-D, and document the inherited Type-D home-repeater/channel-map path.

The public specifications establish Type-C trunking at both NXDN rates; NXDN48 trunking is not synonymous with Type-D. Research and sources: https://github.com/arancormonk/dsd-neo/issues/375#issuecomment-5556228772.

**Capture availability is not a merge or issue-closure blocker.** Neither NXDN48 Type-C nor Type-D trunk scanning has been verified against a live site or trunked I/Q capture. The docs retain that limitation. Contributions of a Type-C control-channel capture including a grant, or a Type-D home-repeater capture covering idle and a call, remain welcome after this issue closes.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- Scope is limited to coordinator target classification, existing test files, and documentation; no protocol decoder or library-boundary changes.
- High-risk area touched: parser (one additional target-type token, with focused acceptance/rejection coverage).
- Human/outside review is not claimed; requested through this PR.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off.

## Quality Review

- [x] Parser and radio-timing behavior have focused regression coverage.
- [x] No new static-analysis suppressions.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions.

## Tests And Guardrails

- [x] `cmake --preset dev-debug` and `cmake --build --preset dev-debug -j 8`
- [x] Focused CTest: `ENGINE_TRUNK_SCAN`, `ENGINE_TRUNK_RETUNE_REGRESSION`, `RUNTIME_SCAN_MODE`, `ENGINE_CHANNEL_SCAN` (4/4 passed after the final test edits were built).
- [x] `ctest --preset dev-debug -L iq-decode --output-on-failure` (30/30 passed).
- [x] Separate radio-off debug build with RTL-SDR and SoapySDR disabled; complete CTest suite (569/569 passed).
- [x] Isolated negative controls fail for missing NXDN48 parsing, missing tuned-call hold, and incorrect symbol rate; temporary artifacts removed.
- [x] `tools/check_arch_rules.sh`
- [x] `tools/preflight_ci.sh` (including formatting and static analysis).
- Full radio-enabled CTest suite and `tools/quality_preflight.sh` were not run. No CMake, workflow, or dependency changes.

## Risk

- Security/dependency impact: no dependency or permission changes; existing CSV parsing machinery accepts one additional type.
- CLI/UI behavior impact: a new opt-in CSV target type; existing enum values and existing target behavior remain unchanged.
- Compatibility or packaging impact: radio-on and radio-off builds pass; no new build targets.
- On-air risk: live NXDN48 trunk operation remains unverified. Type-C composite-control-channel ambiguity in the existing LICH routing is unchanged and out of scope.
