### PR TITLE
fix(build): make Linux source installs self-contained

### DIFF
--- a/docs/linux-installation.md
+++ b/docs/linux-installation.md
@@ -38,7 +38,13 @@ specific dependency prefix.
 
 ## Runtime Loader Setup
 
-For `/usr` or `/usr/local` dependency installs, the script refreshes the Linux
+The bootstrap installer embeds source-built dependency directories in the
+installed binary's runtime search path, including for `$HOME/.local`. Its
+installed-binary smoke test removes the installer's temporary library-path
+environment so a missing runtime dependency fails the installation instead of
+appearing only in a new shell. No `LD_LIBRARY_PATH` setup is needed.
+
+For `/usr` or `/usr/local` dependency installs, the script also refreshes the Linux
 dynamic linker cache with `ldconfig`. If you install `mbelib-neo` manually into
 one of those prefixes and `dsd-neo` reports that `libmbe-neo.so.2` cannot be
 opened, run:
@@ -47,21 +53,25 @@ opened, run:
 sudo ldconfig
 ```
 
-For non-system prefixes such as `$HOME/.local`, use environment variables
-instead of `ldconfig`:
+For a user-prefix install, add the executable directory to `PATH` if your
+distribution does not already include it, or run `$HOME/.local/bin/dsd-neo`:
 
 ```sh
 export PATH="$HOME/.local/bin:$PATH"
-export LD_LIBRARY_PATH="$HOME/.local/lib:$HOME/.local/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 ```
 
 Useful options:
 
 - `--radio auto|required|off` controls RTL-SDR and SoapySDR package setup.
   `required` fails configure if either backend is unavailable.
-- `--codec2 auto|required|off` controls Codec2 setup. Alpine does not ship a
-  Codec2 development package in the validated image, so `required` builds the
-  pinned source fallback there.
+- `--codec2 auto|required|off` controls Codec2 setup (default: `required`).
+  Missing development packages trigger a pinned source build, including on
+  Alpine, so the default installation retains M17 voice support. Explicit
+  `auto` permits a build without Codec2; `off` disables it.
+- libcurl and expat development packages are installed and required at
+  configure time, preserving rdio uploads and RadioReference import.
+- A package installation failure is fatal, including for optional radio or
+  Codec2 packages. `auto` tolerates unavailable packages, not failed transactions.
 - `--build-dir DIR` chooses the CMake build directory.
 - `--dry-run` prints package, dependency, build, and install commands.
 
@@ -79,6 +89,10 @@ pacman. The Docker matrix validates the bootstrap path on pinned images for:
 - Arch Linux base-devel for source-build validation; use AUR for normal Arch
   installs.
 
+openSUSE Leap 16.0 provides RTL-SDR but no SoapySDR development package in its
+standard repositories. Its default `--radio auto` installation includes RTL-SDR
+and omits SoapySDR; `--radio required` requires both and fails there.
+
 Run one Docker validation target:
 
 ```sh
@@ -91,8 +105,19 @@ Run the full local matrix:
 tools/docker_linux_install_matrix.sh --all
 ```
 
-The Docker wrapper copies the current checkout into each container instead of
-mounting the repo writable, so validation does not leave root-owned build
-outputs in the working tree. Container image pins live in
-`tools/ci-dependency-pins.env` and are checked by
-`tools/check_workflow_download_pins.sh`.
+The Docker wrapper pulls each pinned image and starts a fresh, automatically
+removed container. It copies the current checkout, including uncommitted source
+changes, instead of mounting the repo writable, so validation does not leave
+root-owned build outputs in the working tree. Containers carry the
+`org.dsd-neo.install-matrix` label to distinguish them from unrelated workloads.
+
+Each image validates the default user-prefix installation first, then an
+independent `/usr/local` build staged with `DESTDIR`. Both installed binaries
+must start outside the installer environment. Codec2 is required on every image;
+both radio backends are required except for Leap's documented SoapySDR gap.
+A separate Debug build runs the CTest suite; use `--no-tests` to run only the two
+installation checks. `--jobs N` limits build/test parallelism inside each container.
+
+Container image pins live in `tools/ci-dependency-pins.env` and are checked by
+`tools/check_workflow_download_pins.sh`. Pulling a pinned image does not advance
+its version: refreshing a supported tag requires updating its recorded digest.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,13 @@ if(NOT WIN32)
                 ${PROJECT_SOURCE_DIR}/tests/tools/test_gcc_fanalyzer.sh
             WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         )
