### PR TITLE
fix(core): resolve open CodeQL fixture lifetime warnings

### DIFF
--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -3021,9 +3021,7 @@ trunk_scan_coord_free(dsd_trunk_scan_coord* coord) {
     free(coord->scratch_snapshot.trunk_lcn_freq_ext);
     free(coord->scratch_snapshot.chan_map_chan);
     free(coord->scratch_snapshot.chan_map_freq);
-    if (coord->targets != NULL) {
-        free(coord->targets);
-    }
+    free(coord->targets);
     free(coord);
 }
 

--- a/tests/core/test_core_audio2_helpers.c
+++ b/tests/core/test_core_audio2_helpers.c
@@ -1312,7 +1312,7 @@ test_mono_voice_preserves_samples_in_configured_output(void) {
     dsd_opts* opts = calloc(1, sizeof(*opts));
     dsd_state* state = calloc(1, sizeof(*state));
     assert(opts && state);
-    short history[960];
+    static short history[960];
     short expected_short[1920];
     float expected_float[320];
     const int sinks[] = {0, 1, 8};

--- a/tests/core/test_core_mbe_transform_context.c
+++ b/tests/core/test_core_mbe_transform_context.c
@@ -1952,7 +1952,7 @@ test_process_mbe_frame_mixed_clear_and_bp(void) {
         free(state);
         return 1;
     }
-    mbe_parms cur, prev, enhanced, cur2, prev2, enhanced2;
+    static mbe_parms cur, prev, enhanced, cur2, prev2, enhanced2;
     mbe_parms expected_cur, expected_prev, expected_enhanced;
     char imbe[8][23] = {{0}}, ambe[4][24] = {{0}}, imbe7100[7][24] = {{0}};
     int rc = 0;


### PR DESCRIPTION
## Summary

- Address all eight currently open CodeQL findings without suppressing or dismissing alerts.
- Give the mono-audio history buffer and mixed clear/BP vocoder parameter fixtures static storage, matching adjacent tests and preventing stack addresses from being retained in heap-allocated decoder state.
- Remove the redundant null check before freeing trunk-scan targets; `free(NULL)` is already safe.
- Leave the two Scorecard findings unchanged: [CodeReviewID #637](https://github.com/arancormonk/dsd-neo/security/code-scanning/637) and [BranchProtectionID #628](https://github.com/arancormonk/dsd-neo/security/code-scanning/628).

### CodeQL alerts addressed

- `cpp/stack-address-escape`: [#1814](https://github.com/arancormonk/dsd-neo/security/code-scanning/1814), [#1374](https://github.com/arancormonk/dsd-neo/security/code-scanning/1374), [#1375](https://github.com/arancormonk/dsd-neo/security/code-scanning/1375), [#1376](https://github.com/arancormonk/dsd-neo/security/code-scanning/1376), [#1377](https://github.com/arancormonk/dsd-neo/security/code-scanning/1377), [#1378](https://github.com/arancormonk/dsd-neo/security/code-scanning/1378), [#1379](https://github.com/arancormonk/dsd-neo/security/code-scanning/1379).
- `cpp/guarded-free`: [#1812](https://github.com/arancormonk/dsd-neo/security/code-scanning/1812).

## Review

- [x] Changes checked against surrounding fixture lifetime and cleanup conventions.
- [ ] Human review of behavior, ownership boundaries, and failure modes.
- [x] DCO sign-off included.
- High-risk areas: none; test-storage lifetime changes and behavior-preserving cleanup only.
- No static-analysis suppressions, new APIs, includes, dependencies, or workflow permissions.
- Existing regression tests remain intact; no source-text tests added. No operator/API/boundary changes requiring documentation updates.

## Tests And Guardrails

- [x] `cmake --preset dev-debug` (RTL-SDR and SoapySDR enabled)
- [x] `cmake --build --preset dev-debug -j 8`
- [x] Focused CTest: `CORE_AUDIO2_HELPERS`, `CORE_MBE_TRANSFORM_CONTEXT`, `ENGINE_TRUNK_SCAN` (3/3 passed)
- [x] `ctest --preset dev-debug --output-on-failure` (616/616 passed)
- [x] `tools/preflight_ci.sh --base origin/main` (all enabled checks passed)
- [ ] GitHub CodeQL analysis (pending PR workflow)

The heavier scan-build/quality-preflight pass was not run; no broad or high-risk changes. Main-branch alerts will close after merge and a successful main-branch CodeQL analysis.

## Risk

- Security/dependency impact: removes flagged stack-address storage; no dependency or policy changes.
- CLI/UI behavior impact: none.
- Compatibility/packaging impact: none.