### PR TITLE
feat(ui): add live Android talkgroup list controls

### DIFF
--- a/.github/workflows/android-ci.yaml
+++ b/.github/workflows/android-ci.yaml
@@ -318,6 +318,7 @@ jobs:
             dsd-neo_test_ui_qt_spectrum_math \
             dsd-neo_test_ui_qt_spectrum_model \
             dsd-neo_test_ui_qt_metrics_model \
+            dsd-neo_test_ui_qt_talkgroup_list_model \
             dsd-neo_test_ui_qt_radio_reference_model
 
       # The QML test carries its own headless environment (offscreen platform,

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -499,6 +499,13 @@ Qt Quick frontend (`src/ui/qt`):
   the runtime client, previews what an import would produce, and writes the generated CSVs into that same library with
   provenance, while the add-system wizard stays the single writer of a saved system. See
   `docs/radioreference-import.md`.
+- `talkgroup_list_model.{h,cpp}` polls the effective core policy's source-context/generation pair after call-history
+  ingestion, merging listed rows with uncovered talkgroups heard this session. `talkgroup_filter_model.{h,cpp}`
+  filters by category and name/ID for `qml/TalkgroupsScreen.qml`, opened by the monitor's **TG list** action.
+  `CommandBridge` submits `TG_LISTEN_SET`/`TG_LISTEN_SET_ALL` through app-control; only the decoder thread mutates
+  policy and atomically rewrites a configured group file. Scan-row lists remain session-only. Skip shares this
+  mutation path, preserving labels. Runtime's `dsd_rr_talkgroups_apply_categories()` supplies category names to
+  both RadioReference frontends before CSV generation.
 - Platform-free by rule: it may include Qt and `include/dsd-neo/app_control/` headers, never engine/io/protocol
   internals, and never platform APIs (`QJniObject`, `<android/*.h>`). Platform specifics live behind the `DecoderHost`
   interface, implemented per host (`android/decoder_host_android.cpp` today).

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -55,14 +55,14 @@ accepted/skipped/total row counts without touching live decoder state.
 The RadioReference import (`docs/radioreference-import.md`) writes into the same library through the same validator,
 and its files are ordinary CSVs in the formats below — nothing reads them differently. Two things distinguish them:
 
-- **Their header line names its origin.** `DEC,Mode,Name (generated from RadioReference)` for a group list; a
+- **Their header line names its origin.** `DEC,Mode,Name,Category,(generated from RadioReference)` for a group list; a
   trunked channel map gets `ChannelNumber(dec),frequency(Hz) (generated from RadioReference; do not delete this
   line)`. A **conventional** channel map's header differs —
   `ChannelNumber(dec),frequency(Hz),name,(generated from RadioReference; do not delete this line)` — because its
   third field is exactly `name`, which is what opts every row into the channel map's optional name column (see
   below); a trunked map has no per-channel name to offer, so its header stays two-field and the note stays free