+        add_test(
+            NAME TOOLS_INSTALL_LINUX_PACKAGE_FAILURE
+            COMMAND
+                ${DSD_NEO_BASH_EXECUTABLE}
+                ${PROJECT_SOURCE_DIR}/tests/tools/test_install_linux_package_failure.sh
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        )
     endif()
 endif()
 

--- a/tests/tools/test_check_runner.sh
+++ b/tests/tools/test_check_runner.sh
@@ -12,7 +12,7 @@
 # printed and what it exited with.
 set -euo pipefail
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 # Keep the runner's own mktemp -d inside the throwaway directory.

--- a/tests/tools/test_ci_arch_toolchain_pull_retry.sh
+++ b/tests/tools/test_ci_arch_toolchain_pull_retry.sh
@@ -9,7 +9,7 @@
 # are both observable without a daemon.
 set -euo pipefail
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 

--- a/tests/tools/test_gcc_fanalyzer.sh
+++ b/tests/tools/test_gcc_fanalyzer.sh
@@ -11,7 +11,7 @@
 # database and check that a seeded defect is actually reported and counted.
 set -euo pipefail
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
 
 if ! command -v gcc > /dev/null 2>&1 || ! command -v python3 > /dev/null 2>&1; then
   echo "SKIP: gcc or python3 not available"

--- a/tests/tools/test_install_linux_package_failure.sh
+++ b/tests/tools/test_install_linux_package_failure.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+# Package transactions must fail the installer, including optional groups called
+# inside an `if !`: POSIX shells disable errexit throughout those functions.
+set -euo pipefail
+
+ROOT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/apt-get" << 'FAKE'
+#!/bin/sh
+for arg; do
+  [ "$arg" != "$FAIL_PACKAGE" ] || exit 42
+done
+FAKE
+cat > "$WORK/apt-cache" << 'FAKE'
+#!/bin/sh
+[ "$2" != "${MISSING_PACKAGE:-}" ]
+FAKE
+cat > "$WORK/id" << 'FAKE'
+#!/bin/sh
+echo 0
+FAKE
+cat > "$WORK/git" << 'FAKE'
+#!/bin/sh
+echo "Dependency compilation reached after a failed package transaction" >&2
+exit 98
+FAKE
+chmod +x "$WORK/apt-get" "$WORK/apt-cache" "$WORK/id" "$WORK/git"
+
+check_failure() {
+  local rc=0
+  env PATH="$WORK:$PATH" FAIL_PACKAGE="$1" MISSING_PACKAGE="$2" \
+    sh "$ROOT_DIR/tools/install_linux.sh" --yes --build-dir "$WORK/build" \
+    --radio "$3" > "$WORK/output" 2>&1 || rc=$?
+  if [[ "$rc" -ne 42 ]]; then
+    cat "$WORK/output" >&2
+    echo "Expected package failure 42 for $1 (missing: $2, radio: $3), got $rc" >&2
+    exit 1
+  fi
+}
+
+check_failure librtlsdr-dev '' auto
+check_failure librtlsdr-dev libsoapysdr-dev auto
+check_failure librtlsdr-dev '' required
+check_failure libcodec2-dev '' off
+
+echo "Installer preserves package transaction failures."

