### PR TITLE
fix(terminal): warn when -Z payload output will be suppressed

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -112,7 +112,11 @@ Tip: If paths or names contain spaces, wrap them in single quotes.
 - `--frontend terminal` Use the terminal UI (`-N` is the supported short alias)
 - `--frontend native` remains accepted and maps to headless mode. The retired native provider was a non-rendering
   scaffold; this keeps existing invocations working without restoring its provider/threading layer.
-- `-Z` Log MBE/PDU payloads to the console (verbose), including encrypted P25 voice frames when media is gated
+- `-Z` Log MBE/PDU payloads to stderr (verbose), including encrypted P25 voice frames when media is gated.
+  With `--frontend terminal` / `-N`, redirect stderr to capture them:
+  `dsd-neo -Z --frontend terminal 2> console_log.txt`. The terminal frontend suppresses stderr when it is a TTY
+  to protect the screen, and warns before opening the UI if payload logging is enabled without a redirect.
+  Already-redirected stderr is preserved; `--frontend none -Z` leaves console payload output visible.
 - `--frame-log <file>` Append one-line timestamped frame traces (separate from event log)
 - `--p25-sm-log <file>` Append one-line P25 state-machine decision diagnostics (separate from stdout/stderr, event log, and frame log)
 - `-O` List PulseAudio input sources and output sinks

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -2116,9 +2116,9 @@ dsd_parse_args(int argc, char** argv, dsd_opts* opts, dsd_state* state, int* out
             LOG_INFO("NOTICE: Trunking: Private call follow disabled.\n");                                             \
             break;                                                                                                     \
         case 'Z':                                                                                                      \
-            /* Log MBE/PDU payloads to console */                                                                      \
+            /* Log MBE/PDU payloads to stderr */                                                                       \
             opts->payload = 1;                                                                                         \
-            LOG_INFO("NOTICE: Logging MBE/PDU payloads to console.\n");                                                \
+            LOG_INFO("NOTICE: MBE/PDU payload logging to stderr enabled.\n");                                          \
             break;                                                                                                     \
         case 'N':                                                                                                      \
             /* Compatibility alias for --frontend terminal. */                                                         \

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -35,7 +35,8 @@ dsd_cli_usage_section_intro(void) {
     printf("                 native is accepted as a headless alias for the retired non-rendering scaffold\n");
     printf("                 dsd-neo --frontend terminal 2> console_log.txt\n");
     printf("  -N            Enable terminal frontend (alias for --frontend terminal)\n");
-    printf("  -Z            Log MBE/PDU Payloads to console\n");
+    printf("  -Z            Log MBE/PDU Payloads to stderr\n");
+    printf("                 Terminal frontend suppresses TTY stderr; capture with -Z -N 2> console_log.txt\n");
     printf("      --frame-log <file>    Append one-line timestamped frame trace output\n");
     printf("      --p25-sm-log <file>   Append P25 state-machine decision diagnostics\n");
     printf("  -^            Prefer P25 CC candidates (RFSS/Adjacent/Network) during hunt\n");

--- a/src/ui/terminal/dsd-neo/ui/ncurses.h
+++ b/src/ui/terminal/dsd-neo/ui/ncurses.h
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-void dsd_terminal_open(dsd_opts* opts, dsd_state* state);
+void dsd_terminal_open(const dsd_opts* opts, dsd_state* state);
 void dsd_terminal_render(dsd_opts* opts, dsd_state* state);
 void dsd_terminal_close(void);
 

--- a/src/ui/terminal/ncurses_init.c
+++ b/src/ui/terminal/ncurses_init.c
@@ -9,8 +9,10 @@
 
 #include <curses.h>
 #include <dsd-neo/core/constants.h>
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/platform/curses_compat.h>
 #include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/unicode.h>
 #include <dsd-neo/ui/ncurses.h>
 #include <stdio.h>
@@ -23,10 +25,16 @@ static int s_stderr_suppressed = 0;
 static int s_saved_stderr_fd = -1;
 
 void
-dsd_terminal_open(dsd_opts* opts, dsd_state* state) {
+dsd_terminal_open(const dsd_opts* opts, dsd_state* state) {
 
-    UNUSED(opts);
     UNUSED(state);
+
+    // Warn on the normal screen, before curses takes over or stderr is suppressed.
+    if (opts && opts->payload && !s_stderr_suppressed && dsd_isatty(dsd_fileno(stderr))) {
+        LOG_WARN("MBE/PDU payload logging (-Z) is enabled, but the terminal frontend suppresses stderr; "
+                 "re-run with 2> console_log.txt to capture payload output.\n");
+        fflush(stderr);
+    }
 
     // menu overlays are nonblocking and do not gate demod processing
     dsd_unicode_init_locale();
@@ -92,7 +100,6 @@ dsd_terminal_open(dsd_opts* opts, dsd_state* state) {
 
     noecho();
     cbreak();
-
     // When ncurses UI is active, suppress direct stderr logging to prevent
     // screen corruption from background fprintf calls in protocol paths.
     // This avoids mixed ncurses/stdio output overwriting the UI until resize.

--- a/src/ui/terminal/ui_async.c
+++ b/src/ui/terminal/ui_async.c
@@ -113,7 +113,7 @@ ui_open_curses_if_needed(void) {
     if (!dsd_opts_frontend_is_terminal(g_ui_opts)) {
         return 0;
     }
-    dsd_terminal_open(g_ui_opts, g_ui_state);
+    dsd_terminal_open(ui_get_opts_snapshot_or_default(), g_ui_state);
     return 1;
 }
 

--- a/tests/ui/test_ui_async_lifecycle.c
+++ b/tests/ui/test_ui_async_lifecycle.c
@@ -171,7 +171,7 @@ dsd_app_frontend_redraw_consume(void) {
 }
 
 void
-dsd_terminal_open(dsd_opts* opts, dsd_state* state) {
+dsd_terminal_open(const dsd_opts* opts, dsd_state* state) {
     (void)opts;
     (void)state;
     g_ncurses_open_calls++;

--- a/tests/ui/test_ui_ncurses_init.c
+++ b/tests/ui/test_ui_ncurses_init.c
@@ -7,14 +7,18 @@
  */
 
 #include <assert.h>
+#include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/platform/file_compat.h>
+#include <dsd-neo/runtime/log.h>
 #include <dsd-neo/runtime/unicode.h>
 #include <dsd-neo/ui/ncurses.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 
 #include "curses.h"
+#include "dsd-neo/core/opts_fwd.h"
 
 struct WINDOW {
     int unused;
@@ -49,6 +53,25 @@ static int g_fopen_private_calls;
 static const char* g_fopen_private_path;
 static const char* g_fopen_private_mode;
 static int g_unicode_init_calls;
+static int g_payload_warnings;
+
+void
+dsd_neo_log_write(dsd_neo_log_level_t level, const char* format, ...) {
+    char message[512];
+    va_list args;
+    va_start(args, format);
+    DSD_VSNPRINTF(message, sizeof(message), format, args);
+    va_end(args);
+
+    assert(level == LOG_LEVEL_WARN);
+    assert(strstr(message, "payload") != NULL);
+    assert(strstr(message, "stderr") != NULL);
+    assert(strstr(message, "2>") != NULL);
+    /* A warning inside the alternate screen or after redirection is lost. */
+    assert(g_initscr_calls == 0);
+    assert(g_dup2_calls == 0);
+    g_payload_warnings++;
+}
 
 WINDOW*
 initscr(void) {
@@ -225,6 +248,7 @@ reset_stubs(void) {
     g_fopen_private_path = NULL;
     g_fopen_private_mode = NULL;
     g_unicode_init_calls = 0;
+    g_payload_warnings = 0;
 }
 
 static void
@@ -247,6 +271,7 @@ test_non_tty_stderr_is_not_suppressed(void) {
     assert(g_dup2_calls == 0);
     assert(g_close_calls == 0);
     assert(g_endwin_calls == 1);
+    assert(g_payload_warnings == 0);
 }
 
 static void
@@ -271,6 +296,7 @@ test_tty_stderr_suppressed_once_and_restored(void) {
     assert(g_close_calls == 1);
     assert(g_closed_fd[0] == 42);
     assert(g_endwin_calls == 1);
+    assert(g_payload_warnings == 0);
 
     dsd_terminal_close();
     assert(g_dup2_calls == 2);
@@ -296,11 +322,37 @@ test_devnull_open_failure_closes_backup(void) {
     assert(g_endwin_calls == 1);
 }
 
+static void
+test_payload_warning_only_when_stderr_will_be_suppressed(void) {
+    static dsd_opts opts;
+    opts.payload = 1;
+
+    reset_stubs();
+    g_isatty_result = 1;
+    dsd_terminal_open(&opts, NULL);
+    dsd_terminal_open(&opts, NULL);
+    dsd_terminal_close();
+    assert(g_payload_warnings == 1);
+
+    reset_stubs();
+    dsd_terminal_open(&opts, NULL);
+    dsd_terminal_close();
+    assert(g_payload_warnings == 0);
+
+    reset_stubs();
+    opts.payload = 0;
+    g_isatty_result = 1;
+    dsd_terminal_open(&opts, NULL);
+    dsd_terminal_close();
+    assert(g_payload_warnings == 0);
+}
+
 int
 main(void) {
     test_non_tty_stderr_is_not_suppressed();
     test_tty_stderr_suppressed_once_and_restored();
     test_devnull_open_failure_closes_backup();
+    test_payload_warning_only_when_stderr_will_be_suppressed();
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #497.

- Warn before curses enters the alternate screen when payload logging is enabled and stderr is a TTY. The warning names `2> console_log.txt` and remains in normal terminal history rather than being swallowed or overwritten by the UI.
- Preserve the existing stderr suppression/restoration lifecycle and already-redirected stderr. No new output sink or option.
- Open the terminal frontend using the existing options-snapshot path rather than introducing a live read of mutable payload settings.
- Clarify stderr as the destination in the `-Z` notice/help and document capture beside the flag and in `docs/cli.md`.

## Issue validation

The report is supported by the relevant implementation paths: `src/runtime/cli/args.c` enables payload logging during parsing; `PrintIMBEData` / `PrintAMBEData` in `src/core/file/dsd_file.c` and the DMR PDU renderer write console payload output to stderr; `src/ui/terminal/ncurses_init.c` suppresses that stream when it is a TTY. Existing help documented redirection under the frontend but omitted the interaction beside `-Z`.

This applies to console/stderr output, not independent file sinks such as `--frame-log`. No radio-specification behavior or protocol interpretation is involved; no decoding changes or protocol assumptions are introduced.

## Review

- [x] Changes reviewed against surrounding module design and existing logging, safe-formatting, and snapshot conventions.
- [ ] Behavior, ownership boundaries, and failure modes reviewed by a human.
- [ ] Outside review requested when available, or unavailability documented.
- [x] DCO sign-off included.

Human review remains pending. Scope is terminal startup diagnostics and CLI wording; parser semantics, network input, crypto, dependencies, and workflows are unchanged.

## Tests and guardrails

- Added coverage to the existing `UI_NCURSES_INIT` executable: warning before screen takeover/redirection, once per open lifecycle, absent for redirected stderr and payload-disabled startup. It failed on the original source and passes with the fix.
- Built the CLI and focused test targets with the dev-debug preset.
- Passed `UI_NCURSES_INIT`, `UI_ASYNC_LIFECYCLE`, and `RUNTIME_CLI_FRONTEND` (3/3).
- Exercised the actual CLI under PTYs using `tests/fixtures/iq/p25p1_c4fm_vc.iq.json`; every replay exited 0:

| Frontend | `-Z` | stderr | Result |
| --- | --- | --- | --- |
| terminal | on | TTY | One warning before alternate-screen entry; payload output suppressed |
| terminal | on | file | No warning; 90 IMBE records captured |
| none | on | TTY | No warning; 90 IMBE records visible |
| terminal | off | TTY | No warning |

- Started the real interactive terminal frontend on idle UDP input; observed the warning followed by the rendered UI.
- Checked actual `-h` output for redirect guidance beside `-Z`.
- `tools/check_arch_rules.sh`: passed.
- Scoped clang-tidy on all four changed production translation units: clean for error diagnostics.
- Full CTest suite and broad quality preflight were not run. Push-hook results are recorded below.

## Risk

- Security/dependency impact: none; no new file sink or secret exposure path.
- CLI/UI impact: one actionable startup warning for terminal + payload logging + TTY stderr. Existing screen protection and explicit stderr redirection remain unchanged.
- Compatibility/packaging impact: no new options; the internal terminal-open options parameter is now const-correct. Curses initialization errors remain visible because suppression still occurs at its original point.

### Final push-hook results

All enabled pre-push checks passed: strict cppcheck, clang-tidy, IWYU, GCC fanalyzer, Semgrep, Lizard complexity, clang-format, architecture rules, CMake runtime-install destinations, secret redaction, workflow Git/download pins, and vcpkg overlay pins. Optional scan-build was not enabled. The hooks were not bypassed.
