### PR TITLE
feat(core): add verified NXDN and DMR MBE playback

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -200,6 +200,18 @@ Windows console runs:
 - `--rdio-upload-retries <n>` API upload attempts per call (default 1)
 - `--rdio-api-delete-after-upload` Delete the per-call WAV after a successful API-only upload
 - `-r <files>` Play saved MBE files
+  SDRTrunk JSON exports support P25, DMR, and NXDN enhanced-half-rate voice. NXDN playback accepts clear voice,
+  the 15-bit scrambler, DES-OFB, and AES-256-OFB; use `-R`, `-1`, or `-H`, respectively, or a key CSV indexed by
+  the recorded key ID. For an encrypted NXDN scrambler export without algorithm metadata, use `-4 -R <key>`.
+  DES/AES require a recorded 64-bit `encryption_mi`; an absent IV is not guessed. SACCH tags align the scrambler
+  to each 16-frame superframe and DES/AES to their 32-frame sessions. Exports that omit the positions of
+  FACCH-stolen voice within an RF frame cannot fully reconstruct that frame's keystream alignment.
+  NXDN full-rate voice is not supported by this reader.
+  DMR AES-128/AES-256 exports use ALGID `0x24`/`0x25` and a 32-bit MI. For metadata-free DMR exports, use
+  `-H '<key>' --dmr-force-algid 24` (or `25`); audio remains muted until a Golay/CRC-verified late-entry MI
+  supplies the next superframe's context. For example:
+  `dsd-neo -o null -w decoded.wav -H '<key>' --dmr-force-algid 25 -r call.mbe`.
+  These are known-key playback modes, not key recovery.
 - `-c <file>` Save symbol captures to a .bin file
 - `--symbol-capture-format <soft|legacy>` Select the current soft/v2 writer. `legacy` remains accepted as an alias; it
   does not reactivate the removed one-byte writer.

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -147,6 +147,9 @@ Tests: `tests/engine/test_engine_trunk_scan.c` (`ENGINE_TRUNK_SCAN`) and
 - Target: `dsd-neo_core`
 - Responsibilities: cross-protocol glue (audio output helpers, vocoder glue, frame helpers, GPS, file import),
   misc/util
+- `src/core/file/dsd_file.c` reads SDRTrunk JSON MBE exports. Its file-local crypto context owns NXDN SACCH
+  position/session tracking and DMR AES late-entry context; playback does not call protocol-layer state-mutating
+  IV expansion. Voice bits are FEC-decoded before decryption and then passed to the normal vocoder/output path.
 - API note: the high-pass filter in `<dsd-neo/core/audio_filters.h>` is `dsd_hpf()`. It was renamed from
   `hpf()` because codec2 exports a symbol of that name and Android links codec2 statically, which turns the
   duplicate into a link error. It is the only filter in that header that is prefixed: codec2 exports none of
@@ -391,6 +394,11 @@ Build files: `src/io/CMakeLists.txt` (defines radio/audio/control subtargets)
 - Path: `src/crypto`, `include/dsd-neo/crypto`
 - Target: `dsd-neo_crypto`
 - Responsibilities: stream/block ciphers and helpers (RC2/RC4/DES/AES/etc)