--- a/tools/docker_linux_install_matrix.sh
+++ b/tools/docker_linux_install_matrix.sh
@@ -10,8 +10,8 @@ Usage: tools/docker_linux_install_matrix.sh (--all | --distro ID [--distro ID ..
 
 Validate tools/install_linux.sh in pinned Linux container images.
 
-Each distro runs the Release install path, then configures a separate Debug
-build with BUILD_TESTING=ON and runs the CTest suite.
+Each distro validates default user-prefix and staged system-prefix Release
+installs, then configures a separate Debug build and runs the CTest suite.
 
 Options:
   --all          Run every distro in the matrix.
@@ -171,7 +171,8 @@ run_one() {
 
   list_archive_paths |
     tar --null -T - -cf - |
-    docker run --rm -i \
+    docker run --rm --pull=always -i \
+      --label org.dsd-neo.install-matrix="$distro" \
       --env "DSD_NEO_BUILD_JOBS=$JOBS" \
       --env "DSD_NEO_MATRIX_TESTS=$RUN_TESTS" \
       --env "DSD_NEO_MATRIX_RADIO=$radio_mode" \
@@ -201,6 +202,12 @@ run_one() {
         tar -xf - -C /workspace
         cd /workspace
         chmod +x tools/install_linux.sh tools/fetch-pinned-git.sh
+        echo "==> Default user-prefix install"
+        tools/install_linux.sh --yes --build-dir /tmp/dsd-neo-build-user
+        test -x "$HOME/.local/bin/dsd-neo"
+        "$HOME/.local/bin/dsd-neo" -h > /dev/null
+
+        echo "==> System-prefix staged install"
         tools/install_linux.sh \
           --yes \
           --prefix /usr/local \
@@ -208,7 +215,7 @@ run_one() {
           --build-dir /tmp/dsd-neo-build \
           --destdir /tmp/dsd-neo-root \
           --radio "$DSD_NEO_MATRIX_RADIO" \
-          --codec2 auto
+          --codec2 required
         test -x /tmp/dsd-neo-root/usr/local/bin/dsd-neo
         /tmp/dsd-neo-root/usr/local/bin/dsd-neo -h > /dev/null
 

--- a/tools/install_linux.sh
+++ b/tools/install_linux.sh
@@ -18,7 +18,7 @@ Options:
   --build-dir DIR    DSD-neo build directory (default: build/install-linux)
   --destdir DIR      Stage DSD-neo install under DESTDIR instead of installing live
   --radio MODE       Radio backend setup: auto, required, off (default: auto)
-  --codec2 MODE      Codec2 setup: auto, required, off (default: auto)
+  --codec2 MODE      Codec2 setup: auto, required, off (default: required)
   --yes              Do not prompt before installing distro packages
   --dry-run          Print commands without executing them
   -h, --help         Show this help
@@ -35,7 +35,7 @@ DEPS_PREFIX=
 BUILD_DIR=build/install-linux
 DESTDIR_VALUE=
 RADIO_MODE=auto
-CODEC2_MODE=auto
+CODEC2_MODE=required
 ASSUME_YES=0
 DRY_RUN=0
 ORIGINAL_LD_LIBRARY_PATH=
@@ -359,7 +359,7 @@ install_optional_packages() {
 
   [ "$mode" != off ] || return 1
   if all_packages_available "$@"; then
-    install_packages "$@"
+    install_packages "$@" || exit $?
     return 0
   fi
 
@@ -387,7 +387,7 @@ install_optional_packages() {
 
   echo "Skipping unavailable optional $label distro packages:$unavailable"
   # shellcheck disable=SC2086
-  install_packages $available
+  install_packages $available || exit $?
   return 0
 }
 
@@ -456,44 +456,20 @@ installed_binary_path() {
 
 run_installed_dsd_neo_help() {
   installed_binary=$1
-  if system_library_prefix "$DEPS_PREFIX"; then
-    if [ "$ORIGINAL_LD_LIBRARY_PATH_SET" -eq 1 ]; then
-      env "LD_LIBRARY_PATH=$ORIGINAL_LD_LIBRARY_PATH" "$installed_binary" -h > /dev/null
-    else
-      env LD_LIBRARY_PATH= "$installed_binary" -h > /dev/null
-    fi
+  if [ "$ORIGINAL_LD_LIBRARY_PATH_SET" -eq 1 ]; then
+    env "LD_LIBRARY_PATH=$ORIGINAL_LD_LIBRARY_PATH" "$installed_binary" -h > /dev/null
   else
-    "$installed_binary" -h > /dev/null
+    env LD_LIBRARY_PATH= "$installed_binary" -h > /dev/null
   fi
-}
-
-print_loader_fix_hint() {
-  smoke_output=$1
-  case "$smoke_output" in
-    *libmbe-neo.so.2*)
-      if system_library_prefix "$DEPS_PREFIX"; then
-        echo "Installed dsd-neo could not load libmbe-neo.so.2; run sudo ldconfig and try again." >&2
-      else
-        cat >&2 << EOF
-Installed dsd-neo could not load libmbe-neo.so.2; update this shell before running it:
-  export LD_LIBRARY_PATH="$DEPS_PREFIX/lib:$DEPS_PREFIX/lib64\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}"
-EOF
-      fi
-      ;;
-  esac
 }
 
 validate_installed_dsd_neo() {
   installed_binary=$(installed_binary_path)
   if [ "$DRY_RUN" -eq 1 ]; then
-    if system_library_prefix "$DEPS_PREFIX"; then
-      if [ "$ORIGINAL_LD_LIBRARY_PATH_SET" -eq 1 ]; then
-        run env "LD_LIBRARY_PATH=$ORIGINAL_LD_LIBRARY_PATH" "$installed_binary" -h
-      else
-        run env LD_LIBRARY_PATH= "$installed_binary" -h
-      fi
+    if [ "$ORIGINAL_LD_LIBRARY_PATH_SET" -eq 1 ]; then
+      run env "LD_LIBRARY_PATH=$ORIGINAL_LD_LIBRARY_PATH" "$installed_binary" -h
     else
-      run "$installed_binary" -h
+      run env LD_LIBRARY_PATH= "$installed_binary" -h
     fi
     return 0
   fi
@@ -501,7 +477,6 @@ validate_installed_dsd_neo() {
   if ! smoke_output=$(run_installed_dsd_neo_help "$installed_binary" 2>&1); then
     printf '%s\n' "$smoke_output" >&2
     echo "Installed dsd-neo smoke test failed: $installed_binary -h" >&2
-    print_loader_fix_hint "$smoke_output"
     exit 1
   fi
 }
@@ -543,26 +518,26 @@ build_codec2() {
 }
 
 configure_build_install_dsd_neo() {
-  cmake_args="-DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DDSD_ENABLE_LTO=ON -DDSD_ENABLE_FAST_MATH=ON -DDSD_WARNINGS_AS_ERRORS=OFF"
+  cmake_args="-DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DDSD_ENABLE_LTO=ON -DDSD_ENABLE_FAST_MATH=ON -DDSD_WARNINGS_AS_ERRORS=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DDSD_REQUIRE_CURL=ON -DDSD_REQUIRE_EXPAT=ON"
 
   case "$RADIO_MODE" in
     off)
-      cmake_args="$cmake_args -DDSD_ENABLE_RTLSDR=OFF -DDSD_ENABLE_SOAPYSDR=OFF"
+      cmake_args="$cmake_args -DDSD_ENABLE_RTLSDR=OFF -DDSD_REQUIRE_RTLSDR=OFF -DDSD_ENABLE_SOAPYSDR=OFF -DDSD_REQUIRE_SOAPYSDR=OFF"
       ;;
     required)
       cmake_args="$cmake_args -DDSD_ENABLE_RTLSDR=ON -DDSD_REQUIRE_RTLSDR=ON -DDSD_ENABLE_SOAPYSDR=ON -DDSD_REQUIRE_SOAPYSDR=ON"
       ;;
     auto)
-      cmake_args="$cmake_args -DDSD_ENABLE_RTLSDR=ON -DDSD_ENABLE_SOAPYSDR=ON"
+      cmake_args="$cmake_args -DDSD_ENABLE_RTLSDR=ON -DDSD_REQUIRE_RTLSDR=OFF -DDSD_ENABLE_SOAPYSDR=ON -DDSD_REQUIRE_SOAPYSDR=OFF"
       ;;
   esac
 
   case "$CODEC2_MODE" in
     off)
-      cmake_args="$cmake_args -DCMAKE_DISABLE_FIND_PACKAGE_CODEC2=ON"
+      cmake_args="$cmake_args -DCMAKE_DISABLE_FIND_PACKAGE_CODEC2=ON -DDSD_REQUIRE_CODEC2=OFF"
       ;;
     auto)
-      cmake_args="$cmake_args -DCMAKE_DISABLE_FIND_PACKAGE_CODEC2=OFF"
+      cmake_args="$cmake_args -DCMAKE_DISABLE_FIND_PACKAGE_CODEC2=OFF -DDSD_REQUIRE_CODEC2=OFF"
       ;;
     required)
       cmake_args="$cmake_args -DCMAKE_DISABLE_FIND_PACKAGE_CODEC2=OFF -DDSD_REQUIRE_CODEC2=ON"
@@ -645,6 +620,5 @@ if [ "$PREFIX" != /usr ] && [ "$PREFIX" != /usr/local ]; then
 
 For this shell, you may need:
   export PATH="$PREFIX/bin:\$PATH"
-  export LD_LIBRARY_PATH="$DEPS_PREFIX/lib:$DEPS_PREFIX/lib64\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}"
 EOF
 fi


### PR DESCRIPTION
## Summary

- Fix optional-package transaction failures being swallowed inside conditional shell functions; add regression coverage for complete/partial radio groups and Codec2.
- Make default user-prefix installs runnable without `LD_LIBRARY_PATH`: embed dependency library search paths and smoke-test the installed executable outside the installer's temporary environment.
- Require Codec2 by default, using the existing pinned source fallback when distro packages are unavailable. Require libcurl and expat discovery, and reset requirement flags when users select `auto` or `off` in an existing build directory.
- Strengthen the Linux Docker matrix: always pull the pinned image, label disposable containers, and verify independent default user-prefix and staged system-prefix builds before the Debug/CTest run.
- Make three tool regressions work from source archives without `.git`, and update the Linux installation documentation.

## Review

- [x] Changes were reviewed against the existing installer and package-manager conventions.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Second/outside review completed or solo-maintainer exception documented.
- [x] High-risk areas touched: dependency installation and packaging/runtime loader setup. No dependency pins or workflow permissions changed.
- [x] Non-trivial commit includes a DCO sign-off.

## Quality Review

- [x] Focused regression reproduces package transaction failures and verifies that installation stops rather than continuing into compilation.
- [x] Default-prefix loader failure reproduced in a clean Ubuntu container, then verified fixed by the expanded clean-image matrix.
- [x] The three existing tool regressions and the new installer regression pass from a temporary source tree with no Git metadata.
- [x] No new static-analysis suppressions, C memory/string APIs, or broad workflow permissions.

## Tests And Guardrails

All image tags were pulled and their registry digests matched `tools/ci-dependency-pins.env`. Each distribution ran `tools/docker_linux_install_matrix.sh --distro <id> --jobs 2` against the working checkout in a fresh linux/amd64 container. Stale-baseline failures were fixed and affected distributions rechecked; only successful runs are counted below.

| Distribution | Default user install | Staged /usr/local install | CTest |
| --- | --- | --- | --- |
| Ubuntu 26.04 | Pass | Pass | 617/617 |
| Ubuntu 24.04 | Pass | Pass | 617/617 |
| Debian 13 | Pass | Pass | 617/617 |
| Debian 12 | Pass | Pass | 617/617 |
| Fedora 44 | Pass | Pass | 617/617 |
| Rocky Linux 9 | Pass | Pass | 617/617 |
| AlmaLinux 9 | Pass | Pass | 617/617 |
| CentOS Stream 9 | Pass | Pass | 617/617 |
| openSUSE Leap 16.0 | Pass | Pass | 617/617 |
| openSUSE Tumbleweed | Pass | Pass | 617/617 |
| Alpine 3.24 | Pass | Pass | 617/617 |
| Arch Linux | Pass | Pass | 617/617 |

**24 successful installation checks; 7,404 CTest passes.** All containers were removed after validation.

Dependency evidence in each default, staged, and Debug configuration: mbelib-neo soft API, Codec2, libcurl, expat, RTL-SDR, and PulseAudio available. SoapySDR available on every image except Leap's existing documented RTL-only profile. Alpine built Codec2 from pinned source automatically.

- [x] `tools/preflight_ci.sh` passed.
- [x] Shellcheck/shfmt, gersemi, strict Semgrep, architecture rules, secret-redaction, Git/download/vcpkg pin guardrails, and complexity checks passed through preflight.
- [x] `tools/cmake_format_check.sh --fix tests/CMakeLists.txt`, followed by preflight's format check.
- [ ] Host `dev-debug` preset build/CTest: not separately run; the matrix built and tested Debug on every image instead.
- [ ] `tools/quality_preflight.sh`: not run.
- Workflow/OSV checks beyond preflight: not separately run; workflows and dependency pins were unchanged.

## Risk

- **Dependency impact:** Codec2 changes from optional-by-default to required-by-default, with a source fallback on Alpine. Explicit `--codec2 auto` and `off` remain available. Package transaction errors now fail immediately rather than permitting a reduced build.
- **CLI/UI behavior:** no decoder or UI source changes. The installer still uses the existing Release settings; user-prefix binaries no longer need loader-environment setup. Users may still need to add `$HOME/.local/bin` to `PATH`.
- **Compatibility/packaging:** installed binaries retain paths to their source-built dependencies, which must remain installed. Staged checks use an explicit `/usr/local` dependency prefix.
- **Leap limitation:** standard Leap 16.0 repositories provide RTL-SDR but no SoapySDR development package. `--radio auto` retains RTL-SDR; `--radio required` still fails there. No core-only SoapySDR fallback was added.
- **Verification boundary:** linux/amd64 containers; physical SDR/audio hardware and other architectures were not exercised.
