### PR TITLE
chore(release): bump version to 2.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(dsd-neo VERSION 2.8.1 LANGUAGES C CXX)
+project(dsd-neo VERSION 2.9.0 LANGUAGES C CXX)
 if(POLICY CMP0083)
     cmake_policy(SET CMP0083 NEW)
 endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "dsd-neo",
-  "version-string": "2.8.1",
+  "version-string": "2.9.0",
   "builtin-baseline": "9e593bb18ea69cc5095e012465dcd675a822ed0d",
   "description": "Digital Speech Decoder: DSD-neo",
   "homepage": "https://github.com/arancormonk/dsd-neo",


### PR DESCRIPTION
Updates CMake project and vcpkg manifest version metadata from 2.8.1 to 2.9.0. Validation: cmake --preset dev-debug succeeded; configured CMake version and vcpkg manifest both equal 2.9.0. Per maintainer request, merge without waiting for checks, then publish the signed v2.9.0 release tag.