+- `nxdn_keystream.c` / `<dsd-neo/crypto/nxdn_keystream.h>` share the NXDN TS 1-D scrambler and AES IV
+  expansion between protocol data handling and MBE playback.
+- `dmr_mi.c` / `<dsd-neo/crypto/dmr_keystream.h>` own RC4 MI advancement and the pure DMR AES
+  `dmr_aes_expand_iv()` helper. The live protocol wrapper `LFSR128d()` retains slot-state updates and logging;
+  MBE playback uses the same expansion without those side effects.
 - Build files: `src/crypto/CMakeLists.txt`
 
 ## Protocols

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,6 +27,27 @@ cmake --build --preset dev-debug -j
 ctest --preset dev-debug --output-on-failure
 ```
 
+### Known-key MBE playback
+
+`CORE_MBE_FILE_IO` checks decrypted AMBE payloads, not merely output-file existence. Its NXDN vectors come
+from [NXDN TS 1-D v1.3](https://www.qsl.net/kb9mwr/projects/dv/nxdn/NXDN-TS-1-D_v0103.pdf),
+§§7.2.1.1–7.2.1.3: every EHR frame decrypts to the published 1031 Hz tone. Scrambler repetitions cover the
+16-frame reset; DES/AES cover the 32-frame session. Missing-IV, changed-to-unloaded-key, manual-key versus
+stale-CSV, and skipped-SACCH cases defend against stale crypto context and incorrect positioning.
+
+The DMR AES-128/256 and RC4 excerpts come from the Baofeng DM-32 recordings in
+[known-key-mbe-samples](https://github.com/tylerwatt12/known-key-mbe-samples/tree/2e15b86e305b7a3c71d52873518e2908747f6e09).
+The tests compare exact plaintext voice bits independently checked with OpenSSL-backed AES/OFB and an
+[RFC 6229](https://www.rfc-editor.org/rfc/rfc6229)-checked RC4 reference, both with serialized MI metadata and
+with MI recovered from the preceding superframe's Golay/CRC-protected fragments. A late-arriving AES algorithm
+without an IV must not corrupt the keyring or the plaintext of subsequent valid frames. The short vectors
+are embedded in the test; running it requires neither a network nor a radio.
+
+For full-capture verification, replay the repository's `encrypted.mbe` and `encrypted_legacy.mbe` files with
+their supplied keys using the CLI examples in [cli.md](cli.md). Compare decrypted frame logs as well as audio:
+PCM need not be byte-identical across vocoder versions or synthesis histories. These exports validate playback
+and crypto, not RF reception or demodulator sensitivity.
+
 ### Full-chain modulation decode tests
 
 The `DECODE_IQ_*` cases (CTest label `iq-decode`) are end-to-end regression

--- a/include/dsd-neo/core/file_io.h
+++ b/include/dsd-neo/core/file_io.h
@@ -40,6 +40,12 @@ void PrintAMBEData(dsd_opts* opts, const dsd_state* state, const char* ambe_d);
 void PrintIMBEData(dsd_opts* opts, const dsd_state* state, const char* imbe_d);
 int readImbe4400Data(dsd_opts* opts, dsd_state* state, char* imbe_d);
 int readAmbe2450Data(dsd_opts* opts, dsd_state* state, char* ambe_d);
+/** Replay an SDRTrunk JSON MBE file from the start of opts->mbe_in_f.
+ * Supports P25, DMR, and NXDN enhanced-half-rate voice. Uses supplied keys;
+ * encrypted NXDN DES/AES frames without an IV and DMR AES frames without
+ * explicit or verified late-entry context remain muted. Caller initializes
+ * FEC tables and vocoder state as for ordinary MBE playback.
+ */
 void read_sdrtrunk_json_format(dsd_opts* opts, dsd_state* state);
 void openMbeInFile(dsd_opts* opts, dsd_state* state);
 void openMbeOutFile(dsd_opts* opts, dsd_state* state);

--- a/include/dsd-neo/crypto/dmr_keystream.h
+++ b/include/dsd-neo/crypto/dmr_keystream.h
@@ -43,6 +43,11 @@ int dmr_ambe49_should_skip_crypto(const char ambe_d[49]);
 int dmr_voice_stream_apply_frame49(const uint8_t* ks_bits, long int* bit_counter, int algid, char ambe_d[49]);
 /** Advance the DMR RC4 message indicator by one 32-bit LFSR cycle. */
 uint32_t dmr_mi_advance32(uint32_t mi);
+/** Expand a DMR AES 32-bit MI into 16 IV bytes; return the next superframe's MI.
+ * Uses the same x^32 + x^22 + x^2 + x + 1 recurrence as live DMR AES.
+ * Does not mutate decoder state. Null output leaves the MI unchanged.
+ */
+uint32_t dmr_aes_expand_iv(uint32_t mi, uint8_t iv[16]);
 int dmr_basic_privacy_apply_frame49(unsigned long long key_id, char ambe_d[49]);
 int tyt_ap_pc4_apply_frame49(const dsd_state* state, char ambe_d[49]);
 int tyt_ep_aes_apply_frame49(const dsd_state* state, char ambe_d[49]);

--- a/include/dsd-neo/crypto/nxdn_keystream.h
+++ b/include/dsd-neo/crypto/nxdn_keystream.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+#ifndef DSD_NEO_CRYPTO_NXDN_KEYSTREAM_H
+#define DSD_NEO_CRYPTO_NXDN_KEYSTREAM_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Generate len_bits unpacked scrambler bits from a 15-bit key (NXDN TS 1-D §5.3.1).
+ * The caller supplies room for len_bits bytes. Null output or nonpositive length is ignored.
+ */
+void nxdn_pdu_scrambler_keystream_creation(uint8_t* ks, int lfsr, int len_bits);
+
+/** Expand a transmitted 64-bit MI into the 128-bit AES IV (NXDN TS 1-D §5.3.3.2).
+ * Writes 16 bytes; bytes 8..15 also contain the next encryption session's 64-bit MI.
+ * Null output is ignored. Does not advance decoder state.
+ */
+void nxdn_lfsr128_expand_iv_from_mi64(uint64_t mi, uint8_t out[16]);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/core/file/dsd_file.c
+++ b/src/core/file/dsd_file.c
@@ -37,6 +37,7 @@
 #include <dsd-neo/crypto/aes.h>
 #include <dsd-neo/crypto/des.h>
 #include <dsd-neo/crypto/dmr_keystream.h>
+#include <dsd-neo/crypto/nxdn_keystream.h>
 #include <dsd-neo/crypto/rc4.h>
 #include <dsd-neo/fec/dmr_late_entry.h>
 #include <dsd-neo/platform/file_compat.h>
@@ -1109,7 +1110,11 @@ sdrtrunk_build_rc4_keystream_bytes(const dsd_state* state, uint16_t key_id, cons
     rc4_kiv[2] = (uint8_t)((rc4_key >> 16ULL) & 0xFFULL);
     rc4_kiv[3] = (uint8_t)((rc4_key >> 8ULL) & 0xFFULL);
     rc4_kiv[4] = (uint8_t)((rc4_key >> 0ULL) & 0xFFULL);
-    DSD_MEMCPY(rc4_kiv + 5, iv64, 8);
+    if (rc4_mod == 9) {
+        DSD_MEMCPY(rc4_kiv + 5, iv64 + 4, 4);
+    } else {
+        DSD_MEMCPY(rc4_kiv + 5, iv64, 8);
+    }
     // codeql[cpp/weak-cryptographic-algorithm] RC4 is required for active radio protocol interoperability.
     rc4_block_output(rc4_db, rc4_mod, SDRTRUNK_KS_BYTES, rc4_kiv, ks_bytes);
     return 1;
@@ -1122,8 +1127,8 @@ sdrtrunk_build_des_keystream_bytes(const dsd_state* state, uint16_t key_id, cons
         return 0;
     }
 
-    unsigned long long int des_key = state->rkey_array[key_id];
-    if (des_key == 0ULL) {
+    unsigned long long int des_key = (protocol == 3 && state->keyloader != 1) ? state->R : state->rkey_array[key_id];
+    if (des_key == 0ULL && (protocol != 3 || state->keyloader != 1)) {
         des_key = state->R;
     }
     if (des_key == 0ULL) {
@@ -1138,41 +1143,73 @@ sdrtrunk_build_des_keystream_bytes(const dsd_state* state, uint16_t key_id, cons
 }
 
 static int
+sdrtrunk_load_aes_key(const dsd_state* state, uint16_t key_id, int strict_lookup, uint8_t key[32]) {
+    uint64_t words[4];
+    if (strict_lookup && state->keyloader != 1) {
+        words[0] = state->K1;
+        words[1] = state->K2;
+        words[2] = state->K3;
+        words[3] = state->K4;
+    } else {
+        words[0] = state->rkey_array[key_id];
+        words[1] = state->rkey_array[key_id + 0x101];
+        words[2] = state->rkey_array[key_id + 0x201];
+        words[3] = state->rkey_array[key_id + 0x301];
+    }
+    uint64_t present = words[0] | words[1] | words[2] | words[3];
+    if (!present && !strict_lookup) {
+        words[0] = state->K1;
+        words[1] = state->K2;
+        words[2] = state->K3;
+        words[3] = state->K4;
+        present = words[0] | words[1] | words[2] | words[3];
+    }
+    if (!present && !(strict_lookup && state->keyloader == 1 && state->rkey_array_loaded[key_id])) {
+        return 0;
+    }
+    for (unsigned word = 0; word < 4U; word++) {
+        for (unsigned byte = 0; byte < 8U; byte++) {
+            key[word * 8U + byte] = (uint8_t)(words[word] >> (56U - byte * 8U));
+        }
+    }
+    return 1;
+}
+
+static int
+sdrtrunk_expand_aes_iv(const dsd_state* state, uint8_t alg_id, int protocol, const uint8_t mi_bytes[8],
+                       uint8_t iv[16]) {
+    const uint64_t mi = sdrtrunk_u64_from_be8(mi_bytes);
+    if (alg_id == 0x24 || alg_id == 0x25) {
+        if (mi > UINT32_MAX || !DSD_SYNC_IS_DMR(state->synctype)) {
+            return 0;
+        }
+        (void)dmr_aes_expand_iv((uint32_t)mi, iv);
+    } else if (protocol == 3) {
+        nxdn_lfsr128_expand_iv_from_mi64(mi, iv);
+    } else {
+        DSD_MEMCPY(iv, mi_bytes, 8);
+        sdrtrunk_lfsr_64_to_128(iv);
+    }
+    return 1;
+}
+
+static int
 sdrtrunk_build_aes_keystream_bytes(const dsd_state* state, uint16_t key_id, uint8_t alg_id, const uint8_t iv64[8],
                                    int protocol, uint8_t* ks_bytes, size_t ks_cap, size_t* skip_bytes) {
     if (!state || !iv64 || !ks_bytes || !skip_bytes || ks_cap < SDRTRUNK_KS_BYTES) {
         return 0;
     }
-
+    const int dmr_aes = alg_id == 0x24 || alg_id == 0x25;
+    const int nxdn = protocol == 3;
     uint8_t aes_key[32];
-    DSD_MEMSET(aes_key, 0, sizeof(aes_key));
-    unsigned long long int a1 = state->rkey_array[key_id + 0x000];
-    unsigned long long int a2 = state->rkey_array[key_id + 0x101];
-    unsigned long long int a3 = state->rkey_array[key_id + 0x201];
-    unsigned long long int a4 = state->rkey_array[key_id + 0x301];
-    if (a1 == 0ULL && a2 == 0ULL && a3 == 0ULL && a4 == 0ULL) {
-        a1 = state->K1;
-        a2 = state->K2;
-        a3 = state->K3;
-        a4 = state->K4;
-    }
-    for (int i = 0; i < 8; i++) {
-        aes_key[i + 0] = (uint8_t)((a1 >> (56 - (i * 8))) & 0xFFULL);
-        aes_key[i + 8] = (uint8_t)((a2 >> (56 - (i * 8))) & 0xFFULL);
-        aes_key[i + 16] = (uint8_t)((a3 >> (56 - (i * 8))) & 0xFFULL);
-        aes_key[i + 24] = (uint8_t)((a4 >> (56 - (i * 8))) & 0xFFULL);
-    }
-    uint8_t zeros[32];
-    DSD_MEMSET(zeros, 0, sizeof(zeros));
-    if (memcmp(aes_key, zeros, sizeof(aes_key)) == 0) {
+    if (!sdrtrunk_load_aes_key(state, key_id, dmr_aes || nxdn, aes_key)) {
         return 0;
     }
-
-    uint8_t aes_iv[16];
-    DSD_MEMSET(aes_iv, 0, sizeof(aes_iv));
-    DSD_MEMCPY(aes_iv, iv64, 8);
-    sdrtrunk_lfsr_64_to_128(aes_iv);
-    const dsd_aes_key_size key_size = (alg_id == 0x84) ? DSD_AES_KEY_256 : DSD_AES_KEY_128;
+    uint8_t aes_iv[16] = {0};
+    if (!sdrtrunk_expand_aes_iv(state, alg_id, protocol, iv64, aes_iv)) {
+        return 0;
+    }
+    const dsd_aes_key_size key_size = (nxdn || alg_id == 0x84 || alg_id == 0x25) ? DSD_AES_KEY_256 : DSD_AES_KEY_128;
     aes_ofb_keystream_output(aes_iv, aes_key, ks_bytes, key_size, SDRTRUNK_KS_BYTES / 16);
     *skip_bytes = (protocol == 1) ? 27u : 16u;
     return 1;
@@ -1186,13 +1223,23 @@ sdrtrunk_build_voice_keystream_bytes(const dsd_state* state, uint8_t alg_id, uin
         return 0;
     }
     *skip_bytes = 0;
+    if (protocol == 3) {
+        if (alg_id == 2) {
+            return sdrtrunk_build_des_keystream_bytes(state, key_id, iv64, protocol, ks_bytes, ks_cap, skip_bytes);
+        }
+        if (alg_id == 3) {
+            return sdrtrunk_build_aes_keystream_bytes(state, key_id, alg_id, iv64, protocol, ks_bytes, ks_cap,
+                                                      skip_bytes);
+        }
+        return 0;
+    }
     if (alg_id == 0xAA || alg_id == 0x21) {
         return sdrtrunk_build_rc4_keystream_bytes(state, key_id, iv64, rc4_db, rc4_mod, ks_bytes, ks_cap);
     }
     if (alg_id == 0x81) {
         return sdrtrunk_build_des_keystream_bytes(state, key_id, iv64, protocol, ks_bytes, ks_cap, skip_bytes);
     }
-    if (alg_id == 0x84 || alg_id == 0x89) {
+    if (alg_id == 0x84 || alg_id == 0x89 || alg_id == 0x24 || alg_id == 0x25) {
         return sdrtrunk_build_aes_keystream_bytes(state, key_id, alg_id, iv64, protocol, ks_bytes, ks_cap, skip_bytes);
     }
     return 0;
@@ -1266,9 +1313,6 @@ sdrtrunk_dmr_process_late_entry_mi(dsd_state* state) {
 
     if (state->payload_mi != result.mi && result.crc_ok) {
         state->payload_mi = result.mi;
-    }
-    if (state->payload_algid == 0x21) {
-        state->payload_mi = dmr_mi_advance32((uint32_t)state->payload_mi);
     }
 }
 
@@ -1352,7 +1396,7 @@ ambe2_str_to_decode(dsd_opts* opts, dsd_state* state, const char* ambe_str, cons
         ambe_fr[map->low_row][map->low_col] = (char)(dibits[i] & 1U);
     }
 
-    if (dmra_le != 0 && ambe2_counter != NULL) {
+    if (dmra_le != 0 && ambe2_counter != NULL && *ambe2_counter >= 0 && *ambe2_counter < 18) {
         uint8_t c3[24];
         DSD_MEMSET(c3, 0, sizeof(c3));
         for (int i = 0; i < 24; i++) {
@@ -1362,10 +1406,6 @@ ambe2_str_to_decode(dsd_opts* opts, dsd_state* state, const char* ambe_str, cons
         state->currentslot = 0;
         uint8_t c3_hex = (uint8_t)convert_bits_into_output(c3, 4);
         state->late_entry_mi_fragment[0][(*ambe2_counter / 3) + 1][*ambe2_counter % 3] = c3_hex;
-
-        if (*ambe2_counter == 17) {
-            sdrtrunk_dmr_process_late_entry_mi(state);
-        }
     }
 
     char ambe_d[49];
@@ -1476,6 +1516,7 @@ typedef struct {
     uint8_t dmra_le;
     uint8_t show_time;
     uint8_t alg_id;
+    uint8_t alg_seen;
     uint16_t key_id;
     int rc4_db;
     int rc4_mod;
@@ -1497,6 +1538,7 @@ typedef struct {
     uint16_t ks_idx_i;
     int imbe_counter;
     int ambe2_counter;
+    uint8_t nxdn_sacch;
     dsd_call_kind kind;
     uint32_t source_id;
     uint32_t target_id;
@@ -1504,7 +1546,7 @@ typedef struct {
 
 static char*
 sdrtrunk_json_next_value(char** str_saveptr) {
-    return dsd_strtok_r(NULL, " : \"", str_saveptr);
+    return dsd_strtok_r(NULL, " : \",{}[]\r\n\t", str_saveptr);
 }
 
 static void
@@ -1517,6 +1559,7 @@ sdrtrunk_json_context_init(sdrtrunk_json_context* ctx) {
     ctx->dmra_le = 0;
     ctx->show_time = 1;
     ctx->alg_id = 0;
+    ctx->alg_seen = 0;
     ctx->key_id = 0;
     ctx->rc4_db = 256;
     ctx->rc4_mod = 13;
@@ -1532,6 +1575,7 @@ sdrtrunk_json_context_init(sdrtrunk_json_context* ctx) {
     ctx->ks_idx_i = 808;
     ctx->imbe_counter = 0;
     ctx->ambe2_counter = 0;
+    ctx->nxdn_sacch = 0;
     ctx->kind = DSD_CALL_KIND_VOICE;
     ctx->source_id = 0U;
     ctx->target_id = 0U;
@@ -1582,12 +1626,22 @@ sdrtrunk_json_target_is_group(const sdrtrunk_json_context* ctx) {
 }
 
 static void
+sdrtrunk_json_apply_forced_nxdn(const dsd_state* state, sdrtrunk_json_context* ctx) {
+    if (ctx->is_enc && !ctx->alg_seen && state->M == 1 && ctx->alg_id != 1) {
+        ctx->alg_id = 1;
+        ctx->ks_built = 0;
+    }
+}
+
+static void
 sdrtrunk_json_apply_forced_algid(dsd_state* state, sdrtrunk_json_context* ctx) {
     if (state->M >= 0x21 && state->M <= 0x25) {
         ctx->is_dmra = 1;
         ctx->dmra_le = 1;
         ctx->is_enc = 1;
-        ctx->alg_id = (uint8_t)state->M;
+        if (!ctx->alg_seen) {
+            ctx->alg_id = (uint8_t)state->M;
+        }
         state->payload_algid = ctx->alg_id;
         ctx->rc4_db = 256;
         ctx->rc4_mod = 9;
@@ -1619,7 +1673,7 @@ sdrtrunk_json_apply_forced_algid(dsd_state* state, sdrtrunk_json_context* ctx) {
             }
         }
         if (ctx->alg_id == 0x21) {
-            if (state->R != 0 && state->payload_mi != 0) {
+            if (state->payload_mi != 0) {
                 uint8_t iv64[8] = {0};
                 iv64[4] = (uint8_t)((state->payload_mi >> 24ULL) & 0xFFULL);
                 iv64[5] = (uint8_t)((state->payload_mi >> 16ULL) & 0xFFULL);
@@ -1634,8 +1688,7 @@ sdrtrunk_json_apply_forced_algid(dsd_state* state, sdrtrunk_json_context* ctx) {
                 // bytes.
                 ctx->ks_key_id = effective_kid;
                 ctx->ks_built = 1;
-            } else {
-                // No key or no IV yet: we have no keystream. Leaving the previous token's in place
+            } else { // No key or no IV yet: we have no keystream. Leaving the previous token's in place
                 // kept the decoder XORing against an earlier key while still reporting the record
                 // decryptable. Self-corrects on the next token once the MI lands, like everything
                 // else in this file.
@@ -1672,6 +1725,13 @@ sdrtrunk_json_set_protocol(const char* value, dsd_state* state, sdrtrunk_json_co
         ctx->rc4_mod = 9;
         state->synctype = DSD_SYNC_DMR_BS_DATA_POS;
         state->lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    }
+    if (strcmp(value, "NXDN") == 0) {
+        ctx->protocol = 3;
+        ctx->is_dmra = 0;
+        ctx->dmra_le = 0;
+        state->synctype = DSD_SYNC_NXDN_POS;
+        state->lastsynctype = DSD_SYNC_NXDN_POS;
     }
 }
 
@@ -1742,6 +1802,7 @@ sdrtrunk_json_handle_encrypted(const char* token, char** str_saveptr, sdrtrunk_j
     ctx->is_enc = (strncmp("true", value, 4) == 0) ? 1 : 0;
     ctx->alg_id = 0;
     ctx->key_id = 0;
+    ctx->alg_seen = 0;
     DSD_FPRINTF(stderr, "\n Encryption: %s", value);
     return 1;
 }
@@ -1780,8 +1841,14 @@ sdrtrunk_json_handle_alg(const dsd_opts* opts, const char* token, char** str_sav
         return 1;
     }
     uint8_t alg_id = 0;
+    const uint8_t previous_alg = ctx->alg_id;
     if (dsd_parse_uint8_strict(value, 10, UINT8_MAX, &alg_id) == 0) {
         ctx->alg_id = alg_id;
+        ctx->alg_seen = 1;
+    }
+    if (ctx->alg_id != previous_alg) {
+        ctx->ks_built = 0;
+        ctx->ks_available = 0;
     }
     if (opts->payload == 1) {
         DSD_FPRINTF(stderr, "\n Alg ID: %02X;", ctx->alg_id);
@@ -1801,8 +1868,13 @@ sdrtrunk_json_handle_key_id(const dsd_opts* opts, const char* token, char** str_
         return 1;
     }
     uint16_t key_id = 0;
+    const uint16_t previous_key = ctx->key_id;
     if (dsd_parse_uint16_strict(value, 10, UINT16_MAX, &key_id) == 0) {
         ctx->key_id = key_id;
+    }
+    if (ctx->key_id != previous_key) {
+        ctx->ks_built = 0;
+        ctx->ks_available = 0;
     }
     if (opts->payload == 1) {
         DSD_FPRINTF(stderr, "\n Key ID: %04X;", ctx->key_id);
@@ -1843,6 +1915,23 @@ sdrtrunk_json_build_keystreams(const dsd_opts* opts, const dsd_state* state, sdr
     // ctx->is_enc themselves.
     ctx->ks_built = 1;
     ctx->ks_key_id = key_id;
+    if (ctx->protocol == 3) {
+        DSD_MEMSET(ctx->ks, 0, sizeof(ctx->ks));
+        if (key_id > 63U) {
+            return 0;
+        }
+        if (ctx->alg_id == 1) {
+            const uint64_t key = state->keyloader == 1 ? state->rkey_array[key_id] : state->R;
+            if (key == 0U || key > 0x7FFFU) {
+                return 0;
+            }
+            nxdn_pdu_scrambler_keystream_creation(ctx->ks, (int)key, 16 * 49);
+            return 1;
+        }
+        if (!ctx->mi_seen) {
+            return 0;
+        }
+    }
     uint8_t ks_available = (uint8_t)sdrtrunk_build_voice_keystream_bits(
         state, ctx->alg_id, key_id, ctx->mi_iv, ctx->rc4_db, ctx->rc4_mod, ctx->protocol, ctx->ks, sizeof(ctx->ks));
     if (ctx->protocol == 1 && ctx->version == 1 && ks_available) {
@@ -1960,15 +2049,21 @@ sdrtrunk_json_handle_mi(const dsd_opts* opts, dsd_state* state, const char* toke
     char iv_str[20];
     sdrtrunk_json_extract_iv(value, iv_str);
     uint64_t iv_parsed = 0;
-    unsigned long long int iv_hex =
-        (dsd_parse_uint64_strict(iv_str, 16, UINT64_MAX, &iv_parsed) == 0) ? (unsigned long long int)iv_parsed : 0ULL;
+    const int iv_valid = dsd_parse_uint64_strict(iv_str, 16, UINT64_MAX, &iv_parsed) == 0;
+    const unsigned long long int iv_hex = iv_valid ? (unsigned long long int)iv_parsed : 0ULL;
     if (opts->payload == 1) {
         DSD_FPRINTF(stderr, "\n IV: %016llX;", iv_hex);
     }
 
     DSD_MEMSET(ctx->mi_iv, 0, sizeof(ctx->mi_iv));
     (void)parse_raw_user_string(iv_str, ctx->mi_iv, sizeof(ctx->mi_iv));
-    ctx->mi_seen = 1;
+    ctx->mi_seen = (uint8_t)iv_valid;
+    if (DSD_SYNC_IS_DMR(state->synctype) && strlen(iv_str) == 8U && iv_valid) {
+        for (unsigned i = 0; i < 8U; i++) {
+            ctx->mi_iv[i] = (uint8_t)(iv_parsed >> (56U - i * 8U));
+        }
+        ctx->ambe2_counter = 0;
+    }
 
     state->currentslot = 0;
     state->payload_algid = ctx->alg_id;
@@ -2020,14 +2115,119 @@ sdrtrunk_json_decode_imbe_hex(dsd_opts* opts, dsd_state* state, sdrtrunk_json_co
 }
 
 static void
+sdrtrunk_json_prepare_dmr_aes(const dsd_opts* opts, dsd_state* state, sdrtrunk_json_context* ctx) {
+    if (!ctx->dmra_le) {
+        ctx->ambe2_counter = 0;
+        ctx->ks_idx = 0;
+        DSD_MEMSET(state->late_entry_mi_fragment[0], 0, sizeof(state->late_entry_mi_fragment[0]));
+    }
+    ctx->is_dmra = 1;
+    ctx->dmra_le = 1;
+    state->payload_algid = ctx->alg_id;
+    uint16_t kid = ctx->key_id;
+    if (state->keyloader == 1) {
+        kid = (uint16_t)keyring_dmr_effective_kid(state, ctx->target_id, sdrtrunk_json_target_is_group(ctx),
+                                                  dsd_dmr_alg_key_need(ctx->alg_id), ctx->key_id, NULL);
+    }
+    if (!ctx->mi_seen) {
+        ctx->ks_available = 0;
+    } else if (!ctx->ks_built || ctx->ks_key_id != kid) {
+        ctx->ks_available = sdrtrunk_json_build_keystreams(opts, state, ctx, kid);
+    }
+}
+
+static void
+sdrtrunk_json_finish_dmr_aes(dsd_state* state, sdrtrunk_json_context* ctx) {
+    dsd_dmr_late_entry_result result = {0};
+    if (dsd_dmr_late_entry_decode(&state->late_entry_mi_fragment[0][0][0], &result) && result.crc_ok) {
+        // A verified late-entry MI belongs to the following 18-frame superframe.
+        state->payload_mi = result.mi;
+        ctx->mi_seen = 1;
+    } else if (ctx->mi_seen) {
+        uint8_t iv[16];
+        state->payload_mi = dmr_aes_expand_iv((uint32_t)state->payload_mi, iv);
+    }
+    for (unsigned i = 0; i < 8U; i++) {
+        ctx->mi_iv[i] = (uint8_t)(state->payload_mi >> (56U - i * 8U));
+    }
+    ctx->ks_built = 0;
+}
+
+static void
 sdrtrunk_json_decode_ambe_hex(dsd_opts* opts, dsd_state* state, sdrtrunk_json_context* ctx, const char* value) {
+    const int dmr_aes = DSD_SYNC_IS_DMR(state->synctype) && (ctx->alg_id == 0x24 || ctx->alg_id == 0x25);
+    if (dmr_aes) {
+        sdrtrunk_json_prepare_dmr_aes(opts, state, ctx);
+    }
     ctx->ks_idx = ambe2_str_to_decode(opts, state, value, ctx->ks, ctx->ks_idx, ctx->is_dmra, ctx->dmra_le,
                                       &ctx->ambe2_counter, ctx->is_enc, ctx->ks_available);
     ctx->ambe2_counter++;
     if (ctx->dmra_le != 0 && ctx->ambe2_counter == 18) {
+        if (dmr_aes) {
+            sdrtrunk_json_finish_dmr_aes(state, ctx);
+        } else {
+            sdrtrunk_dmr_process_late_entry_mi(state);
+        }
         ctx->ambe2_counter = 0;
         ctx->ks_idx = 0;
     }
+}
+
+static void
+sdrtrunk_json_handle_nxdn_tag(const char* token, char** str_saveptr, sdrtrunk_json_context* ctx) {
+    if (ctx->protocol != 3 || strcmp(token, "tag") != 0) {
+        return;
+    }
+    const char* value = sdrtrunk_json_next_value(str_saveptr);
+    if (!value || strcmp(value, "SACCH") != 0) {
+        return;
+    }
+    const char* position = sdrtrunk_json_next_value(str_saveptr);
+    uint8_t part = 0;
+    if (position && dsd_parse_uint8_strict(position, 10, 4U, &part) == 0 && part != 0U) {
+        ctx->nxdn_sacch = part;
+    }
+}
+
+static void
+sdrtrunk_json_decode_nxdn_hex(dsd_opts* opts, dsd_state* state, sdrtrunk_json_context* ctx, const char* value) {
+    // NXDN EHR transports 72 bits per 49-bit vocoder frame. Do not interpret EFR as EHR.
+    if (strlen(value) != 18U) {
+        LOG_WARN("Unsupported NXDN MBE voice frame length\n");
+        return;
+    }
+    if (ctx->nxdn_sacch != 0U) {
+        unsigned position = (ctx->ks_idx / (16U * 49U)) * (16U * 49U) + (ctx->nxdn_sacch - 1U) * (4U * 49U);
+        if (position < ctx->ks_idx) {
+            position += 16U * 49U;
+        }
+        ctx->ks_idx = (uint16_t)position;
+        ctx->nxdn_sacch = 0U;
+    }
+    // Scrambling restarts each superframe. DES/AES sessions span two superframes;
+    // advance the transmitted MI only when the next session actually begins.
+    const unsigned session_bits = (ctx->alg_id == 1 ? 16U : 32U) * 49U;
+    if (ctx->ks_idx >= session_bits) {
+        if (ctx->alg_id != 1 && ctx->mi_seen) {
+            uint8_t iv[16];
+            nxdn_lfsr128_expand_iv_from_mi64(sdrtrunk_u64_from_be8(ctx->mi_iv), iv);
+            DSD_MEMCPY(ctx->mi_iv, iv + 8, sizeof(ctx->mi_iv));
+            ctx->ks_built = 0;
+        }
+        ctx->ks_idx %= session_bits;
+    }
+    if (!ctx->is_enc) {
+        DSD_MEMSET(ctx->ks, 0, sizeof(ctx->ks));
+        ctx->ks_available = 0;
+        ctx->ks_built = 0;
+    } else if (!ctx->ks_built || ctx->ks_key_id != ctx->key_id) {
+        ctx->ks_available = sdrtrunk_json_build_keystreams(opts, state, ctx, ctx->key_id);
+    }
+    state->payload_algid = ctx->alg_id;
+    state->payload_keyid = ctx->key_id;
+    state->payload_mi = sdrtrunk_u64_from_be8(ctx->mi_iv);
+    ctx->ks_idx =
+        ambe2_str_to_decode(opts, state, value, ctx->ks, ctx->ks_idx, 0, 0, NULL, ctx->is_enc, ctx->ks_available);
 }
 
 static int
@@ -2045,6 +2245,8 @@ sdrtrunk_json_handle_hex(dsd_opts* opts, dsd_state* state, const char* token, ch
         sdrtrunk_json_decode_imbe_hex(opts, state, ctx, value);
     } else if (ctx->protocol == 2) {
         sdrtrunk_json_decode_ambe_hex(opts, state, ctx, value);
+    } else if (ctx->protocol == 3) {
+        sdrtrunk_json_decode_nxdn_hex(opts, state, ctx, value);
     }
     return 1;
 }
@@ -2116,12 +2318,17 @@ sdrtrunk_json_process_token(dsd_opts* opts, dsd_state* state, sdrtrunk_json_cont
     (void)sdrtrunk_json_handle_protocol(opts, state, token, str_saveptr, ctx);
     (void)sdrtrunk_json_handle_call_type(token, str_saveptr, ctx);
     (void)sdrtrunk_json_handle_encrypted(token, str_saveptr, ctx);
-    sdrtrunk_json_apply_forced_algid(state, ctx);
+    if (ctx->protocol == 3) {
+        sdrtrunk_json_apply_forced_nxdn(state, ctx);
+    } else {
+        sdrtrunk_json_apply_forced_algid(state, ctx);
+    }
     sdrtrunk_json_apply_dmr_tg_key_map(opts, state, ctx);
     (void)sdrtrunk_json_handle_to_from(ctx, token, str_saveptr);
     (void)sdrtrunk_json_handle_alg(opts, token, str_saveptr, ctx);
     (void)sdrtrunk_json_handle_key_id(opts, token, str_saveptr, ctx);
     (void)sdrtrunk_json_handle_mi(opts, state, token, str_saveptr, ctx);
+    sdrtrunk_json_handle_nxdn_tag(token, str_saveptr, ctx);
     (void)sdrtrunk_json_handle_hex(opts, state, token, str_saveptr, ctx);
     (void)sdrtrunk_json_handle_time(token, str_saveptr, state, ctx);
     sdrtrunk_json_publish_call(state, ctx);
@@ -2129,6 +2336,12 @@ sdrtrunk_json_process_token(dsd_opts* opts, dsd_state* state, sdrtrunk_json_cont
 
 void
 read_sdrtrunk_json_format(dsd_opts* opts, dsd_state* state) {
+    // openMbeInFile() probes a four-byte binary cookie even for JSON exports.
+    // Rewind so compact JSON does not lose the start of its first property.
+    if (fseek(opts->mbe_in_f, 0L, SEEK_SET) != 0) {
+        LOG_ERROR("Failed to rewind MBE JSON input\n");
+        return;
+    }
     char* source_str = (char*)malloc(0x100000 + 1);
     if (source_str == NULL) {
         LOG_ERROR("Failed to allocate memory for MBE file buffer\n");

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(
         crypt-tyt.c
         dmr_mi.c
         md2ii.c
+        nxdn_keystream.c
 )
 
 target_include_directories(

--- a/src/crypto/dmr_mi.c
+++ b/src/crypto/dmr_mi.c
@@ -4,6 +4,7 @@
  */
 
 #include <dsd-neo/crypto/dmr_keystream.h>
+#include <stddef.h>
 #include <stdint.h>
 
 uint32_t
@@ -14,4 +15,25 @@ dmr_mi_advance32(uint32_t mi) {
         lfsr = (lfsr << 1U) | bit;
     }
     return (uint32_t)lfsr;
+}
+
+uint32_t
+dmr_aes_expand_iv(uint32_t mi, uint8_t iv[16]) {
+    if (iv == NULL) {
+        return mi;
+    }
+    for (unsigned int i = 0; i < 4U; i++) {
+        iv[i] = (uint8_t)(mi >> (24U - 8U * i));
+    }
+    uint32_t lfsr = mi;
+    for (unsigned int i = 4; i < 16U; i++) {
+        uint8_t octet = 0;
+        for (unsigned int j = 0; j < 8U; j++) {
+            const uint32_t bit = ((lfsr >> 31U) ^ (lfsr >> 21U) ^ (lfsr >> 1U) ^ lfsr) & 1U;
+            lfsr = (lfsr << 1U) | bit;
+            octet = (uint8_t)((octet << 1U) | bit);
+        }
+        iv[i] = octet;
+    }
+    return ((uint32_t)iv[4] << 24U) | ((uint32_t)iv[5] << 16U) | ((uint32_t)iv[6] << 8U) | iv[7];
 }

--- a/src/crypto/nxdn_keystream.c
+++ b/src/crypto/nxdn_keystream.c
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+#include <dsd-neo/crypto/nxdn_keystream.h>
+#include <stddef.h>
+
+void
+nxdn_pdu_scrambler_keystream_creation(uint8_t* ks, int lfsr, int len_bits) {
+    if (ks == NULL || len_bits <= 0) {
+        return;
+    }
+    uint16_t reg = (uint16_t)lfsr & 0x7FFFU;
+    for (int i = 0; i < len_bits; i++) {
+        ks[i] = (uint8_t)(reg & 1U);
+        const uint16_t bit = (uint16_t)(((reg >> 1) ^ reg) & 1U);
+        reg = (uint16_t)((reg >> 1) | (bit << 14));
+    }
+}
+
+void
+nxdn_lfsr128_expand_iv_from_mi64(uint64_t mi, uint8_t out[16]) {
+    if (out == NULL) {
+        return;
+    }
+    for (int i = 0; i < 8; i++) {
+        out[i] = (uint8_t)(mi >> (56 - i * 8));
+    }
+    uint64_t lfsr = mi;
+    for (int i = 8; i < 16; i++) {
+        uint8_t octet = 0;
+        for (int j = 0; j < 8; j++) {
+            const uint64_t bit =
+                ((lfsr >> 63) ^ (lfsr >> 61) ^ (lfsr >> 45) ^ (lfsr >> 37) ^ (lfsr >> 26) ^ (lfsr >> 14)) & 1U;
+            lfsr = (lfsr << 1) | bit;
+            octet = (uint8_t)((octet << 1) | bit);
+        }
+        out[i] = octet;
+    }
+}

--- a/src/fec/bptc.c
+++ b/src/fec/bptc.c
@@ -197,6 +197,9 @@ BPTC_128x77_Extract_Data(uint8_t InputDataMatrix[8][16], uint8_t DMRDataExtracte
         /* Apply Hamming (16,11,4) code correction */
         if (Hamming_16_11_4_decode(LineUncorrected, LineCorrected, 1) == false) {
             HammingIrrecoverableErrorNb++;
+            // The decoder leaves LineCorrected unwritten on failure. Preserve the
+            // received row rather than copying uninitialized or previous-row data.
+            continue;
         }
 
         /* Re-inject the line in the matrix (only the util data [11 bit],

--- a/src/protocol/dmr/dmr_pi.c
+++ b/src/protocol/dmr/dmr_pi.c
@@ -16,6 +16,7 @@
 #include <dsd-neo/core/keyring.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/crypto/dmr_keystream.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/runtime/colors.h>
 #include <stdint.h>
@@ -345,54 +346,13 @@ LFSR64(dsd_state* state) {
 //Expand a 32-bit MI into a 128-bit IV for AES
 void
 LFSR128d(dsd_state* state) {
-    unsigned long long int lfsr = 0;
-
-    if (state->currentslot == 0) {
-        lfsr = state->payload_mi;
-    } else {
-        lfsr = state->payload_miR;
+    if (state->currentslot != 0 && state->currentslot != 1) {
+        return;
     }
-
-    unsigned long long int next_mi = 0;
-
-    //start packing aes_iv
-    if (state->currentslot == 0) {
-        state->aes_iv[0] = (lfsr >> 24) & 0xFF;
-        state->aes_iv[1] = (lfsr >> 16) & 0xFF;
-        state->aes_iv[2] = (lfsr >> 8) & 0xFF;
-        state->aes_iv[3] = (lfsr >> 0) & 0xFF;
-    } else if (state->currentslot == 1) {
-        state->aes_ivR[0] = (lfsr >> 24) & 0xFF;
-        state->aes_ivR[1] = (lfsr >> 16) & 0xFF;
-        state->aes_ivR[2] = (lfsr >> 8) & 0xFF;
-        state->aes_ivR[3] = (lfsr >> 0) & 0xFF;
-    }
-
-    int cnt = 0;
-    int x = 32;
-    for (cnt = 0; cnt < 96; cnt++) {
-        //32,22,2,1
-        unsigned long long int bit = ((lfsr >> 31) ^ (lfsr >> 21) ^ (lfsr >> 1) ^ (lfsr >> 0)) & 0x1;
-        lfsr = (lfsr << 1) | bit;
-
-        //continue packing aes_iv
-        if (state->currentslot == 0) {
-            state->aes_iv[x / 8] = (state->aes_iv[x / 8] << 1) + bit;
-        } else if (state->currentslot == 1) {
-            state->aes_ivR[x / 8] = (state->aes_ivR[x / 8] << 1) + bit;
-        }
-        x++;
-    }
-
-    //assign the next 32-bit short MI from 4,5,6,7 so it'll match up with OTA late entry
-    if (state->currentslot == 0) {
-        next_mi = ((unsigned long long int)state->aes_iv[4] << 24) | ((unsigned long long int)state->aes_iv[5] << 16)
-                  | ((unsigned long long int)state->aes_iv[6] << 8) | ((unsigned long long int)state->aes_iv[7] << 0);
-    }
-    if (state->currentslot == 1) {
-        next_mi = ((unsigned long long int)state->aes_ivR[4] << 24) | ((unsigned long long int)state->aes_ivR[5] << 16)
-                  | ((unsigned long long int)state->aes_ivR[6] << 8) | ((unsigned long long int)state->aes_ivR[7] << 0);
-    }
+    uint8_t* iv = state->currentslot == 0 ? state->aes_iv : state->aes_ivR;
+    const uint32_t mi = (uint32_t)(state->currentslot == 0 ? state->payload_mi : state->payload_miR);
+    const unsigned long long int next_mi = dmr_aes_expand_iv(mi, iv);
+    int x;
 
     if (state->currentslot == 0) {
         DSD_FPRINTF(stderr, "%s", KYEL);

--- a/src/protocol/nxdn/nxdn_element.c
+++ b/src/protocol/nxdn/nxdn_element.c
@@ -29,6 +29,7 @@
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/crypto/aes.h>
 #include <dsd-neo/crypto/des.h>
+#include <dsd-neo/crypto/nxdn_keystream.h>
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/protocol/nxdn/nxdn.h>
 #include <dsd-neo/protocol/nxdn/nxdn_alias_decode.h>
@@ -98,8 +99,6 @@ static void nxdn_element_handle_vcall(dsd_opts* opts, dsd_state* state, const ui
 static void nxdn_element_handle_disc(dsd_opts* opts, dsd_state* state, const uint8_t* elements, size_t elements_bits);
 static void nxdn_element_handle_vcall_iv(dsd_opts* opts, dsd_state* state, const uint8_t* elements,
                                          size_t elements_bits);
-static void nxdn_pdu_scrambler_keystream_creation(uint8_t* ks, int lfsr, int len_bits);
-static void nxdn_lfsr128_expand_iv_from_mi64(uint64_t mi, uint8_t out[16]);
 static int nxdn_load_data_aes_key(const dsd_state* state, uint8_t key_id, uint8_t out_key[32]);
 static void nxdn_sdcall_header(const dsd_opts* opts, dsd_state* state, const uint8_t* Message);
 static void nxdn_dcall_header(const dsd_opts* opts, dsd_state* state, const uint8_t* Message, size_t message_bits);
@@ -573,40 +572,6 @@ nxdn_data_call_option_to_str(uint8_t data_call_option, char* duplex, size_t dupl
     if (mode != NULL && mode_sz > 0U) {
         const char* mode_str = modes[data_call_option & 0x0FU];
         DSD_SNPRINTF(mode, mode_sz, "%s", mode_str);
-    }
-}
-
-static void
-nxdn_pdu_scrambler_keystream_creation(uint8_t* ks, int lfsr, int len_bits) {
-    if (ks == NULL || len_bits <= 0) {
-        return;
-    }
-
-    for (int i = 0; i < len_bits; i++) {
-        ks[i] = (uint8_t)(lfsr & 0x1);
-        const int bit = ((lfsr >> 1) ^ (lfsr >> 0)) & 1;
-        lfsr = (lfsr >> 1) | (bit << 14);
-    }
-}
-
-static void
-nxdn_lfsr128_expand_iv_from_mi64(uint64_t mi, uint8_t out[16]) {
-    if (out == NULL) {
-        return;
-    }
-
-    DSD_MEMSET(out, 0, 16U);
-    uint64_t lfsr = mi;
-    for (int i = 0; i < 8; i++) {
-        out[i] = (uint8_t)((lfsr >> (56 - (i * 8))) & 0xFFU);
-    }
-
-    int x = 64;
-    for (int cnt = 0; cnt < 64; cnt++) {
-        uint64_t bit = ((lfsr >> 63) ^ (lfsr >> 61) ^ (lfsr >> 45) ^ (lfsr >> 37) ^ (lfsr >> 26) ^ (lfsr >> 14)) & 1U;
-        lfsr = (lfsr << 1) | bit;
-        out[x / 8] = (uint8_t)((out[x / 8] << 1) | (uint8_t)bit);
-        x++;
     }
 }
 

--- a/tests/core/test_core_mbe_file_io.c
+++ b/tests/core/test_core_mbe_file_io.c
@@ -6,24 +6,22 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
-#include <dsd-neo/core/ambe_interleave.h>
 #include <dsd-neo/core/bit_packing.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dibit.h>
 #include <dsd-neo/core/file_io.h>
 #include <dsd-neo/core/opts.h>
-#include <dsd-neo/core/parse.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/core/time_format.h>
 #include <dsd-neo/fec/block_codes.h>
-#include <dsd-neo/fec/dmr_late_entry.h>
 #include <dsd-neo/runtime/rdio_export.h>
 #include <errno.h>
 #include <sndfile.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #if DSD_PLATFORM_WIN_NATIVE
@@ -375,6 +373,11 @@ static int
 run_sdrtrunk_json(const char* json, dsd_opts* opts, dsd_state* state) {
     FILE* in = NULL;
     if (write_sdrtrunk_json_input(&in, json) != 0) {
+        return 1;
+    }
+    // Match openMbeInFile()'s four-byte cookie probe, including compact JSON.
+    if (fseek(in, 4L, SEEK_SET) != 0) {
+        fclose(in);
         return 1;
     }
     opts->mbe_in_f = in;
@@ -1112,47 +1115,6 @@ test_sdrtrunk_forced_rc4_reports_no_keystream_without_an_iv(void) {
     return rc;
 }
 
-// state->M forces ctx->alg_id to its own literal value for every state->M in 0x21..0x25
-// (sdrtrunk_json_apply_forced_algid()), but sdrtrunk_build_voice_keystream_bytes() only
-// recognizes 0xAA/0x21 (RC4), 0x81 (DES), and 0x84/0x89 (AES) -- none of which match DMR's own
-// forced-DES/AES numbering (0x22 DES, 0x24 AES-128, 0x25 AES-256) or the unused 0x23.
-// sdrtrunk_json_handle_mi() shares that same builder chain, so no path in this file can ever build
-// a keystream for a forced 0x22..0x25 replay today, regardless of whether the signaled key id and
-// MI are both valid. That is what makes the ctx->alg_id == 0x21 scope on the fix above safe rather
-// than merely convenient: an unscoped else would be a no-op for these values today, since
-// ctx->ks_available is already permanently 0 for them. This pins that today-truth, so it fails the
-// day sdrtrunk_build_voice_keystream_bytes() (or the 0x21 branches themselves) is widened to reach
-// these algids without the else being widened to match. The key id (3) and MI are the same valid,
-// imported ones the RC4 tests above use -- not an unkeyed record -- so a regression that wrongly
-// routed 0x22..0x25 through the RC4 path (rather than merely failing to build) would also be
-// caught here.
-static int
-test_sdrtrunk_forced_des_and_aes_never_report_a_keystream(void) {
-    int rc = 0;
-    static const int forced_algids[] = {0x22, 0x23, 0x24, 0x25};
-    static const char json[] = "{\"version\":\"2\",\"protocol\":\"DMR\",\"call_type\":\"GROUP\","
-                               "\"encrypted\":\"true\",\"encryption_key_id\":\"3\","
-                               "\"encryption_mi\":\"001122334455667788\",\"to\":\"4567\","
-                               "\"from\":\"456\",\"time\":\"1700000000000\","
-                               "\"hex\":\"000000000000000000\"}";
-
-    for (size_t i = 0; i < sizeof forced_algids / sizeof forced_algids[0]; i++) {
-        static dsd_state state;
-        unsigned char out[SDRTRUNK_MAP_RECORD_CAP];
-        size_t out_len = 0;
-        char tag[96];
-
-        DSD_MEMSET(&state, 0, sizeof state);
-        seed_sdrtrunk_dmr_replay_keys(&state);
-        state.M = forced_algids[i];
-        DSD_SNPRINTF(tag, sizeof tag, "sdrtrunk forced 0x%02x writes no keystream", forced_algids[i]);
-        rc |= capture_sdrtrunk_replay_records(tag, json, &state, out, sizeof out, &out_len);
-        dsd_state_ext_free_all(&state);
-        rc |= expect_true(tag, out_len == 0U);
-    }
-    return rc;
-}
-
 // With no matching row, the pre-existing implicit "key indexed by talkgroup" replay behavior
 // must be untouched -- replay workflows depend on it. That convention lives only in
 // sdrtrunk_json_apply_forced_algid()'s DMRA branch (state.M in 0x21..0x25): handle_mi has no
@@ -1641,130 +1603,167 @@ test_sdrtrunk_json_encrypted_keystreams_write_voice_records(void) {
     return rc;
 }
 
-static uint8_t
-bits_to_u4_msb(const unsigned char bits4[4]) {
-    uint8_t v = 0;
-    for (int i = 0; i < 4; i++) {
-        v = (uint8_t)((v << 1U) | (bits4[i] & 1U));
-    }
-    return (uint8_t)(v & 0xFU);
-}
+// NXDN TS 1-D v1.3 §§7.2.1.1–7.2.1.3: published EHR 1031 Hz tone vectors.
+// https://www.qsl.net/kb9mwr/projects/dv/nxdn/NXDN-TS-1-D_v0103.pdf
+// Ciphertext bytes also cross-checked against tylerwatt12/known-key-mbe-samples.
+static const char nxdn_scrambler_frames[][19] = {
+    "2AACF8C7CCA0847464", "EC8EFFD1275856A48A", "A080D29DACE081EC62", "9F14FDC32D06B1644D",
+    "B77DA530F731390CC8", "ACCC99F75320B0A406", "C1D05F6188840165EF", "F50AFDC53C4A556850",
+    "907962D490353263B8", "957B840478E876CE6C", "E286A4E7CEA481202E", "128CBD810B03F4A7E8",
+    "F55FF21A199D644020", "4F489C91B0A7882FDA", "DE2756A9C28A23CB8D", "0E8CBD835C2F1C3664",
+};
 
-static void
-fill_sdrtrunk_dmr_le_fragments(dsd_state* state, uint32_t mi32) {
-    uint8_t mi_bits32[32];
-    for (int i = 0; i < 32; i++) {
-        mi_bits32[i] = (uint8_t)((mi32 >> (31 - i)) & 1U);
-    }
-    const uint8_t crc = dsd_dmr_crc4(mi_bits32, 32);
+static const char nxdn_des_ofb_frames[][19] = {
+    "5A15117BC1A2267FA5", "FDB29C8B16A43BFC9B", "12119A8C7ED5F4712D", "5CD92943840389B3E7", "667F483093AE6E8012",
+    "2C7778404A1AC1299B", "EA0ABC8435BC2943A1", "403684D936BA5D8B82", "9046C209B217777E56", "45CCC260D1E3FE98CA",
+    "46AF37612AF2F3C919", "85B75E23B79D259597", "AE7A6D5784C22E53D7", "D6563E77F8652DF7D4", "98942BDC8857F4F52E",
+    "959829B3C31A9086D9", "7F9929683AC175A994", "8A5F512DD6F904E6D2", "BC1679CE445EE2B490", "4B7E315EEC9B1C534E",
+    "F27899AB1451775575", "0D5D2214E38AFC1CC4", "EAF96DA3D359FA44FB", "BC659A00CE74428F3E", "86A31BAC528074E403",
+    "0B621F54051A13994D", "31C5FB690EABA11D71", "3D2F3CFB6AD5A2C740", "57DE8320BE6E3F66E6", "ACFE50291649E11832",
+    "3F88465CD4C8440FF4", "D827718948CC6A04B1",
+};
 
-    unsigned char msg36[36];
-    unsigned char go36[36];
-    DSD_MEMSET(msg36, 0, sizeof msg36);
-    DSD_MEMSET(go36, 0, sizeof go36);
-    for (int i = 0; i < 32; i++) {
-        msg36[i] = (unsigned char)(mi_bits32[i] & 1U);
-    }
-    for (int i = 0; i < 4; i++) {
-        msg36[32 + i] = (unsigned char)((crc >> (3 - i)) & 1U);
-    }
+static const char nxdn_aes256_frames[][19] = {
+    "BD4503BDC7F187AF31", "72FFC7506DB58330D0", "5C0BC6F1471DDE572B", "17D7202AF5EA342472", "4AEF6528DA8145E9BD",
+    "916D09EC70C2D7E5FC", "15A25D968FD1A7F14E", "DB6E471655BBA93502", "6579296763DCF3F8CD", "4E97E1AB77B9C8E5C8",
+    "A1390C285695DB3667", "BBAE0D4F69A2FC8AFF", "2D60701DF171C735B7", "F40E8FB1BB3F9A558D", "7485751FE484A653BB",
+    "644E705B916A310BCF", "50DD37B40C5EBD3638", "6CB7C18B179DB8F2CB", "49245FCEB8D050735F", "7E2D9F89A6ED1FA25F",
+    "E894C53A4D7B5AFBBF", "2CB7A7B4B827B6BD42", "D1F438BC58B930432B", "664A0B0155CBE78BBC", "C683C9BAE6002F0D04",
+    "E8D8D9ACDA07ADE722", "79B5E87D9E41418C13", "E220F3E27131907C6B", "2948D6C1C2EFA230C0", "73B3D3BCFA3E3BB0C7",
+    "00D78E91160FD8FA75", "0FA9A6E8D5160D1F3C",
+};
 
-    for (int chunk = 0; chunk < 3; chunk++) {
-        unsigned char orig[12];
-        unsigned char enc[24];
-        DSD_MEMSET(orig, 0, sizeof orig);
-        DSD_MEMSET(enc, 0, sizeof enc);
-        for (int i = 0; i < 12; i++) {
-            orig[i] = (unsigned char)(msg36[chunk * 12 + i] & 1U);
-        }
-        Golay_24_12_encode(orig, enc);
-        for (int i = 0; i < 12; i++) {
-            go36[chunk * 12 + i] = (unsigned char)(enc[12 + i] & 1U);
-        }
-    }
-
-    for (int col = 0; col < 3; col++) {
-        for (int row = 0; row < 3; row++) {
-            const int bit_base = col * 12 + row * 4;
-            state->late_entry_mi_fragment[0][1 + row][col] = bits_to_u4_msb(&msg36[bit_base]);
-            state->late_entry_mi_fragment[0][4 + row][col] = bits_to_u4_msb(&go36[bit_base]);
+static dsd_state*
+nxdn_replay_test_state(unsigned cipher) {
+    static const unsigned long long keys[3][4] = {
+        {0x0000000000000001ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL},
+        {0xABCDEF0123456789ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL},
+        {0xABCDEF0123456789ULL, 0xCDEF0123456789ABULL, 0xEF0123456789ABCDULL, 0x0123456789ABCDEFULL}};
+    static const unsigned offsets[4] = {0, 0x101, 0x201, 0x301};
+    dsd_state* state = calloc(1, sizeof(*state));
+    if (state) {
+        state->keyloader = 1;
+        for (unsigned i = 0; i < 4U; i++) {
+            state->rkey_array[1U + offsets[i]] = keys[cipher - 1U][i];
+            state->rkey_array_loaded[1U + offsets[i]] = 1;
         }
     }
-}
-
-static uint8_t
-hex_char_to_nibble(char c) {
-    const int parsed = dsd_hex_nibble_value((unsigned char)c);
-    return (parsed < 0) ? 0U : (uint8_t)parsed;
-}
-
-static void
-set_sdrtrunk_dmr_hex_nibble_bit(char hex[19], int row, int col, uint8_t bit) {
-    if ((bit & 1U) == 0U) {
-        return;
-    }
-    for (int map_idx = 0; map_idx < DSD_AMBE_2450_DIBITS; map_idx++) {
-        const dsd_ambe_2450_dibit_map_entry* map = &dsd_ambe_2450_dibit_map[map_idx];
-        if (map->low_row == row && map->low_col == col) {
-            const int hex_idx = map_idx / 2;
-            const uint8_t mask = (map_idx % 2 == 0) ? 0x4U : 0x1U;
-            const uint8_t nibble = hex_char_to_nibble(hex[hex_idx]);
-            static const char lut[] = "0123456789ABCDEF";
-            hex[hex_idx] = lut[(nibble | mask) & 0xFU];
-            return;
-        }
-    }
-}
-
-static void
-build_sdrtrunk_dmr_late_entry_hex(uint8_t nibble, char hex[19]) {
-    DSD_MEMSET(hex, '0', 18);
-    hex[18] = '\0';
-    for (int bit_idx = 0; bit_idx < 4; bit_idx++) {
-        set_sdrtrunk_dmr_hex_nibble_bit(hex, 3, bit_idx, (uint8_t)((nibble >> (3 - bit_idx)) & 1U));
-    }
+    return state;
 }
 
 static int
-test_sdrtrunk_json_dmr_late_entry_updates_mi(void) {
-    int rc = 0;
-    const uint32_t mi = 0xA1B2C3D4U;
-    static dsd_state encoded;
-    static dsd_state state;
-    static dsd_opts opts;
-    static Event_History_I history[2];
-
-    DSD_MEMSET(&encoded, 0, sizeof encoded);
-    DSD_MEMSET(&state, 0, sizeof state);
-    DSD_MEMSET(&opts, 0, sizeof opts);
-    DSD_MEMSET(history, 0, sizeof history);
-    fill_sdrtrunk_dmr_le_fragments(&encoded, mi);
-
-    char json[768];
-    size_t used = 0;
-    used += (size_t)DSD_SNPRINTF(json + used, sizeof(json) - used,
-                                 "{\"version\":\"2\",\"protocol\":\"DMR\",\"encrypted\":\"true\",");
-    for (uint8_t vc = 1; vc <= 6; vc++) {
-        for (uint8_t col = 0; col < 3; col++) {
-            char hex[19];
-            build_sdrtrunk_dmr_late_entry_hex((uint8_t)encoded.late_entry_mi_fragment[0][vc][col], hex);
-            used += (size_t)DSD_SNPRINTF(json + used, sizeof(json) - used, "\"hex\":\"%s\",", hex);
-        }
+expect_nxdn_tone_records(const unsigned char* records, size_t size, size_t frames) {
+    static const unsigned char tone[7] = {0xFE, 0xE2, 0x12, 0x12, 0x12, 0x10, 0x00};
+    int rc = expect_true("NXDN decoded frame count", size == frames * 8U);
+    if (rc) {
+        return rc;
     }
-    rc |= expect_true("sdrtrunk dmr late entry json buffer", used + 2 < sizeof json);
-    json[used - 1] = '}';
-    json[used] = '\0';
+    for (size_t i = 0; i < frames; i++) {
+        rc |= expect_true("NXDN decrypted 1031 Hz tone bits", memcmp(records + i * 8U + 1U, tone, sizeof(tone)) == 0);
+    }
+    return rc;
+}
 
-    opts.playfiles = 1;
-    opts.floating_point = 1;
-    state.event_history_s = history;
-    state.M = 0x21;
-    state.R = 0x0102030405ULL;
+static int
+test_sdrtrunk_nxdn_published_voice_vectors(void) {
+    static const struct {
+        const char (*frames)[19];
+        size_t count;
+        size_t repeat;
+    } vectors[] = {
+        {nxdn_scrambler_frames, 16, 4},
+        {nxdn_des_ofb_frames, 32, 1},
+        {nxdn_aes256_frames, 32, 1},
+    };
 
-    rc |= run_sdrtrunk_json(json, &opts, &state);
-    rc |= expect_int("sdrtrunk dmr late entry synctype", state.synctype, DSD_SYNC_DMR_BS_DATA_POS);
-    rc |= expect_int("sdrtrunk dmr late entry algid", state.payload_algid, 0x21);
-    rc |= expect_u64("sdrtrunk dmr late entry mi", state.payload_mi, 0xDAB4A1A7ULL);
+    int rc = 0;
+    for (unsigned c = 0; c < 3U; c++) {
+        dsd_state* state = nxdn_replay_test_state(c + 1U);
+        if (!state) {
+            return 1;
+        }
+        char json[12000];
+        size_t off = (size_t)DSD_SNPRINTF(json, sizeof(json),
+                                          "{\"protocol\":\"NXDN\",\"version\":2,\"encrypted\":true,"
+                                          "\"encryption_algorithm\":%u,\"encryption_key_id\":1,",
+                                          c + 1U);
+        if (c != 0U) {
+            off += (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, "\"encryption_mi\":\"ABCDEF1234567890\",");
+        }
+        off += (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, "\"frames\":[");
+        const size_t total = vectors[c].count * vectors[c].repeat;
+        for (size_t i = 0; i < total; i++) {
+            off += (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, "%s{", i ? "," : "");
+            if (i % 4U == 0U) {
+                off += (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, "\"tag\":\"SACCH %u\",",
+                                            (unsigned)((i / 4U) % 4U + 1U));
+            }
+            off += (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, "\"hex\":\"%s\"}",
+                                        vectors[c].frames[i % vectors[c].count]);
+        }
+        (void)DSD_SNPRINTF(json + off, sizeof(json) - off, "]}");
+        unsigned char records[64U * 8U];
+        size_t size = 0;
+        rc |= capture_sdrtrunk_replay_records("NXDN published vector", json, state, records, sizeof(records), &size);
+        rc |= expect_nxdn_tone_records(records, size, total);
+        // A manual key disarms the keyloader without clearing the old CSV contents.
+        // Stale indexed material must not override the newly selected manual key.
+        state->R = state->rkey_array[1];
+        state->K1 = state->rkey_array[1];
+        state->K2 = state->rkey_array[1 + 0x101];
+        state->K3 = state->rkey_array[1 + 0x201];
+        state->K4 = state->rkey_array[1 + 0x301];
+        state->rkey_array[1] ^= 0x10U;
+        state->keyloader = 0;
+        rc |= capture_sdrtrunk_replay_records("NXDN manual key overrides stale CSV", json, state, records,
+                                              sizeof(records), &size);
+        rc |= expect_nxdn_tone_records(records, size, total);
+        dsd_state_ext_free_all(state);
+        free(state);
+    }
+    return rc;
+}
+
+static int
+test_sdrtrunk_nxdn_missing_context_and_sacch_alignment(void) {
+    static const char missing_iv[] = "{\"protocol\":\"NXDN\",\"version\":2,\"encrypted\":true,"
+                                     "\"encryption_algorithm\":3,\"encryption_key_id\":1,"
+                                     "\"hex\":\"BD4503BDC7F187AF31\"}";
+    static const char missing_key[] = "{\"protocol\":\"NXDN\",\"version\":2,\"encrypted\":true,"
+                                      "\"encryption_algorithm\":3,\"encryption_key_id\":1,"
+                                      "\"encryption_mi\":\"ABCDEF1234567890\",\"frames\":["
+                                      "{\"hex\":\"BD4503BDC7F187AF31\"},"
+                                      "{\"encryption_key_id\":2,\"hex\":\"72FFC7506DB58330D0\"}]}";
+    dsd_state* state = nxdn_replay_test_state(3);
+    if (!state) {
+        return 1;
+    }
+    unsigned char records[32];
+    size_t size = 0;
+    int rc = capture_sdrtrunk_replay_records("NXDN missing IV", missing_iv, state, records, sizeof(records), &size);
+    rc |= expect_true("NXDN missing IV stays muted", size == 0U);
+    rc |= capture_sdrtrunk_replay_records("NXDN changed to unloaded key", missing_key, state, records, sizeof(records),
+                                          &size);
+    rc |= expect_nxdn_tone_records(records, size, 1U);
+    dsd_state_ext_free_all(state);
+    free(state);
+
+    dsd_state* scrambler_state = nxdn_replay_test_state(1);
+    if (!scrambler_state) {
+        return 1;
+    }
+    char json[512];
+    DSD_SNPRINTF(json, sizeof(json),
+                 "{\"protocol\":\"NXDN\",\"version\":2,\"encrypted\":true,"
+                 "\"encryption_algorithm\":1,\"encryption_key_id\":1,\"frames\":["
+                 "{\"tag\":\"SACCH 1\",\"hex\":\"%s\"},"
+                 "{\"tag\":\"SACCH 3\",\"hex\":\"%s\"}]}",
+                 nxdn_scrambler_frames[0], nxdn_scrambler_frames[8]);
+    rc |= capture_sdrtrunk_replay_records("NXDN skipped SACCH positions", json, scrambler_state, records,
+                                          sizeof(records), &size);
+    rc |= expect_nxdn_tone_records(records, size, 2U);
+    dsd_state_ext_free_all(scrambler_state);
+    free(scrambler_state);
     return rc;
 }
 
@@ -2515,6 +2514,164 @@ test_close_and_rename_wav_exports_rdio_sidecar(void) {
     return rc;
 }
 
+// Baofeng DM-32 captures from tylerwatt12/known-key-mbe-samples, revision
+// 2e15b86e305b7a3c71d52873518e2908747f6e09. Expected AMBE bits independently
+// checked with OpenSSL-backed AES/OFB and an RFC 6229-checked RC4 reference.
+static const char dmr_aes128_capture[][19] = {
+    "67282ED2DE24B6ADF5", "E63B68A8256257D9FF", "2A10FDEAAE02A6F5F2", "EEAC6AF93E74715054", "4E25455B03288D2BC6",
+    "FD0E031C4F91AA0D54", "E2B8C59F9C7CDC481A", "A9A128BA109CB802EA", "0854F0218F90E7DDC5", "95EE50B6FD6A8A28CC",
+    "151C7C77FC2C194CA2", "2DD813AD248AB7A3B2", "DB5E4E3C706AB0FCFC", "E6E88A8DA3B4F1DF95", "E4978DD01A68808530",
+    "5CE3185C5B63DC1F06", "B25E4C67FE32AE2398", "AFBC1307A022CBD958", "598F77265446FDE5AB", "D4C7D9F7FAA268298C",
+    "79147ED9DBA532751A", "137AE51A7FAA8C0309", "62325649F9DB6D0AFC", "6CA9FF606927809373", "E5EC46EA7B2A07AB1E",
+    "DD199288FB2F4D6177", "ED6971CA7069161497", "CEC9EC8B7106F7187C", "FA47C6EBFF75B2892E", "1206C57D5395E60EC1",
+    "71C26BC6B446E52FAB", "09628FE7FB6DE843BD", "439C6365FF2D2BDB29", "7621D886390BE1F388", "7E2B61BDF800F8E1E3",
+    "843DF668456D309A94", "AAD4F6D67093A12D30", "49387969E3FE39DE4B", "43BCB888EC466A071E", "978F4C7E153592F35B",
+};
+
+static const char dmr_aes256_capture[][19] = {
+    "978497BE91C3112AF3", "751981A381ECFA91A5", "ACBDA449FD0AEE79E3", "003DE8D7681FAD7C0D", "C1DB62EAF8E674E290",
+    "DAAC06D3CA7F9789FA", "C80E054A8493E2C62E", "D8D4EB84F13667157E", "DA225992D2933978CC", "EDB245AA13F7B04A82",
+    "002713273747005632", "8A114DFB40B4E7BA7E", "D9C915BCBC3313154B", "21ABC85FF93CA3C079", "B939503297C6F17A24",
+    "D9CA5689F2E9C4DA71", "372F4659F8FA01E51C", "C82EFB1FD7974B7752", "E9DAF61ACFCB0A05D3", "9FDDDC39FA86BD3327",
+    "6AFD22D1C1132F3C9F", "C744C4DDAF1B4E3E95",
+};
+
+static const char dmr_arc4_capture[][19] = {
+    "542736E0D4F0548357", "275B21BDD1608A9BFB", "BF1B30FD161795772D", "463A5B0984D5AA49B7", "8C927784D5A40DFA75",
+    "88E6419929FEF1D9DC", "D113059D16A11466B8", "D5DC079A0484A27742", "2B69FE8E947D8B9D2D", "42FD131D5A07057E07",
+    "64A28364FCFA6DBBDC", "74E5C37B433C58ED23", "429DB9FDFB010A627E", "84FB372BF8629C2F2D", "5184E1CB3183167254",
+    "A72307D35CC1855B27", "D21DF08AF8007CD964", "BEB17DCDA7607460FC", "DFE2B135BEAA505159", "808BD61CFA059EE7B5",
+    "C131FC61728C069AEC", "B273815A2711EC43A9", "891D325727C63830AB", "85EF4296E959EE0FE9", "09095BFF30D45477D6",
+    "B06A21C6FC8FC19AF7", "0FF29FB4DFCF7FFE1F", "0C743687174D931747", "49E531DA41DFEB6B45", "6DF906A6C189696753",
+    "9CA46D9E2BED68B77E", "A5D0BCAAA308BD49EC", "5079D0168EA801829B", "33CBFA0400BE38FB28", "191078C0E10EE6360A",
+    "A946685C02A19B3B80", "8A31C9A73B9DE058B6", "2AAB8886FEB03F7B98", "C9B9536F7A6480AA39", "DB91186FD0C2FD9C67",
+};
+
+static int
+test_sdrtrunk_dmr_capture_and_late_entry(void) {
+    static const struct {
+        const char (*frames)[19];
+        size_t first;
+        unsigned alg;
+        unsigned kid;
+        uint32_t mi;
+        unsigned long long key[4];
+        unsigned char plaintext[4][7];
+    } cases[] = {{dmr_aes128_capture,
+                  36,
+                  0x24,
+                  0x0002,
+                  0xAA6A4E7FU,
+                  {0x0000000000000000ULL, 0xBCDEFA1234567890ULL, 0x0000000000000000ULL, 0x0000000000000000ULL},
+                  {{0xE8, 0x12, 0x6E, 0x67, 0x87, 0x2A, 0x00},
+                   {0xE8, 0x10, 0xDF, 0x89, 0xE7, 0x77, 0x01},
+                   {0xF8, 0x28, 0xF0, 0x51, 0x8C, 0xCA, 0x00},
+                   {0xF8, 0x2B, 0x06, 0x5E, 0x04, 0x7D, 0x00}}},
+                 {dmr_aes256_capture,
+                  18,
+                  0x25,
+                  0x0001,
+                  0x090A47B6U,
+                  {0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL, 0xABCDEF1234567890ULL},
+                  {{0xF8, 0x1D, 0xF9, 0x9D, 0xAC, 0xA7, 0x01},
+                   {0xF8, 0x1D, 0xF3, 0xC1, 0xAC, 0x0D, 0x01},
+                   {0xF8, 0x1D, 0xF3, 0xC1, 0xAC, 0x28, 0x01},
+                   {0xF8, 0x16, 0x73, 0xC1, 0xA4, 0x3D, 0x00}}},
+                 {dmr_arc4_capture,
+                  36,
+                  0x21,
+                  0x0003,
+                  0xEA7E9D12U,
+                  {0x000000CDEFAB1234ULL, 0, 0, 0},
+                  {{0xF8, 0x1B, 0x10, 0x90, 0xEC, 0xB0, 0x00},
+                   {0xF8, 0x1D, 0x20, 0x90, 0xED, 0xA3, 0x01},
+                   {0xF8, 0x1D, 0x20, 0x90, 0xEC, 0xB6, 0x01},
+                   {0xF8, 0x17, 0x30, 0x90, 0xEC, 0xB6, 0x00}}}};
+
+    static const unsigned offsets[4] = {0, 0x101, 0x201, 0x301};
+    int rc = 0;
+    InitAllFecFunction();
+    for (size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
+        for (int legacy = 0; legacy < 2; legacy++) {
+            dsd_state* state = calloc(1, sizeof(*state));
+            if (!state) {
+                return 1;
+            }
+            state->keyloader = legacy ? 0 : 1;
+            // Explicit metadata must override a conflicting forced fallback.
+            state->M = legacy ? (int)cases[c].alg : (cases[c].alg == 0x24 ? 0x25 : 0x24);
+            state->K1 = cases[c].key[0];
+            state->K2 = cases[c].key[1];
+            state->K3 = cases[c].key[2];
+            state->K4 = cases[c].key[3];
+            state->R = cases[c].key[0];
+            for (unsigned k = 0; k < 4U; k++) {
+                state->rkey_array[cases[c].kid + offsets[k]] = cases[c].key[k];
+                state->rkey_array_loaded[cases[c].kid + offsets[k]] = 1;
+            }
+            char json[4096];
+            size_t off =
+                (size_t)DSD_SNPRINTF(json, sizeof(json), "{\"protocol\":\"DMR\",\"version\":2,\"encrypted\":true,");
+            if (!legacy) {
+                // Metadata order differs from the producer: MI can precede ALG/KID.
+                off += (size_t)DSD_SNPRINTF(
+                    json + off, sizeof(json) - off,
+                    "\"encryption_mi\":\"%08X\",\"encryption_algorithm\":%u,\"encryption_key_id\":%u,", cases[c].mi,
+                    cases[c].alg, cases[c].kid);
+            }
+            off += (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, "\"frames\":[");
+            const size_t start = legacy ? 0U : cases[c].first;
+            for (size_t i = start; i < cases[c].first + 4U; i++) {
+                off += (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, "%s{\"hex\":\"%s\"}", i == start ? "" : ",",
+                                            cases[c].frames[i]);
+            }
+            (void)DSD_SNPRINTF(json + off, sizeof(json) - off, "]}");
+            unsigned char records[4U * 8U];
+            size_t size = 0;
+            rc |= capture_sdrtrunk_replay_records("DMR capture", json, state, records, sizeof(records), &size);
+            rc |= expect_true("DMR suppresses pre-context frames", size == sizeof(records));
+            for (size_t i = 0; i < 4U && size == sizeof(records); i++) {
+                rc |=
+                    expect_true("DMR capture plaintext", memcmp(records + i * 8U + 1U, cases[c].plaintext[i], 7U) == 0);
+            }
+            if (!legacy && cases[c].alg != 0x21) {
+                // An algorithm arriving after many context-less frames must not index
+                // past the LE fragment matrix and corrupt keys for later valid audio.
+                state->M = 0;
+                off = (size_t)DSD_SNPRINTF(json, sizeof(json),
+                                           "{\"protocol\":\"DMR\",\"version\":2,\"encrypted\":true,\"frames\":[");
+                for (unsigned i = 0; i < 45U; i++) {
+                    off += (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, "{\"hex\":\"000000000000000000\"},");
+                }
+                off += (size_t)DSD_SNPRINTF(
+                    json + off, sizeof(json) - off,
+                    "{\"encryption_algorithm\":%u,\"encryption_key_id\":%u,\"hex\":\"FFFFFFFFFFFFFFFFFF\"},",
+                    cases[c].alg, cases[c].kid);
+                for (unsigned i = 0; i < 3U; i++) {
+                    off += (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, "{\"hex\":\"FFFFFFFFFFFFFFFFFF\"},");
+                }
+                off +=
+                    (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, "{\"encryption_mi\":\"%08X\",\"hex\":\"%s\"}",
+                                         cases[c].mi, cases[c].frames[cases[c].first]);
+                for (size_t i = 1; i < 4U; i++) {
+                    off += (size_t)DSD_SNPRINTF(json + off, sizeof(json) - off, ",{\"hex\":\"%s\"}",
+                                                cases[c].frames[cases[c].first + i]);
+                }
+                (void)DSD_SNPRINTF(json + off, sizeof(json) - off, "]}");
+                rc |= capture_sdrtrunk_replay_records("late AES context", json, state, records, sizeof(records), &size);
+                rc |= expect_true("late AES context remains muted until IV", size == sizeof(records));
+                for (size_t i = 0; i < 4U && size == sizeof(records); i++) {
+                    rc |= expect_true("late AES context preserves subsequent plaintext",
+                                      memcmp(records + i * 8U + 1U, cases[c].plaintext[i], 7U) == 0);
+                }
+            }
+            dsd_state_ext_free_all(state);
+            free(state);
+        }
+    }
+    return rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -2530,7 +2687,6 @@ main(void) {
     rc |= test_sdrtrunk_json_dmr_tg_key_map_settles_regardless_of_algorithm_order();
     rc |= test_sdrtrunk_json_dmr_tg_key_map_keys_forced_algid_keystream();
     rc |= test_sdrtrunk_forced_rc4_reports_no_keystream_without_an_iv();
-    rc |= test_sdrtrunk_forced_des_and_aes_never_report_a_keystream();
     rc |= test_sdrtrunk_json_private_call_never_keeps_a_map_row();
     rc |= test_sdrtrunk_json_without_map_row_keeps_target_keyed_lookup();
     rc |= test_sdrtrunk_json_p25_replay_keyloader_uses_full_width_key_id();
@@ -2542,7 +2698,9 @@ main(void) {
     rc |= test_sdrtrunk_json_hex_voice_writes_unencrypted_mbe_records();
     rc |= test_sdrtrunk_json_hex_voice_blocks_encrypted_without_keystream();
     rc |= test_sdrtrunk_json_encrypted_keystreams_write_voice_records();
-    rc |= test_sdrtrunk_json_dmr_late_entry_updates_mi();
+    rc |= test_sdrtrunk_nxdn_published_voice_vectors();
+    rc |= test_sdrtrunk_nxdn_missing_context_and_sacch_alignment();
+    rc |= test_sdrtrunk_dmr_capture_and_late_entry();
     rc |= test_open_mbe_out_file_creates_slot_files_and_closes();
     rc |= test_truncated_reads_fail();
     rc |= test_open_mbe_in_file_classifies_cookies();

--- a/tests/fec/test_fec_bptc_rs.c
+++ b/tests/fec/test_fec_bptc_rs.c
@@ -124,6 +124,17 @@ test_bptc_128x77(void) {
     irr = BPTC_128x77_Extract_Data(mat_err, extracted);
     assert(irr == 0);
 
+    // An uncorrectable row must retain its received bits, not the previous row's
+    // decoded output. The block remains failed even when its checksum happens to match.
+    DSD_MEMCPY(mat_err, mat, sizeof(mat_err));
+    mat_err[1][0] ^= 1U;
+    mat_err[1][1] ^= 1U;
+    irr = BPTC_128x77_Extract_Data(mat_err, extracted);
+    assert(irr != 0);
+    for (int col = 0; col < 11; col++) {
+        assert(extracted[11 + col] == mat_err[1][col]);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
## Summary

- Add NXDN enhanced-half-rate SDRTrunk JSON MBE playback for clear voice, the 15-bit scrambler, DES-OFB, and AES-256-OFB, with SACCH positioning and encryption-session tracking.
- Add DMR AES-128/256 playback using serialized message indicators or Golay/CRC-verified late-entry context. Share IV expansion with live decoding without importing its state-changing side effects.
- Correct BPTC failed-row handling, compact JSON cookie offsets, manual-key versus stale-CSV precedence, explicit algorithm versus forced-fallback precedence, DMR RC4 IV packing/advancement, and late-entry fragment bounds.
- Add exact-plaintext regression coverage and update CLI, testing, and architecture documentation.

## Evidence

- [NXDN TS 1-D v1.3](https://www.qsl.net/kb9mwr/projects/dv/nxdn/NXDN-TS-1-D_v0103.pdf), sections 5.3–5.4 and 7.2, defines the cipher/session behavior and conformance vectors.
- [SDRTrunk's NXDN recorder](https://github.com/DSheirer/sdrtrunk/blob/master/src/main/java/io/github/dsheirer/module/decode/nxdn/audio/NXDNCallSequenceRecorder.java) establishes the producer format and SACCH tags.
- [Independent known-key captures](https://github.com/tylerwatt12/known-key-mbe-samples/tree/2e15b86e305b7a3c71d52873518e2908747f6e09) provide radio-derived DMR samples and standards-derived NXDN fixtures.
- Actual CLI playback produced the published 1031 Hz tone for 128 NXDN frames. Independent cipher calculations matched 738 DMR AES frames and 360 DMR RC4 frames; marked and metadata-free late-entry playback agreed after context recovery. The RC4 reference was checked against [RFC 6229](https://www.rfc-editor.org/rfc/rfc6229).

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [ ] Risky or broad changes have a second human reviewer, or the solo-maintainer exception and extra guardrails are documented.
- [x] High-risk areas touched: parser / crypto.
- [ ] Outside human review completed.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off.

Two independent automated reviews were completed and their actionable findings were fixed. Human review remains pending; the unchecked items above are intentional.

## Quality Review

- [x] Parser, decoder, and file-input changes include focused regression tests.
- [x] Protocol, crypto, and file-input behavior received extra scrutiny.
- [x] No new static-analysis suppressions were added.
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were introduced.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j8`
- [x] `ctest --preset dev-debug --output-on-failure -j8` — 617/617 passed.
- [x] Focused `CORE_MBE_FILE_IO` and `FEC_BPTC_RS` tests under `asan-ubsan-debug` — 2/2 passed.
- [x] `tools/preflight_ci.sh --base HEAD` before committing — all enabled checks passed for the complete change set.
- [x] `tools/cmake_format_check.sh --fix src/crypto/CMakeLists.txt`; final gersemi check passed in preflight.
- [x] Architecture rules, secret-redaction checks, clang-format, clang-tidy, cppcheck, IWYU, GCC fanalyzer, Semgrep, and complexity checks passed.
- [ ] `tools/quality_preflight.sh` — not run; optional scan-build was not enabled.
- Workflow and dependency-input changes: none; corresponding pin guardrails passed in preflight.

## Risk

- **Security/dependency impact:** No dependency changes. Encrypted frames without usable keys/context stay muted. Regression coverage includes stale key material and late-entry indexing that could otherwise corrupt later decoding.
- **CLI/UI behavior impact:** Extends existing `-r` playback and existing key/force options; no new switches or UI changes. Existing P25 behavior is retained and covered by the suite.
- **Compatibility or packaging impact:** New shared crypto helpers are included in the existing crypto target. NXDN full-rate playback is not supported. Exports omitting the positions of FACCH-stolen voice within an RF frame cannot reconstruct exact intra-frame alignment; this producer-format limitation is documented rather than guessed around.
- These checks establish file playback and crypto correctness, not RF reception or demodulator sensitivity. Reference PCM can differ across vocoder versions or synthesis histories; exact decrypted voice bits were used for comparisons.