-  text. Both parsers discard physical line 1 unconditionally, so the text is for humans — but deleting it eats the
-  first data row.
+  text. Headers are required: group categories and conventional channel names opt in through named columns,
+  while deleting the header causes the parser to consume the first data row as the header.
 - **Their library row records provenance**, so the file can be re-fetched later. In
   `files/imported_files.json` those rows carry five extra keys beyond the ordinary
   `name`/`path`/`type`/`importedAt`/`accepted`/`skipped`: `origin` (`"radioreference"`), `rrSid` (the RadioReference
@@ -410,7 +410,9 @@ Required columns:
 Notes:
 
 - The first line is treated as header text and is required.
-- Basic/default behavior uses only the first 3 columns; extra columns are ignored.
+- Basic/default behavior uses the first 3 columns. A fourth header field named `tag`, `tags`, or `category`
+  (case-insensitive, surrounding whitespace ignored) retains that column as a category; other extra columns,
+  including `metadata`, are ignored. Categories are trimmed and capped at 49 bytes, like names.
 - `mode` is matched literally by features that consult it:
   - `A` usually means allow/normal.
   - `B` and `DE` are treated as locked out.
@@ -425,7 +427,7 @@ Extended policy columns are supported only when the header opts into this exact 
 3. `audio` (`on`/`off`, default from `mode`)
 4. `record` (`on`/`off`, default from `mode`)
 5. `stream` (`on`/`off`, default from `mode`)
-6. `tags` (free text metadata; accepted for notes/round-tripping, not applied to runtime policy)
+6. `tags` (free text category retained for frontend filtering and round-tripping; never a policy condition)
 
 Important behavior:
 
@@ -439,6 +441,22 @@ Important behavior:
 - Exact duplicates preserve first-match behavior.
 - `audio=off` forces `record=off` and `stream=off`.
 - `mode=B`/`DE` forces media fields off regardless of optional values.
+- Android: **TG list** on the live monitor lists configured talkgroups/ranges plus voice talkgroups heard this
+  session that no listed row covers. Tap a card to choose **Listening** (`A`) or **Not tuned** (`B`); the screen
+  waits for the decoder snapshot before showing the change. Search matches names or IDs; category chips use the
+  retained tags (RadioReference imports supply their category names).
+- **Listen all** and **Do not tune all** edit listed rows in the selected category, or every listed row under
+  **All**. Search text does not narrow bulk edits. Learned radio-ID alias rows and mode `D` rows are excluded.
+  In allow-list mode, heard-but-unlisted talkgroups remain blocked until individually allowed.
+- A listening edit preserves a row's name, category, priority and preemption setting, but resets its media flags
+  from the selected mode. The monitor's **Skip** uses the same name-preserving block path.
+- When a group file is configured, edits atomically rewrite that file in table order, preserving ranges and
+  modeled fields. Existing extended policy headers remain extended; otherwise the output is `id,mode,name,tags`
+  when categories exist, or `id,mode,name`. Unmodeled metadata/note columns are discarded. Android rewrites its
+  app-private imported copy, not the original document.
+- Without a group file, edits last only for the session. A scan row's own effective list is also edited only
+  in memory, never written into the global group file. If saving fails, the decoder keeps the live edit and
+  reports that it is session-only; the previous file remains intact.
 
 Example:
 

--- a/include/dsd-neo/app_control/commands.h
+++ b/include/dsd-neo/app_control/commands.h
@@ -241,6 +241,13 @@ enum dsd_app_command_id {
     // P25 helpers
     DSD_APP_CMD_P25_P2_PARAMS_SET = 580, // payload: struct { uint64_t wacn, sysid, cc; }
 
+    // Edit the first effective policy row with these bounds, preserving its metadata.
+    // Missing exact IDs are added. listen=1 selects A; listen=0 selects B and releases
+    // blocked active group calls. Persist to group_in_file unless a scan row owns the list.
+    DSD_APP_CMD_TG_LISTEN_SET = 590, // payload: dsd_app_tg_listen_payload
+    // Edit all rows except radio-ID aliases; a nonempty tag selects exact tag matches.
+    DSD_APP_CMD_TG_LISTEN_SET_ALL = 591, // payload: dsd_app_tg_listen_all_payload
+
     // UI display toggles
     DSD_APP_CMD_UI_SHOW_DSP_PANEL_TOGGLE = 620,
     DSD_APP_CMD_UI_SHOW_P25_METRICS_TOGGLE = 621,
@@ -313,6 +320,17 @@ typedef struct {
 } dsd_app_p25_p2_params_payload;
 
 typedef struct {
+    uint32_t id_start;
+    uint32_t id_end; /* Equal to id_start for an exact talkgroup. */
+    int32_t listen;  /* 1 = listen (A), 0 = do not tune (B). */
+} dsd_app_tg_listen_payload;
+
+typedef struct {
+    int32_t listen;
+    char tags[50]; /* Empty = all rows; otherwise an exact category match. */
+} dsd_app_tg_listen_all_payload;
+
+typedef struct {
     uint64_t H;
     uint64_t K1;
     uint64_t K2;
@@ -353,6 +371,8 @@ int dsd_app_command_set_float(int cmd_id, float value);
 int dsd_app_command_set_string(int cmd_id, const char* value);
 int dsd_app_command_set_endpoint(int cmd_id, const char* host, int32_t port);
 int dsd_app_command_set_p25_p2_params(const dsd_app_p25_p2_params_payload* payload);
+int dsd_app_command_set_tg_listen(const dsd_app_tg_listen_payload* payload);
+int dsd_app_command_set_tg_listen_all(const dsd_app_tg_listen_all_payload* payload);
 int dsd_app_command_set_hytera_key(const dsd_app_hytera_key_payload* payload);
 int dsd_app_command_set_aes_key(const dsd_app_aes_key_payload* payload);
 int dsd_app_command_dsp_op(const dsd_app_dsp_payload* payload);

--- a/include/dsd-neo/core/scan_profile.h
+++ b/include/dsd-neo/core/scan_profile.h
@@ -74,6 +74,8 @@ void dsd_scan_groups_leave(dsd_state* state);
 /** Park the row policy so a group import edits the global baseline beneath it. Returns 1 when
  * parked (resume is then owed), 0 when no row policy is active. */
 int dsd_scan_groups_suspend(dsd_state* state);
+/** A scan row's own group list is the effective policy (edits must not be written to the global group file). */
+int dsd_scan_groups_row_active(const dsd_state* state);
 /** Adopt the edited global baseline and restore the parked policy with active calls intact. */
 void dsd_scan_groups_resume(dsd_state* state);
 #ifdef __cplusplus

--- a/include/dsd-neo/core/talkgroup_policy.h
+++ b/include/dsd-neo/core/talkgroup_policy.h
@@ -66,6 +66,7 @@ typedef struct {
     uint32_t id_end;
     char mode[8];
     char name[50];
+    char tags[50]; /* Free text from the CSV tags/category column; frontends only, never consulted by policy. */
     int priority;
     uint8_t preempt;
     uint8_t audio;
@@ -155,6 +156,31 @@ int dsd_tg_policy_reload_group_file(const dsd_opts* opts, dsd_state* state);
  *         loaded), -1 on a null state or allocation failure.
  */
 int dsd_tg_policy_clear(dsd_state* state);
+
+/** Rows in table order (file order, then runtime appends). 0 without a policy context.
+ * Works on live decoder state and frontend snapshot copies. */
+size_t dsd_tg_policy_entry_count(const dsd_state* state);
+/** Copy row @p index into @p out. Returns 1 when copied, 0 for NULL out or out of range (out zeroed). */
+int dsd_tg_policy_entry_at(const dsd_state* state, size_t index, dsd_tg_policy_entry* out);
+/** Live source context identity and table generation; both 0 without a context.
+ * Every row mutation advances the generation. Equal pairs mean equal rows; snapshots report their source id. */
+void dsd_tg_policy_table_version(const dsd_state* state, uint64_t* out_context_id, unsigned int* out_generation);
+/** Set the mode of the first row with exactly these bounds, keeping its name, tags, priority,
+ * preempt and source, and re-deriving audio/record/stream from mode. A missing exact id is
+ * appended with an empty name and source USER_LOCKOUT; a missing range is refused.
+ * Creates the context when absent.
+ * Returns 0 applied, 1 invalid (NULL state/mode, empty or over-long mode, reversed bounds,
+ * missing range), -1 allocation failure. */
+int dsd_tg_policy_set_mode(dsd_state* state, uint32_t id_start, uint32_t id_end, const char* mode);
+/** Same edit on the row at @p index (decoder thread only; indices remain stable while it holds state).
+ * Returns 0 applied, 1 bad index or mode. */
+int dsd_tg_policy_set_mode_at(dsd_state* state, size_t index, const char* mode);
+/** Atomically rewrite opts->group_in_file from the effective table using a sibling temporary file.
+ * Keeps an existing extended policy header, otherwise uses id,mode,name,tags when any row has tags,
+ * or id,mode,name. Ranges are written as start-end. Unmodelled free-text columns (e.g. alias metadata)
+ * are not preserved. Returns 0 written or nothing to write (NULL opts, empty path), -1 on I/O
+ * failure with the old file intact. */
+int dsd_tg_policy_write_group_file(const dsd_opts* opts, const dsd_state* state);
 
 /**
  * Decoder-thread owned, reference-counted policy context. References preserve row-local

--- a/include/dsd-neo/runtime/radioreference_generate.h
+++ b/include/dsd-neo/runtime/radioreference_generate.h
@@ -211,13 +211,14 @@ int dsd_rr_site_is_simulcast(const dsd_rr_site* site);
 /**
  * @brief Generate a group (talkgroup) CSV.
  *
- * Three columns, sorted ascending by ID, duplicate IDs dropped keeping the
- * first. Encrypted talkgroups get mode "DE", which blocks tuning, audio,
- * recording and streaming for that ID. Names are sanitized for a parser with no
- * quoting: commas become slashes, control bytes are stripped, whitespace runs
- * collapse, and the result is truncated on a UTF-8 boundary to fit the
- * importer's 49-byte name field. No space follows a comma, because the importer
- * does not trim the name column.
+ * ID, mode and name columns, plus a fourth category column when non-empty.
+ * Sorted ascending by ID, duplicate IDs dropped keeping the first. Encrypted
+ * talkgroups get mode "DE", which blocks tuning, audio, recording and streaming
+ * for that ID. Names and categories are sanitized for a parser with no quoting:
+ * commas become slashes, control bytes are stripped, whitespace runs collapse,
+ * and each result is truncated on a UTF-8 boundary to fit the importer's 49-byte
+ * fields. No space follows a comma, because the importer does not trim the name
+ * column. Category shortening is not included in talkgroup-name warnings.
  *
  * @param talkgroups      Talkgroups to emit.
  * @param count           Number of talkgroups.

--- a/include/dsd-neo/runtime/radioreference_import.h
+++ b/include/dsd-neo/runtime/radioreference_import.h
@@ -72,6 +72,9 @@ typedef struct {
 int dsd_rr_system_info_resolve(dsd_rr_client* client, const dsd_rr_auth* auth, const dsd_rr_trs_details* details,
                                dsd_rr_system_info* info, dsd_rr_error* err);
 
+/** Splice matching category names onto talkgroups; NULL categories clears their labels. */
+void dsd_rr_talkgroups_apply_categories(dsd_rr_talkgroup_list* talkgroups, const dsd_rr_talkgroup_cat_list* categories);
+
 /**
  * @brief Import options. Tri-state members: -1 = follow the RadioReference record.
  *

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -2771,6 +2771,18 @@ dsd_app_command_set_p25_p2_params(const dsd_app_p25_p2_params_payload* payload) 
 }
 
 int
+dsd_app_command_set_tg_listen(const dsd_app_tg_listen_payload* payload) {
+    return payload ? dsd_app_command_submit(DSD_APP_CMD_TG_LISTEN_SET, payload, sizeof *payload)
+                   : DSD_APP_COMMAND_SUBMIT_REJECTED;
+}
+
+int
+dsd_app_command_set_tg_listen_all(const dsd_app_tg_listen_all_payload* payload) {
+    return payload ? dsd_app_command_submit(DSD_APP_CMD_TG_LISTEN_SET_ALL, payload, sizeof *payload)
+                   : DSD_APP_COMMAND_SUBMIT_REJECTED;
+}
+
+int
 dsd_app_command_set_hytera_key(const dsd_app_hytera_key_payload* payload) {
     return payload ? dsd_app_command_submit(DSD_APP_CMD_KEY_HYTERA_SET, payload, sizeof *payload)
                    : DSD_APP_COMMAND_SUBMIT_REJECTED;
@@ -2847,6 +2859,8 @@ static const struct ui_cmd_payload_min_size_rule k_ui_cmd_payload_min_size_rules
     {DSD_APP_CMD_RIGCTL_CONNECT_CFG, sizeof(dsd_app_endpoint_payload)},
     {DSD_APP_CMD_UDP_INPUT_CFG, sizeof(dsd_app_udp_input_payload)},
     {DSD_APP_CMD_P25_P2_PARAMS_SET, sizeof(dsd_app_p25_p2_params_payload)},
+    {DSD_APP_CMD_TG_LISTEN_SET, sizeof(dsd_app_tg_listen_payload)},
+    {DSD_APP_CMD_TG_LISTEN_SET_ALL, sizeof(dsd_app_tg_listen_all_payload)},
     {DSD_APP_CMD_KEY_HYTERA_SET, sizeof(dsd_app_hytera_key_payload)},
     {DSD_APP_CMD_KEY_AES_SET, sizeof(dsd_app_aes_key_payload)},
     {DSD_APP_CMD_DSP_OP, sizeof(dsd_app_dsp_payload)},
@@ -3733,6 +3747,113 @@ apply_cmd_lockout_resolve_target(const dsd_state* state, const struct dsd_app_co
 }
 
 static int
+tg_listen_apply(dsd_state* state, uint32_t id_start, uint32_t id_end, int listen) {
+    return dsd_tg_policy_set_mode(state, id_start, id_end, listen ? "A" : "B");
+}
+
+static void
+tg_listen_persist(dsd_opts* opts, dsd_state* state) {
+    if (dsd_scan_groups_row_active(state)) {
+        return;
+    }
+    if (dsd_tg_policy_write_group_file(opts, state) != 0) {
+        LOG_WARN("WARNING: Talkgroup list changes could not be written to '%s'.\n", opts->group_in_file);
+        ui_set_toast(state, 4, "Talkgroup change kept for this session only");
+    }
+}
+
+static int
+tg_listen_row_is_editable(const dsd_tg_policy_entry* entry) {
+    return entry->source != DSD_TG_POLICY_SOURCE_RUNTIME_ALIAS && strcmp(entry->mode, "D") != 0;
+}
+
+static void
+tg_listen_release_blocked_calls(dsd_opts* opts, dsd_state* state) {
+    for (unsigned int slot = 0; slot < 2U; ++slot) {
+        dsd_call_snapshot call;
+        if (dsd_call_state_get(state, slot, &call) <= 0 || call.phase != DSD_CALL_PHASE_ACTIVE
+            || call.kind == DSD_CALL_KIND_PRIVATE_VOICE) {
+            continue;
+        }
+        const uint64_t target = call.policy_target_id ? call.policy_target_id : call.ota_target_id;
+        if (target == 0U || target > UINT32_MAX) {
+            continue;
+        }
+        dsd_tg_policy_decision decision;
+        if (dsd_tg_policy_evaluate_group_call(opts, state, (uint32_t)target, 0, 0, 0, &decision) == 0
+            && (decision.block_reasons & DSD_TG_POLICY_BLOCK_MODE)) {
+            if (apply_lockout_decoder_transition(opts, state) == UI_CMD_APPLY_FAILED) {
+                ui_set_toast(state, 4, "TG %u not tuned; return-to-CC tune failed", (unsigned)target);
+            }
+            return;
+        }
+    }
+}
+
+static int
+apply_cmd_tg_listen_one(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    dsd_app_tg_listen_payload payload;
+    DSD_MEMCPY(&payload, c->data, sizeof payload);
+    if (payload.id_start > payload.id_end) {
+        ui_set_toast(state, 3, "Invalid talkgroup range");
+        return UI_CMD_APPLY_FAILED;
+    }
+    const int rc = tg_listen_apply(state, payload.id_start, payload.id_end, payload.listen);
+    if (rc == 1) {
+        ui_set_toast(state, 3, "Range %u-%u is not on the list", (unsigned)payload.id_start, (unsigned)payload.id_end);
+        return UI_CMD_APPLY_FAILED;
+    }
+    if (rc != 0) {
+        LOG_WARN("WARNING: Could not update TG %u (rc=%d).\n", (unsigned)payload.id_start, rc);
+        ui_set_toast(state, 4, "Could not update TG %u", (unsigned)payload.id_start);
+        return UI_CMD_APPLY_FAILED;
+    }
+    tg_listen_persist(opts, state);
+    if (!payload.listen) {
+        tg_listen_release_blocked_calls(opts, state);
+    }
+    return UI_CMD_APPLY_COMPLETED;
+}
+
+static int
+apply_cmd_tg_listen_all(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    dsd_app_tg_listen_all_payload payload;
+    DSD_MEMCPY(&payload, c->data, sizeof payload);
+    payload.tags[sizeof payload.tags - 1U] = '\0';
+    size_t applied = 0;
+    for (size_t i = 0; i < dsd_tg_policy_entry_count(state); ++i) {
+        dsd_tg_policy_entry entry;
+        if (!dsd_tg_policy_entry_at(state, i, &entry) || !tg_listen_row_is_editable(&entry)
+            || (payload.tags[0] && strcmp(entry.tags, payload.tags) != 0)) {
+            continue;
+        }
+        if (dsd_tg_policy_set_mode_at(state, i, payload.listen ? "A" : "B") == 0) {
+            ++applied;
+        }
+    }
+    ui_set_toast(state, 3, "%zu talkgroups %s", applied, payload.listen ? "listening" : "not tuned");
+    tg_listen_persist(opts, state);
+    if (!payload.listen) {
+        tg_listen_release_blocked_calls(opts, state);
+    }
+    return UI_CMD_APPLY_COMPLETED;
+}
+
+static int
+apply_cmd_tg_listen(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
+    if (c->id != DSD_APP_CMD_TG_LISTEN_SET && c->id != DSD_APP_CMD_TG_LISTEN_SET_ALL) {
+        return 0;
+    }
+    if (!state) {
+        return 1;
+    }
+    if (c->id == DSD_APP_CMD_TG_LISTEN_SET) {
+        return apply_cmd_tg_listen_one(opts, state, c);
+    }
+    return apply_cmd_tg_listen_all(opts, state, c);
+}
+
+static int
 apply_cmd_lockout_slot(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     if (!state) {
         return (c && c->id == DSD_APP_CMD_LOCKOUT_SLOT) ? 1 : 0;
@@ -3742,8 +3863,6 @@ apply_cmd_lockout_slot(dsd_opts* opts, dsd_state* state, const struct dsd_app_co
     }
     uint8_t slot = 0U;
     uint32_t target = 0U;
-    dsd_tg_policy_entry lockout_entry;
-    char metadata[16];
     int upsert_rc = 0;
     if (opts->frame_provoice == 1) {
         return 1;
@@ -3752,14 +3871,9 @@ apply_cmd_lockout_slot(dsd_opts* opts, dsd_state* state, const struct dsd_app_co
         return 1;
     }
     int tg = (int)target;
-    if (dsd_tg_policy_make_exact_entry(target, "B", "LOCKOUT", DSD_TG_POLICY_SOURCE_USER_LOCKOUT, &lockout_entry)
-        != 0) {
-        return 1;
-    }
-    upsert_rc = dsd_tg_policy_upsert_exact(state, &lockout_entry, DSD_TG_POLICY_UPSERT_REPLACE_FIRST);
+    upsert_rc = tg_listen_apply(state, target, target, 0);
     if (upsert_rc != 0) {
-        LOG_WARN("WARNING: User lockout for TG %d could not be applied (rc=%d); skipping persistence.\n", tg,
-                 upsert_rc);
+        LOG_WARN("WARNING: User lockout for TG %d could not be applied (rc=%d).\n", tg, upsert_rc);
         return 1;
     }
 
@@ -3773,12 +3887,7 @@ apply_cmd_lockout_slot(dsd_opts* opts, dsd_state* state, const struct dsd_app_co
     dsd_event_history_transaction_end(&transaction);
     watchdog_event_current(opts, state, eh_slot);
 
-    DSD_SNPRINTF(metadata, sizeof(metadata), "%02X",
-                 (unsigned int)((slot == 0) ? state->payload_algid : state->payload_algidR));
-    if (dsd_tg_policy_append_group_file_row(opts, &lockout_entry, metadata) != 0) {
-        LOG_WARN("WARNING: User lockout for TG %d was applied in-memory but could not be persisted to '%s'.\n", tg,
-                 opts->group_in_file);
-    }
+    tg_listen_persist(opts, state);
 
     const int transition_status = apply_lockout_decoder_transition(opts, state);
     if (transition_status == UI_CMD_APPLY_FAILED) {
@@ -4216,9 +4325,10 @@ apply_cmd_misc_config(dsd_opts* opts, dsd_state* state, const struct dsd_app_com
 static int
 apply_cmd_unscoped(dsd_opts* opts, dsd_state* state, const struct dsd_app_command* c) {
     static const dsd_app_command_handler_fn k_command_groups[] = {
-        apply_cmd_basic_a,       apply_cmd_slot_controls,  apply_cmd_payload_filters,  apply_cmd_constellation,
-        apply_cmd_eye_spectrum,  apply_cmd_trunk_controls, apply_cmd_lockout_slot,     apply_cmd_provoice_m17,
-        apply_cmd_scan_controls, apply_cmd_channel_cycle,  apply_cmd_capture_playback, apply_cmd_misc_config,
+        apply_cmd_basic_a,      apply_cmd_slot_controls,  apply_cmd_payload_filters, apply_cmd_constellation,
+        apply_cmd_eye_spectrum, apply_cmd_trunk_controls, apply_cmd_lockout_slot,    apply_cmd_tg_listen,
+        apply_cmd_provoice_m17, apply_cmd_scan_controls,  apply_cmd_channel_cycle,   apply_cmd_capture_playback,
+        apply_cmd_misc_config,
     };
     if (!c) {
         return UI_CMD_APPLY_INVALID_PAYLOAD;

--- a/src/core/file/dsd_import.c
+++ b/src/core/file/dsd_import.c
@@ -106,6 +106,7 @@ typedef struct {
     int policy_active;
     unsigned int prefix_len;
     int invalid_order;
+    int basic_tags;
 } group_policy_header;
 
 typedef struct {
@@ -120,7 +121,7 @@ typedef struct {
 
 static group_policy_header
 group_parse_policy_header(char* header_line) {
-    group_policy_header info = {0, 0, 0};
+    group_policy_header info = {0};
     char* fields[16];
     static const char* expected[] = {"preempt", "audio", "record", "stream", "tags"};
     size_t field_count = csv_split_preserve_empty(header_line, fields, sizeof(fields) / sizeof(fields[0]));
@@ -130,6 +131,9 @@ group_parse_policy_header(char* header_line) {
         return info;
     }
     if (csv_ascii_casecmp(trim_ws(fields[3]), "priority") != 0) {
+        const char* col = trim_ws(fields[3]);
+        info.basic_tags = csv_ascii_casecmp(col, "tag") == 0 || csv_ascii_casecmp(col, "tags") == 0
+                          || csv_ascii_casecmp(col, "category") == 0;
         return info;
     }
     info.policy_active = 1;
@@ -287,6 +291,23 @@ group_apply_policy_fields(const group_policy_header* header, const char* filenam
     group_enforce_media_constraints(filename, row_count, entry, mode_blocking, has_audio, has_record, has_stream);
 }
 
+static void
+group_apply_tags_field(const group_policy_header* header, size_t field_count, char** fields,
+                       dsd_tg_policy_entry* entry) {
+    const char* value = NULL;
+    if (!header || !fields || !entry) {
+        return;
+    }
+    if (header->policy_active && header->prefix_len >= 6 && field_count > 8) {
+        value = trim_ws(fields[8]);
+    } else if (!header->policy_active && header->basic_tags && field_count > 3) {
+        value = trim_ws(fields[3]);
+    }
+    if (value) {
+        DSD_SNPRINTF(entry->tags, sizeof(entry->tags), "%s", value);
+    }
+}
+
 static int
 group_commit_entry(dsd_state* state, dsd_tg_policy_store* store, const dsd_tg_policy_entry* entry, int is_range,
                    const char* filename, unsigned int row_count, size_t* dropped_policy_alloc_rows) {
@@ -341,6 +362,7 @@ group_import_row(dsd_state* state, dsd_tg_policy_store* store, const char* filen
     name_field = fields[2];
     group_entry_init(&entry, id_start, id_end, is_range, mode_field, name_field, row_count, &mode_blocking);
     group_apply_policy_fields(header, filename, row_count, field_count, fields, &entry, mode_blocking);
+    group_apply_tags_field(header, field_count, fields, &entry);
     return group_commit_entry(state, store, &entry, is_range, filename, row_count, dropped_policy_alloc_rows);
 }
 
@@ -367,7 +389,7 @@ group_import_path(const char* group_file_path, dsd_state* state, dsd_tg_policy_s
     FILE* fp = NULL;
     unsigned int row_count = 0;
     size_t dropped_policy_alloc_rows = 0;
-    group_policy_header header = {0, 0, 0};
+    group_policy_header header = {0};
 
     if (!group_file_path || group_file_path[0] == '\0' || (!state && !store)) {
         return -1;

--- a/src/core/util/dsd_state_trunk_lcn.c
+++ b/src/core/util/dsd_state_trunk_lcn.c
@@ -625,6 +625,12 @@ dsd_scan_groups_enter(dsd_state* state, const dsd_scan_row_profile* profile) {
 }
 
 int
+dsd_scan_groups_row_active(const dsd_state* state) {
+    const channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
+    return modes && modes->group_active && !modes->group_suspended;
+}
+
+int
 dsd_scan_groups_suspend(dsd_state* state) {
     channel_modes* modes = DSD_STATE_EXT_GET_AS(channel_modes, state, DSD_STATE_EXT_CORE_CHANNEL_MODES);
     if (!modes || !modes->group_active || modes->group_suspended) {

--- a/src/core/util/talkgroup_policy.c
+++ b/src/core/util/talkgroup_policy.c
@@ -230,6 +230,18 @@ tg_policy_normalize_entry(dsd_tg_policy_entry* e) {
     }
 }
 
+static int
+tg_policy_mode_valid(const char* mode) {
+    return mode && mode[0] != '\0' && strlen(mode) < sizeof(((dsd_tg_policy_entry*)0)->mode);
+}
+
+static void
+tg_policy_entry_apply_mode(dsd_tg_policy_entry* e, const char* mode) {
+    tg_policy_safe_copy(e->mode, sizeof(e->mode), mode);
+    tg_policy_defaults_from_mode(e->mode, &e->audio, &e->record, &e->stream);
+    tg_policy_normalize_entry(e);
+}
+
 static void
 tg_policy_copy_entry_normalized(dsd_tg_policy_entry* dst, const dsd_tg_policy_entry* src) {
     if (!dst || !src) {
@@ -240,6 +252,7 @@ tg_policy_copy_entry_normalized(dsd_tg_policy_entry* dst, const dsd_tg_policy_en
     dst->id_end = src->id_end;
     tg_policy_safe_copy(dst->mode, sizeof(dst->mode), src->mode);
     tg_policy_safe_copy(dst->name, sizeof(dst->name), src->name);
+    tg_policy_safe_copy(dst->tags, sizeof(dst->tags), src->tags);
     dst->priority = src->priority;
     dst->preempt = src->preempt;
     dst->audio = src->audio;
@@ -383,6 +396,16 @@ tg_policy_find_policy_exact_idx_first(const dsd_tg_policy_context* ctx, uint32_t
     return -1;
 }
 
+static int
+tg_policy_find_bounds_idx_first(const dsd_tg_policy_context* ctx, uint32_t id_start, uint32_t id_end) {
+    for (size_t i = 0; i < ctx->table.count; i++) {
+        if (ctx->table.entries[i].id_start == id_start && ctx->table.entries[i].id_end == id_end) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
 static int DSD_ATTR_USED
 tg_policy_lookup_exact_only(const dsd_state* state, uint32_t id, dsd_tg_policy_entry* out) {
     dsd_tg_policy_lookup lookup;
@@ -515,6 +538,71 @@ dsd_tg_policy_upsert_exact(dsd_state* state, const dsd_tg_policy_entry* entry, d
         return dsd_tg_policy_append_exact(state, &normalized);
     }
     ctx->table.entries[policy_idx] = normalized;
+    tg_policy_table_note_mutation(ctx);
+    return 0;
+}
+
+size_t
+dsd_tg_policy_entry_count(const dsd_state* state) {
+    const dsd_tg_policy_context* ctx = tg_policy_ctx_get_const(state);
+    return ctx ? ctx->table.count : 0;
+}
+
+int
+dsd_tg_policy_entry_at(const dsd_state* state, size_t index, dsd_tg_policy_entry* out) {
+    const dsd_tg_policy_context* ctx = tg_policy_ctx_get_const(state);
+    if (!out) {
+        return 0;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    if (!ctx || index >= ctx->table.count) {
+        return 0;
+    }
+    *out = ctx->table.entries[index];
+    return 1;
+}
+
+void
+dsd_tg_policy_table_version(const dsd_state* state, uint64_t* out_context_id, unsigned int* out_generation) {
+    const dsd_tg_policy_context* ctx = tg_policy_ctx_get_const(state);
+    if (out_context_id) {
+        *out_context_id = ctx ? ctx->snapshot_source_context_id : 0;
+    }
+    if (out_generation) {
+        *out_generation = ctx ? ctx->table.generation : 0;
+    }
+}
+
+int
+dsd_tg_policy_set_mode(dsd_state* state, uint32_t id_start, uint32_t id_end, const char* mode) {
+    if (!state || !tg_policy_mode_valid(mode) || id_start > id_end) {
+        return 1;
+    }
+    dsd_tg_policy_context* ctx = tg_policy_ctx_get_mut(state, 1);
+    if (!ctx) {
+        return -1;
+    }
+    int index = tg_policy_find_bounds_idx_first(ctx, id_start, id_end);
+    if (index >= 0) {
+        tg_policy_entry_apply_mode(&ctx->table.entries[index], mode);
+        tg_policy_table_note_mutation(ctx);
+        return 0;
+    }
+    if (id_start != id_end) {
+        return 1;
+    }
+    dsd_tg_policy_entry entry;
+    dsd_tg_policy_make_exact_entry(id_start, mode, "", DSD_TG_POLICY_SOURCE_USER_LOCKOUT, &entry);
+    return dsd_tg_policy_store_append(ctx, &entry);
+}
+
+int
+dsd_tg_policy_set_mode_at(dsd_state* state, size_t index, const char* mode) {
+    dsd_tg_policy_context* ctx = tg_policy_ctx_get_mut(state, 0);
+    if (!ctx || index >= ctx->table.count || !tg_policy_mode_valid(mode)) {
+        return 1;
+    }
+    tg_policy_entry_apply_mode(&ctx->table.entries[index], mode);
     tg_policy_table_note_mutation(ctx);
     return 0;
 }
@@ -1093,7 +1181,7 @@ tg_policy_header_is_policy(const char* header_line) {
     return 1;
 }
 
-static void
+static int
 tg_policy_probe_group_file(const char* path, int* has_existing_header, int* existing_policy_header,
                            int* file_missing_or_empty) {
     char first_line[512];
@@ -1109,13 +1197,13 @@ tg_policy_probe_group_file(const char* path, int* has_existing_header, int* exis
         *file_missing_or_empty = 0;
     }
     if (!path || !file_missing_or_empty) {
-        return;
+        return -1;
     }
 
     rf = dsd_fopen_existing_regular_file(path, "r");
     if (!rf) {
         *file_missing_or_empty = 1;
-        return;
+        return errno == ENOENT ? 0 : -1;
     }
 
     if (fgets(first_line, sizeof(first_line), rf) != NULL) {
@@ -1128,7 +1216,11 @@ tg_policy_probe_group_file(const char* path, int* has_existing_header, int* exis
     } else {
         *file_missing_or_empty = 1;
     }
-    fclose(rf);
+    int failed = ferror(rf);
+    if (fclose(rf) != 0) {
+        failed = 1;
+    }
+    return failed ? -1 : 0;
 }
 
 static int
@@ -1166,27 +1258,97 @@ tg_policy_bool_on_off(uint8_t v) {
 }
 
 static int
+tg_policy_write_group_row(FILE* wf, const dsd_tg_policy_entry* entry, const char* id_text, int use_policy,
+                          int use_extra, const char* clean_mode, const char* clean_name, const char* clean_extra) {
+    int written;
+    if (use_policy) {
+        written = DSD_FPRINTF(wf, "%s,%s,%s,%d,%s,%s,%s,%s,%s\n", id_text, clean_mode, clean_name, entry->priority,
+                              tg_policy_bool_true_false(entry->preempt), tg_policy_bool_on_off(entry->audio),
+                              tg_policy_bool_on_off(entry->record), tg_policy_bool_on_off(entry->stream), clean_extra);
+    } else if (use_extra) {
+        written = DSD_FPRINTF(wf, "%s,%s,%s,%s\n", id_text, clean_mode, clean_name, clean_extra);
+    } else {
+        written = DSD_FPRINTF(wf, "%s,%s,%s\n", id_text, clean_mode, clean_name);
+    }
+    return written < 0 ? -1 : 0;
+}
+
+static int
 tg_policy_write_group_file_entry(FILE* wf, const dsd_tg_policy_entry* entry, int has_existing_header,
                                  int existing_policy_header, const char* clean_mode, const char* clean_name,
                                  const char* clean_meta) {
     if (!wf || !entry || !clean_mode || !clean_name || !clean_meta) {
         return -1;
     }
-    if (has_existing_header && existing_policy_header) {
-        if (DSD_FPRINTF(wf, "%u,%s,%s,%d,%s,%s,%s,%s,%s\n", entry->id_start, clean_mode, clean_name, entry->priority,
-                        tg_policy_bool_true_false(entry->preempt), tg_policy_bool_on_off(entry->audio),
-                        tg_policy_bool_on_off(entry->record), tg_policy_bool_on_off(entry->stream), clean_meta)
-            < 0) {
-            return -1;
+    char id_text[24];
+    DSD_SNPRINTF(id_text, sizeof(id_text), "%u", entry->id_start);
+    return tg_policy_write_group_row(wf, entry, id_text, has_existing_header && existing_policy_header,
+                                     clean_meta[0] != '\0', clean_mode, clean_name, clean_meta);
+}
+
+static int
+tg_policy_write_group_table(FILE* wf, const dsd_tg_policy_entry* entries, size_t count, int use_policy, int any_tags) {
+    const char* header = "id,mode,name\n";
+    if (use_policy) {
+        header = "id,mode,name,priority,preempt,audio,record,stream,tags\n";
+    } else if (any_tags) {
+        header = "id,mode,name,tags\n";
+    }
+    int failed = DSD_FPRINTF(wf, "%s", header) < 0;
+    for (size_t i = 0; !failed && i < count; i++) {
+        const dsd_tg_policy_entry* entry = &entries[i];
+        char id_text[24];
+        char clean_mode[sizeof(entry->mode)];
+        char clean_name[sizeof(entry->name)];
+        char clean_tags[sizeof(entry->tags)];
+        if (entry->is_range) {
+            DSD_SNPRINTF(id_text, sizeof(id_text), "%u-%u", entry->id_start, entry->id_end);
+        } else {
+            DSD_SNPRINTF(id_text, sizeof(id_text), "%u", entry->id_start);
         }
-    } else if (clean_meta[0] != '\0') {
-        if (DSD_FPRINTF(wf, "%u,%s,%s,%s\n", entry->id_start, clean_mode, clean_name, clean_meta) < 0) {
-            return -1;
+        tg_policy_csv_sanitize_copy(clean_mode, sizeof(clean_mode), entry->mode);
+        tg_policy_csv_sanitize_copy(clean_name, sizeof(clean_name), entry->name);
+        tg_policy_csv_sanitize_copy(clean_tags, sizeof(clean_tags), entry->tags);
+        failed = tg_policy_write_group_row(wf, entry, id_text, use_policy, any_tags, clean_mode, clean_name, clean_tags)
+                 != 0;
+    }
+    return failed ? -1 : 0;
+}
+
+int
+dsd_tg_policy_write_group_file(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || opts->group_in_file[0] == '\0') {
+        return 0;
+    }
+    const char* path = opts->group_in_file;
+    int has_header = 0;
+    int policy_header = 0;
+    int missing = 0;
+    if (tg_policy_probe_group_file(path, &has_header, &policy_header, &missing) != 0) {
+        return -1;
+    }
+    int use_policy = has_header && policy_header;
+    int any_tags = 0;
+    const dsd_tg_policy_context* ctx = tg_policy_ctx_get_const(state);
+    size_t count = ctx ? ctx->table.count : 0;
+    for (size_t i = 0; i < count; i++) {
+        if (ctx->table.entries[i].tags[0] != '\0') {
+            any_tags = 1;
+            break;
         }
-    } else {
-        if (DSD_FPRINTF(wf, "%u,%s,%s\n", entry->id_start, clean_mode, clean_name) < 0) {
-            return -1;
-        }
+    }
+    char tmp[sizeof(opts->group_in_file) + 32];
+    FILE* wf = dsd_fopen_private_temp_for_replace(path, tmp, sizeof(tmp), "w");
+    if (!wf) {
+        return -1;
+    }
+    int failed = tg_policy_write_group_table(wf, ctx ? ctx->table.entries : NULL, count, use_policy, any_tags) != 0;
+    if (fclose(wf) != 0) {
+        failed = 1;
+    }
+    if (failed || dsd_replace_file_with_temp(tmp, path) != 0) {
+        (void)remove(tmp);
+        return -1;
     }
     return 0;
 }
@@ -1217,7 +1379,9 @@ dsd_tg_policy_append_group_file_row(const dsd_opts* opts, const dsd_tg_policy_en
     tg_policy_csv_sanitize_copy(clean_name, sizeof(clean_name), entry->name);
     tg_policy_csv_sanitize_copy(clean_meta, sizeof(clean_meta), metadata ? metadata : "");
 
-    tg_policy_probe_group_file(path, &has_existing_header, &existing_policy_header, &file_missing_or_empty);
+    if (tg_policy_probe_group_file(path, &has_existing_header, &existing_policy_header, &file_missing_or_empty) != 0) {
+        return -1;
+    }
 
     wf = dsd_fopen_private(path, "a");
     if (!wf) {

--- a/src/runtime/radioreference/rr_generate.c
+++ b/src/runtime/radioreference/rr_generate.c
@@ -29,10 +29,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* Human-facing only: both importers discard physical line 1 without looking at
- * it. The group header stays at three columns so it can never be mistaken for a
- * policy header, whose 4th field would have to read "priority". */
-#define RR_GROUP_HEADER "DEC,Mode,Name (generated from RadioReference)\n"
+/* The fourth field opts into categories without being mistaken for an extended
+ * policy header, whose fourth field must read "priority". */
+#define RR_GROUP_HEADER "DEC,Mode,Name,Category,(generated from RadioReference)\n"
 #define RR_CHAN_HEADER  "ChannelNumber(dec),frequency(Hz) (generated from RadioReference; do not delete this line)\n"
 
 /* The importer's opt-in for the channel map's name column is the header's
@@ -1380,7 +1379,7 @@ rr_group_mode(const dsd_rr_talkgroup* talkgroup, int partial_enc_as_de) {
 /**
  * @brief Append one talkgroup row.
  *
- * No space follows either comma: the importer trims the mode column but hands
+ * No space follows a comma: the importer trims the mode column but hands
  * the name column through verbatim, so " Fire Dispatch" would keep its space in
  * the UI and in event history.
  *
@@ -1388,13 +1387,18 @@ rr_group_mode(const dsd_rr_talkgroup* talkgroup, int partial_enc_as_de) {
  * @param talkgroup Talkgroup.
  * @param mode      Mode column.
  * @param name      Sanitized name column.
+ * @param category  Sanitized category column; omitted when empty.
  */
 static void
-rr_text_group_row(rr_text* text, const dsd_rr_talkgroup* talkgroup, const char* mode, const char* name) {
-    char line[128];
-    const int written = DSD_SNPRINTF(line, sizeof(line), "%lu,%s,%s\n", (unsigned long)talkgroup->tg_dec, mode, name);
+rr_text_group_row(rr_text* text, const dsd_rr_talkgroup* talkgroup, const char* mode, const char* name,
+                  const char* category) {
+    char line[256];
+    const int written =
+        category[0]
+            ? DSD_SNPRINTF(line, sizeof(line), "%lu,%s,%s,%s\n", (unsigned long)talkgroup->tg_dec, mode, name, category)
+            : DSD_SNPRINTF(line, sizeof(line), "%lu,%s,%s\n", (unsigned long)talkgroup->tg_dec, mode, name);
     /* BSIZE is 999 and the importer reads with fgets, so a longer line would be
-     * split into two malformed rows. The 49-byte name cap makes this
+     * split into two malformed rows. The 49-byte name and category caps make this
      * unreachable; the check is here so it stays unreachable. */
     if (written <= 0 || (size_t)written >= sizeof(line)) {
         text->failed = 1;
@@ -1435,7 +1439,11 @@ rr_group_emit(rr_text* text, const dsd_rr_talkgroup* talkgroup, int partial_enc_
     if (name[0] == '\0') {
         (void)DSD_SNPRINTF(name, sizeof(name), "TG %lu", (unsigned long)talkgroup->tg_dec);
     }
-    rr_text_group_row(text, talkgroup, rr_group_mode(talkgroup, partial_enc_as_de), name);
+    char category[RR_NAME_MAX + 1U] = {0};
+    if (talkgroup->category[0]) {
+        (void)rr_sanitize_name(talkgroup->category, category, sizeof(category));
+    }
+    rr_text_group_row(text, talkgroup, rr_group_mode(talkgroup, partial_enc_as_de), name, category);
     counts->emitted++;
 }
 

--- a/src/runtime/radioreference/rr_import.c
+++ b/src/runtime/radioreference/rr_import.c
@@ -29,6 +29,23 @@
 #define RR_STEM_MAX_BYTES 64U
 #define RR_STEM_FALLBACK  "radioreference"
 
+void
+dsd_rr_talkgroups_apply_categories(dsd_rr_talkgroup_list* talkgroups, const dsd_rr_talkgroup_cat_list* categories) {
+    for (size_t i = 0; i < talkgroups->count; i++) {
+        talkgroups->items[i].category[0] = '\0';
+        if (categories == NULL) {
+            continue;
+        }
+        for (size_t k = 0; k < categories->count; k++) {
+            if (categories->items[k].tg_cid == talkgroups->items[i].tg_cid) {
+                DSD_SNPRINTF(talkgroups->items[i].category, sizeof talkgroups->items[i].category, "%s",
+                             categories->items[k].name);
+                break;
+            }
+        }
+    }
+}
+
 int
 dsd_rr_hz_to_mhz_text(long long hz, char* out, size_t out_sz) {
     if (out == NULL || out_sz == 0U) {

--- a/src/ui/qt/CMakeLists.txt
+++ b/src/ui/qt/CMakeLists.txt
@@ -27,6 +27,8 @@ target_sources(
         spectrum_model.cpp
         spectrum_view_item.cpp
         session_args.cpp
+        talkgroup_filter_model.cpp
+        talkgroup_list_model.cpp
         ui_controller.cpp
 )
 
@@ -72,6 +74,8 @@ qt_add_resources(
         qml/SegmentedControl.qml
         qml/SettingsScreen.qml
         qml/SpectrumScreen.qml
+        qml/TalkgroupCard.qml
+        qml/TalkgroupsScreen.qml
         qml/ToggleRow.qml
         qml/TunerMarker.qml
         qml/UiPanel.qml

--- a/src/ui/qt/command_bridge.cpp
+++ b/src/ui/qt/command_bridge.cpp
@@ -5,8 +5,10 @@
 
 #include "command_bridge.h"
 
+#include <QByteArray>
 #include <dsd-neo/app_control/commands.h>
 #include <dsd-neo/app_control/history.h>
+#include <dsd-neo/core/safe_api.h>
 #include <stdint.h>
 
 #include "decode_mode_flag.h"
@@ -43,6 +45,26 @@ bool
 CommandBridge::lockoutSlot(int slot) const {
     const uint8_t index = (slot > 0) ? 1U : 0U;
     return accepted(dsd_app_command_set_u8(DSD_APP_CMD_LOCKOUT_SLOT, index));
+}
+
+bool
+// cppcheck-suppress functionStatic -- Q_INVOKABLE members cannot be static (Qt meta-object)
+CommandBridge::setTalkgroupListening(unsigned int idStart, unsigned int idEnd, bool listen) const {
+    dsd_app_tg_listen_payload payload;
+    DSD_MEMSET(&payload, 0, sizeof(payload));
+    payload.id_start = idStart;
+    payload.id_end = idEnd;
+    payload.listen = listen ? 1 : 0;
+    return accepted(dsd_app_command_set_tg_listen(&payload));
+}
+
+bool
+CommandBridge::setAllTalkgroupsListening(bool listen, const QString& tag) const {
+    dsd_app_tg_listen_all_payload payload;
+    DSD_MEMSET(&payload, 0, sizeof(payload));
+    payload.listen = listen ? 1 : 0;
+    DSD_SNPRINTF(payload.tags, sizeof(payload.tags), "%s", tag.toUtf8().constData());
+    return accepted(dsd_app_command_set_tg_listen_all(&payload));
 }
 
 bool

--- a/src/ui/qt/command_bridge.h
+++ b/src/ui/qt/command_bridge.h
@@ -35,6 +35,12 @@ class CommandBridge : public QObject {
     /** @brief Lock out the target currently active on @p slot (0 or 1). */
     Q_INVOKABLE bool lockoutSlot(int slot) const;
 
+    /** @brief Listen to or stop tuning one talkgroup or range; a missing exact id is added. */
+    Q_INVOKABLE bool setTalkgroupListening(unsigned int idStart, unsigned int idEnd, bool listen) const;
+
+    /** @brief Edit every listed talkgroup, or only those tagged @p tag when non-empty. */
+    Q_INVOKABLE bool setAllTalkgroupsListening(bool listen, const QString& tag) const;
+
     /** @brief Forget every encrypted-target lockout. */
     Q_INVOKABLE bool clearEncLockouts() const;
 

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -56,6 +56,7 @@ Window {
     // The spectrum view is pushed over the monitor, so it can only be open
     // while a session is; ending one has to take it down with it.
     property bool spectrumOpen: false
+    property bool talkgroupsOpen: false
     // The saved-system map the running session was started from.
     property var sessionSystem: null
     // Whether this session is free to be retuned by hand. False for anything
@@ -112,8 +113,8 @@ Window {
     }
 
     onMonitorModeChanged: {
-        // The spectrum layer lives above the monitor; when the session goes so
-        // does it, or the next one would open onto a stale panorama.
+        // Pushed session screens must close with the session rather than showing
+        // stale content when the next one starts.
         if (!monitorMode) {
             // Where the exploring got to, so the next one resumes there rather
             // than back at the start frequency.
@@ -121,6 +122,7 @@ Window {
                 prefs.exploreFreqMhz = mainRoot.lastExploreFreqMhz
             mainRoot.exploring = false
             mainRoot.spectrumOpen = false
+            mainRoot.talkgroupsOpen = false
             // Row indices shift when a system is removed, and Home is reachable
             // again from here; a row remembered past its session would name a
             // different system by the time anything read it.
@@ -135,6 +137,8 @@ Window {
             // last hour rather than the whole persisted log.
             if (monitorView.minWhen === 0)
                 monitorView.minWhen = Math.floor(Date.now() / 1000) - 3600
+            if (talkgroups.sinceWhen === 0)
+                talkgroups.sinceWhen = monitorView.minWhen
         }
     }
 
@@ -219,6 +223,7 @@ Window {
         callHistory.sessionLabel = sys.name
         // The monitor's recent-calls pane shows this session, not the whole log.
         monitorView.minWhen = Math.floor(Date.now() / 1000)
+        talkgroups.sinceWhen = monitorView.minWhen
         savedSystems.touch(row)
     }
 
@@ -410,7 +415,7 @@ Window {
         // what lets that screen stay lit over the monitor rather than standing
         // down into a three-layer deadlock.
         enabled: opacity > 0.9 && !mainRoot.wizardOpen && !mainRoot.spectrumOpen
-                 && !mainRoot.radioReferenceOpen
+                 && !mainRoot.radioReferenceOpen && !mainRoot.talkgroupsOpen && !talkgroupsScreen.visible
 
         Behavior on opacity {
             NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
@@ -420,6 +425,7 @@ Window {
             spectrumLoader.active = true
             mainRoot.spectrumOpen = true
         }
+        onOpenTalkgroups: mainRoot.talkgroupsOpen = true
         onEditSystem: {
             // Only a session started from a saved row has a system to edit; a
             // reattached or quick-start session has no row to write back to.
@@ -445,7 +451,7 @@ Window {
         // The wizard can now open over a running session ("Save as a system"), and
         // TapHandlers never take exclusive grabs — without this, a tap meant for a
         // wizard field also reaches the spectrum underneath and retunes the radio.
-        enabled: opacity > 0.9 && !mainRoot.wizardOpen
+        enabled: opacity > 0.9 && !mainRoot.wizardOpen && !talkgroupsScreen.visible
 
         Behavior on opacity {
             NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
@@ -497,6 +503,28 @@ Window {
                 wizard.openForFound(mainRoot.sessionSystem, Util.mhzText(freqHz))
                 mainRoot.wizardOpen = true
             }
+        }
+    }
+
+    // ---- Talkgroups (pushed over the monitor) ----
+    TalkgroupsScreen {
+        id: talkgroupsScreen
+
+        objectName: "talkgroupsScreen"
+        anchors.fill: safeArea
+        systemName: monitor.systemName
+        opacity: mainRoot.monitorMode && mainRoot.talkgroupsOpen && !mainRoot.wizardOpen ? 1.0 : 0.0
+        visible: opacity > 0.0
+        enabled: opacity > 0.9 && mainRoot.monitorMode && mainRoot.talkgroupsOpen
+                 && !mainRoot.wizardOpen && !mainRoot.radioReferenceOpen
+
+        Behavior on opacity {
+            NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
+        }
+
+        onClosed: {
+            mainRoot.talkgroupsOpen = false
+            Qt.inputMethod.hide()
         }
     }
 

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -11,6 +11,7 @@ Item {
 
     // Raised by the header's spectrum button; Main.qml owns the layer.
     signal openSpectrum()
+    signal openTalkgroups()
 
     // Raised by a long-press on the header title, the same gesture that edits a
     // card on Home. Main.qml opens the wizard on the running system — the only
@@ -410,7 +411,7 @@ Item {
             spacing: 10
 
             OutlineButton {
-                width: (parent.width - 20) / 3
+                width: (parent.width - 30) / 4
                 text: screen.muted ? qsTr("Unmute") : qsTr("Mute")
                 enabled: decoderHost.running
                 // The label follows metrics.audioMuted once the engine applies the
@@ -419,7 +420,7 @@ Item {
             }
 
             OutlineButton {
-                width: (parent.width - 20) / 3
+                width: (parent.width - 30) / 4
                 text: screen.holding ? qsTr("Release") : qsTr("Hold TG")
                 // Disabled, not a silent no-op, when the call has no numeric
                 // talkgroup (M17/D-STAR callsigns, dPMR dial strings).
@@ -429,10 +430,18 @@ Item {
             }
 
             OutlineButton {
-                width: (parent.width - 20) / 3
+                width: (parent.width - 30) / 4
                 text: qsTr("Skip")
                 enabled: decoderHost.running && screen.heroSlot !== 0
                 onClicked: commands.lockoutSlot(screen.heroSlot === 2 ? 1 : 0)
+            }
+
+            OutlineButton {
+                objectName: "talkgroupsButton"
+                width: (parent.width - 30) / 4
+                text: qsTr("TG list")
+                enabled: decoderHost.running
+                onClicked: screen.openTalkgroups()
             }
         }
 

--- a/src/ui/qt/qml/TalkgroupCard.qml
+++ b/src/ui/qt/qml/TalkgroupCard.qml
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+
+Rectangle {
+    id: card
+
+    required property string idText
+    required property string name
+    required property string tags
+    required property bool listening
+    required property bool listed
+    signal clicked()
+
+    radius: Theme.radiusPanel
+    color: Theme.panel
+    border.width: 1
+    border.color: listening ? Theme.cyan : Theme.controlBorder
+
+    Column {
+        anchors.fill: parent
+        anchors.margins: 10
+        spacing: 4
+
+        Text {
+            width: parent.width
+            text: card.idText
+            font.family: Theme.mono
+            font.pixelSize: 15
+            font.weight: Font.DemiBold
+            color: Theme.textPrimary
+            elide: Text.ElideRight
+        }
+
+        Text {
+            width: parent.width
+            text: card.name
+            font.family: Theme.sans
+            font.pixelSize: 12
+            color: Theme.textSecondary
+            maximumLineCount: 2
+            wrapMode: Text.Wrap
+            elide: Text.ElideRight
+        }
+
+        MicroLabel {
+            width: parent.width
+            text: card.listed ? card.tags : qsTr("Heard")
+            visible: text.length > 0
+            elide: Text.ElideRight
+        }
+
+        Row {
+            width: parent.width
+            spacing: 5
+
+            Rectangle {
+                width: 6
+                height: 6
+                radius: 3
+                anchors.verticalCenter: parent.verticalCenter
+                color: card.listening ? Theme.cyan : Theme.textSubdued
+            }
+
+            Text {
+                width: parent.width - 11
+                text: card.listening ? qsTr("Listening") : qsTr("Not tuned")
+                font.family: Theme.sans
+                font.pixelSize: 11
+                color: card.listening ? Theme.cyan : Theme.textSubdued
+                elide: Text.ElideRight
+            }
+        }
+    }
+
+    TapHandler {
+        onTapped: card.clicked()
+    }
+}

--- a/src/ui/qt/qml/TalkgroupsScreen.qml
+++ b/src/ui/qt/qml/TalkgroupsScreen.qml
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+
+Item {
+    id: screen
+
+    property string systemName: ""
+    signal closed()
+
+    Rectangle {
+        anchors.fill: parent
+        color: Theme.bg
+    }
+
+    Item {
+        id: header
+
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.margins: Theme.screenPadding
+        height: 46
+
+        Text {
+            id: back
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            text: "‹"
+            font.pixelSize: 28
+            color: Theme.textSecondary
+
+            TapHandler {
+                onTapped: screen.closed()
+            }
+        }
+
+        Text {
+            anchors.left: back.right
+            anchors.right: parent.right
+            anchors.leftMargin: 14
+            anchors.verticalCenter: parent.verticalCenter
+            text: screen.systemName.length > 0 ? screen.systemName : qsTr("Talk groups")
+            font.family: Theme.sans
+            font.pixelSize: 22
+            font.weight: Font.Bold
+            font.letterSpacing: -0.22
+            color: Theme.textPrimary
+            elide: Text.ElideRight
+        }
+    }
+
+    MicroLabel {
+        id: countLabel
+
+        anchors.top: header.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: 6
+        anchors.leftMargin: Theme.screenPadding
+        anchors.rightMargin: Theme.screenPadding
+        text: qsTr("Talk groups · %1").arg(talkgroups.count)
+              + (talkgroups.notTunedCount > 0 ? qsTr(" · %1 not tuned").arg(talkgroups.notTunedCount) : "")
+        elide: Text.ElideRight
+    }
+
+    PlexTextField {
+        id: search
+        objectName: "talkgroupSearch"
+
+        anchors.top: countLabel.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: Theme.gap
+        anchors.leftMargin: Theme.screenPadding
+        anchors.rightMargin: Theme.screenPadding
+        placeholderText: qsTr("Search talkgroups")
+        onTextChanged: talkgroupView.filterText = text
+    }
+
+    ListView {
+        id: chips
+        objectName: "talkgroupChips"
+
+        anchors.top: search.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: Theme.gap
+        anchors.leftMargin: Theme.screenPadding
+        anchors.rightMargin: Theme.screenPadding
+        orientation: ListView.Horizontal
+        spacing: 8
+        clip: true
+        implicitHeight: 34
+        visible: talkgroups.categories.length > 0
+        model: [qsTr("All")].concat(talkgroups.categories)
+
+        delegate: FilterPill {
+            required property int index
+            required property string modelData
+
+            caret: false
+            text: modelData
+            active: index === 0 ? talkgroupView.filterTag === "" : talkgroupView.filterTag === modelData
+            onClicked: talkgroupView.filterTag = index === 0 ? "" : modelData
+        }
+    }
+
+    Row {
+        id: bulkActions
+
+        anchors.top: chips.visible ? chips.bottom : search.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: Theme.gap
+        anchors.leftMargin: Theme.screenPadding
+        anchors.rightMargin: Theme.screenPadding
+        spacing: 10
+
+        OutlineButton {
+            id: noTuneAll
+            objectName: "noTuneAllButton"
+            width: (parent.width - 10) / 2
+            height: 50
+            text: noTuneLabel.elidedText
+            enabled: decoderHost.running && talkgroups.count > 0
+            onClicked: commands.setAllTalkgroupsListening(false, talkgroupView.filterTag)
+
+            // Category names can be much wider than half a phone screen. Keep
+            // the shared button styling while bounding its single-line label.
+            TextMetrics {
+                id: noTuneLabel
+                font.family: Theme.sans
+                font.pixelSize: 15
+                font.weight: Font.DemiBold
+                text: talkgroupView.filterTag.length > 0
+                      ? qsTr("Do not tune all · %1").arg(talkgroupView.filterTag) : qsTr("Do not tune all")
+                elide: Text.ElideRight
+                elideWidth: noTuneAll.width - 16
+            }
+        }
+
+        GradientButton {
+            id: listenAll
+            objectName: "listenAllButton"
+            width: (parent.width - 10) / 2
+            text: listenLabel.elidedText
+            enabled: decoderHost.running && talkgroups.count > 0
+            onClicked: commands.setAllTalkgroupsListening(true, talkgroupView.filterTag)
+
+            TextMetrics {
+                id: listenLabel
+                font.family: Theme.sans
+                font.pixelSize: 15
+                font.weight: Font.Bold
+                text: talkgroupView.filterTag.length > 0
+                      ? qsTr("Listen all · %1").arg(talkgroupView.filterTag) : qsTr("Listen all")
+                elide: Text.ElideRight
+                elideWidth: listenAll.width - 16
+            }
+        }
+    }
+
+    GridView {
+        id: grid
+        objectName: "talkgroupGrid"
+
+        anchors.top: bulkActions.bottom
+        anchors.bottom: footer.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: Theme.gap
+        anchors.bottomMargin: Theme.gap
+        anchors.leftMargin: Theme.screenPadding
+        anchors.rightMargin: Theme.screenPadding
+        clip: true
+        model: talkgroupView
+        cellWidth: Math.floor(width / 3)
+        cellHeight: 122
+        enabled: decoderHost.running
+
+        delegate: TalkgroupCard {
+            required property var idStart
+            required property var idEnd
+
+            width: GridView.view.cellWidth - 8
+            height: GridView.view.cellHeight - 8
+            // Snapshot truth, not a local toggle: the decoder may refuse an edit.
+            onClicked: commands.setTalkgroupListening(idStart, idEnd, !listening)
+        }
+
+        Text {
+            anchors.centerIn: parent
+            width: parent.width - 24
+            visible: talkgroups.count === 0
+            text: qsTr("No talkgroups yet. Calls heard on this system will appear here.")
+            font.family: Theme.sans
+            font.pixelSize: 14
+            color: Theme.textSubdued
+            wrapMode: Text.Wrap
+            horizontalAlignment: Text.AlignHCenter
+        }
+    }
+
+    Column {
+        id: footer
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: Theme.screenPadding
+        spacing: 8
+
+        Row {
+            spacing: 8
+
+            Rectangle {
+                width: 6
+                height: 6
+                radius: 3
+                anchors.verticalCenter: parent.verticalCenter
+                color: Theme.cyan
+            }
+
+            Text {
+                text: qsTr("Listening")
+                font.family: Theme.sans
+                font.pixelSize: 11
+                color: Theme.textSecondary
+            }
+
+            Rectangle {
+                width: 6
+                height: 6
+                radius: 3
+                anchors.verticalCenter: parent.verticalCenter
+                color: Theme.textSubdued
+            }
+
+            Text {
+                text: qsTr("Not tuned")
+                font.family: Theme.sans
+                font.pixelSize: 11
+                color: Theme.textSecondary
+            }
+        }
+
+        Text {
+            objectName: "sessionOnlyNote"
+            width: parent.width
+            visible: !talkgroups.persistent
+            text: qsTr("Changes last for this session. Give the system a talkgroup list to keep them.")
+            font.family: Theme.sans
+            font.pixelSize: 12
+            color: Theme.textSubdued
+            wrapMode: Text.Wrap
+        }
+
+        Text {
+            width: parent.width
+            visible: talkgroups.allowListMode
+            text: qsTr("Allow list on: talkgroups not on this list are never tuned.")
+            font.family: Theme.sans
+            font.pixelSize: 12
+            color: Theme.textSubdued
+            wrapMode: Text.Wrap
+        }
+    }
+}

--- a/src/ui/qt/qt_ui.cpp
+++ b/src/ui/qt/qt_ui.cpp
@@ -30,6 +30,8 @@
 #include "session_args.h"
 #include "spectrum_model.h"
 #include "spectrum_view_item.h"
+#include "talkgroup_filter_model.h"
+#include "talkgroup_list_model.h"
 #include "ui_controller.h"
 
 namespace dsd_qt {
@@ -80,6 +82,9 @@ ui_load(QQmlApplicationEngine& engine, DecoderHost* host) {
     auto* systems = new SavedSystemsModel(&engine);
     auto* importedFiles = new ImportedFilesModel(host, &engine);
     auto* history = new CallHistoryModel(&engine);
+    auto* talkgroups = new TalkgroupListModel(history, &engine);
+    auto* talkgroupView = new TalkgroupFilterModel(&engine);
+    talkgroupView->setSourceModel(talkgroups);
     auto* spectrum = new SpectrumModel(&engine);
     // Each view that shows the call log owns its filter state: the history tab's
     // search and pills must not silently filter the monitor's recent-calls pane.
@@ -88,7 +93,7 @@ ui_load(QQmlApplicationEngine& engine, DecoderHost* host) {
     auto* monitorView = new CallHistoryFilterModel(&engine);
     monitorView->setSourceModel(history);
     auto* radioReference = new RadioReferenceModel(prefs, importedFiles, host, &engine);
-    auto* controller = new UiController(host, metrics, history, &engine);
+    auto* controller = new UiController(host, metrics, history, talkgroups, &engine);
 
     // The library drops rows whose stored copy vanished behind the app's back;
     // saved systems that still point at one would build a `-G <missing>` argv and
@@ -125,6 +130,8 @@ ui_load(QQmlApplicationEngine& engine, DecoderHost* host) {
     context->setContextProperty(QStringLiteral("callHistory"), history);
     context->setContextProperty(QStringLiteral("historyView"), historyView);
     context->setContextProperty(QStringLiteral("monitorView"), monitorView);
+    context->setContextProperty(QStringLiteral("talkgroups"), talkgroups);
+    context->setContextProperty(QStringLiteral("talkgroupView"), talkgroupView);
     context->setContextProperty(QStringLiteral("spectrum"), spectrum);
     context->setContextProperty(QStringLiteral("sansFontFamily"),
                                 sans_family.isEmpty() ? QStringLiteral("sans-serif") : sans_family);

--- a/src/ui/qt/radio_reference_model.cpp
+++ b/src/ui/qt/radio_reference_model.cpp
@@ -162,8 +162,8 @@ error_kind_for(dsd_rr_status status) {
 /**
  * One completion, already converted off the worker thread.
  *
- * Site and talkgroup payloads keep their C form because the generators read the
- * structs rather than the QVariant views. They travel as shared_ptr so the data
+ * Site, talkgroup and category payloads keep their C form because the generators
+ * read the structs rather than the QVariant views. They travel as shared_ptr so the data
  * is released even when the queued call is dropped - which happens when the
  * model is destroyed between the callback and the event loop.
  */
@@ -176,6 +176,7 @@ struct RadioReferenceModel::Reply {
     QVariantMap map;
     std::shared_ptr<dsd_rr_site_list> sites;
     std::shared_ptr<dsd_rr_talkgroup_list> talkgroups;
+    std::shared_ptr<dsd_rr_talkgroup_cat_list> categories;
 };
 
 /** Per-request context handed to the C callback as its user pointer. */
@@ -269,8 +270,6 @@ take_categories(void* result) {
         row.insert(QStringLiteral("name"), field(list->items[i].name));
         out.append(row);
     }
-    dsd_rr_talkgroup_cat_list_free(list);
-    free(list);
     return out;
 }
 
@@ -347,8 +346,8 @@ take_details(void* result, dsd_rr_client* client, const dsd_rr_auth* auth) {
 void
 RadioReferenceModel::convertResult(const Request& request, void* result, Reply* reply) {
     /* WORKER THREAD. The C result becomes the reply's, one way or another: the
-     * small shapes are converted and released here, while sites and talkgroups
-     * keep their C form under a shared_ptr whose deleter runs even if the queued
+     * small shapes are converted and released here, while sites, talkgroups and
+     * categories keep their C form under a shared_ptr whose deleter runs even if the queued
      * call is never delivered. */
     switch (request.kind) {
         case FetchUserData: reply->map = take_user_info(result); break;
@@ -358,7 +357,14 @@ RadioReferenceModel::convertResult(const Request& request, void* result, Reply* 
         case FetchCounties: reply->list = take_counties(result); break;
         case FetchSystems: reply->list = take_systems(result); break;
         case FetchDetails: reply->map = take_details(result, request.client, &request.auth); break;
-        case FetchTalkgroupCats: reply->list = take_categories(result); break;
+        case FetchTalkgroupCats:
+            reply->categories = std::shared_ptr<dsd_rr_talkgroup_cat_list>(
+                static_cast<dsd_rr_talkgroup_cat_list*>(result), [](dsd_rr_talkgroup_cat_list* p) {
+                    dsd_rr_talkgroup_cat_list_free(p);
+                    free(p);
+                });
+            reply->list = take_categories(result);
+            break;
         case FetchSites:
             reply->sites =
                 std::shared_ptr<dsd_rr_site_list>(static_cast<dsd_rr_site_list*>(result), [](dsd_rr_site_list* p) {
@@ -446,6 +452,7 @@ RadioReferenceModel::~RadioReferenceModel() {
 
     dsd_rr_site_list_free(&m_siteData);
     dsd_rr_talkgroup_list_free(&m_talkgroupData);
+    dsd_rr_talkgroup_cat_list_free(&m_talkgroupCatData);
     scrub(m_password);
 }
 
@@ -816,6 +823,7 @@ RadioReferenceModel::clearSystem() {
     m_recordSaysEsk = false;
     dsd_rr_site_list_free(&m_siteData);
     dsd_rr_talkgroup_list_free(&m_talkgroupData);
+    dsd_rr_talkgroup_cat_list_free(&m_talkgroupCatData);
     m_sites.clear();
     m_systemDetails.clear();
     m_talkgroupSummary.clear();
@@ -846,7 +854,14 @@ RadioReferenceModel::applySystemReply(const Reply& reply) {
                 DSD_MEMSET(reply.talkgroups.get(), 0, sizeof(*reply.talkgroups));
             }
             break;
-        case FetchTalkgroupCats: m_talkgroupSummary.insert(QStringLiteral("categories"), reply.list); break;
+        case FetchTalkgroupCats:
+            if (reply.categories) {
+                dsd_rr_talkgroup_cat_list_free(&m_talkgroupCatData);
+                m_talkgroupCatData = *reply.categories;
+                DSD_MEMSET(reply.categories.get(), 0, sizeof(*reply.categories));
+            }
+            m_talkgroupSummary.insert(QStringLiteral("categories"), reply.list);
+            break;
         default: return false;
     }
 
@@ -944,6 +959,7 @@ RadioReferenceModel::applyReply(const Reply& reply) {
 
 void
 RadioReferenceModel::finishSystemLoad() {
+    dsd_rr_talkgroups_apply_categories(&m_talkgroupData, &m_talkgroupCatData);
     m_recordSaysSimulcast = false;
 
     QVariantList rows;

--- a/src/ui/qt/radio_reference_model.h
+++ b/src/ui/qt/radio_reference_model.h
@@ -431,6 +431,7 @@ class RadioReferenceModel : public QObject {
     bool m_recordSaysEsk = false;
     dsd_rr_site_list m_siteData;
     dsd_rr_talkgroup_list m_talkgroupData;
+    dsd_rr_talkgroup_cat_list m_talkgroupCatData{};
     /* How many of the four system calls are still outstanding, so the preview is
      * assembled once rather than four times. */
     int m_systemPending = 0;

--- a/src/ui/qt/talkgroup_filter_model.cpp
+++ b/src/ui/qt/talkgroup_filter_model.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "talkgroup_filter_model.h"
+
+#include <QAbstractListModel>
+#include <QVariant>
+#include <Qt>
+
+#include "talkgroup_list_model.h"
+
+namespace dsd_qt {
+
+TalkgroupFilterModel::TalkgroupFilterModel(QObject* parent) : QSortFilterProxyModel(parent) {
+    connect(this, &QAbstractItemModel::rowsInserted, this, &TalkgroupFilterModel::countChanged);
+    connect(this, &QAbstractItemModel::rowsRemoved, this, &TalkgroupFilterModel::countChanged);
+    connect(this, &QAbstractItemModel::modelReset, this, &TalkgroupFilterModel::countChanged);
+}
+
+void
+TalkgroupFilterModel::setFilterText(const QString& text) {
+    if (text == m_filterText) {
+        return;
+    }
+    applyFilterChange([&]() { m_filterText = text; });
+    Q_EMIT filterChanged();
+}
+
+void
+TalkgroupFilterModel::setFilterTag(const QString& tag) {
+    if (tag == m_filterTag) {
+        return;
+    }
+    applyFilterChange([&]() { m_filterTag = tag; });
+    Q_EMIT filterChanged();
+}
+
+bool
+TalkgroupFilterModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const {
+    const QAbstractItemModel* source = sourceModel();
+    if (source == nullptr) {
+        return false;
+    }
+    const QModelIndex idx = source->index(source_row, 0, source_parent);
+    if (!m_filterTag.isEmpty() && source->data(idx, TalkgroupListModel::TagsRole).toString() != m_filterTag) {
+        return false;
+    }
+    return m_filterText.isEmpty()
+           || source->data(idx, TalkgroupListModel::NameRole).toString().contains(m_filterText, Qt::CaseInsensitive)
+           || source->data(idx, TalkgroupListModel::IdTextRole).toString().contains(m_filterText);
+}
+
+} // namespace dsd_qt

--- a/src/ui/qt/talkgroup_filter_model.h
+++ b/src/ui/qt/talkgroup_filter_model.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#ifndef DSD_NEO_SRC_UI_QT_TALKGROUP_FILTER_MODEL_H_
+#define DSD_NEO_SRC_UI_QT_TALKGROUP_FILTER_MODEL_H_
+
+#include <QObject>
+#include <QSortFilterProxyModel>
+#include <QString>
+#include <QtGlobal>
+
+namespace dsd_qt {
+
+class TalkgroupFilterModel : public QSortFilterProxyModel {
+    Q_OBJECT
+    Q_PROPERTY(QString filterText READ filterText WRITE setFilterText NOTIFY filterChanged)
+    Q_PROPERTY(QString filterTag READ filterTag WRITE setFilterTag NOTIFY filterChanged)
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+
+  public:
+    explicit TalkgroupFilterModel(QObject* parent = nullptr);
+
+    int
+    count() const {
+        return rowCount();
+    }
+
+    QString
+    filterText() const {
+        return m_filterText;
+    }
+
+    QString
+    filterTag() const {
+        return m_filterTag;
+    }
+
+    void setFilterText(const QString& text);
+    void setFilterTag(const QString& tag);
+
+  Q_SIGNALS:
+    void countChanged();
+    void filterChanged();
+
+  protected:
+    bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
+
+  private:
+    template <typename Mutate>
+    void
+    applyFilterChange(Mutate&& mutate) {
+/* Qt 6.10's granular change protocol, retaining support for Qt 6.9. */
+#if QT_VERSION >= 0x060a00
+        beginFilterChange();
+        mutate();
+        endFilterChange(QSortFilterProxyModel::Direction::Rows);
+#else
+        mutate();
+        invalidateRowsFilter();
+#endif
+    }
+
+    QString m_filterText;
+    QString m_filterTag;
+};
+
+} // namespace dsd_qt
+
+#endif /* DSD_NEO_SRC_UI_QT_TALKGROUP_FILTER_MODEL_H_ */

--- a/src/ui/qt/talkgroup_list_model.cpp
+++ b/src/ui/qt/talkgroup_list_model.cpp
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include "talkgroup_list_model.h"
+
+#include <QByteArray>
+#include <QDebug>
+#include <QHash>
+#include <QSet>
+#include <QVariant>
+#include <algorithm>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <limits>
+#include <string.h>
+#include <utility>
+
+namespace dsd_qt {
+
+TalkgroupListModel::TalkgroupListModel(QAbstractItemModel* history, QObject* parent)
+    : QAbstractListModel(parent), m_history(history) {
+    if (history == nullptr) {
+        return;
+    }
+    const auto roles = history->roleNames();
+    m_tgRole = roles.key("tg", -1);
+    m_whenRole = roles.key("when", -1);
+    m_kindRole = roles.key("kind", -1);
+    const auto dirty = [this]() { m_heardDirty = true; };
+    connect(history, &QAbstractItemModel::rowsInserted, this, dirty);
+    connect(history, &QAbstractItemModel::rowsRemoved, this, dirty);
+    connect(history, &QAbstractItemModel::dataChanged, this, dirty);
+    connect(history, &QAbstractItemModel::modelReset, this, dirty);
+    connect(history, &QObject::destroyed, this, dirty);
+}
+
+int
+TalkgroupListModel::rowCount(const QModelIndex& parent) const {
+    return parent.isValid() ? 0 : count();
+}
+
+QVariant
+TalkgroupListModel::data(const QModelIndex& index, int role) const {
+    if (!index.isValid() || index.row() < 0 || index.row() >= count() || index.column() != 0) {
+        return {};
+    }
+    const Row& row = m_rows.at(index.row());
+    switch (role) {
+        case IdStartRole: return QVariant::fromValue(static_cast<qulonglong>(row.idStart));
+        case IdEndRole: return QVariant::fromValue(static_cast<qulonglong>(row.idEnd));
+        case IdTextRole:
+            return row.idStart == row.idEnd ? QString::number(row.idStart)
+                                            : QStringLiteral("%1–%2").arg(row.idStart).arg(row.idEnd);
+        case NameRole: return row.name;
+        case TagsRole: return row.tags;
+        case ListeningRole: return row.listening;
+        case ListedRole: return row.listed;
+        default: return {};
+    }
+}
+
+QHash<int, QByteArray>
+TalkgroupListModel::roleNames() const {
+    return {{IdStartRole, "idStart"}, {IdEndRole, "idEnd"},         {IdTextRole, "idText"}, {NameRole, "name"},
+            {TagsRole, "tags"},       {ListeningRole, "listening"}, {ListedRole, "listed"}};
+}
+
+void
+TalkgroupListModel::setSinceWhen(qint64 when) {
+    if (when == m_sinceWhen) {
+        return;
+    }
+    m_sinceWhen = when;
+    m_heardDirty = true;
+    Q_EMIT sinceWhenChanged();
+}
+
+void
+TalkgroupListModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) {
+    if (opts_snapshot == nullptr || snapshot == nullptr) {
+        clear();
+        return;
+    }
+    const bool allowListedOnly = opts_snapshot->trunk_use_allow_list == 1;
+    const bool allowListChanged = allowListedOnly != m_allowListMode;
+    const bool hasGroupFile = opts_snapshot->group_in_file[0] != '\0';
+    if (allowListChanged || hasGroupFile != m_persistent) {
+        m_allowListMode = allowListedOnly;
+        m_persistent = hasGroupFile;
+        Q_EMIT policyChanged();
+    }
+    uint64_t contextId = 0;
+    unsigned int generation = 0;
+    dsd_tg_policy_table_version(snapshot, &contextId, &generation);
+    if (contextId == m_contextId && generation == m_generation && !m_heardDirty && !allowListChanged) {
+        return;
+    }
+
+    QSet<QString> categoryTags;
+    QVector<Row> rows = listedRows(snapshot, categoryTags);
+    appendHeardRows(rows, allowListedOnly);
+    std::stable_sort(rows.begin(), rows.end(), [](const Row& a, const Row& b) {
+        return a.idStart < b.idStart || (a.idStart == b.idStart && a.idEnd < b.idEnd);
+    });
+    replaceRows(std::move(rows));
+    updateCategories(categoryTags);
+    m_contextId = contextId;
+    m_generation = generation;
+    m_heardDirty = false;
+}
+
+QVector<TalkgroupListModel::Row>
+TalkgroupListModel::listedRows(const dsd_state* snapshot, QSet<QString>& categoryTags) {
+    QVector<Row> rows;
+    const size_t entries = dsd_tg_policy_entry_count(snapshot);
+    rows.reserve(static_cast<qsizetype>(entries));
+    for (size_t i = 0; i < entries; ++i) {
+        dsd_tg_policy_entry entry;
+        if (!dsd_tg_policy_entry_at(snapshot, i, &entry) || entry.source == DSD_TG_POLICY_SOURCE_RUNTIME_ALIAS
+            || strcmp(entry.mode, "D") == 0) {
+            continue;
+        }
+        rows.push_back({entry.id_start, entry.id_end, QString::fromUtf8(entry.name), QString::fromUtf8(entry.tags),
+                        strcmp(entry.mode, "B") != 0 && strcmp(entry.mode, "DE") != 0, true});
+        if (!rows.back().tags.isEmpty()) {
+            categoryTags.insert(rows.back().tags);
+        }
+    }
+    return rows;
+}
+
+void
+TalkgroupListModel::appendHeardRows(QVector<Row>& rows, bool allowListedOnly) const {
+    if (m_history == nullptr || m_tgRole < 0 || m_whenRole < 0 || m_kindRole < 0) {
+        return;
+    }
+    const qsizetype listedCount = rows.size();
+    QSet<uint32_t> heard;
+    for (int i = 0; i < m_history->rowCount(); ++i) {
+        const QModelIndex idx = m_history->index(i, 0);
+        if (m_history->data(idx, m_kindRole).toInt() != 0
+            || m_history->data(idx, m_whenRole).toLongLong() < m_sinceWhen) {
+            continue;
+        }
+        const qulonglong target = m_history->data(idx, m_tgRole).toULongLong();
+        if (target == 0 || target > std::numeric_limits<uint32_t>::max()) {
+            continue;
+        }
+        const auto tg = static_cast<uint32_t>(target);
+        if (heard.contains(tg)) {
+            continue;
+        }
+        heard.insert(tg);
+        const bool covered = std::any_of(rows.cbegin(), rows.cbegin() + listedCount,
+                                         [tg](const Row& row) { return tg >= row.idStart && tg <= row.idEnd; });
+        if (!covered) {
+            rows.push_back({tg, tg, {}, {}, !allowListedOnly, false});
+        }
+    }
+}
+
+void
+TalkgroupListModel::replaceRows(QVector<Row> rows) {
+    const int oldCount = count();
+    const int notTuned =
+        static_cast<int>(std::count_if(rows.cbegin(), rows.cend(), [](const Row& row) { return !row.listening; }));
+    const bool sameBounds = rows.size() == m_rows.size()
+                            && std::equal(rows.cbegin(), rows.cend(), m_rows.cbegin(), [](const Row& a, const Row& b) {
+                                   return a.idStart == b.idStart && a.idEnd == b.idEnd;
+                               });
+    if (sameBounds) {
+        for (int i = 0; i < count(); ++i) {
+            const Row& row = rows.at(i);
+            Row& old = m_rows[i];
+            if (old.name != row.name || old.tags != row.tags || old.listening != row.listening
+                || old.listed != row.listed) {
+                old = std::move(rows[i]);
+                Q_EMIT dataChanged(index(i, 0), index(i, 0));
+            }
+        }
+    } else {
+        beginResetModel();
+        m_rows = std::move(rows);
+        endResetModel();
+    }
+    if (oldCount != count() || m_notTunedCount != notTuned) {
+        m_notTunedCount = notTuned;
+        Q_EMIT countChanged();
+    }
+}
+
+void
+TalkgroupListModel::updateCategories(const QSet<QString>& categoryTags) {
+    QStringList updatedCategories = categoryTags.values();
+    std::sort(updatedCategories.begin(), updatedCategories.end(), [](const QString& a, const QString& b) {
+        const int order = QString::compare(a, b, Qt::CaseInsensitive);
+        return order != 0 ? order < 0 : a < b;
+    });
+    if (updatedCategories != m_categories) {
+        m_categories = std::move(updatedCategories);
+        Q_EMIT categoriesChanged();
+    }
+}
+
+void
+TalkgroupListModel::clear() {
+    const bool hadCounts = !m_rows.isEmpty() || m_notTunedCount != 0;
+    if (!m_rows.isEmpty()) {
+        beginResetModel();
+        m_rows.clear();
+        endResetModel();
+    }
+    m_notTunedCount = 0;
+    if (hadCounts) {
+        Q_EMIT countChanged();
+    }
+    if (!m_categories.isEmpty()) {
+        m_categories.clear();
+        Q_EMIT categoriesChanged();
+    }
+    if (m_allowListMode || m_persistent) {
+        m_allowListMode = false;
+        m_persistent = false;
+        Q_EMIT policyChanged();
+    }
+    m_contextId = 0;
+    m_generation = 0;
+    m_heardDirty = true;
+}
+
+} // namespace dsd_qt

--- a/src/ui/qt/talkgroup_list_model.h
+++ b/src/ui/qt/talkgroup_list_model.h
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Effective talkgroup policy plus talkgroups heard during this session.
+ *
+ * Refreshed from the single UI poll tick (see ui_controller.h), on the Qt main
+ * thread — never from another thread or a second snapshot reader.
+ */
+
+#ifndef DSD_NEO_SRC_UI_QT_TALKGROUP_LIST_MODEL_H_
+#define DSD_NEO_SRC_UI_QT_TALKGROUP_LIST_MODEL_H_
+
+#include <QAbstractListModel>
+#include <QList>
+#include <QObject>
+#include <QPointer>
+#include <QString>
+#include <QStringList>
+#include <Qt>
+#include <QtGlobal>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <stdint.h>
+// Qt template conversions require this in some consumers; IWYU's answer depends on instantiation.
+#include <type_traits> // IWYU pragma: keep
+
+template <class T>
+class QSet;
+
+namespace dsd_qt {
+
+class TalkgroupListModel : public QAbstractListModel {
+    Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(int notTunedCount READ notTunedCount NOTIFY countChanged)
+    Q_PROPERTY(QStringList categories READ categories NOTIFY categoriesChanged)
+    Q_PROPERTY(bool allowListMode READ allowListMode NOTIFY policyChanged)
+    Q_PROPERTY(bool persistent READ persistent NOTIFY policyChanged)
+    Q_PROPERTY(qint64 sinceWhen READ sinceWhen WRITE setSinceWhen NOTIFY sinceWhenChanged)
+
+  public:
+    enum Role {
+        IdStartRole = Qt::UserRole + 1,
+        IdEndRole,
+        IdTextRole,
+        NameRole,
+        TagsRole,
+        ListeningRole,
+        ListedRole,
+    };
+
+    explicit TalkgroupListModel(QAbstractItemModel* history, QObject* parent = nullptr);
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    int
+    count() const {
+        return static_cast<int>(m_rows.size());
+    }
+
+    int
+    notTunedCount() const {
+        return m_notTunedCount;
+    }
+
+    QStringList
+    categories() const {
+        return m_categories;
+    }
+
+    bool
+    allowListMode() const {
+        return m_allowListMode;
+    }
+
+    bool
+    persistent() const {
+        return m_persistent;
+    }
+
+    qint64
+    sinceWhen() const {
+        return m_sinceWhen;
+    }
+
+    void setSinceWhen(qint64 when);
+    void refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot);
+    /** @brief Drop snapshot state, retaining the session's history cutoff. */
+    void clear();
+
+  Q_SIGNALS:
+    void countChanged();
+    void categoriesChanged();
+    void policyChanged();
+    void sinceWhenChanged();
+
+  private:
+    struct Row {
+        uint32_t idStart = 0;
+        uint32_t idEnd = 0;
+        QString name;
+        QString tags;
+        bool listening = false;
+        bool listed = false;
+    };
+
+    static QVector<Row> listedRows(const dsd_state* snapshot, QSet<QString>& categoryTags);
+    void appendHeardRows(QVector<Row>& rows, bool allowListedOnly) const;
+    void replaceRows(QVector<Row> rows);
+    void updateCategories(const QSet<QString>& categoryTags);
+
+    QPointer<QAbstractItemModel> m_history;
+    int m_tgRole = -1;
+    int m_whenRole = -1;
+    int m_kindRole = -1;
+    QVector<Row> m_rows;
+    QStringList m_categories;
+    int m_notTunedCount = 0;
+    bool m_allowListMode = false;
+    bool m_persistent = false;
+    qint64 m_sinceWhen = 0;
+    uint64_t m_contextId = 0;
+    unsigned int m_generation = 0;
+    bool m_heardDirty = true;
+};
+
+} // namespace dsd_qt
+
+#endif /* DSD_NEO_SRC_UI_QT_TALKGROUP_LIST_MODEL_H_ */

--- a/src/ui/qt/ui_controller.cpp
+++ b/src/ui/qt/ui_controller.cpp
@@ -14,6 +14,7 @@
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 #include "metrics_model.h"
+#include "talkgroup_list_model.h"
 
 namespace dsd_qt {
 
@@ -26,8 +27,9 @@ constexpr int kDefaultPollIntervalMs = 250;
 
 } // namespace
 
-UiController::UiController(DecoderHost* host, MetricsModel* metrics, CallHistoryModel* history, QObject* parent)
-    : QObject(parent), m_host(host), m_metrics(metrics), m_history(history) {
+UiController::UiController(DecoderHost* host, MetricsModel* metrics, CallHistoryModel* history,
+                           TalkgroupListModel* talkgroups, QObject* parent)
+    : QObject(parent), m_host(host), m_metrics(metrics), m_history(history), m_talkgroups(talkgroups) {
     m_timer.setInterval(kDefaultPollIntervalMs);
     m_timer.setTimerType(Qt::CoarseTimer);
     connect(&m_timer, &QTimer::timeout, this, &UiController::tick);
@@ -87,6 +89,9 @@ UiController::onSessionStateChanged() {
         if (m_metrics != nullptr) {
             m_metrics->clear();
         }
+        if (m_talkgroups != nullptr) {
+            m_talkgroups->clear();
+        }
     }
 }
 
@@ -102,7 +107,7 @@ UiController::tick() {
         return;
     }
 
-    /* Consumed once, here, and handed to both models. Each accessor deep-copies
+    /* Consumed once, here, and handed to the models. Each accessor deep-copies
      * whenever the publisher has moved on, so fetching per model would let a publish
      * land mid-frame and leave the status card describing one generation and the
      * event list another — and would repeat the copy for every fetch. */
@@ -116,6 +121,9 @@ UiController::tick() {
      * cleared on session boundaries — only fed. */
     if (m_history != nullptr) {
         m_history->refresh(snapshot);
+    }
+    if (m_talkgroups != nullptr) {
+        m_talkgroups->refresh(opts_snapshot, snapshot);
     }
 }
 

--- a/src/ui/qt/ui_controller.h
+++ b/src/ui/qt/ui_controller.h
@@ -25,13 +25,15 @@ namespace dsd_qt {
 
 class CallHistoryModel;
 class MetricsModel;
+class TalkgroupListModel;
 
 class UiController : public QObject {
     Q_OBJECT
     Q_PROPERTY(int pollIntervalMs READ pollIntervalMs WRITE setPollIntervalMs NOTIFY pollIntervalChanged)
 
   public:
-    UiController(DecoderHost* host, MetricsModel* metrics, CallHistoryModel* history, QObject* parent = nullptr);
+    UiController(DecoderHost* host, MetricsModel* metrics, CallHistoryModel* history, TalkgroupListModel* talkgroups,
+                 QObject* parent = nullptr);
     ~UiController() override;
 
     int pollIntervalMs() const;
@@ -61,6 +63,7 @@ class UiController : public QObject {
     DecoderHost* m_host = nullptr;
     MetricsModel* m_metrics = nullptr;
     CallHistoryModel* m_history = nullptr;
+    TalkgroupListModel* m_talkgroups = nullptr;
     QTimer m_timer;
     DecoderHost::SessionState m_session = DecoderHost::Idle;
 };

--- a/src/ui/terminal/rr_wizard_core.c
+++ b/src/ui/terminal/rr_wizard_core.c
@@ -1601,25 +1601,6 @@ rr_refresh_complete(RrWizardCore* w) {
 
 /* ---- System assembly ----------------------------------------------------- */
 
-/**
- * @brief Splice category names onto the talkgroups.
- *
- * Display only in v1: no generator reads dsd_rr_talkgroup::category, and the Qt
- * model never filled it, so there is nothing to port here.
- */
-static void
-rr_apply_categories(dsd_rr_talkgroup_list* tgs, const dsd_rr_talkgroup_cat_list* cats) {
-    for (size_t i = 0; i < tgs->count; i++) {
-        tgs->items[i].category[0] = '\0';
-        for (size_t k = 0; k < cats->count; k++) {
-            if (cats->items[k].tg_cid == tgs->items[i].tg_cid) {
-                DSD_STRNCPY(tgs->items[i].category, cats->items[k].name, sizeof tgs->items[i].category - 1U);
-                break;
-            }
-        }
-    }
-}
-
 /** @brief Move a heap list sink's contents into a core-owned struct. */
 static void
 rr_core_take_list(void* dst, void* src, size_t size) {
@@ -1816,7 +1797,7 @@ rr_system_assemble(RrWizardCore* w) {
     rr_core_take_list(&w->talkgroups, w->pend_tgs, sizeof w->talkgroups);
     w->pend_tgs = NULL;
     if (w->pend_cats != NULL) {
-        rr_apply_categories(&w->talkgroups, w->pend_cats);
+        dsd_rr_talkgroups_apply_categories(&w->talkgroups, w->pend_cats);
         dsd_rr_talkgroup_cat_list_free(w->pend_cats);
         free(w->pend_cats);
         w->pend_cats = NULL;
@@ -2074,12 +2055,12 @@ static int
 rr_core_dispatch_error(RrWizardCore* w, RrWizResult* r) {
     if (r->kind == RR_FETCH_TRS_TALKGROUP_CATS
         && (w->step == RR_STEP_LOADING_SYSTEM || w->step == RR_STEP_REFRESHING)) {
-        /* Category names are display-only; losing them must not lose the load.
+        /* Categories are optional labels; losing them must not lose the load.
            RR_STEP_REFRESHING is the same load seen from the browser -
            rr_wizard_core_begin_refresh() overwrites the step right after
            rr_load_system() queues the four fetches - and rr_refresh_complete()
-           reads sites and talkgroups only, so a categories fault must not abort a
-           refresh either. */
+           can generate without categories, so a categories fault must not abort
+           a refresh either. */
         r->payload = rr_payload_none();
         return rr_core_apply_system_slot(w, r);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2677,6 +2677,40 @@ if(DSD_ENABLE_QT_UI)
     )
     add_test(NAME UI_QT_METRICS_MODEL COMMAND dsd-neo_test_ui_qt_metrics_model)
 
+    add_executable(
+        dsd-neo_test_ui_qt_talkgroup_list_model
+        ui/test_ui_qt_talkgroup_list_model.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/talkgroup_list_model.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/talkgroup_filter_model.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/call_history_model.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/qt/json_store.cpp
+    )
+    target_include_directories(
+        dsd-neo_test_ui_qt_talkgroup_list_model
+        PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/ui/qt
+    )
+    target_link_libraries(
+        dsd-neo_test_ui_qt_talkgroup_list_model
+        PRIVATE
+            Qt6::Core
+            dsd-neo_core
+            dsd-neo_runtime
+            dsd-neo_feature_codec2
+            ${LIBS}
+    )
+    target_compile_definitions(
+        dsd-neo_test_ui_qt_talkgroup_list_model
+        PRIVATE QT_NO_KEYWORDS DSD_NEO_TEST_HOOKS
+    )
+    set_target_properties(
+        dsd-neo_test_ui_qt_talkgroup_list_model
+        PROPERTIES AUTOMOC ON
+    )
+    add_test(
+        NAME UI_QT_TALKGROUP_LIST_MODEL
+        COMMAND dsd-neo_test_ui_qt_talkgroup_list_model
+    )
+
     # The call-history model's ring ingest, driven against synthetic event
     # rings: the slot/seq row keying, merge-versus-duplicate decisions, the
     # commit_rev rescan gate, and the relaunch (Activity restart) path.
@@ -2896,6 +2930,8 @@ if(DSD_ENABLE_QT_UI)
             ui/qml_test_context.h
             ui/qml_spectrum_stub.cpp
             ${PROJECT_SOURCE_DIR}/src/ui/qt/call_history_filter.cpp
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/talkgroup_list_model.cpp
+            ${PROJECT_SOURCE_DIR}/src/ui/qt/talkgroup_filter_model.cpp
             ${PROJECT_SOURCE_DIR}/src/ui/qt/spectrum_model.cpp
             ${PROJECT_SOURCE_DIR}/src/ui/qt/spectrum_view_item.cpp
             # The home screen, the imports library, the wizard's CSV pickers and

--- a/tests/core/test_core_csv_import.c
+++ b/tests/core/test_core_csv_import.c
@@ -906,23 +906,40 @@ test_group_import_policy_and_basic_headers(void) {
     }
     (void)dsd_close(fd);
 
-    if (write_text_file(tmpl, "id,mode,name,tag\n100,B,LOCK,90,true,on,on,on\n101,A,ALLOW,meta\n") != 0) {
-        (void)remove(tmpl);
-        free(opts);
-        free_test_state(state);
-        return 1;
-    }
+    static const struct {
+        const char* header;
+        const char* expected_tags;
+    } basic_cases[] = {
+        {"DEC,Mode,Name,Tag", "Fire"},
+        {"id,mode,name, tags ", "Fire"},
+        {"DEC,Mode,Name,Category,(generated from RadioReference)", "Fire"},
+        {"id,mode,name,metadata", ""},
+    };
+
     DSD_SNPRINTF(opts->group_in_file, sizeof(opts->group_in_file), "%s", tmpl);
-    if (csvGroupImport(opts, state) != 0) {
-        failed = 1;
-    }
-    if (dsd_tg_policy_lookup_id(state, 100, &lookup) != 0 || lookup.match != DSD_TG_POLICY_MATCH_EXACT
-        || lookup.entry.priority != 0 || lookup.entry.preempt != 0 || lookup.entry.audio != 0) {
-        failed = 1;
-    }
-    if (dsd_tg_policy_lookup_id(state, 101, &lookup) != 0 || lookup.match != DSD_TG_POLICY_MATCH_EXACT
-        || lookup.entry.priority != 0 || lookup.entry.preempt != 0 || lookup.entry.audio != 1) {
-        failed = 1;
+    for (size_t i = 0; i < sizeof(basic_cases) / sizeof(basic_cases[0]); i++) {
+        char text[256];
+        dsd_state_ext_free_all(state);
+        DSD_MEMSET(state, 0, sizeof(*state));
+        DSD_SNPRINTF(text, sizeof(text), "%s\n100,B,LOCK, Fire ,true,on,on,on\n101,A,ALLOW\n", basic_cases[i].header);
+        if (write_text_file(tmpl, text) != 0) {
+            failed = 1;
+            break;
+        }
+        if (csvGroupImport(opts, state) != 0) {
+            failed = 1;
+        }
+        if (dsd_tg_policy_lookup_id(state, 100, &lookup) != 0 || lookup.match != DSD_TG_POLICY_MATCH_EXACT
+            || lookup.entry.priority != 0 || lookup.entry.preempt != 0 || lookup.entry.audio != 0
+            || strcmp(lookup.entry.tags, basic_cases[i].expected_tags) != 0) {
+            DSD_FPRINTF(stderr, "basic group header case %zu lost tags or changed policy\n", i);
+            failed = 1;
+        }
+        if (dsd_tg_policy_lookup_id(state, 101, &lookup) != 0 || lookup.match != DSD_TG_POLICY_MATCH_EXACT
+            || lookup.entry.priority != 0 || lookup.entry.preempt != 0 || lookup.entry.audio != 1
+            || lookup.entry.tags[0] != '\0') {
+            failed = 1;
+        }
     }
 
     dsd_state_ext_free_all(state);
@@ -943,7 +960,7 @@ test_group_import_policy_and_basic_headers(void) {
         }
         if (dsd_tg_policy_lookup_id(state, 200, &lookup) != 0 || lookup.entry.priority != 90
             || lookup.entry.preempt != 1 || lookup.entry.audio != 1 || lookup.entry.record != 1
-            || lookup.entry.stream != 1) {
+            || lookup.entry.stream != 1 || strcmp(lookup.entry.tags, "fire") != 0) {
             failed = 1;
         }
         if (dsd_tg_policy_lookup_id(state, 201, &lookup) != 0 || lookup.entry.priority != 0 || lookup.entry.preempt != 1

--- a/tests/core/test_core_talkgroup_policy.c
+++ b/tests/core/test_core_talkgroup_policy.c
@@ -3,12 +3,15 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/scan_profile.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/posix_compat.h>
+#include <dsd-neo/runtime/scan_options.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -47,35 +50,16 @@ init_entry(dsd_tg_policy_entry* e, uint32_t id, const char* mode, const char* na
     e->stream = e->audio;
 }
 
-typedef struct {
-    dsd_tg_policy_entry* entries;
-    size_t count;
-    size_t capacity;
-    unsigned int generation;
-} test_tg_policy_table_view;
-
-typedef struct {
-    test_tg_policy_table_view table;
-} test_tg_policy_context_view;
-
 static unsigned int
 policy_generation(const dsd_state* st) {
-    const test_tg_policy_context_view* ctx =
-        (const test_tg_policy_context_view*)dsd_state_ext_get_const(st, DSD_STATE_EXT_CORE_TG_POLICY);
-    if (!ctx) {
-        return 0u;
-    }
-    return ctx->table.generation;
+    unsigned int generation = 0;
+    dsd_tg_policy_table_version(st, NULL, &generation);
+    return generation;
 }
 
 static size_t
 policy_count(const dsd_state* st) {
-    const test_tg_policy_context_view* ctx =
-        (const test_tg_policy_context_view*)dsd_state_ext_get_const(st, DSD_STATE_EXT_CORE_TG_POLICY);
-    if (!ctx) {
-        return 0u;
-    }
-    return ctx->table.count;
+    return dsd_tg_policy_entry_count(st);
 }
 
 static int
@@ -866,6 +850,249 @@ test_reload_group_file(void) {
     return rc;
 }
 
+static int
+expect_zeroed_entry(const char* tag, const dsd_tg_policy_entry* entry) {
+    int rc = expect_true(tag, entry->id_start == 0);
+    rc |= expect_true(tag, entry->id_end == 0);
+    rc |= expect_true(tag, entry->mode[0] == '\0');
+    rc |= expect_true(tag, entry->name[0] == '\0');
+    rc |= expect_true(tag, entry->tags[0] == '\0');
+    rc |= expect_true(tag, entry->priority == 0);
+    rc |= expect_true(tag, entry->preempt == 0);
+    rc |= expect_true(tag, entry->audio == 0);
+    rc |= expect_true(tag, entry->record == 0);
+    rc |= expect_true(tag, entry->stream == 0);
+    rc |= expect_true(tag, entry->is_range == 0);
+    rc |= expect_true(tag, entry->source == 0);
+    rc |= expect_true(tag, entry->row == 0);
+    return rc;
+}
+
+static int
+test_mode_edits_and_enumeration(void) {
+    int rc = 0;
+    dsd_state* st = (dsd_state*)calloc(1, sizeof(*st));
+    dsd_state* snap = (dsd_state*)calloc(1, sizeof(*snap));
+    dsd_tg_policy_entry e;
+    dsd_tg_policy_entry row;
+    uint64_t context = 1;
+    uint64_t snapshot_context = 0;
+    unsigned int generation = 1;
+    unsigned int snapshot_generation = 0;
+    if (!st || !snap) {
+        free_test_state(st);
+        free_test_state(snap);
+        return 1;
+    }
+
+    dsd_tg_policy_table_version(st, &context, &generation);
+    rc |= expect_true("absent table identity", context == 0 && generation == 0);
+    rc |= expect_true("absent table count", dsd_tg_policy_entry_count(st) == 0);
+    DSD_MEMSET(&row, 0xff, sizeof(row));
+    rc |= expect_true("absent row", dsd_tg_policy_entry_at(st, 0, &row) == 0);
+    rc |= expect_zeroed_entry("absent row zeroed", &row);
+    rc |= expect_true("null row destination", dsd_tg_policy_entry_at(st, 0, NULL) == 0);
+
+    init_entry(&e, 1001, "A", "Dispatch", DSD_TG_POLICY_SOURCE_IMPORTED);
+    DSD_SNPRINTF(e.tags, sizeof(e.tags), "%s", "FIRE");
+    e.priority = 23;
+    e.preempt = 1;
+    rc |= expect_true("seed editable row", dsd_tg_policy_append_exact(st, &e) == 0);
+    rc |= expect_true("seed duplicate row", dsd_tg_policy_append_exact(st, &e) == 0);
+    dsd_tg_policy_table_version(st, &context, &generation);
+    rc |= expect_true("copy editable snapshot", dsd_tg_policy_copy_snapshot(snap, st) == 0);
+    dsd_tg_policy_table_version(snap, &snapshot_context, &snapshot_generation);
+    rc |= expect_true("snapshot shares source version",
+                      context != 0 && snapshot_context == context && snapshot_generation == generation);
+    rc |= expect_true("block existing row", dsd_tg_policy_set_mode(st, 1001, 1001, "B") == 0);
+    rc |= expect_true("mode edit advances generation", policy_generation(st) > generation);
+    rc |= expect_true("read blocked row", dsd_tg_policy_entry_at(st, 0, &row) == 1);
+    rc |= expect_true("mode edit preserves metadata", strcmp(row.name, "Dispatch") == 0 && strcmp(row.tags, "FIRE") == 0
+                                                          && row.priority == 23 && row.preempt == 1
+                                                          && row.source == DSD_TG_POLICY_SOURCE_IMPORTED);
+    rc |= expect_true("blocking disables media",
+                      strcmp(row.mode, "B") == 0 && row.audio == 0 && row.record == 0 && row.stream == 0);
+    rc |= expect_true("read duplicate row", dsd_tg_policy_entry_at(st, 1, &row) == 1);
+    rc |= expect_true("only first bounds match changes", strcmp(row.mode, "A") == 0);
+    rc |= expect_true("read original snapshot", dsd_tg_policy_entry_at(snap, 0, &row) == 1);
+    rc |= expect_true("snapshot keeps old row", strcmp(row.mode, "A") == 0 && strcmp(row.tags, "FIRE") == 0);
+    rc |= expect_true("refresh edited snapshot", dsd_tg_policy_copy_snapshot(snap, st) == 0);
+    rc |= expect_true("read refreshed snapshot", dsd_tg_policy_entry_at(snap, 0, &row) == 1);
+    rc |= expect_true("snapshot receives edit", strcmp(row.mode, "B") == 0 && strcmp(row.tags, "FIRE") == 0);
+    rc |= expect_true("listen to existing row", dsd_tg_policy_set_mode(st, 1001, 1001, "A") == 0);
+    rc |= expect_true("read listening row", dsd_tg_policy_entry_at(st, 0, &row) == 1);
+    rc |= expect_true("listening restores media",
+                      strcmp(row.mode, "A") == 0 && row.audio == 1 && row.record == 1 && row.stream == 1);
+    rc |= expect_true("listen preserves metadata", strcmp(row.name, "Dispatch") == 0 && strcmp(row.tags, "FIRE") == 0
+                                                       && row.priority == 23 && row.preempt == 1
+                                                       && row.source == DSD_TG_POLICY_SOURCE_IMPORTED);
+
+    init_entry(&e, 1300, "A", "Regional", DSD_TG_POLICY_SOURCE_IMPORTED);
+    e.id_end = 1399;
+    e.is_range = 1;
+    rc |= expect_true("append editable range", dsd_tg_policy_add_range_entry(st, &e) == 0);
+    rc |= expect_true("edit range bounds", dsd_tg_policy_set_mode(st, 1300, 1399, "B") == 0);
+    rc |= expect_true("append missing exact", dsd_tg_policy_set_mode(st, 900, 900, "B") == 0);
+    rc |= expect_true("enumerated append count", dsd_tg_policy_entry_count(st) == 4);
+    rc |= expect_true("enumerate range in append order", dsd_tg_policy_entry_at(st, 2, &row) == 1);
+    rc |= expect_true("range edit retained bounds",
+                      row.id_start == 1300 && row.id_end == 1399 && row.is_range && strcmp(row.mode, "B") == 0);
+    rc |= expect_true("enumerate runtime row last", dsd_tg_policy_entry_at(st, 3, &row) == 1);
+    rc |= expect_true("runtime row identity", row.id_start == 900 && row.id_end == 900 && row.name[0] == '\0'
+                                                  && row.source == DSD_TG_POLICY_SOURCE_USER_LOCKOUT);
+    generation = policy_generation(st);
+    rc |= expect_true("index edit", dsd_tg_policy_set_mode_at(st, 2, "A") == 0);
+    rc |= expect_true("index edit advances version", policy_generation(st) > generation);
+    rc |= expect_true("read index edit", dsd_tg_policy_entry_at(st, 2, &row) == 1);
+    rc |= expect_true("index edit restores range media", row.audio && row.record && row.stream);
+    generation = policy_generation(st);
+    rc |= expect_true("missing range refused", dsd_tg_policy_set_mode(st, 1400, 1499, "B") == 1);
+    rc |= expect_true("reversed bounds refused", dsd_tg_policy_set_mode(st, 2, 1, "B") == 1);
+    rc |= expect_true("null state refused", dsd_tg_policy_set_mode(NULL, 1, 1, "B") == 1);
+    rc |= expect_true("null mode refused", dsd_tg_policy_set_mode(st, 1, 1, NULL) == 1);
+    rc |= expect_true("empty mode refused", dsd_tg_policy_set_mode(st, 1, 1, "") == 1);
+    rc |= expect_true("eight byte mode refused", dsd_tg_policy_set_mode(st, 1, 1, "12345678") == 1);
+    rc |= expect_true("bad index refused", dsd_tg_policy_set_mode_at(st, 4, "A") == 1);
+    rc |= expect_true("index empty mode refused", dsd_tg_policy_set_mode_at(st, 0, "") == 1);
+    rc |= expect_true("index long mode refused", dsd_tg_policy_set_mode_at(st, 0, "12345678") == 1);
+    rc |= expect_true("invalid edits leave table unchanged",
+                      policy_generation(st) == generation && dsd_tg_policy_entry_count(st) == 4);
+    rc |= expect_true("out of range enumeration", dsd_tg_policy_entry_at(st, 4, &row) == 0);
+    rc |= expect_zeroed_entry("out of range row zeroed", &row);
+    dsd_state_ext_free_all(st);
+    rc |= expect_true("setter creates absent context", dsd_tg_policy_set_mode(st, 7, 7, "A") == 0);
+    dsd_tg_policy_table_version(st, &snapshot_context, NULL);
+    rc |= expect_true("recreated context differs", snapshot_context != 0 && snapshot_context != context);
+    free_test_state(st);
+    free_test_state(snap);
+    return rc;
+}
+
+static int
+test_group_file_rewrite(void) {
+    int rc = 0;
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* st = (dsd_state*)calloc(1, sizeof(*st));
+    dsd_state* loaded = (dsd_state*)calloc(1, sizeof(*loaded));
+    dsd_tg_policy_entry e;
+    dsd_tg_policy_entry row;
+    char path[] = "dsd-neo-test-tg-rewrite-XXXXXX";
+    char l1[256] = {0};
+    char l2[256] = {0};
+    char l3[256] = {0};
+    if (!opts || !st || !loaded) {
+        free(opts);
+        free_test_state(st);
+        free_test_state(loaded);
+        return 1;
+    }
+    int fd = dsd_mkstemp(path);
+    if (fd < 0) {
+        free(opts);
+        free_test_state(st);
+        free_test_state(loaded);
+        return 1;
+    }
+    (void)dsd_close(fd);
+    (void)remove(path);
+    rc |= expect_true("empty path rewrite ignored", dsd_tg_policy_write_group_file(opts, st) == 0);
+    rc |= expect_true("null options rewrite ignored", dsd_tg_policy_write_group_file(NULL, st) == 0);
+    FILE* fp = fopen(path, "r");
+    rc |= expect_true("empty path creates no file", fp == NULL);
+    if (fp) {
+        fclose(fp);
+    }
+    init_entry(&e, 1001, "B", "Dispatch", DSD_TG_POLICY_SOURCE_IMPORTED);
+    DSD_SNPRINTF(e.tags, sizeof(e.tags), "%s", "FIRE");
+    rc |= expect_true("seed rewrite exact", dsd_tg_policy_append_exact(st, &e) == 0);
+    init_entry(&e, 1300, "A", "Regional", DSD_TG_POLICY_SOURCE_IMPORTED);
+    e.id_end = 1399;
+    e.is_range = 1;
+    rc |= expect_true("seed rewrite range", dsd_tg_policy_add_range_entry(st, &e) == 0);
+    DSD_SNPRINTF(opts->group_in_file, sizeof(opts->group_in_file), "%s", path);
+    rc |= expect_true("rewrite tagged table", dsd_tg_policy_write_group_file(opts, st) == 0);
+    rc |=
+        expect_true("read rewritten table", read_file_lines(path, l1, sizeof(l1), l2, sizeof(l2), l3, sizeof(l3)) == 0);
+    rc |= expect_true("tagged header", strcmp(l1, "id,mode,name,tags\n") == 0);
+    rc |= expect_true("tagged exact row", strcmp(l2, "1001,B,Dispatch,FIRE\n") == 0);
+    rc |= expect_true("range row with empty category", strcmp(l3, "1300-1399,A,Regional,\n") == 0);
+    rc |= expect_true("reload tagged table", csvGroupImportPath(path, loaded) == 0);
+    rc |= expect_true("roundtrip row count", dsd_tg_policy_entry_count(loaded) == 2);
+    rc |= expect_true("roundtrip exact row", dsd_tg_policy_entry_at(loaded, 0, &row) == 1);
+    rc |= expect_true("roundtrip exact fields", row.id_start == 1001 && row.id_end == 1001 && strcmp(row.mode, "B") == 0
+                                                    && strcmp(row.name, "Dispatch") == 0
+                                                    && strcmp(row.tags, "FIRE") == 0);
+    rc |= expect_true("roundtrip range row", dsd_tg_policy_entry_at(loaded, 1, &row) == 1);
+    rc |= expect_true("roundtrip range fields", row.id_start == 1300 && row.id_end == 1399 && row.is_range
+                                                    && strcmp(row.mode, "A") == 0 && strcmp(row.name, "Regional") == 0
+                                                    && row.tags[0] == '\0');
+
+    fp = dsd_fopen_private(path, "w");
+    if (!fp) {
+        rc = 1;
+        goto cleanup;
+    }
+    DSD_FPRINTF(fp, "id,mode,name,priority,preempt,audio,record,stream,tags\n");
+    fclose(fp);
+    rc |= expect_true("clear rewrite fixture", dsd_tg_policy_clear(st) == 0);
+    init_entry(&e, 2001, "A", "EMS Dispatch", DSD_TG_POLICY_SOURCE_IMPORTED);
+    DSD_SNPRINTF(e.tags, sizeof(e.tags), "%s", "EMS");
+    e.priority = 17;
+    e.preempt = 1;
+    e.record = 0;
+    rc |= expect_true("seed extended rewrite", dsd_tg_policy_append_exact(st, &e) == 0);
+    rc |= expect_true("rewrite extended table", dsd_tg_policy_write_group_file(opts, st) == 0);
+    rc |= expect_true("read extended table", read_file_lines(path, l1, sizeof(l1), l2, sizeof(l2), NULL, 0) == 0);
+    rc |= expect_true("extended header preserved",
+                      strcmp(l1, "id,mode,name,priority,preempt,audio,record,stream,tags\n") == 0);
+    rc |= expect_true("extended row media", strcmp(l2, "2001,A,EMS Dispatch,17,true,on,off,on,EMS\n") == 0);
+    dsd_state_ext_free_all(loaded);
+    rc |= expect_true("reload extended table", csvGroupImportPath(path, loaded) == 0);
+    rc |= expect_true("extended roundtrip count", dsd_tg_policy_entry_count(loaded) == 1);
+    rc |= expect_true("extended roundtrip row", dsd_tg_policy_entry_at(loaded, 0, &row) == 1);
+    rc |= expect_true("extended roundtrip policy", row.priority == 17 && row.preempt && row.audio && !row.record
+                                                       && row.stream && strcmp(row.tags, "EMS") == 0);
+    (void)remove(path);
+    DSD_SNPRINTF(opts->group_in_file, sizeof(opts->group_in_file), "%s/groups.csv", path);
+    rc |= expect_true("missing directory rewrite fails", dsd_tg_policy_write_group_file(opts, st) == -1);
+    DSD_SNPRINTF(opts->group_in_file, sizeof(opts->group_in_file), "%s", path);
+    rc |= expect_true("clear untagged fixture", dsd_tg_policy_clear(st) == 0);
+    rc |= expect_true("seed untagged runtime row", dsd_tg_policy_set_mode(st, 99, 99, "B") == 0);
+    rc |= expect_true("rewrite untagged table", dsd_tg_policy_write_group_file(opts, st) == 0);
+    rc |= expect_true("read untagged table", read_file_lines(path, l1, sizeof(l1), l2, sizeof(l2), NULL, 0) == 0);
+    rc |= expect_true("untagged header", strcmp(l1, "id,mode,name\n") == 0);
+    rc |= expect_true("untagged runtime row", strcmp(l2, "99,B,\n") == 0);
+cleanup:
+    (void)remove(path);
+    free(opts);
+    free_test_state(st);
+    free_test_state(loaded);
+    return rc;
+}
+
+static int
+test_scan_row_policy_activity(void) {
+    int rc = 0;
+    dsd_state* st = (dsd_state*)calloc(1, sizeof(*st));
+    dsd_scan_row_profile profile = {0};
+    if (!st) {
+        return 1;
+    }
+    rc |= expect_true("no scan policy active", !dsd_scan_groups_row_active(st));
+    profile.values.present = DSD_SCAN_OPT_GROUP;
+    rc |= expect_true("reserve scan groups", dsd_scan_groups_begin(st) == 0);
+    dsd_scan_groups_enter(st, &profile);
+    rc |= expect_true("row policy active", dsd_scan_groups_row_active(st));
+    rc |= expect_true("suspend row policy", dsd_scan_groups_suspend(st) == 1);
+    rc |= expect_true("suspended row policy inactive", !dsd_scan_groups_row_active(st));
+    dsd_scan_groups_resume(st);
+    rc |= expect_true("resumed row policy active", dsd_scan_groups_row_active(st));
+    dsd_scan_groups_leave(st);
+    rc |= expect_true("left row policy inactive", !dsd_scan_groups_row_active(st));
+    free_test_state(st);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -879,5 +1106,8 @@ main(void) {
     rc |= test_group_file_append_helper();
     rc |= test_preemption_helpers();
     rc |= test_reload_group_file();
+    rc |= test_mode_edits_and_enumeration();
+    rc |= test_group_file_rewrite();
+    rc |= test_scan_row_policy_activity();
     return rc;
 }

--- a/tests/runtime/test_runtime_rr_generate.c
+++ b/tests/runtime/test_runtime_rr_generate.c
@@ -540,15 +540,17 @@ test_group_csv(void) {
     tg_set(&tgs[5], 400U, "A\r\nB\tC", "", 0);
     tg_set(&tgs[6], 500U, over, "", 0);
     tg_set(&tgs[7], 600U, exact, "", 0);
+    (void)DSD_SNPRINTF(tgs[0].category, sizeof(tgs[0].category), "%s", "Fire");
+    (void)DSD_SNPRINTF(tgs[5].category, sizeof(tgs[5].category), "%s", "  Law,\r\nDispatch  ");
 
     char want[1024];
     (void)DSD_SNPRINTF(want, sizeof(want),
-                       "DEC,Mode,Name (generated from RadioReference)\n"
+                       "DEC,Mode,Name,Category,(generated from RadioReference)\n"
                        "100,A,Lead and trail\n"
                        "200,DE,Description only\n"
                        "250,DE,TG 250\n"
-                       "300,A,Fire/ Dispatch\n"
-                       "400,A,A B C\n"
+                       "300,A,Fire/ Dispatch,Fire\n"
+                       "400,A,A B C,Law/ Dispatch\n"
                        "500,A,%.48s\n"
                        "600,A,%s\n",
                        over, exact);
@@ -584,7 +586,7 @@ test_group_csv(void) {
     tg_set(&partial[1], 260U, "Full", "", 2);
     expect("partial csv generated", dsd_rr_generate_group_csv(partial, 2U, 0, &text, &len, &warnings) == 0);
     expect_str("partial enc kept clear", text,
-               "DEC,Mode,Name (generated from RadioReference)\n"
+               "DEC,Mode,Name,Category,(generated from RadioReference)\n"
                "250,A,Partial\n"
                "260,DE,Full\n");
     free(text);

--- a/tests/ui/qml/tst_context_fixture.qml
+++ b/tests/ui/qml/tst_context_fixture.qml
@@ -18,7 +18,7 @@ TestCase {
         var missing = testContext.missingContextKeys(
             ["HistoryScreen.qml", "MonitorScreen.qml", "SpectrumScreen.qml", "ExploreSetupScreen.qml", "RadioSheet.qml",
              "ImportsScreen.qml", "WizardScreen.qml", "HomeScreen.qml", "SettingsScreen.qml", "Main.qml",
-             "RadioReferenceScreen.qml", "Theme.qml"])
+             "RadioReferenceScreen.qml", "TalkgroupsScreen.qml", "TalkgroupCard.qml", "Theme.qml"])
 
         compare(missing.length, 0,
                 "read by the screens, missing from the fixture: " + missing.join(", "))

--- a/tests/ui/qml/tst_talkgroups_screen.qml
+++ b/tests/ui/qml/tst_talkgroups_screen.qml
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+
+import QtQuick
+import QtTest
+
+Item {
+    id: root
+
+    width: 420
+    height: 900
+
+    Loader {
+        id: screenLoader
+
+        anchors.fill: parent
+        source: uiDir + "/TalkgroupsScreen.qml"
+        onLoaded: item.systemName = "County Public Safety"
+    }
+
+    TestCase {
+        id: tc
+
+        name: "TalkgroupsScreen"
+        when: windowShown
+
+        property var grid: null
+        property var chips: null
+        property var search: null
+
+        function initTestCase() {
+            verify(screenLoader.item !== null, "TalkgroupsScreen.qml failed to load")
+            tc.grid = findChild(screenLoader.item, "talkgroupGrid")
+            tc.chips = findChild(screenLoader.item, "talkgroupChips")
+            tc.search = findChild(screenLoader.item, "talkgroupSearch")
+            verify(tc.grid !== null && tc.chips !== null && tc.search !== null)
+        }
+
+        function init() {
+            callHistory.clearAll()
+            talkgroups.sinceWhen = 0
+            talkgroupView.filterTag = ""
+            tc.search.text = ""
+            talkgroupView.filterText = ""
+            verify(testContext.clearTalkgroups())
+            testContext.setGroupFileConfigured(false)
+            testContext.setHostRunning(true)
+            testContext.resetCommands()
+            verify(testContext.pushTalkgroup(1001, "A", "Fire Dispatch", "FIRE"))
+            verify(testContext.pushTalkgroup(1002, "B", "Fire Tactical", "FIRE"))
+            verify(testContext.pushTalkgroup(2001, "A", "EMS Dispatch", "EMS"))
+            tryCompare(tc.grid, "count", 3)
+            tc.grid.positionViewAtBeginning()
+            tc.waitForRendering(tc.grid)
+            tryVerify(function () { return tc.grid.itemAtIndex(2) !== null })
+        }
+
+        function cleanup() {
+            tc.search.text = ""
+            talkgroupView.filterText = ""
+            talkgroupView.filterTag = ""
+            callHistory.clearAll()
+            verify(testContext.clearTalkgroups())
+            testContext.setGroupFileConfigured(false)
+            testContext.setHostRunning(false)
+            testContext.resetCommands()
+        }
+
+        function selectFire() {
+            var fire = null
+            tryVerify(function () {
+                for (var i = 0; i < tc.chips.count; ++i) {
+                    var chip = tc.chips.itemAtIndex(i)
+                    if (chip !== null && chip.text === "FIRE") {
+                        fire = chip
+                        return true
+                    }
+                }
+                return false
+            }, 5000, "the FIRE category chip is missing")
+            mouseClick(fire, fire.width / 2, fire.height / 2)
+            tryCompare(talkgroupView, "filterTag", "FIRE")
+        }
+
+        function test_rows_render_and_blocked_card_requests_listening() {
+            var dispatch = tc.grid.itemAtIndex(0)
+            var tactical = tc.grid.itemAtIndex(1)
+            var ems = tc.grid.itemAtIndex(2)
+            verify(dispatch !== null && tactical !== null && ems !== null)
+            compare(dispatch.idText, "1001")
+            compare(dispatch.name, "Fire Dispatch")
+            compare(dispatch.tags, "FIRE")
+            verify(dispatch.listening && dispatch.listed)
+            compare(tactical.idText, "1002")
+            compare(tactical.name, "Fire Tactical")
+            verify(!tactical.listening)
+            compare(ems.idText, "2001")
+            compare(ems.name, "EMS Dispatch")
+            compare(ems.tags, "EMS")
+            verify(ems.listening)
+
+            mouseClick(tactical, tactical.width / 2, tactical.height / 2)
+            compare(testContext.talkgroupListenCalls(), 1)
+            compare(testContext.lastTalkgroupListenIdStart(), 1002)
+            compare(testContext.lastTalkgroupListenIdEnd(), 1002)
+            compare(testContext.lastTalkgroupListenOn(), true)
+            // The decoder has not published an updated snapshot: do not pretend
+            // the queued request has already changed the effective policy.
+            compare(tactical.listening, false)
+        }
+
+        function test_category_filter_and_bulk_follow_tag_not_search() {
+            selectFire()
+            tryCompare(tc.grid, "count", 2)
+            tryVerify(function () {
+                var first = tc.grid.itemAtIndex(0)
+                var second = tc.grid.itemAtIndex(1)
+                return first !== null && second !== null
+                        && first.idText === "1001" && second.idText === "1002"
+                        && first.tags === "FIRE" && second.tags === "FIRE"
+            })
+
+            tc.search.text = "Tactical"
+            tryCompare(tc.grid, "count", 1)
+            tryVerify(function () {
+                var card = tc.grid.itemAtIndex(0)
+                return card !== null && card.idText === "1002"
+            })
+            var listen = findChild(screenLoader.item, "listenAllButton")
+            verify(listen !== null && listen.enabled)
+            mouseClick(listen, listen.width / 2, listen.height / 2)
+            compare(testContext.allTalkgroupsListenCalls(), 1)
+            compare(testContext.lastAllTalkgroupsListenOn(), true)
+            compare(testContext.lastAllTalkgroupsTag(), "FIRE")
+        }
+
+        function test_session_note_tracks_group_file_configuration() {
+            var note = findChild(screenLoader.item, "sessionOnlyNote")
+            verify(note !== null, "the session-only persistence note is missing")
+            tryCompare(note, "visible", true)
+            testContext.setGroupFileConfigured(true)
+            tryCompare(note, "visible", false)
+            testContext.setGroupFileConfigured(false)
+            tryCompare(note, "visible", true)
+        }
+    }
+}

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -14,8 +14,8 @@
  * analyse moc output nobody can fix.
  *
  * What is real here and what is not: the view models are the production
- * CallHistoryFilterModel, so the filter and its change signalling are under
- * test. Behind it sits CallLogStore, a stand-in for CallHistoryModel that
+ * CallHistoryFilterModel, TalkgroupListModel and TalkgroupFilterModel, so their
+ * filtering and change signalling are under test. Behind them sits CallLogStore, a stand-in for CallHistoryModel that
  * prepends rows on demand — the real store only grows by ingesting a decoder
  * snapshot ring, which is covered by UI_QT_CALL_HISTORY_MODEL instead. The
  * engine-facing objects (metrics, decoderHost, commands, prefs) are plain maps
@@ -50,6 +50,12 @@
 #include <QStringList>
 #include <QVariantMap>
 #include <QtQuickTest>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <memory>
 
 #include "app_prefs.h"
 #include "call_history_filter.h"
@@ -62,6 +68,8 @@
 #include "session_args.h"
 #include "spectrum_model.h"
 #include "spectrum_view_item.h"
+#include "talkgroup_filter_model.h"
+#include "talkgroup_list_model.h"
 
 using dsd_qt::CallHistoryFilterModel;
 using dsd_qt::CallHistoryModel;
@@ -177,6 +185,23 @@ class CommandRecorder : public QObject {
     }
 
     Q_INVOKABLE bool
+    setTalkgroupListening(double idStart, double idEnd, bool listen) {
+        m_talkgroup_listen_calls++;
+        m_last_talkgroup_id_start = idStart;
+        m_last_talkgroup_id_end = idEnd;
+        m_last_talkgroup_listen = listen;
+        return true;
+    }
+
+    Q_INVOKABLE bool
+    setAllTalkgroupsListening(bool listen, const QString& tag) {
+        m_all_talkgroups_listen_calls++;
+        m_last_all_talkgroups_listen = listen;
+        m_last_all_talkgroups_tag = tag;
+        return true;
+    }
+
+    Q_INVOKABLE bool
     clearEncLockouts() {
         return true;
     }
@@ -287,6 +312,13 @@ class CommandRecorder : public QObject {
         m_scan_avoid_calls = 0;
         m_scan_avoid_clear_calls = 0;
         m_next_channel_calls = 0;
+        m_talkgroup_listen_calls = 0;
+        m_last_talkgroup_id_start = 0.0;
+        m_last_talkgroup_id_end = 0.0;
+        m_last_talkgroup_listen = false;
+        m_all_talkgroups_listen_calls = 0;
+        m_last_all_talkgroups_listen = false;
+        m_last_all_talkgroups_tag.clear();
     }
 
     int
@@ -371,6 +403,41 @@ class CommandRecorder : public QObject {
         return static_cast<double>(m_last_manual_tune_hz);
     }
 
+    int
+    talkgroupListenCalls() const {
+        return m_talkgroup_listen_calls;
+    }
+
+    double
+    lastTalkgroupListenIdStart() const {
+        return m_last_talkgroup_id_start;
+    }
+
+    double
+    lastTalkgroupListenIdEnd() const {
+        return m_last_talkgroup_id_end;
+    }
+
+    bool
+    lastTalkgroupListenOn() const {
+        return m_last_talkgroup_listen;
+    }
+
+    int
+    allTalkgroupsListenCalls() const {
+        return m_all_talkgroups_listen_calls;
+    }
+
+    bool
+    lastAllTalkgroupsListenOn() const {
+        return m_last_all_talkgroups_listen;
+    }
+
+    QString
+    lastAllTalkgroupsTag() const {
+        return m_last_all_talkgroups_tag;
+    }
+
   private:
     int m_src_import_calls = 0;
     int m_src_clear_calls = 0;
@@ -391,6 +458,13 @@ class CommandRecorder : public QObject {
     int m_last_modulation = -1;
     int m_last_decode_mode = -1;
     int m_last_ppm = 9999;
+    int m_talkgroup_listen_calls = 0;
+    double m_last_talkgroup_id_start = 0.0;
+    double m_last_talkgroup_id_end = 0.0;
+    bool m_last_talkgroup_listen = false;
+    int m_all_talkgroups_listen_calls = 0;
+    bool m_last_all_talkgroups_listen = false;
+    QString m_last_all_talkgroups_tag;
 };
 
 /**
@@ -604,6 +678,75 @@ class Setup : public QObject {
     Q_OBJECT
 
   public:
+    ~Setup() override { dsd_state_ext_free_all(m_talkgroup_state.get()); }
+
+    Q_INVOKABLE bool
+    pushTalkgroup(double id, const QString& mode, const QString& name, const QString& tags) {
+        dsd_tg_policy_entry entry{};
+        if (dsd_tg_policy_make_exact_entry(static_cast<uint32_t>(id), mode.toUtf8().constData(),
+                                           name.toUtf8().constData(), DSD_TG_POLICY_SOURCE_IMPORTED, &entry)
+            != 0) {
+            return false;
+        }
+        DSD_SNPRINTF(entry.tags, sizeof(entry.tags), "%s", tags.toUtf8().constData());
+        if (dsd_tg_policy_append_exact(m_talkgroup_state.get(), &entry) != 0) {
+            return false;
+        }
+        m_talkgroups->refresh(m_talkgroup_opts.get(), m_talkgroup_state.get());
+        return true;
+    }
+
+    Q_INVOKABLE void
+    setGroupFileConfigured(bool configured) {
+        DSD_SNPRINTF(m_talkgroup_opts->group_in_file, sizeof(m_talkgroup_opts->group_in_file), "%s",
+                     configured ? "fixture-talkgroups.csv" : "");
+        m_talkgroups->refresh(m_talkgroup_opts.get(), m_talkgroup_state.get());
+    }
+
+    Q_INVOKABLE bool
+    clearTalkgroups() {
+        if (dsd_tg_policy_clear(m_talkgroup_state.get()) != 0) {
+            return false;
+        }
+        m_talkgroups->refresh(m_talkgroup_opts.get(), m_talkgroup_state.get());
+        return true;
+    }
+
+    Q_INVOKABLE int
+    talkgroupListenCalls() const {
+        return m_commands != nullptr ? m_commands->talkgroupListenCalls() : -1;
+    }
+
+    Q_INVOKABLE double
+    lastTalkgroupListenIdStart() const {
+        return m_commands != nullptr ? m_commands->lastTalkgroupListenIdStart() : 0.0;
+    }
+
+    Q_INVOKABLE double
+    lastTalkgroupListenIdEnd() const {
+        return m_commands != nullptr ? m_commands->lastTalkgroupListenIdEnd() : 0.0;
+    }
+
+    Q_INVOKABLE bool
+    lastTalkgroupListenOn() const {
+        return m_commands != nullptr && m_commands->lastTalkgroupListenOn();
+    }
+
+    Q_INVOKABLE int
+    allTalkgroupsListenCalls() const {
+        return m_commands != nullptr ? m_commands->allTalkgroupsListenCalls() : -1;
+    }
+
+    Q_INVOKABLE bool
+    lastAllTalkgroupsListenOn() const {
+        return m_commands != nullptr && m_commands->lastAllTalkgroupsListenOn();
+    }
+
+    Q_INVOKABLE QString
+    lastAllTalkgroupsTag() const {
+        return m_commands != nullptr ? m_commands->lastAllTalkgroupsTag() : QString();
+    }
+
     /**
      * @brief Change one engine reading and republish it.
      *
@@ -881,12 +1024,18 @@ class Setup : public QObject {
         auto* monitorView = new CallHistoryFilterModel(engine);
         monitorView->setSourceModel(store);
         store->setParent(engine);
+        m_talkgroups = new dsd_qt::TalkgroupListModel(store, engine);
+        auto* talkgroupView = new dsd_qt::TalkgroupFilterModel(engine);
+        talkgroupView->setSourceModel(m_talkgroups);
+        m_talkgroups->refresh(m_talkgroup_opts.get(), m_talkgroup_state.get());
 
         QQmlContext* ctx = engine->rootContext();
         ctx->setContextProperty(QStringLiteral("uiDir"), QStringLiteral(DSD_QML_UI_DIR));
         ctx->setContextProperty(QStringLiteral("callHistory"), store);
         ctx->setContextProperty(QStringLiteral("historyView"), historyView);
         ctx->setContextProperty(QStringLiteral("monitorView"), monitorView);
+        ctx->setContextProperty(QStringLiteral("talkgroups"), m_talkgroups);
+        ctx->setContextProperty(QStringLiteral("talkgroupView"), talkgroupView);
         ctx->setContextProperty(QStringLiteral("sansFontFamily"), QStringLiteral("IBM Plex Sans"));
         ctx->setContextProperty(QStringLiteral("monoFontFamily"), QStringLiteral("IBM Plex Mono"));
 
@@ -1076,6 +1225,9 @@ class Setup : public QObject {
     dsd_qt::SpectrumModel* m_spectrum = nullptr;
     CommandRecorder* m_commands = nullptr;
     ImportOnlyHost* m_import_host = nullptr;
+    std::unique_ptr<dsd_opts> m_talkgroup_opts = std::make_unique<dsd_opts>();
+    std::unique_ptr<dsd_state> m_talkgroup_state = std::make_unique<dsd_state>();
+    dsd_qt::TalkgroupListModel* m_talkgroups = nullptr;
 };
 
 #endif /* DSD_NEO_TESTS_UI_QML_TEST_CONTEXT_H_ */

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1041,6 +1041,11 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
 
     init_test_context(&opts, &state);
     seed_active_p25_voice(&opts, &state, 853000000L, 854000000L, 2201);
+    dsd_tg_policy_entry dispatch_entry;
+    rc |= expect_int(
+        "seed lockout named row",
+        dsd_tg_policy_make_exact_entry(2201, "A", "Dispatch", DSD_TG_POLICY_SOURCE_IMPORTED, &dispatch_entry), 0);
+    rc |= expect_int("append lockout named row", dsd_tg_policy_append_exact(&state, &dispatch_entry), 0);
     reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
     const uint64_t lockout_history_revision = state.event_history_s[0].revision;
     rc |= expect_int("deferred lockout queued", dsd_app_command_set_u8(DSD_APP_CMD_LOCKOUT_SLOT, 0U),
@@ -1058,7 +1063,7 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
                                                 sizeof(lockout_name)),
                      1);
     rc |= expect_str("deferred lockout policy mode", lockout_mode, "B");
-    rc |= expect_str("deferred lockout policy name", lockout_name, "LOCKOUT");
+    rc |= expect_str("deferred lockout policy name", lockout_name, "Dispatch");
     rc |= expect_true("deferred lockout advances event history revision",
                       state.event_history_s[0].revision > lockout_history_revision);
     rc |= expect_true("deferred lockout reports cleanup separately",
@@ -2470,9 +2475,80 @@ test_source_alias_commands(void) {
     return rc;
 }
 
+static int
+test_talkgroup_list_commands(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    if (!opts || !state) {
+        free(opts);
+        free(state);
+        return 1;
+    }
+    init_test_context(opts, state);
+    const char* path = "dsd_neo_test_talkgroup_commands.csv";
+    static const char csv[] = "DEC,Mode,Name,Tag\n1001,A,Fire Dispatch,FIRE\n2001,A,EMS Dispatch,EMS\n"
+                              "3001,D,Radio,FIRE\n4001,A,Untagged\n";
+    int rc = write_file_bytes(path, csv, sizeof csv - 1U);
+    DSD_SNPRINTF(opts->group_in_file, sizeof opts->group_in_file, "%s", path);
+    rc |= expect_int("load talkgroup command fixture", dsd_tg_policy_reload_group_file(opts, state), 0);
+#ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
+    seed_active_p25_voice(opts, state, 851000000L, 852000000L, 1001);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
+#endif
+    dsd_app_tg_listen_payload one = {1001, 1001, 0};
+    rc |= expect_int("block talkgroup queued", dsd_app_command_set_tg_listen(&one), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("block talkgroup drained", dsd_app_drain_cmds(opts, state), 1);
+    dsd_tg_policy_lookup lookup;
+    rc |= expect_int("blocked talkgroup lookup", dsd_tg_policy_lookup_id(state, 1001, &lookup), 0);
+    rc |= expect_str("blocked mode", lookup.entry.mode, "B");
+    rc |= expect_str("blocked name retained", lookup.entry.name, "Fire Dispatch");
+    rc |= expect_str("blocked tags retained", lookup.entry.tags, "FIRE");
+#ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
+    rc |= expect_int("blocked call returns to CC", g_cc_tune_calls, 1);
+#endif
+    FILE* file = dsd_fopen_existing_regular_file(path, "r");
+    char contents[512] = {0};
+    if (file) {
+        size_t bytes = fread(contents, 1, sizeof contents - 1U, file);
+        contents[bytes] = '\0';
+        rc |= expect_int("close rewritten groups", fclose(file), 0);
+    } else {
+        rc = 1;
+    }
+    rc |= expect_contains("rewrite contains named blocked row", contents, "1001,B,Fire Dispatch,FIRE\n");
+    rc |= expect_int("reload persisted blocked mode", dsd_tg_policy_reload_group_file(opts, state), 0);
+    rc |= expect_int("reloaded talkgroup lookup", dsd_tg_policy_lookup_id(state, 1001, &lookup), 0);
+    rc |= expect_str("reloaded mode", lookup.entry.mode, "B");
+    one.listen = 1;
+    rc |= expect_int("listen queued", dsd_app_command_set_tg_listen(&one), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("listen drained", dsd_app_drain_cmds(opts, state), 1);
+    rc |= expect_int("listening lookup", dsd_tg_policy_lookup_id(state, 1001, &lookup), 0);
+    rc |= expect_str("listening mode", lookup.entry.mode, "A");
+#ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
+    rc |= expect_int("listen does not retune", g_cc_tune_calls, 1);
+#endif
+    dsd_app_tg_listen_all_payload all = {0, "FIRE"};
+    rc |= expect_int("category block queued", dsd_app_command_set_tg_listen_all(&all), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("category block drained", dsd_app_drain_cmds(opts, state), 1);
+    rc |= expect_int("category row lookup", dsd_tg_policy_lookup_id(state, 1001, &lookup), 0);
+    rc |= expect_str("category row blocked", lookup.entry.mode, "B");
+    rc |= expect_int("other category lookup", dsd_tg_policy_lookup_id(state, 2001, &lookup), 0);
+    rc |= expect_str("other category unchanged", lookup.entry.mode, "A");
+    rc |= expect_int("alias row lookup", dsd_tg_policy_lookup_id(state, 3001, &lookup), 0);
+    rc |= expect_str("alias row unchanged", lookup.entry.mode, "D");
+    rc |= expect_int("untagged row lookup", dsd_tg_policy_lookup_id(state, 4001, &lookup), 0);
+    rc |= expect_str("untagged row unchanged", lookup.entry.mode, "A");
+    freeState(state);
+    free(state);
+    free(opts);
+    remove(path);
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
+    rc |= test_talkgroup_list_commands();
     rc |= test_source_alias_commands();
     rc |= test_scoped_direct_key_mutes();
     rc |= test_scoped_row_option_commands();

--- a/tests/ui/test_ui_qt_radio_reference_model.cpp
+++ b/tests/ui/test_ui_qt_radio_reference_model.cpp
@@ -495,7 +495,11 @@ test_trunked_system(void) {
                QStringLiteral("851.05"));
     expect_int("plan emits the 11-frequency hunt list", row_count(plan.value(QStringLiteral("chanCsvText")).toString()),
                12);
-    expect("plan emits a talkgroup file", !plan.value(QStringLiteral("groupCsvText")).toString().isEmpty());
+    const QString groupCsv = plan.value(QStringLiteral("groupCsvText")).toString();
+    expect("plan opts into talkgroup categories",
+           groupCsv.startsWith(QStringLiteral("DEC,Mode,Name,Category,(generated from RadioReference)\n")));
+    expect("plan splices the fetched category onto its talkgroup",
+           groupCsv.contains(QStringLiteral("\n52007,DE,RESERVOIR RANGRS,Coralville\n")));
     expect("plan warns the map column is a placeholder", warned(plan, QStringLiteral("placeholder")));
     expect("plan has no blocked reason", plan.value(QStringLiteral("blockedReason")).toString().isEmpty());
 

--- a/tests/ui/test_ui_qt_talkgroup_list_model.cpp
+++ b/tests/ui/test_ui_qt_talkgroup_list_model.cpp
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <QAbstractListModel>
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDebug>
+#include <QDir>
+#include <QHash>
+#include <QList>
+#include <QObject>
+#include <QSettings>
+#include <QStandardPaths>
+#include <QString>
+#include <QStringList>
+#include <QTemporaryDir>
+#include <QVariant>
+#include <Qt>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_ext.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/talkgroup_policy.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <utility>
+
+#include "call_history_model.h"
+#include "talkgroup_filter_model.h"
+#include "talkgroup_list_model.h"
+
+using dsd_qt::CallHistoryModel;
+using dsd_qt::TalkgroupFilterModel;
+using dsd_qt::TalkgroupListModel;
+
+namespace {
+
+int failures = 0;
+
+void
+expect(const char* what, bool ok) {
+    if (!ok) {
+        DSD_FPRINTF(stderr, "FAIL: %s\n", what);
+        ++failures;
+    }
+}
+
+struct Fixture {
+    dsd_opts* opts = static_cast<dsd_opts*>(calloc(1, sizeof(dsd_opts)));
+    dsd_state* state = static_cast<dsd_state*>(calloc(1, sizeof(dsd_state)));
+    Event_History_I* rings = static_cast<Event_History_I*>(calloc(2, sizeof(Event_History_I)));
+
+    Fixture() {
+        if (!opts || !state || !rings) {
+            abort();
+        }
+        state->event_history_s = rings;
+        for (int slot = 0; slot < 2; ++slot) {
+            rings[slot].revision = 1;
+            rings[slot].commit_rev = 1;
+        }
+    }
+
+    ~Fixture() {
+        dsd_state_ext_free_all(state);
+        free(rings);
+        free(state);
+        free(opts);
+    }
+
+    Fixture(const Fixture&) = delete;
+    Fixture& operator=(const Fixture&) = delete;
+
+    void
+    append(uint32_t start, uint32_t end, const char* mode, const char* name, const char* tags,
+           dsd_tg_policy_entry_source source = DSD_TG_POLICY_SOURCE_IMPORTED) {
+        dsd_tg_policy_entry entry;
+        expect("create policy row", dsd_tg_policy_make_exact_entry(start, mode, name, source, &entry) == 0);
+        entry.id_end = end;
+        entry.is_range = start != end;
+        DSD_SNPRINTF(entry.tags, sizeof(entry.tags), "%s", tags);
+        expect("append policy row", (entry.is_range ? dsd_tg_policy_add_range_entry(state, &entry)
+                                                    : dsd_tg_policy_append_exact(state, &entry))
+                                        == 0);
+    }
+
+    void
+    commit(uint32_t tg, time_t when, bool voice = true) {
+        Event_History_I* ring = &rings[0];
+        DSD_MEMMOVE(&ring->Event_History_Items[2], &ring->Event_History_Items[1],
+                    sizeof(Event_History) * (DSD_EVENT_HISTORY_LEN - 2));
+        Event_History* row = &ring->Event_History_Items[1];
+        DSD_MEMSET(row, 0, sizeof(*row));
+        row->category = voice ? DSD_EVENT_CATEGORY_VOICE : DSD_EVENT_CATEGORY_DATA;
+        row->target_id = tg;
+        row->source_id = 42;
+        row->event_start_time = when;
+        row->event_time = when + 1;
+        DSD_SNPRINTF(row->event_string, sizeof(row->event_string), "test call");
+        ++ring->push_seq;
+        ++ring->commit_rev;
+        ++ring->revision;
+    }
+};
+
+QModelIndex
+find(const TalkgroupListModel& model, uint32_t id) {
+    for (int i = 0; i < model.count(); ++i) {
+        const QModelIndex idx = model.index(i, 0);
+        if (model.data(idx, TalkgroupListModel::IdStartRole).toULongLong() == id) {
+            return idx;
+        }
+    }
+    return {};
+}
+
+void
+test_policy_and_heard_rows() {
+    Fixture fixture;
+    fixture.append(2001, 2001, "DE", "EMS dispatch", "ems");
+    fixture.append(1300, 1399, "B", "Fire range", "FIRE");
+    fixture.append(1001, 1001, "A", "Fire dispatch", "FIRE");
+    fixture.append(9001, 9001, "D", "Radio alias", "Ignored");
+    fixture.append(9002, 9002, "A", "Learned alias", "Ignored", DSD_TG_POLICY_SOURCE_RUNTIME_ALIAS);
+    CallHistoryModel history;
+    TalkgroupListModel model(&history);
+    const time_t now = time(nullptr);
+    model.setSinceWhen(now);
+    fixture.commit(6001, now - 60);
+    fixture.commit(4001, now);
+    fixture.commit(4001, now + 5);
+    fixture.commit(1350, now + 10);
+    fixture.commit(1001, now + 15);
+    fixture.commit(7001, now + 20, false);
+    history.refresh(fixture.state);
+    model.refresh(fixture.opts, fixture.state);
+
+    expect("listed rows plus unique uncovered session voice target", model.count() == 4);
+    expect("aliases excluded", !find(model, 9001).isValid() && !find(model, 9002).isValid());
+    expect("old calls and notices excluded", !find(model, 6001).isValid() && !find(model, 7001).isValid());
+    expect("range covers heard target", !find(model, 1350).isValid());
+    expect("numeric ordering", model.data(model.index(0, 0), TalkgroupListModel::IdStartRole).toULongLong() == 1001);
+    expect("range label uses en dash",
+           model.data(find(model, 1300), TalkgroupListModel::IdTextRole).toString() == QStringLiteral("1300–1399"));
+    expect("B and DE are not tuned", !model.data(find(model, 1300), TalkgroupListModel::ListeningRole).toBool()
+                                         && !model.data(find(model, 2001), TalkgroupListModel::ListeningRole).toBool()
+                                         && model.notTunedCount() == 2);
+    expect("categories unique and case insensitive sorted",
+           model.categories() == QStringList({QStringLiteral("ems"), QStringLiteral("FIRE")}));
+    expect("heard target unlisted and listening",
+           !model.data(find(model, 4001), TalkgroupListModel::ListedRole).toBool()
+               && model.data(find(model, 4001), TalkgroupListModel::ListeningRole).toBool());
+
+    int resets = 0;
+    int changes = 0;
+    int changedId = 0;
+    QObject::connect(&model, &QAbstractItemModel::modelReset, &model, [&]() { ++resets; });
+    QObject::connect(&model, &QAbstractItemModel::dataChanged, &model,
+                     [&](const QModelIndex& first, const QModelIndex& last) {
+                         ++changes;
+                         changedId = model.data(first, TalkgroupListModel::IdStartRole).toInt();
+                         expect("row-local update", first == last);
+                     });
+    model.refresh(fixture.opts, fixture.state);
+    expect("unchanged snapshot emits no row signals", resets == 0 && changes == 0);
+    expect("set row mode", dsd_tg_policy_set_mode(fixture.state, 1001, 1001, "B") == 0);
+    model.refresh(fixture.opts, fixture.state);
+    expect("one mode edit does not reset or update neighbours", resets == 0 && changes == 1 && changedId == 1001);
+    expect("row edit updates count and retains label",
+           model.notTunedCount() == 3
+               && model.data(find(model, 1001), TalkgroupListModel::NameRole).toString()
+                      == QStringLiteral("Fire dispatch"));
+
+    changes = 0;
+    fixture.opts->trunk_use_allow_list = 1;
+    model.refresh(fixture.opts, fixture.state);
+    expect("allowlist changes heard target without resetting",
+           model.allowListMode() && resets == 0 && changes == 1 && changedId == 4001
+               && !model.data(find(model, 4001), TalkgroupListModel::ListeningRole).toBool()
+               && model.notTunedCount() == 4);
+
+    TalkgroupFilterModel view;
+    view.setSourceModel(&model);
+    view.setFilterTag(QStringLiteral("FIRE"));
+    expect("tag filters listed rows only", view.count() == 2);
+    view.setFilterText(QStringLiteral("DISPATCH"));
+    expect("search intersects selected category case insensitively",
+           view.count() == 1 && view.data(view.index(0, 0), TalkgroupListModel::IdStartRole).toULongLong() == 1001);
+    view.setFilterText(QStringLiteral("1399"));
+    expect("search matches range text",
+           view.count() == 1 && view.data(view.index(0, 0), TalkgroupListModel::IdStartRole).toULongLong() == 1300);
+    view.setFilterTag(QStringLiteral("fire"));
+    expect("category match remains exact", view.count() == 0);
+
+    changes = 0;
+    DSD_SNPRINTF(fixture.opts->group_in_file, sizeof(fixture.opts->group_in_file), "groups.csv");
+    model.refresh(fixture.opts, fixture.state);
+    expect("configured file changes persistence without rebuilding rows",
+           model.persistent() && resets == 0 && changes == 0);
+    model.setSinceWhen(now + 6);
+    model.refresh(fixture.opts, fixture.state);
+    expect("moving cutoff removes heard rows even with unchanged policy",
+           model.count() == 3 && !find(model, 4001).isValid());
+    model.refresh(nullptr, fixture.state);
+    expect("missing snapshot clears policy and rows", model.count() == 0 && model.notTunedCount() == 0
+                                                          && model.categories().isEmpty() && !model.allowListMode()
+                                                          && !model.persistent());
+    model.refresh(fixture.opts, fixture.state);
+    expect("clear retains session cutoff", model.count() == 3 && model.sinceWhen() == now + 6);
+}
+
+/* Deliberately unrelated numeric roles: the QML fixture is not CallHistoryModel. */
+class AlternateHistory : public QAbstractListModel {
+  public:
+    bool present = false;
+    uint32_t tg = 8001;
+
+    int
+    rowCount(const QModelIndex& parent = QModelIndex()) const override {
+        return !parent.isValid() && present ? 1 : 0;
+    }
+
+    QHash<int, QByteArray>
+    roleNames() const override {
+        return {{Qt::UserRole + 71, "tg"}, {Qt::UserRole + 72, "when"}, {Qt::UserRole + 73, "kind"}};
+    }
+
+    QVariant
+    data(const QModelIndex& index, int role) const override {
+        if (!index.isValid() || !present) {
+            return {};
+        }
+        switch (role) {
+            case Qt::UserRole + 71: return tg;
+            case Qt::UserRole + 72: return 100;
+            case Qt::UserRole + 73: return 0;
+            default: return {};
+        }
+    }
+
+    void
+    insert() {
+        beginInsertRows({}, 0, 0);
+        present = true;
+        endInsertRows();
+    }
+
+    void
+    change() {
+        tg = 8002;
+        Q_EMIT dataChanged(index(0, 0), index(0, 0));
+    }
+
+    void
+    remove() {
+        beginRemoveRows({}, 0, 0);
+        present = false;
+        endRemoveRows();
+    }
+
+    void
+    reset() {
+        beginResetModel();
+        present = true;
+        endResetModel();
+    }
+};
+
+void
+test_history_role_names_and_mutations() {
+    Fixture fixture;
+    AlternateHistory history;
+    TalkgroupListModel model(&history);
+    model.refresh(fixture.opts, fixture.state);
+    history.insert();
+    model.refresh(fixture.opts, fixture.state);
+    expect("inserted history resolves roles by name", model.count() == 1 && find(model, 8001).isValid());
+    history.change();
+    model.refresh(fixture.opts, fixture.state);
+    expect("history edits invalidate heard set", model.count() == 1 && find(model, 8002).isValid());
+    history.remove();
+    model.refresh(fixture.opts, fixture.state);
+    expect("history removal invalidates heard set", model.count() == 0);
+    history.reset();
+    model.refresh(fixture.opts, fixture.state);
+    expect("history reset invalidates heard set", model.count() == 1 && find(model, 8002).isValid());
+}
+
+} // namespace
+
+int
+main(int argc, char** argv) {
+    QCoreApplication app(argc, argv);
+    QCoreApplication::setOrganizationName(QStringLiteral("dsd-neo-test"));
+    QCoreApplication::setApplicationName(
+        QStringLiteral("dsd-neo-talkgroups-%1").arg(QCoreApplication::applicationPid()));
+    QStandardPaths::setTestModeEnabled(true);
+    const QString dataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    QDir(dataDir).removeRecursively();
+    QTemporaryDir settingsDir;
+    if (!settingsDir.isValid()) {
+        return 1;
+    }
+    QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, settingsDir.path());
+    QSettings::setPath(QSettings::NativeFormat, QSettings::UserScope, settingsDir.path());
+    test_policy_and_heard_rows();
+    test_history_role_names_and_mutations();
+    QDir(dataDir).removeRecursively();
+    if (failures != 0) {
+        return 1;
+    }
+    DSD_FPRINTF(stderr, "OK\n");
+    return 0;
+}

--- a/tests/ui/test_ui_rr_wizard.c
+++ b/tests/ui/test_ui_rr_wizard.c
@@ -2596,9 +2596,11 @@ test_refresh_honours_the_stored_partial_encryption_answer(void) {
         return;
     }
     expect("A1: refresh succeeded", rr_wizard_core_step(rc.c.core) == RR_STEP_IDLE);
-    expect_file_contains("A1: partial stays listenable", rc.csv_path, "\n57991,A,Test A\n");
-    expect_file_lacks("A1: partial not blocked", rc.csv_path, "\n57991,DE,Test A\n");
-    expect_file_contains("A1: full enc blocked", rc.csv_path, "\n52007,DE,RESERVOIR RANGRS\n");
+    expect_file_contains("A1: category header written", rc.csv_path,
+                         "DEC,Mode,Name,Category,(generated from RadioReference)\n");
+    expect_file_contains("A1: partial stays listenable", rc.csv_path, "\n57991,A,Test A,Radio Maintenance\n");
+    expect_file_lacks("A1: partial not blocked", rc.csv_path, "\n57991,DE,Test A,Radio Maintenance\n");
+    expect_file_contains("A1: full enc blocked", rc.csv_path, "\n52007,DE,RESERVOIR RANGRS,Coralville\n");
 
     /* A2: flip the stored answer and refresh the same file again. */
     ref_prov(&prov, "group", 6673, "16863", 1);
@@ -2609,8 +2611,8 @@ test_refresh_honours_the_stored_partial_encryption_answer(void) {
         return;
     }
     expect("A2: refresh succeeded", rr_wizard_core_step(rc.c.core) == RR_STEP_IDLE);
-    expect_file_contains("A2: partial now blocked", rc.csv_path, "\n57991,DE,Test A\n");
-    expect_file_contains("A2: full enc still blocked", rc.csv_path, "\n52007,DE,RESERVOIR RANGRS\n");
+    expect_file_contains("A2: partial now blocked", rc.csv_path, "\n57991,DE,Test A,Radio Maintenance\n");
+    expect_file_contains("A2: full enc still blocked", rc.csv_path, "\n52007,DE,RESERVOIR RANGRS,Coralville\n");
     ref_case_close(&rc);
 }
 


### PR DESCRIPTION
## Summary

Implements [LtRZ's request for live talkgroup whitelist/blacklist controls](https://github.com/arancormonk/dsd-neo/discussions/90#discussioncomment-18303819) in discussion #90.

- Add **TG list** to the Android/Qt monitor, opening searchable talkgroup cards with category chips, per-row listening toggles, and category-scoped bulk actions.
- Merge configured exact/range rows with talkgroups heard this session; render decoder snapshot truth rather than optimistic local state.
- Apply edits on the decoder thread and release active group calls that become blocked. Skip now preserves the talkgroup's name and tags.
- Atomically rewrite configured group CSV files, retain imported tags, and carry RadioReference categories through both frontends. Scan-row lists remain session-only.
- Add core, importer, RR, command-queue, Qt model, and QML regressions; update CSV documentation and the code map.

## Review

- [x] Changes were checked against surrounding module conventions and architecture rules.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Second reviewer / solo-maintainer exception confirmed.
- High-risk areas touched: parser and file persistence; no crypto, workflow, release, or dependency changes.
- Human/outside review is pending on this PR.
- [x] Non-trivial commit includes a DCO sign-off.

## Quality Review

- [x] Parser/file-input changes include focused behavioral tests.
- [x] Policy metadata preservation, snapshot updates, category ownership, CSV round trips, and command-triggered return-to-control-channel behavior exercised.
- [x] Static-analysis exceptions are narrow and explained: Qt meta-object instance methods and a Qt-template include whose IWYU requirement varies by consumer.
- [x] Project safe APIs and atomic file-replacement helpers used; no new shell execution or dependencies.

## Tests And Guardrails

- [x] Full Qt-enabled Debug build: `cmake --build build/446-qt -j8`.
- [x] 21 targeted core, runtime, app-control, Qt, public-header, architecture, and QML-resource checks passed, including all 13 `UI_QT_` suites.
- [x] Radio-disabled build (`RTLSDR=OFF`, `SOAPYSDR=OFF`): all 569 tests passed. Affected core policy and command-queue tests passed again after guardrail refactoring.
- [x] Standalone command submission/drain smoke rewrote `1001,A,Fire Dispatch,FIRE` to `1001,B,Fire Dispatch,FIRE`; reloading restored mode B with name and tags intact.
- [x] Desktop Qt Quick visual capture at 420×900 inspected: system title, category chips, bulk buttons, three-column cards, listening borders, and legend. Temporary capture case and smoke program removed.
- [x] `tools/check_arch_rules.sh`.
- [x] `tools/cmake_format_check.sh --fix` and final gersemi/clang-format checks.
- [x] `tools/preflight_ci.sh`, with Qt enabled in the analyzer compilation database: all checks passed, including clang-tidy, IWYU, cppcheck, GCC fanalyzer (C only), Semgrep, complexity, architecture, redaction, and pin guardrails.
- Not run: Android-device validation, `tools/quality_preflight.sh`, optional scan-build, or the complete Qt-enabled CTest suite.

## Risk

- **Persistence:** edits rewrite the app-private configured group CSV, not the originally picked document. Unmodeled metadata/note columns are discarded. Failed writes retain the live edit and leave the old file intact; scan-row-owned lists are never written to the global file.
- **Policy/UI:** listening edits reset media flags from mode A/B while retaining name, category, priority, preemption, and source. Bulk edits exclude learned radio-ID aliases and mode D rows; the category chip, not search text, scopes bulk actions.
- **Compatibility/packaging:** new QML resources are registered and audited. Generated RR group CSVs opt into a fourth Category column; uncategorized rows remain three-column. No new dependencies or CLI flags.
