### PR TITLE
fix(core): preserve mono voice on stereo outputs (#483)

### DIFF
--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -111,6 +111,8 @@ Notes:
   existing behavior. The initial input uses global settings until the first scheduled row entry. Explicit global
   modulation locks remain effective. Manual `L` cycling and avoid/advance use the same row-entry rules and visit
   same-frequency rows with different metadata. Zero-frequency placeholders change neither the mode nor keys.
+  An NXDN48 row needs only `mode=nxdn48`, not an outer `-fi` or a decoder switch in `options`. Audio keeps the
+  startup output layout; mono voice is duplicated into both channels when that layout is stereo.
 - Modes are stored by scan-list slot: duplicate channel numbers and repeated frequencies remain distinct rows.
   Trunk-scan target `type` is authoritative; `mode` values inside a target's `chan_csv` are validated and discarded.
 - A `name` is trimmed of surrounding whitespace, capped at 63 bytes (never splitting a UTF-8 character), and must not

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -35,17 +35,20 @@ id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes
 Example:
 
 ```csv
-id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain
-county-p25,p25-trunk,851012500,,3000,,P25 control channel,cqpsk,18
-city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel,auto,
-plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR,gfsk,auto
-site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel,auto,
-site-nxdn48,nxdn48-trunk,461556250,nxdn_chan_map.csv,3000,,NXDN48 Type-C control channel (6.25 kHz),gfsk,
-field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96,gfsk,
-field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz),gfsk,
+id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain,options,p25_bandplan_csv
+county-p25,p25-trunk,851012500,,3000,,P25 control channel,cqpsk,18,,p25_bandplan.csv
+city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel,auto,,,
+plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR,gfsk,auto,--no-force-key,
+site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel,auto,,,
+site-nxdn48,nxdn48-trunk,461556250,nxdn_chan_map.csv,3000,,NXDN48 Type-C control channel (6.25 kHz),gfsk,,,
+field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96,gfsk,,,
+field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz),gfsk,,,
 ```
 
-The repository includes a starter file at `examples/trunk_scan_targets.csv`.
+The repository includes a starter file at `examples/trunk_scan_targets.csv`. Companion paths in these examples
+refer to files in `examples/`; replace the illustrative frequencies, keys and band plan with your system's values.
+Omitted scoped settings inherit the outer CLI/configuration; the DMR conventional example uses
+`--no-force-key` to disable inherited privacy forcing without changing other settings.
 
 Column behavior:
 
@@ -64,6 +67,7 @@ Column behavior:
 | `keys_dec_csv` | No | Per-target decimal key file (`-k` format), resolved relative to the target CSV. Empty uses the global keys. |
 | `single_key_dec` | No | Embedded `-b` Motorola Basic Privacy key number (`0..255`). Explicit `0` is an active override. It may be combined with `single_key_hex`, but not either key-file column. |
 | `single_key_hex` | No | Embedded `-H` key. It accepts an optional `0x`, ignores ASCII whitespace, and requires exactly 10, 32, or 64 hex digits. It may be combined with `single_key_dec`, but not either key-file column. |
+| `options` | No | Per-target [scoped switches](#per-target-options); `relevant_CLI_switches` is an alias. This header and its alias match ASCII case-insensitively, and naming both rejects the file. The target `type` determines which protocol-specific switches are accepted. Omitted settings inherit the outer CLI/configuration. |
 | `p25_bandplan_csv` | No | P25 band plan CSV for a `p25-trunk` target (format in [csv-formats.md](csv-formats.md)), resolved relative to the target CSV. Its rows are parked in the target's snapshot, so an exported multi-system plan can be named on every P25 row and each target keeps only the rows that carry its WACN/SYS (plus rows that carry none). |
 
 Targets that turn out to be sites of the same P25 system (same WACN/SYS) share what one of them learned over the
@@ -150,6 +154,8 @@ both phases and exclude DMR and X2-TDMA; DMR and NXDN targets enable only their 
 lists, including both NXDN rates, work without `-fa`. The target's `modulation` column keeps its existing precedence:
 an explicit value, including `auto`, overrides global modulation handling. An empty value preserves an explicit
 global modulation lock. Modes declared in a target's `chan_csv` do not override its type.
+NXDN48 targets do not require an outer `-fi`. Audio retains the startup output layout, with mono NXDN voice
+duplicated into both channels when the output is stereo.
 
 Global mode/modulation commands update the configured settings while the parked target remains constrained.
 Stopping trunk scan restores those configured settings, and configuration saves record them rather than the parked

--- a/examples/trunk_scan_targets.csv
+++ b/examples/trunk_scan_targets.csv
@@ -1,8 +1,8 @@
-id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain,keys_hex_csv,single_key_dec,single_key_hex
-county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learned from control-channel data,auto,,example_aes_keys.csv,,
-city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel using examples/dmr_t3_chan.csv,auto,,,,
-plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,,,1,0000001F00
-site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel; channel map optional when the site broadcasts DFA,auto,,,,
-site-nxdn48,nxdn48-trunk,461556250,nxdn_chan_map.csv,3000,,NXDN48 Type-C control channel (6.25 kHz); for a Type-D home repeater map repeater numbers 1-30 and row 31 = the home repeater,gfsk,,,,
-field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,,,,
-field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz) conventional channel,gfsk,,,,
+id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain,keys_hex_csv,single_key_dec,single_key_hex,options,p25_bandplan_csv
+county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learned from control-channel data,auto,,example_aes_keys.csv,,,,p25_bandplan.csv
+city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel using examples/dmr_t3_chan.csv,auto,,,,,,
+plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,,,1,0000001F00,--no-force-key,
+site-nxdn,nxdn-trunk,461037500,,3000,,NXDN Type-C control channel; channel map optional when the site broadcasts DFA,auto,,,,,,
+site-nxdn48,nxdn48-trunk,461556250,nxdn_chan_map.csv,3000,,NXDN48 Type-C control channel (6.25 kHz); for a Type-D home repeater map repeater numbers 1-30 and row 31 = the home repeater,gfsk,,,,,,
+field-nxdn,nxdn-conventional,461550000,,1500,1200,one-frequency NXDN96 channel,gfsk,,,,,,
+field-nxdn48,nxdn48-conventional,461556250,,1500,1200,one-frequency NXDN48 (6.25 kHz) conventional channel,gfsk,,,,,,

--- a/include/dsd-neo/core/audio.h
+++ b/include/dsd-neo/core/audio.h
@@ -66,12 +66,12 @@ void playSynthesizedVoiceFS(dsd_opts* opts, dsd_state* state); // float stereo m
 void playSynthesizedVoiceFS3(dsd_opts* opts, dsd_state* state); // float stereo mix 3v2 DMR
 /** @brief Play synthesized voice (float stereo mix 4v2 P25p2). */
 void playSynthesizedVoiceFS4(dsd_opts* opts, dsd_state* state); // float stereo mix 4v2 P25p2
-/** @brief Play synthesized voice (float mono). */
+/** @brief Play float mono voice, duplicating samples when the configured output is stereo. */
 void playSynthesizedVoiceFM(dsd_opts* opts, dsd_state* state); // float mono
 
 /** @brief Play synthesized voice (short mono output slot 1). */
 void playSynthesizedVoice(dsd_opts* opts, dsd_state* state); // short mono output slot 1
-/** @brief Play synthesized voice (short mono mix). */
+/** @brief Play short mono voice, duplicating samples when the configured output is stereo. */
 void playSynthesizedVoiceMS(dsd_opts* opts, dsd_state* state); // short mono mix
 /** @brief Play synthesized voice (short stereo mix). */
 void playSynthesizedVoiceSS(dsd_opts* opts, dsd_state* state); // short stereo mix

--- a/src/core/audio/dsd_audio2.c
+++ b/src/core/audio/dsd_audio2.c
@@ -1116,14 +1116,20 @@ playSynthesizedVoiceFM(dsd_opts* opts, dsd_state* state) {
     encL = dsd_fdma_apply_group_gate(opts, state, TGL, encL);
 
     if (!encL && opts->slot1_on != 0) {
-        dsd_output_float_block(opts, state, state->f_l, 160, 1);
+        if (opts->audio_out == 1 && opts->pulse_digi_out_channels == 2) {
+            float stereo[320];
+            audio_mono_to_stereo_f32(state->f_l, stereo, 160);
+            dsd_output_float_block(opts, state, stereo, 160, 2);
+        } else {
+            dsd_output_float_block(opts, state, state->f_l, 160, 1);
+        }
     }
     dsd_audio_maybe_reset_output_ring_left(state);
     DSD_MEMSET(state->f_l, 0.0f, sizeof(state->f_l));
     DSD_MEMSET(state->audio_out_temp_buf, 0.0f, sizeof(state->audio_out_temp_buf));
 }
 
-//Mono - Short (SB16LE) - Drop-in replacement for playSyntesizedVoice, but easier to manipulate
+// Mono source, formatted for the device opened at startup (which stays stereo in AUTO/mixed scans).
 void
 playSynthesizedVoiceMS(dsd_opts* opts, dsd_state* state) {
     size_t len = state->audio_out_idx;
@@ -1140,7 +1146,13 @@ playSynthesizedVoiceMS(dsd_opts* opts, dsd_state* state) {
         if (opts->use_hpf_d == 1) {
             hpf_dL(state, mono_samp, (int)len);
         }
-        dsd_output_s16_block(opts, state, mono_samp, len, 1);
+        if (opts->audio_out == 1 && opts->pulse_digi_out_channels == 2) {
+            short stereo[1920];
+            audio_mono_to_stereo_s16(mono_samp, stereo, len);
+            dsd_output_s16_block(opts, state, stereo, len, 2);
+        } else {
+            dsd_output_s16_block(opts, state, mono_samp, len, 1);
+        }
         dsd_write_static_wav_from_mono(opts, mono_samp, len);
     }
     dsd_audio_reset_short_mono_left_working_state(state);

--- a/tests/core/test_core_audio2_helpers.c
+++ b/tests/core/test_core_audio2_helpers.c
@@ -11,6 +11,7 @@
  * paths do not require live audio/device stubs.
  */
 
+#include <assert.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
@@ -18,6 +19,7 @@
 #include <sndfile.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 
@@ -59,14 +61,15 @@ dsd_p25_sm_logf(dsd_opts* opts, const char* format, ...) {
 
 static int g_audio_write_calls;
 static size_t g_audio_write_frames;
-static int16_t g_audio_write_samples[640];
+static int g_audio_write_channels = 2;
+static int16_t g_audio_write_samples[1920];
 static int g_udp_blast_calls;
 static size_t g_udp_blast_bytes;
-static uint8_t g_udp_blast_data[256];
+static uint8_t g_udp_blast_data[1920 * sizeof(short)];
 static int g_dsd_write_calls;
 static int g_dsd_write_fd;
 static size_t g_dsd_write_bytes;
-static uint8_t g_dsd_write_data[256];
+static uint8_t g_dsd_write_data[1920 * sizeof(short)];
 static int g_dmr_missing_alg_key_allowed[2];
 static int g_dmr_voice_slot_allowed[2];
 static int g_gate_mono_forced_enc = -1;
@@ -241,7 +244,7 @@ dsd_audio_write(dsd_audio_stream* stream, const int16_t* buffer, size_t frames) 
     (void)stream;
     g_audio_write_calls++;
     g_audio_write_frames = frames;
-    size_t samples = frames * 2U;
+    size_t samples = frames * (size_t)g_audio_write_channels;
     if (samples > sizeof(g_audio_write_samples) / sizeof(g_audio_write_samples[0])) {
         samples = sizeof(g_audio_write_samples) / sizeof(g_audio_write_samples[0]);
     }
@@ -1302,6 +1305,87 @@ test_audio_gate_target_preserves_p25_ota_identity(void) {
     return rc;
 }
 
+/* A mono vocoder frame must retain its duration, pitch and samples when the
+ * startup preset leaves a stereo device open during a mixed-protocol scan. */
+static int
+test_mono_voice_preserves_samples_in_configured_output(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts && state);
+    short history[960];
+    short expected_short[1920];
+    float expected_float[320];
+    const int sinks[] = {0, 1, 8};
+    int rc = 0;
+    opts->audio_out = 1;
+    opts->slot1_on = 1;
+    opts->audio_out_stream = (dsd_audio_stream*)opts;
+    state->synctype = DSD_SYNC_NXDN_POS;
+    reset_gate_capture();
+
+    for (int channels = 1; channels <= 2; channels++) {
+        opts->pulse_digi_out_channels = channels;
+        g_audio_write_channels = channels;
+        for (int format = 0; format < 3; format++) {
+            const int floating = format == 1;
+            const size_t frames = format == 2 ? 960U : 160U;
+            opts->floating_point = floating;
+            for (size_t sink = 0; sink < sizeof(sinks) / sizeof(sinks[0]); sink++) {
+                opts->audio_out_type = sinks[sink];
+                state->audio_out_idx = (int)frames;
+                state->audio_out_buf_p = history + frames;
+                for (size_t i = 0; i < frames; i++) {
+                    short sample = (short)((int)i - 480);
+                    float value = (float)((int)(i % 29U) - 14) / 32.0f;
+                    history[i] = sample;
+                    if (i < 160U) {
+                        state->s_l[i] = sample;
+                        state->f_l[i] = value;
+                    }
+                    for (int channel = 0; channel < channels; channel++) {
+                        size_t index = i * (size_t)channels + (size_t)channel;
+                        expected_short[index] = floating ? (short)(value * 32767.0f) : sample;
+                        if (floating) {
+                            expected_float[index] = value;
+                        }
+                    }
+                }
+                reset_sink_capture();
+                if (floating) {
+                    playSynthesizedVoiceFM(opts, state);
+                } else {
+                    playSynthesizedVoiceMS(opts, state);
+                }
+                size_t count = frames * (size_t)channels;
+                if (opts->audio_out_type == 0) {
+                    rc |= expect_size("mono voice device frame duration", g_audio_write_frames, frames);
+                    rc |= expect_bytes("mono voice device channel samples", g_audio_write_samples, expected_short,
+                                       count * sizeof(short));
+                } else {
+                    const void* data = opts->audio_out_type == 1 ? g_dsd_write_data : g_udp_blast_data;
+                    size_t bytes = opts->audio_out_type == 1 ? g_dsd_write_bytes : g_udp_blast_bytes;
+                    rc |= expect_size("mono voice stream frame duration", bytes,
+                                      count * (floating ? sizeof(float) : sizeof(short)));
+                    if (floating) {
+                        for (size_t i = 0; i < count; i++) {
+                            float sample;
+                            DSD_MEMCPY(&sample, (const uint8_t*)data + i * sizeof(float), sizeof(sample));
+                            rc |= expect_float("mono voice stream channel sample", sample, expected_float[i]);
+                        }
+                    } else {
+                        rc |= expect_bytes("mono voice stream channel samples", data, expected_short,
+                                           count * sizeof(short));
+                    }
+                }
+            }
+        }
+    }
+    g_audio_write_channels = 2;
+    free(state);
+    free(opts);
+    return rc;
+}
+
 static int
 test_silent_s16_helper(void) {
     short all_zero[4] = {0, 0, 0, 0};
@@ -1331,6 +1415,7 @@ main(void) {
     rc |= test_short_dmr_mono_honors_slot_controls_and_one_channel_output();
     rc |= test_float_playback_orchestrators_emit_expected_blocks();
     rc |= test_audio_gate_target_preserves_p25_ota_identity();
+    rc |= test_mono_voice_preserves_samples_in_configured_output();
     rc |= test_silent_s16_helper();
     return rc;
 }


### PR DESCRIPTION
## Summary

Fix the NXDN48 playback corruption reported by @noamlivne on [PR #483](https://github.com/arancormonk/dsd-neo/pull/483#issuecomment-5558504830): mixed DMR/NXDN scans sounded bad unless the outer CLI used `-fi`.

AUTO opens a stereo audio stream, and per-row scan presets intentionally retain that startup layout. NXDN's mono players supplied only one channel of valid samples. The device backend consumed a 160-sample mono frame as 80 stereo frames followed by 80 frames beyond the valid audio, corrupting playback without increasing decoder errors. `-fi` avoided the mismatch by opening a mono stream.

- Format mono-source short and float playback for the configured output channel count, duplicating samples for stereo. This also corrects other callers of the same mono players.
- Preserve existing gain, crypto gates, WAV recording and frame duration; no demodulator or scanner-profile changes and no new per-row decoder switches.
- Add regression coverage for mono/stereo device, stdout and UDP output, including 960-sample upsampled short blocks.
- Add the `options` entry to the trunk-scan column table, extend the target example with `options` and `p25_bandplan_csv`, and document that an NXDN48 row does not require an outer `-fi`.

## Audio evidence

Analyzed excerpts from the reporter's `fiNXDN.iq` and `faNXDN.iq` captures using realtime replay. Measured the actual PulseAudio playback bytes, forwarded to an isolated null sink, rather than relying only on saved WAVs or decoder error counts. The existing scan-mode replay host applied the real NXDN48 row profile because I/Q replay rejects scanner-initiated retunes.

For one AUTO speech excerpt:

| Measurement | Decoded reference | Before: left speaker channel | After: both speaker channels |
| --- | ---: | ---: | ---: |
| Energy above 2 kHz | 20.15% | 49.40% | 20.15% |
| Spectral centroid | 1,384 Hz | 1,985 Hz | 1,384 Hz |
| PCM samples match reference | — | No | Exactly |

The row-profile comparison produced sample-identical decoded WAVs and identical error counts under AUTO and `-fi`, while AUTO's device output was corrupted. Three paired row-profile comparisons, including alternating run order, reproduced the defect before the fix and exact reference samples on both channels afterward. An independent excerpt from the AUTO-recorded capture confirmed the same correction. Float playback also changed from unequal left/right samples to identical channels.

These results establish output-layout correctness, not improved RF decoding: decoded samples and decoder error counts were unchanged. Capture data and audio recordings are not included in this PR.

## Review

- [x] Changes reviewed against the surrounding module design, ownership boundaries and failure modes.
- [ ] Human review of behavior and failure modes.
- [ ] Second/outside review (requested through this PR).
- [x] High-risk areas identified: audio buffer/channel-count handling. No parser, crypto algorithm, dependency or workflow changes.
- [x] Generated changes read and adapted to project conventions.
- [x] Non-trivial commit includes a DCO sign-off.

## Quality Review

- [x] Regression asserts emitted audio samples and duration, not only which player was called; failed before the fix and passes afterward.
- [x] Existing encryption gates, gain and WAV semantics retained; routing through different stereo players was avoided because their policies differ.
- [x] No new static-analysis suppressions, dependencies, subprocess execution or raw production memory/string APIs.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j 6`
- [x] `ctest --preset dev-debug --output-on-failure -j 6`: **624 passed**, including 30 I/Q decode tests.
- [x] `ctest --preset asan-ubsan-debug -R '^CORE_AUDIO2_HELPERS$' --output-on-failure`: passed after rebuilding the target.
- [x] Repeated realtime capture replays, actual device-output sample comparisons and spectral analysis, including float playback.
- [x] `tools/preflight_ci.sh`: passed, including architecture, redaction, formatting, Semgrep, clang-tidy, IWYU, cppcheck and GCC fanalyzer checks. Fanalyzer notes that it does not analyze the selected C++ translation unit.
- CMake/workflow/dependency-specific checks and broad quality preflight are not applicable to this focused change.

## Risk

- Security/dependency impact: corrects consumption of samples beyond valid mono audio at a stereo device; no dependency or encryption-policy changes.
- CLI/UI behavior impact: mono voice now respects the session's stereo output layout, including stdout/UDP. No flags added; `--scan-voice-only` remains a separate scanner hold policy, not an audio-quality fix.
- Compatibility/packaging impact: verified on Linux with the real PulseAudio backend and shared playback regressions. Windows and live-radio confirmation remain for the reporter. Residual RF decode errors are outside this output-format correction.
