### PR TITLE
fix(engine): isolate and repair DMR control-channel recovery

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -517,7 +517,7 @@ Notes
     group/private and encrypted-call policy. PDU data never refreshes its hold, so `-e` has no effect on that row.
     Phase 1 decode captures are available for replay checks, not proof of on-air target holds; Phase 2 conventional
     parking is untested on air.
-  - Voice-only scan (`--scan-voice-only` with the qualify/hold flags above): conventional targets hold only from
+  - Voice-only scan (`--scan-voice-only`): conventional targets hold only from
     decoded voice, with `dwell_ms` as the qualify window and `activity_hold_ms` as the hold; trunked targets are
     unchanged (control-only rotates after dwell) and show no `Voice:` marker on the status line. A conventional
     target shows `VOICE` while its call is active and `TAIL` after the call ends while the hold remains.
@@ -556,6 +556,8 @@ Notes
 - rigctl over TCP: `-U <port>` (SDR++ default 4532)
 - Set rigctl bandwidth (Hz): `-B <hertz>` (e.g., 7000–48000 by mode)
 - Hang time after voice/sync loss (seconds): `-t <secs>`
+  - This is not the idle dwell between `--trunk-scan` targets. DMR control/rest-channel acquisition has its own
+    two-second window; use target `dwell_ms` to budget each visit. See [trunk-scan timing](trunk-scan.md).
   - P25 Talk Complete, TDU, TDULC, MAC_END_PTT, MAC_IDLE, and MAC_HANGTIME mark a transmission boundary. They close
     that slot's media and start or refresh the traffic-carrier inactivity timer without returning to the control
     channel. A follow-up PTT/ACTIVE on the retained carrier opens a clean call epoch without retuning.

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -97,11 +97,14 @@ trust 1 (`trunk_scan_share_peer_idens()`), and `dsd_engine_p25_bandplan_export()
 `<dsd-neo/core/key_set.h>`, restoring the globals on unkeyed targets and at shutdown without touching the key epoch.
 
 Recovery ownership is checked at the P25 watchdog and engine frame-sync callback boundaries. Runtime trunk-scan
-hooks identify the parked protocol; P25's eligibility helper additionally preserves genuine standalone acquisition
-and voice contexts across sync loss. DMR owns its decoded CC heartbeat, two-second acquisition window, candidate
-probes and pending tune IDs inside each target's `dmr_sm_ctx_t`. Probe frequency is separate from the saved CC
+hooks identify the parked protocol. Outside trunk scan, validated control/grant evidence retains a protocol owner
+across sync loss; raw sync cannot evict it. Ownership is written and checked under the decoder/SM guard, so the
+watchdog predicate does not read the sync or CC-format hints modified by frame acquisition. DMR owns its decoded
+CC heartbeat, two-second acquisition window, candidate probes and pending tune IDs inside each target's `dmr_sm_ctx_t`. Probe frequency is separate from the saved CC
 anchor. Target entry and accepted CC return restart acquisition, preventing a previous call or probe from holding
-or retuning a newly parked target. The coordinator's idle dwell remains independent of protocol recovery.
+or retuning a newly parked target. Pending backend probes hold the target and disarm idle dwell; completion starts
+a fresh dwell. The subsequent decoded-acquisition wait counts toward dwell. DMR heartbeats use the completed
+tuning generation and frequency, avoiding blocking rigctl queries in the CSBK path.
 
 Tests: `tests/engine/test_engine_trunk_scan.c` (`ENGINE_TRUNK_SCAN`) and
 `tests/engine/test_engine_synced_trunk_scan_tick.c` (`ENGINE_SYNCED_TRUNK_SCAN_TICK`), and

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -98,7 +98,7 @@ trust 1 (`trunk_scan_share_peer_idens()`), and `dsd_engine_p25_bandplan_export()
 
 Recovery ownership is checked at the P25 watchdog and engine frame-sync callback boundaries. Runtime trunk-scan
 hooks identify the parked protocol. Outside trunk scan, validated control/grant evidence retains a protocol owner
-across sync loss; raw sync cannot evict it. Ownership is written and checked under the decoder/SM guard, so the
+across sync loss; raw sync cannot evict it. Ownership writes and watchdog reads share the decoder/SM guard, so the
 watchdog predicate does not read the sync or CC-format hints modified by frame acquisition. DMR owns its decoded
 CC heartbeat, two-second acquisition window, candidate probes and pending tune IDs inside each target's `dmr_sm_ctx_t`. Probe frequency is separate from the saved CC
 anchor. Target entry and accepted CC return restart acquisition, preventing a previous call or probe from holding

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -96,8 +96,16 @@ trust 1 (`trunk_scan_share_peer_idens()`), and `dsd_engine_p25_bandplan_export()
 `dsd_key_set` (key-file or direct-key columns) that the switch installs through the scan key swap in
 `<dsd-neo/core/key_set.h>`, restoring the globals on unkeyed targets and at shutdown without touching the key epoch.
 
+Recovery ownership is checked at the P25 watchdog and engine frame-sync callback boundaries. Runtime trunk-scan
+hooks identify the parked protocol; P25's eligibility helper additionally preserves genuine standalone acquisition
+and voice contexts across sync loss. DMR owns its decoded CC heartbeat, two-second acquisition window, candidate
+probes and pending tune IDs inside each target's `dmr_sm_ctx_t`. Probe frequency is separate from the saved CC
+anchor. Target entry and accepted CC return restart acquisition, preventing a previous call or probe from holding
+or retuning a newly parked target. The coordinator's idle dwell remains independent of protocol recovery.
+
 Tests: `tests/engine/test_engine_trunk_scan.c` (`ENGINE_TRUNK_SCAN`) and
-`tests/engine/test_engine_synced_trunk_scan_tick.c` (`ENGINE_SYNCED_TRUNK_SCAN_TICK`).
+`tests/engine/test_engine_synced_trunk_scan_tick.c` (`ENGINE_SYNCED_TRUNK_SCAN_TICK`), and
+`tests/engine/test_engine_dmr_cc_recovery.c` (`ENGINE_DMR_CC_RECOVERY`, real protocol/coordinator with simulated tuning).
 
 ### Per-channel decoder modes
 

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -96,13 +96,14 @@ trust 1 (`trunk_scan_share_peer_idens()`), and `dsd_engine_p25_bandplan_export()
 `dsd_key_set` (key-file or direct-key columns) that the switch installs through the scan key swap in
 `<dsd-neo/core/key_set.h>`, restoring the globals on unkeyed targets and at shutdown without touching the key epoch.
 
-Recovery ownership is checked at the P25 watchdog and engine frame-sync callback boundaries. Runtime trunk-scan
+Recovery ownership is checked at the P25 watchdog, DMR tick and engine frame-sync callback boundaries. Runtime trunk-scan
 hooks identify the parked protocol. Outside trunk scan, validated control/grant evidence retains a protocol owner
-across sync loss; raw sync cannot evict it. Ownership writes and watchdog reads share the decoder/SM guard, so the
+across sync loss; unrelated protocol decodes and raw sync cannot evict it. Ownership writes and watchdog reads share the decoder/SM guard, so the
 watchdog predicate does not read the sync or CC-format hints modified by frame acquisition. DMR owns its decoded
-CC heartbeat, two-second acquisition window, candidate probes and pending tune IDs inside each target's `dmr_sm_ctx_t`. Probe frequency is separate from the saved CC
-anchor. Target entry and accepted CC return restart acquisition, preventing a previous call or probe from holding
-or retuning a newly parked target. Pending backend probes hold the target and disarm idle dwell; completion starts
+CC heartbeat, six-second loss grace, two-second probe window and five-second backend deadline inside each
+target's `dmr_sm_ctx_t`. Probes honor avoids and revisit the saved CC anchor between alternate frequencies.
+Probe frequency is separate from the saved anchor until control or grant evidence confirms it. Target entry and accepted CC return restart acquisition, preventing a previous call or probe from holding
+or retuning a newly parked target. Pending backend probes hold the target and disarm idle dwell; completion or timeout starts
 a fresh dwell. The subsequent decoded-acquisition wait counts toward dwell. DMR heartbeats use the completed
 tuning generation and frequency, avoiding blocking rigctl queries in the CSBK path.
 

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -145,27 +145,32 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
 - `-t <seconds>` is voice/sync-loss hangtime, not the interval between trunk-scan targets. Zero does not
   bypass target dwell or control-channel acquisition. After a followed trunked call releases, a fresh idle
   dwell starts; repeated calls can keep a busy system parked.
-- DMR control/rest-channel acquisition and loss detection use a separate two-second window. An accepted
-  asynchronous tune starts that window when the backend completes. During a hunt, an explicit channel map
-  is tried in file order, skipping zero frequencies and entries matching the current probe (nonadjacent
-  duplicates can be revisited). Without a map, the known control channel and learned current-site candidates
-  are retried. If the only candidate is the frequency already received, acquisition keeps listening without
-  resetting demodulation. A pending backend probe holds the target past dwell; completion starts a fresh idle
-  dwell. The decoded-acquisition wait counts toward that dwell, so a short dwell may rotate away before every
-  candidate can be tried. Target hold allows recovery to continue on that system.
+- DMR allows six seconds without decoded control on a confirmed channel before hunting. Each probe gets
+  two seconds to acquire control after the backend completes its tune. An explicit channel map is tried in
+  file order, skipping zero frequencies, avoided rows, the current probe and adjacent duplicate frequencies.
+  The known control channel is revisited between alternate probes, limiting time away during a CRC fade.
+  Without a map, the known control channel and learned current-site candidates are retried. With no eligible
+  alternative, the receiver keeps listening without resetting demodulation. A pending backend probe holds
+  the target past dwell for at most five seconds; completion or timeout starts a fresh idle dwell. Timed-out
+  requests cannot accept late completion, and frames remain gated until a replacement tune succeeds.
+  The decoded-acquisition wait counts toward dwell, so a short dwell may rotate away before every candidate
+  can be tried. Target hold allows recovery to continue on that system.
 - A DMR probe does not replace the saved control frequency until accepted control signalling confirms it.
+  A validated grant received on a completed probe also establishes the return channel before following it.
   Valid TIII ALOHA/control-system short LC, Connect Plus control short LC, and mapped Capacity Plus rest status
   maintain their respective control/rest channels. Relaxed CRC heartbeats can retain an established channel,
   but cannot confirm a new probe. Heartbeats use completed tuner attribution without querying rigctl for each
   CSBK. An unresolved CC tune blocks grants and heartbeats until its matching request completes. A decoded
   move announcement can select the next control/rest channel.
   A busy Capacity Plus rest announcement is followed when no call owns the tuner, including when advertised
-  calls are blocked by policy. A followed call retains the tuner while the system is busy.
+  calls are blocked by policy. A followed call retains the tuner through its hangtime even when a status
+  announces no busy channels; its eventual return uses the announced rest channel.
+  XPT free-channel hops do not start dedicated control-channel acquisition.
   DMR state-machine logs at verbosity 1 or higher identify `cc-lost`, `cc-probe`, `cc-listen`, `decoded-cc`,
   and failed tunes. `decoded-cc` is logged on acquisition even when the SM was already in its CC state.
 - Standalone `-T` auto decoding also retains the validated P25 or DMR recovery owner through loss of sync.
-  A stray sync from another protocol cannot take ownership; validated signalling can. Explicit decoder modes
-  and trunk-scan target selection still constrain which protocol may recover.
+  Unrelated decodes and stray syncs cannot take ownership; validated P25/DMR control or grants can. Explicit
+  decoder modes and trunk-scan target selection still constrain which protocol may recover.
 - `--scan-voice-only`: conventional targets hold only from decoded voice media (headers and data no longer hold),
   with the per-target `dwell_ms` as the qualify window in which voice must appear and `activity_hold_ms` as the
   hold after the last voice frame, including when a terminator closes the call before the next scan tick; trunked

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -142,6 +142,19 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
 - `--trunk-scan-activity-hold-ms <ms>` sets the default hold time after allowed conventional DMR/P25/NXDN activity
   (NXDN96 and NXDN48 alike). Default: `1200`.
 - Per-target CSV values override these defaults.
+- `-t <seconds>` is voice/sync-loss hangtime, not the interval between trunk-scan targets. Zero does not
+  bypass target dwell or control-channel acquisition. After a followed trunked call releases, a fresh idle
+  dwell starts; repeated calls can keep a busy system parked.
+- DMR control/rest-channel acquisition and loss detection use a separate two-second window. An accepted
+  asynchronous tune starts that window when the backend completes. During a hunt, an explicit channel map
+  is tried in file order, skipping duplicate/zero frequencies; without one, the known control channel and
+  learned current-site candidates are retried. Idle target dwell includes acquisition time, so a short dwell
+  may rotate away before every candidate can be tried. Target hold allows recovery to continue on that system.
+- A DMR probe does not replace the saved control frequency until accepted control signalling confirms it.
+  Valid TIII ALOHA/control-system short LC, Connect Plus control short LC, and mapped Capacity Plus rest status
+  maintain their respective control/rest channels. Relaxed CRC heartbeats can retain an established channel,
+  but cannot confirm a new probe. A decoded move announcement can select the next control/rest channel.
+  Verbose DMR state-machine logs identify `cc-lost`, `cc-probe`, `decoded-cc`, and failed tunes.
 - `--scan-voice-only`: conventional targets hold only from decoded voice media (headers and data no longer hold),
   with the per-target `dwell_ms` as the qualify window in which voice must appear and `activity_hold_ms` as the
   hold after the last voice frame, including when a terminator closes the call before the next scan tick; trunked

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -147,14 +147,25 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
   dwell starts; repeated calls can keep a busy system parked.
 - DMR control/rest-channel acquisition and loss detection use a separate two-second window. An accepted
   asynchronous tune starts that window when the backend completes. During a hunt, an explicit channel map
-  is tried in file order, skipping duplicate/zero frequencies; without one, the known control channel and
-  learned current-site candidates are retried. Idle target dwell includes acquisition time, so a short dwell
-  may rotate away before every candidate can be tried. Target hold allows recovery to continue on that system.
+  is tried in file order, skipping zero frequencies and entries matching the current probe (nonadjacent
+  duplicates can be revisited). Without a map, the known control channel and learned current-site candidates
+  are retried. If the only candidate is the frequency already received, acquisition keeps listening without
+  resetting demodulation. A pending backend probe holds the target past dwell; completion starts a fresh idle
+  dwell. The decoded-acquisition wait counts toward that dwell, so a short dwell may rotate away before every
+  candidate can be tried. Target hold allows recovery to continue on that system.
 - A DMR probe does not replace the saved control frequency until accepted control signalling confirms it.
   Valid TIII ALOHA/control-system short LC, Connect Plus control short LC, and mapped Capacity Plus rest status
   maintain their respective control/rest channels. Relaxed CRC heartbeats can retain an established channel,
-  but cannot confirm a new probe. A decoded move announcement can select the next control/rest channel.
-  Verbose DMR state-machine logs identify `cc-lost`, `cc-probe`, `decoded-cc`, and failed tunes.
+  but cannot confirm a new probe. Heartbeats use completed tuner attribution without querying rigctl for each
+  CSBK. An unresolved CC tune blocks grants and heartbeats until its matching request completes. A decoded
+  move announcement can select the next control/rest channel.
+  A busy Capacity Plus rest announcement is followed when no call owns the tuner, including when advertised
+  calls are blocked by policy. A followed call retains the tuner while the system is busy.
+  DMR state-machine logs at verbosity 1 or higher identify `cc-lost`, `cc-probe`, `cc-listen`, `decoded-cc`,
+  and failed tunes. `decoded-cc` is logged on acquisition even when the SM was already in its CC state.
+- Standalone `-T` auto decoding also retains the validated P25 or DMR recovery owner through loss of sync.
+  A stray sync from another protocol cannot take ownership; validated signalling can. Explicit decoder modes
+  and trunk-scan target selection still constrain which protocol may recover.
 - `--scan-voice-only`: conventional targets hold only from decoded voice media (headers and data no longer hold),
   with the per-target `dwell_ms` as the qualify window in which voice must appear and `activity_hold_ms` as the
   hold after the last voice frame, including when a terminator closes the call before the next scan tick; trunked

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -457,8 +457,9 @@ struct dsd_state {
     unsigned long long int p2_cc; //p1 NAC
     unsigned long long int p2_siteid;
     unsigned long long int p2_rfssid;
-    long int p25_cc_freq;   // P25 control-channel frequency from network status
-    long int trunk_cc_freq; // generic trunk-owner control-channel frequency
+    long int p25_cc_freq;        // P25 control-channel frequency from network status
+    long int trunk_cc_freq;      // generic trunk-owner control-channel frequency
+    int trunk_recovery_protocol; // validated owner; runtime trunk-scan recovery enum, survives raw sync loss
     unsigned long long int edacs_site_id;
     time_t last_cc_sync_time;    //use this to start hunting for CC after signal lost
     time_t p25_last_cc_msg_time; //last decoded P25 control-channel message

--- a/include/dsd-neo/protocol/dmr/dmr_trunk_sm.h
+++ b/include/dsd-neo/protocol/dmr/dmr_trunk_sm.h
@@ -18,6 +18,7 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -93,6 +94,17 @@ typedef struct {
     double t_voice_m;   // Time of last voice activity
     double t_cc_sync_m; // Time of last CC sync
 
+    /* CC probes do not replace the confirmed/configured return destination.
+     * These fields live in each scan target's existing DMR context. */
+    long cc_freq_hz;
+    long cc_probe_freq_hz;
+    double cc_acquire_start_m;
+    double cc_retry_after_m;
+    uint64_t cc_tune_request_id;
+    int cc_acquiring;
+    int cc_confirmed;
+    int cc_hunt_index;
+
     // Configuration
     double hangtime_s;      // Hangtime after voice ends (default 2.0s)
     double grant_timeout_s; // Max wait for voice after grant (default 4.0s)
@@ -110,6 +122,16 @@ typedef struct {
  * @brief Initialize the DMR state machine context.
  */
 void dmr_sm_init_ctx(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state);
+
+/** Hand an accepted CC tune to the DMR owner. Clears outgoing voice/probe state;
+ * a nonzero request ID is resolved before starting the acquisition deadline. */
+void dmr_sm_begin_cc_acquisition(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state, long freq_hz,
+                                 uint64_t request_id);
+/** Accepted control/rest-channel evidence. Zero frequency queries the active
+ * tuner; a nonzero frequency must match the channel actually being received. */
+void dmr_sm_note_cc_activity(const dsd_opts* opts, dsd_state* state, long freq_hz);
+/** Retain an already confirmed CC only; never validate a probe from raw/relaxed evidence. */
+void dmr_sm_note_cc_heartbeat(const dsd_opts* opts, const dsd_state* state);
 
 /**
  * @brief Process an event and update state machine.

--- a/include/dsd-neo/protocol/dmr/dmr_trunk_sm.h
+++ b/include/dsd-neo/protocol/dmr/dmr_trunk_sm.h
@@ -18,6 +18,7 @@
 
 #include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -44,7 +45,7 @@ typedef enum {
     DMR_SM_EV_VOICE_SYNC, // Voice frame sync detected on slot
     DMR_SM_EV_DATA_SYNC,  // Data frame sync detected on slot
     DMR_SM_EV_RELEASE,    // P_CLEAR or slot termination
-    DMR_SM_EV_CC_SYNC,    // Control channel sync acquired
+    DMR_SM_EV_CC_SYNC,    // Raw sync: retain an established CC, never confirm acquisition
     DMR_SM_EV_SYNC_LOST,  // Sync lost
 } dmr_sm_event_type_e;
 
@@ -98,6 +99,8 @@ typedef struct {
      * These fields live in each scan target's existing DMR context. */
     long cc_freq_hz;
     long cc_probe_freq_hz;
+    long cc_rx_freq_hz; // Completed tune or decoded attribution at cc_rx_generation
+    uint64_t cc_rx_generation;
     double cc_acquire_start_m;
     double cc_retry_after_m;
     uint64_t cc_tune_request_id;
@@ -127,8 +130,12 @@ void dmr_sm_init_ctx(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* s
  * a nonzero request ID is resolved before starting the acquisition deadline. */
 void dmr_sm_begin_cc_acquisition(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state, long freq_hz,
                                  uint64_t request_id);
+/** Return to the explicit DMR control/rest frequency, clearing an obsolete P25
+ * alias only on acceptance. Preserve the previous destination on failure. */
+dsd_trunk_tune_result dmr_sm_return_to_cc(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, long freq_hz);
 /** Accepted control/rest-channel evidence. Zero frequency queries the active
- * tuner; a nonzero frequency must match the channel actually being received. */
+ * tuner only if no completed tune/decoded attribution is available for the
+ * current generation; nonzero frequency must match the received channel. */
 void dmr_sm_note_cc_activity(const dsd_opts* opts, dsd_state* state, long freq_hz);
 /** Retain an already confirmed CC only; never validate a probe from raw/relaxed evidence. */
 void dmr_sm_note_cc_heartbeat(const dsd_opts* opts, const dsd_state* state);

--- a/include/dsd-neo/protocol/dmr/dmr_trunk_sm.h
+++ b/include/dsd-neo/protocol/dmr/dmr_trunk_sm.h
@@ -103,6 +103,7 @@ typedef struct {
     uint64_t cc_rx_generation;
     double cc_acquire_start_m;
     double cc_retry_after_m;
+    double cc_tune_deadline_m;
     uint64_t cc_tune_request_id;
     int cc_acquiring;
     int cc_confirmed;
@@ -111,7 +112,7 @@ typedef struct {
     // Configuration
     double hangtime_s;      // Hangtime after voice ends (default 2.0s)
     double grant_timeout_s; // Max wait for voice after grant (default 4.0s)
-    double cc_grace_s;      // Wait before CC hunting (default 2.0s)
+    double cc_grace_s;      // Confirmed CC loss grace (default 6.0s; probes get 2.0s)
 
     // Initialized flag
     int initialized;

--- a/include/dsd-neo/protocol/p25/p25_cc_activity.h
+++ b/include/dsd-neo/protocol/p25/p25_cc_activity.h
@@ -12,6 +12,7 @@
 
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <time.h>
 #include "dsd-neo/core/state_fwd.h"
 
@@ -32,6 +33,7 @@ p25_sm_note_cc_activity(dsd_state* state) {
     if (!state) {
         return;
     }
+    dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_P25);
     const time_t now = time(NULL);
     const double now_m = dsd_time_now_monotonic_s();
     state->last_cc_sync_time = now;

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -308,10 +308,6 @@ typedef struct {
  * @param opts Decoder options (may be NULL for defaults).
  * @param state Decoder state (may be NULL).
  */
-/** Whether P25 owns recovery, including a retained acquisition/follow context
- * across sync loss. A declared non-P25 scan target always takes precedence. */
-int p25_sm_recovery_allowed(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state);
-
 void p25_sm_init_ctx(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state);
 
 /**

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -308,6 +308,10 @@ typedef struct {
  * @param opts Decoder options (may be NULL for defaults).
  * @param state Decoder state (may be NULL).
  */
+/** Whether P25 owns recovery, including a retained acquisition/follow context
+ * across sync loss. A declared non-P25 scan target always takes precedence. */
+int p25_sm_recovery_allowed(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state);
+
 void p25_sm_init_ctx(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state);
 
 /**

--- a/include/dsd-neo/runtime/trunk_scan_hooks.h
+++ b/include/dsd-neo/runtime/trunk_scan_hooks.h
@@ -69,11 +69,11 @@ typedef enum {
     DSD_TRUNK_RECOVERY_UNKNOWN = 0,
     DSD_TRUNK_RECOVERY_P25,
     DSD_TRUNK_RECOVERY_DMR,
-    DSD_TRUNK_RECOVERY_OTHER,
 } dsd_trunk_recovery_protocol;
 
-/** Publish validated protocol evidence under the decoder/SM guard (or while stopped). Raw sync
- * detection and no-carrier resets must not change this retained owner. */
+/** Publish validated protocol evidence under the decoder/SM guard (or while stopped).
+ * Only P25/DMR control or grant evidence transfers ownership. Other protocol decodes,
+ * raw sync detection and no-carrier resets must not change this retained owner. */
 void dsd_trunk_recovery_note_protocol(dsd_state* state, dsd_trunk_recovery_protocol protocol);
 
 /** Recovery ownership: a parked target overrides retained standalone ownership.

--- a/include/dsd-neo/runtime/trunk_scan_hooks.h
+++ b/include/dsd-neo/runtime/trunk_scan_hooks.h
@@ -64,9 +64,21 @@ void dsd_trunk_scan_hooks_set(dsd_trunk_scan_hooks hooks);
 
 void* dsd_trunk_scan_hook_p25_ctx(void);
 void* dsd_trunk_scan_hook_dmr_ctx(void);
-/** Recovery ownership: a parked target overrides stale sync/frequency state.
- * Call while holding the decoder/SM guard. Outside trunk scan, decoded protocol
- * and the enabled decoder class determine eligibility. */
+
+typedef enum {
+    DSD_TRUNK_RECOVERY_UNKNOWN = 0,
+    DSD_TRUNK_RECOVERY_P25,
+    DSD_TRUNK_RECOVERY_DMR,
+    DSD_TRUNK_RECOVERY_OTHER,
+} dsd_trunk_recovery_protocol;
+
+/** Publish validated protocol evidence under the decoder/SM guard. Raw sync
+ * detection and no-carrier resets must not change this retained owner. */
+void dsd_trunk_recovery_note_protocol(dsd_state* state, dsd_trunk_recovery_protocol protocol);
+
+/** Recovery ownership: a parked target overrides retained standalone ownership.
+ * Call while holding the decoder/SM guard. These predicates do not read volatile
+ * sync, modulation or CC hints written outside that guard by frame acquisition. */
 int dsd_trunk_p25_recovery_allowed(const dsd_opts* opts, const dsd_state* state);
 int dsd_trunk_dmr_recovery_allowed(const dsd_opts* opts, const dsd_state* state);
 void dsd_trunk_scan_hook_tick(dsd_opts* opts, dsd_state* state);

--- a/include/dsd-neo/runtime/trunk_scan_hooks.h
+++ b/include/dsd-neo/runtime/trunk_scan_hooks.h
@@ -72,12 +72,13 @@ typedef enum {
     DSD_TRUNK_RECOVERY_OTHER,
 } dsd_trunk_recovery_protocol;
 
-/** Publish validated protocol evidence under the decoder/SM guard. Raw sync
+/** Publish validated protocol evidence under the decoder/SM guard (or while stopped). Raw sync
  * detection and no-carrier resets must not change this retained owner. */
 void dsd_trunk_recovery_note_protocol(dsd_state* state, dsd_trunk_recovery_protocol protocol);
 
 /** Recovery ownership: a parked target overrides retained standalone ownership.
- * Call while holding the decoder/SM guard. These predicates do not read volatile
+ * Decoder-thread callers may inspect their retained owner directly; other threads
+ * must hold the decoder/SM guard. These predicates do not read volatile
  * sync, modulation or CC hints written outside that guard by frame acquisition. */
 int dsd_trunk_p25_recovery_allowed(const dsd_opts* opts, const dsd_state* state);
 int dsd_trunk_dmr_recovery_allowed(const dsd_opts* opts, const dsd_state* state);

--- a/include/dsd-neo/runtime/trunk_scan_hooks.h
+++ b/include/dsd-neo/runtime/trunk_scan_hooks.h
@@ -64,6 +64,11 @@ void dsd_trunk_scan_hooks_set(dsd_trunk_scan_hooks hooks);
 
 void* dsd_trunk_scan_hook_p25_ctx(void);
 void* dsd_trunk_scan_hook_dmr_ctx(void);
+/** Recovery ownership: a parked target overrides stale sync/frequency state.
+ * Call while holding the decoder/SM guard. Outside trunk scan, decoded protocol
+ * and the enabled decoder class determine eligibility. */
+int dsd_trunk_p25_recovery_allowed(const dsd_opts* opts, const dsd_state* state);
+int dsd_trunk_dmr_recovery_allowed(const dsd_opts* opts, const dsd_state* state);
 void dsd_trunk_scan_hook_tick(dsd_opts* opts, dsd_state* state);
 /**
  * @brief Report decoded conventional DMR/NXDN/P25 activity to the scan coordinator.

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -985,6 +985,7 @@ init_state_p25_and_trunk_defaults(dsd_state* state) {
     state->p25_chan_iden = 0;
 
     //values displayed in ncurses terminal
+    state->trunk_recovery_protocol = 0;
     state->p25_cc_freq = 0;
     state->p25_last_cc_msg_time = 0;
     state->p25_last_cc_msg_time_m = 0.0;

--- a/src/dsp/dsd_frame_sync.c
+++ b/src/dsp/dsd_frame_sync.c
@@ -3581,7 +3581,6 @@ frame_sync_no_sync_try_p25_release(dsd_opts* opts, dsd_state* state, time_t now)
     frame_sync_p25_slot_activity(opts, state, now, fallback_nowm, mac_hold, ring_hold, dt, &left_active, &right_active);
     int both_slots_idle = (!is_p2_vc) ? 1 : !(left_active || right_active);
     if (dt >= opts->trunk_hangtime && both_slots_idle && dt_since_tune >= vc_grace) {
-        state->p25_sm_force_release = 1;
         dsd_frame_sync_hook_p25_sm_release(opts, state);
     }
 }

--- a/src/engine/dispatch/protocol_dispatch.c
+++ b/src/engine/dispatch/protocol_dispatch.c
@@ -4,13 +4,9 @@
  */
 
 #include <dsd-neo/core/state.h>
-#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/protocol_dispatch.h>
-#include <dsd-neo/runtime/trunk_scan_hooks.h>
-#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stddef.h>
-#include <stdint.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -48,16 +44,7 @@ processFrame(dsd_opts* opts, dsd_state* state) {
 
     const dsd_protocol_handler* handler = dsd_find_protocol_handler(state->synctype);
     if (handler != NULL && handler->handle_frame != NULL) {
-        const int sync = state->synctype;
-        const uint64_t generation = dsd_trunk_tuning_generation();
         state->sps_hunt_last_frame_verdict = (int)handler->handle_frame(opts, state);
-        /* These handlers report success only after payload validation. DMR and
-         * P25 publish ownership at their validated control/grant boundaries. */
-        if ((DSD_SYNC_IS_NXDN(sync) || DSD_SYNC_IS_EDACS(sync))
-            && state->sps_hunt_last_frame_verdict == DSD_FRAME_VERDICT_PRODUCTIVE
-            && dsd_trunk_tuning_frame_is_current(generation)) {
-            dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_OTHER);
-        }
     }
 }
 

--- a/src/engine/dispatch/protocol_dispatch.c
+++ b/src/engine/dispatch/protocol_dispatch.c
@@ -4,9 +4,13 @@
  */
 
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/protocol_dispatch.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -44,7 +48,16 @@ processFrame(dsd_opts* opts, dsd_state* state) {
 
     const dsd_protocol_handler* handler = dsd_find_protocol_handler(state->synctype);
     if (handler != NULL && handler->handle_frame != NULL) {
+        const int sync = state->synctype;
+        const uint64_t generation = dsd_trunk_tuning_generation();
         state->sps_hunt_last_frame_verdict = (int)handler->handle_frame(opts, state);
+        /* These handlers report success only after payload validation. DMR and
+         * P25 publish ownership at their validated control/grant boundaries. */
+        if ((DSD_SYNC_IS_NXDN(sync) || DSD_SYNC_IS_EDACS(sync))
+            && state->sps_hunt_last_frame_verdict == DSD_FRAME_VERDICT_PRODUCTIVE
+            && dsd_trunk_tuning_frame_is_current(generation)) {
+            dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_OTHER);
+        }
     }
 }
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1440,7 +1440,8 @@ no_carrier_is_cc_return_due(const dsd_opts* opts, const dsd_state* state, time_t
     if ((opts->trunk_enable != 1) || (opts->trunk_is_tuned != 1)) {
         return 0;
     }
-    if (p25_sm_vc_reacquire_hold_active(p25_sm_get_ctx(), opts, state, dsd_time_now_monotonic_s())) {
+    if (p25_sm_recovery_allowed(p25_sm_get_ctx(), opts, state)
+        && p25_sm_vc_reacquire_hold_active(p25_sm_get_ctx(), opts, state, dsd_time_now_monotonic_s())) {
         return 0;
     }
 
@@ -1857,8 +1858,48 @@ no_carrier_apply_p25_cc_symbolrate(dsd_opts* opts, dsd_state* state) {
     no_carrier_enable_p25_cc_slots(opts);
 }
 
+static int
+no_carrier_tick_dmr_owner(dsd_opts* opts, dsd_state* state) {
+    if (dsd_trunk_dmr_recovery_allowed(opts, state)) {
+        if (!p25_sm_tick_guard_try_enter()) {
+            return 1;
+        }
+        dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+        if (dmr_sm_get_state(ctx) == DMR_SM_TUNED || ctx->cc_tune_request_id != 0U) {
+            /* The DMR owner applies its grant/voice deadlines and tracks the
+             * accepted return; generic/P25 recovery must not race it. */
+            dmr_sm_tick_ctx(ctx, opts, state);
+            p25_sm_tick_guard_leave();
+            return 1;
+        }
+        p25_sm_tick_guard_leave();
+    }
+    return 0;
+}
+
+static void
+no_carrier_finish_cc_return(dsd_opts* opts, dsd_state* state, long cc, int accepted_cc_return,
+                            int clear_failed_helper_state, int clear_unreturnable_voice_state) {
+    if (accepted_cc_return || clear_failed_helper_state || clear_unreturnable_voice_state) {
+        // An accepted return actually retuned to the control channel, so any call still open ended
+        // with that hop rather than with the fade that prompted it. The other two paths never
+        // changed frequency -- the helper failed, or there was no control channel to return to --
+        // so for them the carrier loss really is the end reason.
+        no_carrier_clear_voice_tune_state(opts, state,
+                                          accepted_cc_return ? DSD_CALL_END_EXPLICIT : DSD_CALL_END_SYNC_LOSS);
+        if (accepted_cc_return && dsd_trunk_dmr_recovery_allowed(opts, state)) {
+            dmr_sm_begin_cc_acquisition(dmr_sm_get_ctx(), opts, state, cc, dsd_trunk_tuning_pending_request());
+        }
+        (void)dsd_recent_activity_clear_all(state);
+        state->is_con_plus = 0;
+    }
+}
+
 static void
 no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state, time_t now) {
+    if (no_carrier_tick_dmr_owner(opts, state)) {
+        return;
+    }
     if (!no_carrier_is_cc_return_due(opts, state, now)) {
         return;
     }
@@ -1901,16 +1942,8 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
         clear_unreturnable_voice_state = 1;
     }
 
-    if (accepted_cc_return || clear_failed_helper_state || clear_unreturnable_voice_state) {
-        // An accepted return actually retuned to the control channel, so any call still open ended
-        // with that hop rather than with the fade that prompted it. The other two paths never
-        // changed frequency -- the helper failed, or there was no control channel to return to --
-        // so for them the carrier loss really is the end reason.
-        no_carrier_clear_voice_tune_state(opts, state,
-                                          accepted_cc_return ? DSD_CALL_END_EXPLICIT : DSD_CALL_END_SYNC_LOSS);
-        (void)dsd_recent_activity_clear_all(state);
-        state->is_con_plus = 0;
-    }
+    no_carrier_finish_cc_return(opts, state, cc, accepted_cc_return, clear_failed_helper_state,
+                                clear_unreturnable_voice_state);
 }
 
 static void
@@ -2584,6 +2617,12 @@ live_scanner_main_loop(dsd_opts* opts, dsd_state* state) {
     while (!dsd_exitflag_load()) {
         dsd_runtime_pump_controls(opts, state);
         p25_sm_try_tick(opts, state);
+        if (opts->trunk_scan_enabled != 1 && p25_sm_tick_guard_try_enter()) {
+            if (dsd_trunk_dmr_recovery_allowed(opts, state)) {
+                dmr_sm_tick_ctx(dmr_sm_get_ctx(), opts, state);
+            }
+            p25_sm_tick_guard_leave();
+        }
         dsd_trunk_scan_hook_tick(opts, state);
         dsd_scan_voice_gate_tick(opts, state, 0, dsd_time_now_monotonic_s());
         dsd_runtime_pump_controls(opts, state);

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1440,7 +1440,7 @@ no_carrier_is_cc_return_due(const dsd_opts* opts, const dsd_state* state, time_t
     if ((opts->trunk_enable != 1) || (opts->trunk_is_tuned != 1)) {
         return 0;
     }
-    if (p25_sm_recovery_allowed(p25_sm_get_ctx(), opts, state)
+    if (dsd_trunk_p25_recovery_allowed(opts, state)
         && p25_sm_vc_reacquire_hold_active(p25_sm_get_ctx(), opts, state, dsd_time_now_monotonic_s())) {
         return 0;
     }
@@ -1451,7 +1451,8 @@ no_carrier_is_cc_return_due(const dsd_opts* opts, const dsd_state* state, time_t
 
 static int
 no_carrier_has_mapped_dmr_rest_channel(const dsd_state* state) {
-    if (state->dmr_rest_channel < 0 || state->dmr_rest_channel >= DSD_TRUNK_CHAN_MAP_SIZE) {
+    if (state->trunk_recovery_protocol == DSD_TRUNK_RECOVERY_P25 || state->dmr_rest_channel < 0
+        || state->dmr_rest_channel >= DSD_TRUNK_CHAN_MAP_SIZE) {
         return 0;
     }
     return (state->trunk_chan_map[state->dmr_rest_channel] != 0) ? 1 : 0;
@@ -1508,6 +1509,9 @@ no_carrier_clear_stale_p25_return_hints_after_generic_activity(const dsd_opts* o
     if (opts->trunk_enable != 1) {
         return;
     }
+    if (state->trunk_recovery_protocol == DSD_TRUNK_RECOVERY_P25) {
+        return; // A raw false sync cannot erase validated P25 ownership or return hints.
+    }
     if (!no_carrier_generic_trunk_synctype(state->lastsynctype)
         && !no_carrier_generic_trunk_synctype(state->synctype)) {
         return;
@@ -1534,6 +1538,9 @@ static int
 no_carrier_is_p25_trunk_return(const dsd_opts* opts, const dsd_state* state) {
     if (!opts || !state || opts->trunk_enable != 1 || !no_carrier_p25_frames_enabled(opts)) {
         return 0;
+    }
+    if (state->trunk_recovery_protocol == DSD_TRUNK_RECOVERY_P25) {
+        return 1;
     }
     if (no_carrier_has_mapped_dmr_rest_channel(state)) {
         return 0;
@@ -1643,7 +1650,7 @@ no_carrier_return_to_cc_correlated(dsd_opts* opts, dsd_state* state, uint64_t* o
 static int
 no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, int p25_return,
                                    int clear_generic_p25_alias, int* helper_attempted,
-                                   dsd_trunk_tune_result* helper_result) {
+                                   dsd_trunk_tune_result* helper_result, uint64_t* out_request_id) {
     if (helper_result) {
         *helper_result = DSD_TRUNK_TUNE_RESULT_OK;
     }
@@ -1666,6 +1673,7 @@ no_carrier_try_helper_return_to_cc(dsd_opts* opts, dsd_state* state, long cc, in
 
     uint64_t tune_request_id = 0U;
     dsd_trunk_tune_result tune_result = no_carrier_return_to_cc_correlated(opts, state, &tune_request_id);
+    *out_request_id = tune_request_id;
     if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING) {
         (void)p25_sm_await_pending_cc_tune(p25_sm_get_ctx(), opts, state, tune_request_id, "no-carrier");
     } else if (tune_result == DSD_TRUNK_TUNE_RESULT_OK) {
@@ -1703,7 +1711,8 @@ no_carrier_generic_recovery_is_current(const dsd_state* state, long cc, dsd_trun
 }
 
 static int
-no_carrier_accept_generic_gate_recovery(const dsd_opts* opts, dsd_state* state, long cc) {
+no_carrier_accept_generic_gate_recovery(const dsd_opts* opts, dsd_state* state, long cc, uint64_t* out_request_id) {
+    *out_request_id = s_no_carrier_generic_recovery_request_id;
     no_carrier_clear_generic_recovery_tracking();
     no_carrier_sync_helper_tune_cache(opts, state, cc);
     state->edacs_tuned_lcn = -1;
@@ -1713,7 +1722,7 @@ no_carrier_accept_generic_gate_recovery(const dsd_opts* opts, dsd_state* state, 
 
 static int
 no_carrier_try_generic_gate_recovery(dsd_opts* opts, dsd_state* state, long cc, int p25_return,
-                                     int clear_generic_p25_alias, int* helper_attempted) {
+                                     int clear_generic_p25_alias, int* helper_attempted, uint64_t* out_request_id) {
     if (p25_return) {
         return 0;
     }
@@ -1728,7 +1737,7 @@ no_carrier_try_generic_gate_recovery(dsd_opts* opts, dsd_state* state, long cc, 
         const uint64_t unresolved_request_id = dsd_trunk_tuning_pending_request();
         if (unresolved_request_id == 0U) {
             if (no_carrier_generic_recovery_is_current(state, cc, status)) {
-                return no_carrier_accept_generic_gate_recovery(opts, state, cc);
+                return no_carrier_accept_generic_gate_recovery(opts, state, cc, out_request_id);
             }
             /* The old target failed, changed, or was superseded by a newer
              * completed tune. Establish a fresh boundary for the current CC. */
@@ -1777,7 +1786,7 @@ no_carrier_try_generic_gate_recovery(dsd_opts* opts, dsd_state* state, long cc, 
         return 0;
     }
 
-    return no_carrier_accept_generic_gate_recovery(opts, state, cc);
+    return no_carrier_accept_generic_gate_recovery(opts, state, cc, out_request_id);
 }
 
 static int
@@ -1879,7 +1888,7 @@ no_carrier_tick_dmr_owner(dsd_opts* opts, dsd_state* state) {
 
 static void
 no_carrier_finish_cc_return(dsd_opts* opts, dsd_state* state, long cc, int accepted_cc_return,
-                            int clear_failed_helper_state, int clear_unreturnable_voice_state) {
+                            int clear_failed_helper_state, int clear_unreturnable_voice_state, uint64_t request_id) {
     if (accepted_cc_return || clear_failed_helper_state || clear_unreturnable_voice_state) {
         // An accepted return actually retuned to the control channel, so any call still open ended
         // with that hop rather than with the fade that prompted it. The other two paths never
@@ -1888,7 +1897,7 @@ no_carrier_finish_cc_return(dsd_opts* opts, dsd_state* state, long cc, int accep
         no_carrier_clear_voice_tune_state(opts, state,
                                           accepted_cc_return ? DSD_CALL_END_EXPLICIT : DSD_CALL_END_SYNC_LOSS);
         if (accepted_cc_return && dsd_trunk_dmr_recovery_allowed(opts, state)) {
-            dmr_sm_begin_cc_acquisition(dmr_sm_get_ctx(), opts, state, cc, dsd_trunk_tuning_pending_request());
+            dmr_sm_begin_cc_acquisition(dmr_sm_get_ctx(), opts, state, cc, request_id);
         }
         (void)dsd_recent_activity_clear_all(state);
         state->is_con_plus = 0;
@@ -1907,6 +1916,7 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     long cc = no_carrier_select_control_channel(state);
     const int p25_return = no_carrier_is_p25_trunk_return(opts, state);
     const int clear_generic_p25_alias = no_carrier_should_clear_generic_p25_alias(state, cc, p25_return);
+    uint64_t cc_return_request_id = 0U;
     int accepted_cc_return = 0;
     int clear_failed_helper_state = 0;
     int clear_unreturnable_voice_state = 0;
@@ -1915,14 +1925,14 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
         dsd_trunk_tune_result p25_helper_result = DSD_TRUNK_TUNE_RESULT_OK;
         int generic_helper_attempted = 0;
         if (no_carrier_try_helper_return_to_cc(opts, state, cc, p25_return, clear_generic_p25_alias,
-                                               &p25_helper_attempted, &p25_helper_result)) {
+                                               &p25_helper_attempted, &p25_helper_result, &cc_return_request_id)) {
             no_carrier_enable_p25_cc_slots_if_known(opts, state);
             accepted_cc_return = 1;
         } else if (no_carrier_helper_result_is_deferred(p25_helper_attempted, p25_helper_result)) {
             /* Another P25 transition owns the guard; leave the staged
              * voice state intact so the main loop can retry safely. */
         } else if (no_carrier_try_generic_gate_recovery(opts, state, cc, p25_return, clear_generic_p25_alias,
-                                                        &generic_helper_attempted)) {
+                                                        &generic_helper_attempted, &cc_return_request_id)) {
             accepted_cc_return = 1;
         } else if (!generic_helper_attempted
                    && no_carrier_apply_direct_cc_return(opts, state, cc, p25_helper_attempted)) {
@@ -1943,7 +1953,7 @@ no_carrier_return_to_control_channel_if_needed(dsd_opts* opts, dsd_state* state,
     }
 
     no_carrier_finish_cc_return(opts, state, cc, accepted_cc_return, clear_failed_helper_state,
-                                clear_unreturnable_voice_state);
+                                clear_unreturnable_voice_state, cc_return_request_id);
 }
 
 static void

--- a/src/engine/frame_sync_hooks_install.c
+++ b/src/engine/frame_sync_hooks_install.c
@@ -6,6 +6,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 
 #include <dsd-neo/protocol/edacs/edacs.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
@@ -17,7 +18,7 @@
 
 static void
 p25_sm_release_from_frame_sync(dsd_opts* opts, dsd_state* state) {
-    if (!p25_sm_recovery_allowed(p25_sm_get_ctx(), opts, state)) {
+    if (!dsd_trunk_p25_recovery_allowed(opts, state)) {
         return;
     }
     state->p25_sm_force_release = 1;
@@ -26,7 +27,7 @@ p25_sm_release_from_frame_sync(dsd_opts* opts, dsd_state* state) {
 
 static void
 p25_sm_vc_sync_from_frame_sync(dsd_opts* opts, const dsd_state* state) {
-    if (!p25_sm_recovery_allowed(p25_sm_get_ctx(), opts, state)) {
+    if (!dsd_trunk_p25_recovery_allowed(opts, state)) {
         return;
     }
     p25_sm_note_vc_frame_sync(p25_sm_get_ctx(), opts, state);
@@ -34,7 +35,7 @@ p25_sm_vc_sync_from_frame_sync(dsd_opts* opts, const dsd_state* state) {
 
 static void
 p25_sm_vc_no_sync_from_frame_sync(dsd_opts* opts, const dsd_state* state) {
-    if (!p25_sm_recovery_allowed(p25_sm_get_ctx(), opts, state)) {
+    if (!dsd_trunk_p25_recovery_allowed(opts, state)) {
         return;
     }
     p25_sm_ctx_t* ctx = p25_sm_get_ctx();

--- a/src/engine/frame_sync_hooks_install.c
+++ b/src/engine/frame_sync_hooks_install.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <dsd-neo/core/state.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/runtime/frame_sync_hooks.h>
 
@@ -16,16 +17,26 @@
 
 static void
 p25_sm_release_from_frame_sync(dsd_opts* opts, dsd_state* state) {
+    if (!p25_sm_recovery_allowed(p25_sm_get_ctx(), opts, state)) {
+        return;
+    }
+    state->p25_sm_force_release = 1;
     p25_sm_release(p25_sm_get_ctx(), opts, state, "frame-sync-no-sync");
 }
 
 static void
 p25_sm_vc_sync_from_frame_sync(dsd_opts* opts, const dsd_state* state) {
+    if (!p25_sm_recovery_allowed(p25_sm_get_ctx(), opts, state)) {
+        return;
+    }
     p25_sm_note_vc_frame_sync(p25_sm_get_ctx(), opts, state);
 }
 
 static void
 p25_sm_vc_no_sync_from_frame_sync(dsd_opts* opts, const dsd_state* state) {
+    if (!p25_sm_recovery_allowed(p25_sm_get_ctx(), opts, state)) {
+        return;
+    }
     p25_sm_ctx_t* ctx = p25_sm_get_ctx();
     p25_sm_note_cc_no_sync_pass(ctx, opts, state);
     p25_sm_note_vc_no_sync_pass(ctx, opts, state);

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -2469,6 +2469,11 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
         return -1;
     }
 
+    if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
+        dmr_sm_begin_cc_acquisition(&rt->dmr_ctx, opts, state, trunk_scan_retune_freq(state, &rt->target),
+                                    tune_request_id);
+    }
+
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
         if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING && tune_request_id != 0U) {
             (void)p25_sm_await_pending_cc_tune(&rt->p25_ctx, opts, state, tune_request_id, "scan-retune");
@@ -2625,7 +2630,8 @@ trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coor
                 || p25_sm_get_state(&rt->p25_ctx) == P25_SM_TUNED);
     }
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
-        return (opts->trunk_is_tuned == 1 || dmr_sm_get_state(&rt->dmr_ctx) == DMR_SM_TUNED);
+        return (rt->dmr_ctx.cc_tune_request_id != 0U || opts->trunk_is_tuned == 1
+                || dmr_sm_get_state(&rt->dmr_ctx) == DMR_SM_TUNED);
     }
     if (trunk_scan_type_is_nxdn_trunk(rt->target.type)) {
         return opts->trunk_is_tuned == 1;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -2801,6 +2801,11 @@ static void
 trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord) {
     double now_m = trunk_scan_now_m();
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    if (rt->tune_pending && rt->dmr_ctx.cc_tune_request_id != 0U) {
+        /* Resolve the DMR backend deadline even while the initial park keeps
+         * the coordinator waiting for its request. */
+        trunk_scan_tick_active_target_sm(opts, state, rt);
+    }
     int pending_status = trunk_scan_resolve_pending_retune(state, rt, now_m);
     if (pending_status == 0) {
         return;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -69,6 +69,7 @@ typedef struct {
     unsigned long long p2_rfssid;
     long int p25_cc_freq;
     long int trunk_cc_freq;
+    int trunk_recovery_protocol;
     uint64_t trunk_chan_map_seq;
     time_t p25_sys_time;
     long p25_cc_eval_freq;
@@ -1413,6 +1414,7 @@ trunk_scan_save_p25_identity_snapshot(const dsd_state* state, dsd_trunk_scan_sna
     snapshot->p2_rfssid = state->p2_rfssid;
     snapshot->p25_cc_freq = state->p25_cc_freq;
     snapshot->trunk_cc_freq = state->trunk_cc_freq;
+    snapshot->trunk_recovery_protocol = state->trunk_recovery_protocol;
     DSD_MEMCPY(snapshot->p25_vc_freq, state->p25_vc_freq, sizeof(snapshot->p25_vc_freq));
     DSD_MEMCPY(snapshot->trunk_vc_freq, state->trunk_vc_freq, sizeof(snapshot->trunk_vc_freq));
     trunk_scan_save_enc_lockout_snapshot(state, snapshot);
@@ -1461,6 +1463,7 @@ trunk_scan_restore_p25_identity_snapshot(dsd_state* state, const dsd_trunk_scan_
     state->p2_rfssid = snapshot->p2_rfssid;
     state->p25_cc_freq = snapshot->p25_cc_freq;
     state->trunk_cc_freq = snapshot->trunk_cc_freq;
+    state->trunk_recovery_protocol = snapshot->trunk_recovery_protocol;
     DSD_MEMCPY(state->p25_vc_freq, snapshot->p25_vc_freq, sizeof(state->p25_vc_freq));
     DSD_MEMCPY(state->trunk_vc_freq, snapshot->trunk_vc_freq, sizeof(state->trunk_vc_freq));
     trunk_scan_restore_enc_lockout_snapshot(state, snapshot);

--- a/src/protocol/dmr/dmr_csbk.c
+++ b/src/protocol/dmr/dmr_csbk.c
@@ -35,6 +35,7 @@
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <dsd-neo/runtime/colors.h>
 #include <dsd-neo/runtime/rigctl_query_hooks.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <math.h>
 #include <stdint.h>
@@ -1320,15 +1321,10 @@ dmr_cspdu_pf0_c_bcast_try_switch_tscc(dsd_opts* opts, dsd_state* state, long f1,
     }
 
     if (next > 0 && next != cur) {
-        const long previous_cc = state->trunk_cc_freq;
-        state->trunk_cc_freq = next;
-        uint64_t request_id = 0U;
-        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state, &request_id);
-        if (!dsd_trunk_tune_result_is_ok(tune_result)) {
-            state->trunk_cc_freq = previous_cc;
+        const dsd_trunk_tune_result result = dmr_sm_return_to_cc(dmr_sm_get_ctx(), opts, state, next);
+        if (!dsd_trunk_tune_result_is_ok(result)) {
             return;
         }
-        dmr_sm_begin_cc_acquisition(dmr_sm_get_ctx(), opts, state, next, request_id);
         DSD_FPRINTF(stderr, "\n Switched to announced TSCC: %.6lf MHz\n", (double)next / 1000000.0);
     }
 }
@@ -2033,24 +2029,15 @@ dmr_cspdu_cap_plus_3e_dump_payload(const dsd_opts* opts, dsd_state* state, const
 
 static void
 dmr_cspdu_cap_plus_3e_try_return_to_rest(dsd_opts* opts, dsd_state* state, const dmr_cap_plus_3e_ctx* ctx) {
-    uint16_t empty[24];
-    int busy;
-
-    DSD_MEMSET(empty, 0, sizeof(empty));
-    busy = memcmp(empty, ctx->t_tg, sizeof(empty));
+    const int busy = ctx->bank_one != 0 || ctx->bank_two != 0;
     const long rest = state->trunk_chan_map[ctx->rest_channel];
-    if (busy || opts->trunk_enable != 1 || rest <= 0 || (opts->trunk_is_tuned == 0 && state->trunk_cc_freq == rest)) {
+    if (opts->trunk_enable != 1 || rest <= 0 || (busy && opts->trunk_is_tuned == 1)
+        || (opts->trunk_is_tuned == 0 && state->trunk_cc_freq == rest)) {
         return;
     }
-    const long previous_cc = state->trunk_cc_freq;
-    state->trunk_cc_freq = rest;
-    uint64_t request_id = 0U;
-    const dsd_trunk_tune_result result = dsd_trunk_tuning_hook_return_to_cc(opts, state, &request_id);
-    if (!dsd_trunk_tune_result_is_ok(result)) {
-        state->trunk_cc_freq = previous_cc;
-        return;
-    }
-    dmr_sm_begin_cc_acquisition(dmr_sm_get_ctx(), opts, state, rest, request_id);
+    /* Busy status can announce a new rest channel even when every advertised
+     * call is blocked or unmapped. Follow it unless a call owns the tuner. */
+    (void)dmr_sm_return_to_cc(dmr_sm_get_ctx(), opts, state, rest);
 }
 
 static void
@@ -2650,6 +2637,7 @@ dmr_cspdu(dsd_opts* opts, dsd_state* state, uint8_t cs_pdu_bits[], uint8_t cs_pd
     csbk_pf = dmr_cspdu_apply_protect_flag_checks(IrrecoverableErrors, csbk_o, csbk_fid, csbk_pf);
 
     if (IrrecoverableErrors == 0 && CRCCorrect == 1) {
+        dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_DMR);
         //clear stale Active Channel messages here
         (void)dsd_recent_activity_expire(state, 0U, DSD_RECENT_ACTIVITY_TTL_MS);
 

--- a/src/protocol/dmr/dmr_csbk.c
+++ b/src/protocol/dmr/dmr_csbk.c
@@ -607,18 +607,7 @@ dmr_cspdu_pf0_handle_aloha(dsd_opts* opts, dsd_state* state, uint8_t cs_pdu_bits
     DSD_FPRINTF(stderr, "\n");
     dmr_decode_syscode(opts, state, cs_pdu_bits, csbk_fid, 0);
 
-    if (opts->use_rigctl == 1 && opts->trunk_is_tuned == 0) {
-        long int ccfreq = dsd_rigctl_query_hook_get_current_freq_hz(opts);
-        if (ccfreq != 0) {
-            state->trunk_cc_freq = ccfreq;
-        }
-    }
-    if (opts->audio_in_type == AUDIO_IN_RTL && opts->trunk_is_tuned == 0) {
-        long int ccfreq = (long int)opts->rtlsdr_center_freq;
-        if (ccfreq != 0) {
-            state->trunk_cc_freq = ccfreq;
-        }
-    }
+    dmr_sm_note_cc_activity(opts, state, 0);
     if (opts->trunk_is_tuned == 0) {
         rotate_symbol_out_file(opts, state);
     }
@@ -1333,11 +1322,13 @@ dmr_cspdu_pf0_c_bcast_try_switch_tscc(dsd_opts* opts, dsd_state* state, long f1,
     if (next > 0 && next != cur) {
         const long previous_cc = state->trunk_cc_freq;
         state->trunk_cc_freq = next;
-        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state, NULL);
+        uint64_t request_id = 0U;
+        dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state, &request_id);
         if (!dsd_trunk_tune_result_is_ok(tune_result)) {
             state->trunk_cc_freq = previous_cc;
             return;
         }
+        dmr_sm_begin_cc_acquisition(dmr_sm_get_ctx(), opts, state, next, request_id);
         DSD_FPRINTF(stderr, "\n Switched to announced TSCC: %.6lf MHz\n", (double)next / 1000000.0);
     }
 }
@@ -1740,12 +1731,12 @@ dmr_cspdu_cap_plus_3e_update_multiblock(dsd_state* state, const uint8_t cs_pdu_b
 }
 
 static void
-dmr_cspdu_cap_plus_3e_sync_rest(dsd_opts* opts, dsd_state* state, const dmr_cap_plus_3e_ctx* ctx) {
+dmr_cspdu_cap_plus_3e_sync_rest(const dsd_opts* opts, dsd_state* state, const dmr_cap_plus_3e_ctx* ctx) {
     if (ctx->rest_channel != state->dmr_rest_channel) {
         state->dmr_rest_channel = ctx->rest_channel;
     }
     if (state->trunk_chan_map[ctx->rest_channel] != 0) {
-        opts->trunk_is_tuned = 1;
+        dmr_sm_note_cc_activity(opts, state, state->trunk_chan_map[ctx->rest_channel]);
     }
 }
 
@@ -2047,19 +2038,19 @@ dmr_cspdu_cap_plus_3e_try_return_to_rest(dsd_opts* opts, dsd_state* state, const
 
     DSD_MEMSET(empty, 0, sizeof(empty));
     busy = memcmp(empty, ctx->t_tg, sizeof(empty));
-    if (busy || opts->trunk_enable != 1 || state->trunk_cc_freq == state->trunk_chan_map[ctx->rest_channel]) {
+    const long rest = state->trunk_chan_map[ctx->rest_channel];
+    if (busy || opts->trunk_enable != 1 || rest <= 0 || (opts->trunk_is_tuned == 0 && state->trunk_cc_freq == rest)) {
         return;
     }
-    if (state->trunk_chan_map[ctx->rest_channel] != 0) {
-        state->trunk_cc_freq = state->trunk_chan_map[ctx->rest_channel];
+    const long previous_cc = state->trunk_cc_freq;
+    state->trunk_cc_freq = rest;
+    uint64_t request_id = 0U;
+    const dsd_trunk_tune_result result = dsd_trunk_tuning_hook_return_to_cc(opts, state, &request_id);
+    if (!dsd_trunk_tune_result_is_ok(result)) {
+        state->trunk_cc_freq = previous_cc;
+        return;
     }
-
-    uint8_t dummy[12];
-    uint8_t* dbits = NULL;
-    DSD_MEMSET(dummy, 0, sizeof(dummy));
-    dummy[0] = 46;
-    dummy[1] = 253;
-    dmr_cspdu(opts, state, dbits, dummy, 1, 0);
+    dmr_sm_begin_cc_acquisition(dmr_sm_get_ctx(), opts, state, rest, request_id);
 }
 
 static void
@@ -2665,6 +2656,7 @@ dmr_cspdu(dsd_opts* opts, dsd_state* state, uint8_t cs_pdu_bits[], uint8_t cs_pd
         //update time to prevent random 'Control Channel Signal Lost' hopping
         //in the middle of voice call on current Control Channel (con+ and t3)
         dsd_mark_cc_sync(state);
+        dmr_sm_note_cc_heartbeat(opts, state);
 
         dmr_cspdu_init_cc_anchor(opts, state);
 
@@ -2678,6 +2670,7 @@ dmr_cspdu(dsd_opts* opts, dsd_state* state, uint8_t cs_pdu_bits[], uint8_t cs_pd
     // a last_cc_sync_time refresh to prevent premature CC hunts if configured.
     // This does not process the PDU further — it only keeps the CC timer warm.
     else if (opts->dmr_crc_relaxed_default) {
+        dmr_sm_note_cc_heartbeat(opts, state);
         state->last_cc_sync_time = time(NULL);
         state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
     }

--- a/src/protocol/dmr/dmr_csbk.c
+++ b/src/protocol/dmr/dmr_csbk.c
@@ -2029,10 +2029,17 @@ dmr_cspdu_cap_plus_3e_dump_payload(const dsd_opts* opts, dsd_state* state, const
 
 static void
 dmr_cspdu_cap_plus_3e_try_return_to_rest(dsd_opts* opts, dsd_state* state, const dmr_cap_plus_3e_ctx* ctx) {
-    const int busy = ctx->bank_one != 0 || ctx->bank_two != 0;
     const long rest = state->trunk_chan_map[ctx->rest_channel];
-    if (opts->trunk_enable != 1 || rest <= 0 || (busy && opts->trunk_is_tuned == 1)
-        || (opts->trunk_is_tuned == 0 && state->trunk_cc_freq == rest)) {
+    if (opts->trunk_enable != 1 || rest <= 0) {
+        return;
+    }
+    if (opts->trunk_is_tuned == 1) {
+        /* Save the announced return destination without cutting short voice
+         * hangtime when the other slot reports empty busy banks. */
+        state->trunk_cc_freq = rest;
+        return;
+    }
+    if (state->trunk_cc_freq == rest) {
         return;
     }
     /* Busy status can announce a new rest channel even when every advertised

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -1600,7 +1600,7 @@ typedef struct {
 } dmr_slco_data;
 
 static void
-dmr_slco_tune_and_reset(dsd_opts* opts, dsd_state* state) {
+dmr_slco_tune_and_reset(dsd_opts* opts, dsd_state* state, int control_channel) {
     if (state->trunk_cc_freq == 0) {
         return;
     }
@@ -1614,7 +1614,13 @@ dmr_slco_tune_and_reset(dsd_opts* opts, dsd_state* state) {
     state->p25_vc_freq[0] = state->p25_vc_freq[1] = 0;
     state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = 0;
     dmr_reset_blocks(opts, state);
-    dmr_sm_begin_cc_acquisition(dmr_sm_get_ctx(), opts, state, state->trunk_cc_freq, request_id);
+    if (control_channel) {
+        dmr_sm_begin_cc_acquisition(dmr_sm_get_ctx(), opts, state, state->trunk_cc_freq, request_id);
+    } else {
+        /* XPT has no dedicated control channel. A free-channel hop must not
+         * start (or inherit) Tier III control-channel hunting. */
+        dmr_sm_init_ctx(dmr_sm_get_ctx(), opts, NULL);
+    }
 }
 
 static void
@@ -1770,7 +1776,7 @@ dmr_slco_handle_cap_plus(dsd_opts* opts, dsd_state* state, const dmr_slco_data* 
         if (state->trunk_chan_map[data->restchannel] != 0) {
             state->trunk_cc_freq = state->trunk_chan_map[data->restchannel];
         }
-        dmr_slco_tune_and_reset(opts, state);
+        dmr_slco_tune_and_reset(opts, state, 1);
     }
 }
 
@@ -1801,7 +1807,7 @@ dmr_slco_handle_xpt(dsd_opts* opts, dsd_state* state, const dmr_slco_data* data)
         if (state->trunk_chan_map[xpt_lsn] != 0) {
             state->trunk_cc_freq = state->trunk_chan_map[xpt_lsn];
         }
-        dmr_slco_tune_and_reset(opts, state);
+        dmr_slco_tune_and_reset(opts, state, 0);
     }
 }
 

--- a/src/protocol/dmr/dmr_flco.c
+++ b/src/protocol/dmr/dmr_flco.c
@@ -27,9 +27,9 @@
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/fec/block_codes.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/protocol/dmr/dmr_utils_api.h>
 #include <dsd-neo/runtime/colors.h>
-#include <dsd-neo/runtime/rigctl_query_hooks.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdbool.h>
@@ -1604,7 +1604,9 @@ dmr_slco_tune_and_reset(dsd_opts* opts, dsd_state* state) {
     if (state->trunk_cc_freq == 0) {
         return;
     }
-    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, state->trunk_cc_freq, 0, NULL);
+    uint64_t request_id = 0U;
+    dsd_trunk_tune_result tune_result =
+        dsd_trunk_tuning_hook_tune_to_cc(opts, state, state->trunk_cc_freq, 0, &request_id);
     if (!dsd_trunk_tune_result_is_ok(tune_result)) {
         return;
     }
@@ -1612,6 +1614,7 @@ dmr_slco_tune_and_reset(dsd_opts* opts, dsd_state* state) {
     state->p25_vc_freq[0] = state->p25_vc_freq[1] = 0;
     state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = 0;
     dmr_reset_blocks(opts, state);
+    dmr_sm_begin_cc_acquisition(dmr_sm_get_ctx(), opts, state, state->trunk_cc_freq, request_id);
 }
 
 static void
@@ -1713,12 +1716,7 @@ dmr_slco_handle_c_sys_parms(const dsd_opts* opts, dsd_state* state, uint8_t slco
     DSD_FPRINTF(stderr, " SYS: %04X;", syscode);
     dmr_slco_print_tiii_site_parms(state, data, syscode);
 
-    if (opts->use_rigctl == 1 && state->trunk_cc_freq == 0) {
-        long int ccfreq = dsd_rigctl_query_hook_get_current_freq_hz(opts);
-        if (ccfreq != 0) {
-            state->trunk_cc_freq = ccfreq;
-        }
-    }
+    dmr_sm_note_cc_activity(opts, state, 0);
 }
 
 static void
@@ -1762,6 +1760,10 @@ static void
 dmr_slco_handle_cap_plus(dsd_opts* opts, dsd_state* state, const dmr_slco_data* data) {
     DSD_FPRINTF(stderr, " SLCO Capacity Plus Site: %d - Rest LSN: %d - RS: %02X", data->capsite, data->restchannel,
                 data->cap_reserved);
+
+    if (state->trunk_chan_map[data->restchannel] > 0) {
+        dmr_sm_note_cc_activity(opts, state, state->trunk_chan_map[data->restchannel]);
+    }
 
     if (state->tg_hold != 0 && opts->trunk_enable == 1 && dmr_slco_cap_plus_busy(state)
         && dmr_slco_tg_hold_not_on_slot(state)) {
@@ -1809,18 +1811,7 @@ dmr_slco_handle_con_plus_control(dsd_opts* opts, dsd_state* state, const dmr_slc
                 data->con_siteid);
     DSD_SNPRINTF(state->dmr_site_parms, sizeof(state->dmr_site_parms), "%d-%d ", data->con_netid, data->con_siteid);
 
-    if (opts->use_rigctl == 1 && opts->trunk_is_tuned == 0) {
-        long int ccfreq = dsd_rigctl_query_hook_get_current_freq_hz(opts);
-        if (ccfreq != 0) {
-            state->trunk_cc_freq = ccfreq;
-        }
-    }
-    if (opts->audio_in_type == AUDIO_IN_RTL && opts->trunk_is_tuned == 0) {
-        long int ccfreq = (long int)opts->rtlsdr_center_freq;
-        if (ccfreq != 0) {
-            state->trunk_cc_freq = ccfreq;
-        }
-    }
+    dmr_sm_note_cc_activity(opts, state, 0);
     if ((time(NULL) - state->last_vc_sync_time) > 2) {
         rotate_symbol_out_file(opts, state);
     }

--- a/src/protocol/dmr/dmr_trunk_sm.c
+++ b/src/protocol/dmr/dmr_trunk_sm.c
@@ -42,6 +42,13 @@ sm_status_log_enabled(const dsd_opts* opts) {
     return opts && opts->trunk_enable == 1 && opts->verbose > 0;
 }
 
+static void
+sm_recovery_log(const dsd_opts* opts, const char* tag) {
+    if (sm_status_log_enabled(opts)) {
+        DSD_FPRINTF(stderr, "\n[DMR SM] %s\n", tag);
+    }
+}
+
 static long
 resolve_freq(const dsd_state* state, long freq_hz, int lpcn) {
     if (freq_hz > 0) {
@@ -98,6 +105,8 @@ dmr_cc_resolve_pending(dmr_sm_ctx_t* ctx, const dsd_opts* opts, double now_m) {
     ctx->cc_tune_request_id = 0U;
     if (result == DSD_TRUNK_TUNE_RESULT_OK) {
         ctx->cc_acquire_start_m = completed_m > 0.0 ? completed_m : now_m;
+        ctx->cc_rx_freq_hz = ctx->cc_probe_freq_hz;
+        ctx->cc_rx_generation = dsd_trunk_tuning_generation();
         return 1;
     }
     ctx->cc_acquiring = 0;
@@ -119,11 +128,43 @@ dmr_sm_begin_cc_acquisition(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_s
     ctx->cc_acquire_start_m = dsd_time_now_monotonic_s();
     ctx->cc_tune_request_id = request_id;
     ctx->state = DMR_SM_ON_CC;
+    if (request_id == 0U) {
+        ctx->cc_rx_freq_hz = freq_hz;
+        ctx->cc_rx_generation = dsd_trunk_tuning_generation();
+    }
     (void)dmr_cc_resolve_pending(ctx, opts, ctx->cc_acquire_start_m);
+}
+
+dsd_trunk_tune_result
+dmr_sm_return_to_cc(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, long freq_hz) {
+    if (!ctx || !opts || !state || freq_hz <= 0) {
+        return DSD_TRUNK_TUNE_RESULT_FAILED;
+    }
+    const long previous_cc = state->trunk_cc_freq;
+    const long previous_p25_cc = state->p25_cc_freq;
+    /* The shared return helper prefers the P25 alias. DMR supplies its own
+     * destination and must not inherit that alias or its symbol profile. */
+    state->p25_cc_freq = 0;
+    state->trunk_cc_freq = freq_hz;
+    uint64_t request_id = 0U;
+    const dsd_trunk_tune_result result = dsd_trunk_tuning_hook_return_to_cc(opts, state, &request_id);
+    if (!dsd_trunk_tune_result_is_ok(result)) {
+        state->p25_cc_freq = previous_p25_cc;
+        state->trunk_cc_freq = previous_cc;
+        sm_recovery_log(opts, "cc-return-deferred-or-failed");
+        return result;
+    }
+    state->is_con_plus = 0;
+    set_state(ctx, opts, DMR_SM_ON_CC, "cc-return");
+    dmr_sm_begin_cc_acquisition(ctx, opts, state, freq_hz, request_id);
+    return result;
 }
 
 static long
 dmr_cc_current_frequency(const dsd_opts* opts, const dmr_sm_ctx_t* ctx) {
+    if (ctx && ctx->cc_rx_freq_hz > 0 && ctx->cc_rx_generation == dsd_trunk_tuning_generation()) {
+        return ctx->cc_rx_freq_hz;
+    }
     if (opts->use_rigctl == 1) {
         return dsd_rigctl_query_hook_get_current_freq_hz(opts);
     }
@@ -180,6 +221,9 @@ dmr_sm_note_cc_activity(const dsd_opts* opts, dsd_state* state, long freq_hz) {
     }
     ctx->cc_freq_hz = current;
     ctx->cc_probe_freq_hz = current;
+    ctx->cc_rx_freq_hz = current;
+    ctx->cc_rx_generation = dsd_trunk_tuning_generation();
+    const int acquired = !ctx->cc_confirmed || ctx->cc_acquiring;
     ctx->cc_confirmed = 1;
     ctx->cc_acquiring = 0;
     ctx->cc_retry_after_m = 0.0;
@@ -187,16 +231,31 @@ dmr_sm_note_cc_activity(const dsd_opts* opts, dsd_state* state, long freq_hz) {
     state->trunk_cc_freq = current;
     state->last_cc_sync_time = time(NULL);
     state->last_cc_sync_time_m = ctx->t_cc_sync_m;
+    dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_DMR);
+    if (acquired && ctx->state == DMR_SM_ON_CC) {
+        sm_recovery_log(opts, "decoded-cc");
+    }
     set_state(ctx, opts, DMR_SM_ON_CC, "decoded-cc");
+}
+
+static void
+dmr_cc_note_heartbeat_ctx(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state) {
+    if (!ctx || !opts || !state || opts->trunk_is_tuned == 1 || !ctx->cc_confirmed || ctx->cc_acquiring
+        || !dmr_cc_resolve_pending(ctx, opts, dsd_time_now_monotonic_s())) {
+        return;
+    }
+    /* A heartbeat is in the decode hot path. Attribute it to the completed
+     * tuning boundary, without a blocking rigctl round trip per CSBK. */
+    if (ctx->cc_rx_freq_hz == ctx->cc_freq_hz && dsd_trunk_tuning_frame_is_current(ctx->cc_rx_generation)) {
+        ctx->t_cc_sync_m = dsd_time_now_monotonic_s();
+        set_state(ctx, opts, DMR_SM_ON_CC, "cc-heartbeat");
+    }
 }
 
 void
 dmr_sm_note_cc_heartbeat(const dsd_opts* opts, const dsd_state* state) {
     dmr_sm_ctx_t* ctx = dmr_cc_activity_context(opts, state);
-    if (ctx && ctx->cc_confirmed && !ctx->cc_acquiring && dmr_cc_current_frequency(opts, ctx) == ctx->cc_freq_hz) {
-        ctx->t_cc_sync_m = dsd_time_now_monotonic_s();
-        set_state(ctx, opts, DMR_SM_ON_CC, "cc-heartbeat");
-    }
+    dmr_cc_note_heartbeat_ctx(ctx, opts, state);
 }
 
 static long
@@ -237,6 +296,14 @@ dmr_cc_hunt(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
     if (freq <= 0) {
         return;
     }
+    if (freq == ctx->cc_rx_freq_hz && dsd_trunk_tuning_frame_is_current(ctx->cc_rx_generation)) {
+        /* No alternate candidate: keep listening without resetting demodulation
+         * every acquisition window. Only decoded control evidence confirms it. */
+        ctx->cc_probe_freq_hz = freq;
+        ctx->cc_acquire_start_m = now_m;
+        set_state(ctx, opts, DMR_SM_ON_CC, "cc-listen");
+        return;
+    }
     const long anchor = state->trunk_cc_freq;
     uint64_t request_id = 0U;
     const dsd_trunk_tune_result result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, 0, &request_id);
@@ -244,7 +311,7 @@ dmr_cc_hunt(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
      * probes retain their return destination until a control message proves it. */
     state->trunk_cc_freq = anchor;
     if (!dsd_trunk_tune_result_is_ok(result)) {
-        sm_log(opts, "cc-probe-deferred-or-failed");
+        sm_recovery_log(opts, "cc-probe-deferred-or-failed");
         return;
     }
     ctx->cc_probe_freq_hz = freq;
@@ -277,8 +344,8 @@ do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
 
     sm_log(opts, reason);
 
-    uint64_t request_id = 0U;
-    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state, &request_id);
+    const long cc = state ? (state->trunk_cc_freq > 0 ? state->trunk_cc_freq : state->p25_cc_freq) : 0;
+    dsd_trunk_tune_result tune_result = dmr_sm_return_to_cc(ctx, opts, state, cc);
     if (!dsd_trunk_tune_result_is_ok(tune_result)) {
         sm_log(opts, "release-tune-deferred");
         if (state && had_force_release) {
@@ -315,9 +382,6 @@ do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
     }
 
     set_state(ctx, opts, DMR_SM_ON_CC, reason);
-    if (state) {
-        dmr_sm_begin_cc_acquisition(ctx, opts, state, state->trunk_cc_freq, request_id);
-    }
 }
 
 static int
@@ -355,6 +419,7 @@ handle_grant(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const dmr_sm_e
     if (!ctx || !ev || !opts || !state) {
         return;
     }
+    dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_DMR);
 
     long freq = 0;
     if (!dmr_sm_resolve_tunable_grant(ctx, opts, state, ev, &freq)) {
@@ -506,31 +571,11 @@ handle_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot) {
 }
 
 static void
-handle_cc_sync(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state) {
-    if (!ctx) {
-        return;
-    }
-    if (opts && opts->trunk_is_tuned == 1) {
-        return;
-    }
-    if (state) {
-        ctx->cc_freq_hz = state->trunk_cc_freq;
-    }
-    ctx->cc_acquiring = 0;
-    ctx->cc_confirmed = 1;
-    ctx->t_cc_sync_m = dsd_time_now_monotonic_s();
-
-    if (ctx->state == DMR_SM_IDLE || ctx->state == DMR_SM_HUNTING) {
-        set_state(ctx, opts, DMR_SM_ON_CC, "cc-sync");
-    }
-}
-
-static void
 tick_on_cc(dmr_sm_ctx_t* ctx, const dsd_opts* opts, double now_m, double cc_grace) {
-    if (ctx->t_cc_sync_m <= 0.0) {
+    const double since = ctx->cc_acquiring ? ctx->cc_acquire_start_m : ctx->t_cc_sync_m;
+    if (since <= 0.0) {
         return;
     }
-    const double since = ctx->cc_acquiring ? ctx->cc_acquire_start_m : ctx->t_cc_sync_m;
     if ((now_m - since) > cc_grace) {
         set_state(ctx, opts, DMR_SM_HUNTING, "cc-lost");
     }
@@ -663,7 +708,7 @@ dmr_sm_event(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const dmr_sm_e
         case DMR_SM_EV_VOICE_SYNC: handle_voice_sync(ctx, opts, state, ev->slot); break;
         case DMR_SM_EV_DATA_SYNC: handle_data_sync(ctx, opts, state, ev->slot); break;
         case DMR_SM_EV_RELEASE: handle_release(ctx, opts, state, ev->slot); break;
-        case DMR_SM_EV_CC_SYNC: handle_cc_sync(ctx, opts, state); break;
+        case DMR_SM_EV_CC_SYNC: dmr_cc_note_heartbeat_ctx(ctx, opts, state); break;
         case DMR_SM_EV_SYNC_LOST: break;
     }
 }

--- a/src/protocol/dmr/dmr_trunk_sm.c
+++ b/src/protocol/dmr/dmr_trunk_sm.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/constants.h>
 #include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/events.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
@@ -25,6 +26,9 @@
 #include "dsd-neo/core/state_fwd.h"
 
 void dmr_reset_blocks(dsd_opts* opts, dsd_state* state);
+
+#define DMR_CC_PROBE_GRACE_S  2.0
+#define DMR_CC_TUNE_TIMEOUT_S 5.0
 
 /* ============================================================================
  * Internal Helpers
@@ -98,9 +102,16 @@ dmr_cc_resolve_pending(dmr_sm_ctx_t* ctx, const dsd_opts* opts, double now_m) {
         return 1;
     }
     double completed_m = 0.0;
-    const dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(ctx->cc_tune_request_id, &completed_m);
+    dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(ctx->cc_tune_request_id, &completed_m);
     if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
-        return 0;
+        if (now_m < ctx->cc_tune_deadline_m) {
+            return 0;
+        }
+        /* Keep frames gated until a replacement tune succeeds. Late completion
+         * cannot resurrect the expired request. */
+        dsd_trunk_tuning_request_publish(ctx->cc_tune_request_id, DSD_TRUNK_TUNE_RESULT_FAILED);
+        result = dsd_trunk_tuning_request_status(ctx->cc_tune_request_id, &completed_m);
+        sm_recovery_log(opts, "cc-tune-timeout");
     }
     ctx->cc_tune_request_id = 0U;
     if (result == DSD_TRUNK_TUNE_RESULT_OK) {
@@ -127,6 +138,7 @@ dmr_sm_begin_cc_acquisition(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_s
     ctx->cc_acquiring = 1;
     ctx->cc_acquire_start_m = dsd_time_now_monotonic_s();
     ctx->cc_tune_request_id = request_id;
+    ctx->cc_tune_deadline_m = ctx->cc_acquire_start_m + DMR_CC_TUNE_TIMEOUT_S;
     ctx->state = DMR_SM_ON_CC;
     if (request_id == 0U) {
         ctx->cc_rx_freq_hz = freq_hz;
@@ -202,18 +214,8 @@ dmr_cc_note_monitor_frequency(const dsd_opts* opts, dsd_state* state, long freq_
     }
 }
 
-void
-dmr_sm_note_cc_activity(const dsd_opts* opts, dsd_state* state, long freq_hz) {
-    if (opts && state && opts->trunk_enable != 1 && opts->trunk_is_tuned == 0) {
-        /* Preserve decoded CC attribution in monitor mode without starting a
-         * trunk state machine or giving it permission to retune. */
-        dmr_cc_note_monitor_frequency(opts, state, freq_hz);
-        return;
-    }
-    dmr_sm_ctx_t* ctx = dmr_cc_activity_context(opts, state);
-    if (!ctx) {
-        return;
-    }
+static void
+dmr_cc_note_activity_ctx(dmr_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, long freq_hz) {
     const long current = dmr_cc_current_frequency(opts, ctx);
     if (current <= 0 || (freq_hz > 0 && freq_hz != current)
         || (ctx->cc_acquiring && current != ctx->cc_probe_freq_hz)) {
@@ -238,6 +240,21 @@ dmr_sm_note_cc_activity(const dsd_opts* opts, dsd_state* state, long freq_hz) {
     set_state(ctx, opts, DMR_SM_ON_CC, "decoded-cc");
 }
 
+void
+dmr_sm_note_cc_activity(const dsd_opts* opts, dsd_state* state, long freq_hz) {
+    if (opts && state && opts->trunk_enable != 1 && opts->trunk_is_tuned == 0) {
+        /* Preserve decoded CC attribution in monitor mode without starting a
+         * trunk state machine or giving it permission to retune. */
+        dmr_cc_note_monitor_frequency(opts, state, freq_hz);
+        return;
+    }
+    dmr_sm_ctx_t* ctx = dmr_cc_activity_context(opts, state);
+    if (!ctx) {
+        return;
+    }
+    dmr_cc_note_activity_ctx(ctx, opts, state, freq_hz);
+}
+
 static void
 dmr_cc_note_heartbeat_ctx(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state) {
     if (!ctx || !opts || !state || opts->trunk_is_tuned == 1 || !ctx->cc_confirmed || ctx->cc_acquiring
@@ -258,37 +275,64 @@ dmr_sm_note_cc_heartbeat(const dsd_opts* opts, const dsd_state* state) {
     dmr_cc_note_heartbeat_ctx(ctx, opts, state);
 }
 
+static int
+dmr_cc_map_has_frequency(const dsd_state* state, long freq) {
+    for (int i = 0; i < state->lcn_freq_count; ++i) {
+        if (*dsd_state_trunk_lcn_slot_const(state, i) == freq && !dsd_state_trunk_lcn_avoid_get(state, (size_t)i)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static long
+dmr_cc_next_mapped_candidate(dmr_sm_ctx_t* ctx, const dsd_state* state) {
+    for (int tries = 0; tries < state->lcn_freq_count; ++tries) {
+        if (ctx->cc_hunt_index >= state->lcn_freq_count || ctx->cc_hunt_index < 0) {
+            ctx->cc_hunt_index = 0;
+        }
+        const int index = ctx->cc_hunt_index++;
+        const long freq = *dsd_state_trunk_lcn_slot_const(state, index);
+        if (freq <= 0 || dsd_state_trunk_lcn_avoid_get(state, (size_t)index) || freq == ctx->cc_probe_freq_hz) {
+            continue;
+        }
+        /* Adjacent LSNs often name the same RF channel. */
+        while (ctx->cc_hunt_index < state->lcn_freq_count
+               && *dsd_state_trunk_lcn_slot_const(state, ctx->cc_hunt_index) == freq) {
+            ++ctx->cc_hunt_index;
+        }
+        return freq;
+    }
+    return 0; // No eligible alternative: keep listening without a retune.
+}
+
 static long
 dmr_cc_next_candidate(dmr_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
+    const long anchor = ctx->cc_freq_hz > 0 ? ctx->cc_freq_hz : state->trunk_cc_freq;
     const char* scan_map = dsd_trunk_scan_hook_active_chan_csv(state);
     const int user_list = opts->chan_in_file[0] != '\0' || (scan_map && scan_map[0] != '\0');
     if (user_list && state->lcn_freq_count > 0) {
-        for (int tries = 0; tries < state->lcn_freq_count; ++tries) {
-            if (ctx->cc_hunt_index >= state->lcn_freq_count || ctx->cc_hunt_index < 0) {
-                ctx->cc_hunt_index = 0;
-            }
-            const long freq = *dsd_state_trunk_lcn_slot_const(state, ctx->cc_hunt_index++);
-            if (freq > 0 && (freq != ctx->cc_probe_freq_hz || state->lcn_freq_count == 1)) {
-                return freq;
-            }
+        /* Revisit the anchor between alternate probes so a recovered marginal
+         * CC does not wait for the whole map. Respect session avoids here too. */
+        if (ctx->cc_probe_freq_hz != anchor && anchor > 0 && dmr_cc_map_has_frequency(state, anchor)) {
+            return anchor;
         }
-    } else {
-        if (ctx->cc_probe_freq_hz != ctx->cc_freq_hz && ctx->cc_freq_hz > 0) {
-            return ctx->cc_freq_hz;
-        }
-        long candidate = 0;
-        if (dsd_trunk_cc_candidates_next(state, dsd_time_now_monotonic_s(), DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE,
-                                         &candidate)) {
-            return candidate;
-        }
+        return dmr_cc_next_mapped_candidate(ctx, state);
     }
-    return ctx->cc_freq_hz > 0 ? ctx->cc_freq_hz : state->trunk_cc_freq;
+    if (ctx->cc_probe_freq_hz != anchor && anchor > 0) {
+        return anchor;
+    }
+    long candidate = 0;
+    if (dsd_trunk_cc_candidates_next(state, dsd_time_now_monotonic_s(), DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE,
+                                     &candidate)) {
+        return candidate;
+    }
+    return anchor;
 }
 
 static void
 dmr_cc_hunt(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
-    if (!opts || !state || opts->trunk_enable != 1 || opts->trunk_is_tuned == 1 || ctx->cc_retry_after_m > now_m
-        || (opts->trunk_scan_enabled && !dsd_trunk_scan_hook_dmr_ctx())) {
+    if (!dsd_trunk_dmr_recovery_allowed(opts, state) || opts->trunk_is_tuned == 1 || ctx->cc_retry_after_m > now_m) {
         return;
     }
     ctx->cc_retry_after_m = now_m + 2.0;
@@ -300,6 +344,7 @@ dmr_cc_hunt(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
         /* No alternate candidate: keep listening without resetting demodulation
          * every acquisition window. Only decoded control evidence confirms it. */
         ctx->cc_probe_freq_hz = freq;
+        ctx->cc_acquiring = 1;
         ctx->cc_acquire_start_m = now_m;
         set_state(ctx, opts, DMR_SM_ON_CC, "cc-listen");
         return;
@@ -318,17 +363,36 @@ dmr_cc_hunt(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
     ctx->cc_acquiring = 1;
     ctx->cc_acquire_start_m = dsd_time_now_monotonic_s();
     ctx->cc_tune_request_id = request_id;
+    ctx->cc_tune_deadline_m = ctx->cc_acquire_start_m + DMR_CC_TUNE_TIMEOUT_S;
     set_state(ctx, opts, DMR_SM_ON_CC, "cc-probe");
     (void)dmr_cc_resolve_pending(ctx, opts, ctx->cc_acquire_start_m);
     if (sm_status_log_enabled(opts)) {
         DSD_FPRINTF(stderr, "\n[DMR SM] CC probe %.6lf MHz; acquisition %.2f s\n", (double)freq / 1000000.0,
-                    ctx->cc_grace_s);
+                    DMR_CC_PROBE_GRACE_S);
     }
 }
 
 /* ============================================================================
  * Release to CC
  * ============================================================================ */
+
+static void
+dmr_sm_release_without_cc(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
+    if (state) {
+        const double ended_m = dsd_time_now_monotonic_s();
+        for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; ++slot) {
+            if (dsd_call_state_end_ex(state, (uint8_t)slot, ended_m, DSD_CALL_END_EXPLICIT) > 0) {
+                dsd_event_sync_slot(opts, state, (uint8_t)slot);
+            }
+        }
+        state->is_con_plus = 0;
+        state->p25_vc_freq[0] = state->p25_vc_freq[1] = 0;
+        dmr_reset_blocks(opts, state);
+    }
+    ctx->cc_acquiring = 0;
+    ctx->cc_confirmed = 0;
+    ctx->cc_tune_request_id = 0U;
+}
 
 static void
 do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason) {
@@ -344,8 +408,8 @@ do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
 
     sm_log(opts, reason);
 
-    const long cc = state ? (state->trunk_cc_freq > 0 ? state->trunk_cc_freq : state->p25_cc_freq) : 0;
-    dsd_trunk_tune_result tune_result = dmr_sm_return_to_cc(ctx, opts, state, cc);
+    const long cc = state && state->trunk_cc_freq > 0 ? state->trunk_cc_freq : ctx->cc_freq_hz;
+    dsd_trunk_tune_result tune_result = cc > 0 ? dmr_sm_return_to_cc(ctx, opts, state, cc) : DSD_TRUNK_TUNE_RESULT_OK;
     if (!dsd_trunk_tune_result_is_ok(tune_result)) {
         sm_log(opts, "release-tune-deferred");
         if (state && had_force_release) {
@@ -381,7 +445,10 @@ do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
         state->p25_sm_release_count++;
     }
 
-    set_state(ctx, opts, DMR_SM_ON_CC, reason);
+    if (cc <= 0) {
+        dmr_sm_release_without_cc(ctx, opts, state);
+    }
+    set_state(ctx, opts, cc > 0 ? DMR_SM_ON_CC : DMR_SM_HUNTING, reason);
 }
 
 static int
@@ -426,6 +493,11 @@ handle_grant(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const dmr_sm_e
         return;
     }
 
+    /* A validated grant on a completed probe proves where to return, even
+     * before the next ALOHA/system-parameters message arrives. */
+    if (ctx->cc_acquiring && opts->trunk_is_tuned == 0 && dsd_trunk_tuning_frame_is_current(ctx->cc_rx_generation)) {
+        dmr_cc_note_activity_ctx(ctx, opts, state, ctx->cc_probe_freq_hz);
+    }
     double now_m = dsd_time_now_monotonic_s();
 
     dsd_trunk_tune_result tune_result =
@@ -667,7 +739,7 @@ dmr_sm_init_ctx(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state)
 
     ctx->hangtime_s = 2.0;
     ctx->grant_timeout_s = 4.0;
-    ctx->cc_grace_s = 2.0;
+    ctx->cc_grace_s = 6.0;
 
     // Honor user hangtime setting, including zero for immediate release
     if (opts && opts->trunk_hangtime >= 0.0) {
@@ -715,7 +787,7 @@ dmr_sm_event(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const dmr_sm_e
 
 void
 dmr_sm_tick_ctx(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
-    if (!ctx) {
+    if (!ctx || !dsd_trunk_dmr_recovery_allowed(opts, state)) {
         return;
     }
 
@@ -726,7 +798,7 @@ dmr_sm_tick_ctx(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
     double now_m = dsd_time_now_monotonic_s();
     double hangtime = ctx->hangtime_s;
     double grant_timeout = ctx->grant_timeout_s;
-    double cc_grace = ctx->cc_grace_s;
+    double cc_grace = ctx->cc_acquiring ? DMR_CC_PROBE_GRACE_S : ctx->cc_grace_s;
     if (!dmr_cc_resolve_pending(ctx, opts, now_m)) {
         return;
     }

--- a/src/protocol/dmr/dmr_trunk_sm.c
+++ b/src/protocol/dmr/dmr_trunk_sm.c
@@ -13,11 +13,13 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/rigctl_query_hooks.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <time.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
 #include "dsd-neo/core/state_fwd.h"
@@ -81,6 +83,182 @@ set_state(dmr_sm_ctx_t* ctx, const dsd_opts* opts, dmr_sm_state_e new_state, con
     }
 }
 
+/* Resolve completion before accepting any heartbeat. A successful backend tune
+ * is an acquisition boundary, not decoded control-channel evidence. */
+static int
+dmr_cc_resolve_pending(dmr_sm_ctx_t* ctx, const dsd_opts* opts, double now_m) {
+    if (ctx->cc_tune_request_id == 0U) {
+        return 1;
+    }
+    double completed_m = 0.0;
+    const dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(ctx->cc_tune_request_id, &completed_m);
+    if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
+        return 0;
+    }
+    ctx->cc_tune_request_id = 0U;
+    if (result == DSD_TRUNK_TUNE_RESULT_OK) {
+        ctx->cc_acquire_start_m = completed_m > 0.0 ? completed_m : now_m;
+        return 1;
+    }
+    ctx->cc_acquiring = 0;
+    ctx->cc_retry_after_m = now_m + 2.0;
+    set_state(ctx, opts, DMR_SM_HUNTING, "cc-tune-failed");
+    return 0;
+}
+
+void
+dmr_sm_begin_cc_acquisition(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state, long freq_hz,
+                            uint64_t request_id) {
+    if (!ctx || !state || freq_hz <= 0) {
+        return;
+    }
+    dmr_sm_init_ctx(ctx, opts, state);
+    ctx->cc_freq_hz = freq_hz;
+    ctx->cc_probe_freq_hz = freq_hz;
+    ctx->cc_acquiring = 1;
+    ctx->cc_acquire_start_m = dsd_time_now_monotonic_s();
+    ctx->cc_tune_request_id = request_id;
+    ctx->state = DMR_SM_ON_CC;
+    (void)dmr_cc_resolve_pending(ctx, opts, ctx->cc_acquire_start_m);
+}
+
+static long
+dmr_cc_current_frequency(const dsd_opts* opts, const dmr_sm_ctx_t* ctx) {
+    if (opts->use_rigctl == 1) {
+        return dsd_rigctl_query_hook_get_current_freq_hz(opts);
+    }
+    if (opts->audio_in_type == AUDIO_IN_RTL) {
+        return (long)opts->rtlsdr_center_freq;
+    }
+    /* Fixed audio/file inputs have no tuner query. Their seeded/probed channel
+     * remains the only available frequency attribution. */
+    if (!ctx) {
+        return 0;
+    }
+    return ctx->cc_probe_freq_hz != 0 ? ctx->cc_probe_freq_hz : ctx->cc_freq_hz;
+}
+
+static dmr_sm_ctx_t*
+dmr_cc_activity_context(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state || opts->trunk_enable != 1 || opts->trunk_is_tuned == 1) {
+        return NULL;
+    }
+    if (opts->trunk_scan_enabled && !dsd_trunk_scan_hook_dmr_ctx()) {
+        return NULL;
+    }
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    if (!dmr_cc_resolve_pending(ctx, opts, dsd_time_now_monotonic_s())) {
+        return NULL;
+    }
+    return ctx;
+}
+
+static void
+dmr_cc_note_monitor_frequency(const dsd_opts* opts, dsd_state* state, long freq_hz) {
+    const long current = dmr_cc_current_frequency(opts, NULL);
+    if (current > 0 && (freq_hz <= 0 || freq_hz == current)) {
+        state->trunk_cc_freq = current;
+    }
+}
+
+void
+dmr_sm_note_cc_activity(const dsd_opts* opts, dsd_state* state, long freq_hz) {
+    if (opts && state && opts->trunk_enable != 1 && opts->trunk_is_tuned == 0) {
+        /* Preserve decoded CC attribution in monitor mode without starting a
+         * trunk state machine or giving it permission to retune. */
+        dmr_cc_note_monitor_frequency(opts, state, freq_hz);
+        return;
+    }
+    dmr_sm_ctx_t* ctx = dmr_cc_activity_context(opts, state);
+    if (!ctx) {
+        return;
+    }
+    const long current = dmr_cc_current_frequency(opts, ctx);
+    if (current <= 0 || (freq_hz > 0 && freq_hz != current)
+        || (ctx->cc_acquiring && current != ctx->cc_probe_freq_hz)) {
+        return;
+    }
+    ctx->cc_freq_hz = current;
+    ctx->cc_probe_freq_hz = current;
+    ctx->cc_confirmed = 1;
+    ctx->cc_acquiring = 0;
+    ctx->cc_retry_after_m = 0.0;
+    ctx->t_cc_sync_m = dsd_time_now_monotonic_s();
+    state->trunk_cc_freq = current;
+    state->last_cc_sync_time = time(NULL);
+    state->last_cc_sync_time_m = ctx->t_cc_sync_m;
+    set_state(ctx, opts, DMR_SM_ON_CC, "decoded-cc");
+}
+
+void
+dmr_sm_note_cc_heartbeat(const dsd_opts* opts, const dsd_state* state) {
+    dmr_sm_ctx_t* ctx = dmr_cc_activity_context(opts, state);
+    if (ctx && ctx->cc_confirmed && !ctx->cc_acquiring && dmr_cc_current_frequency(opts, ctx) == ctx->cc_freq_hz) {
+        ctx->t_cc_sync_m = dsd_time_now_monotonic_s();
+        set_state(ctx, opts, DMR_SM_ON_CC, "cc-heartbeat");
+    }
+}
+
+static long
+dmr_cc_next_candidate(dmr_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
+    const char* scan_map = dsd_trunk_scan_hook_active_chan_csv(state);
+    const int user_list = opts->chan_in_file[0] != '\0' || (scan_map && scan_map[0] != '\0');
+    if (user_list && state->lcn_freq_count > 0) {
+        for (int tries = 0; tries < state->lcn_freq_count; ++tries) {
+            if (ctx->cc_hunt_index >= state->lcn_freq_count || ctx->cc_hunt_index < 0) {
+                ctx->cc_hunt_index = 0;
+            }
+            const long freq = *dsd_state_trunk_lcn_slot_const(state, ctx->cc_hunt_index++);
+            if (freq > 0 && (freq != ctx->cc_probe_freq_hz || state->lcn_freq_count == 1)) {
+                return freq;
+            }
+        }
+    } else {
+        if (ctx->cc_probe_freq_hz != ctx->cc_freq_hz && ctx->cc_freq_hz > 0) {
+            return ctx->cc_freq_hz;
+        }
+        long candidate = 0;
+        if (dsd_trunk_cc_candidates_next(state, dsd_time_now_monotonic_s(), DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE,
+                                         &candidate)) {
+            return candidate;
+        }
+    }
+    return ctx->cc_freq_hz > 0 ? ctx->cc_freq_hz : state->trunk_cc_freq;
+}
+
+static void
+dmr_cc_hunt(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double now_m) {
+    if (!opts || !state || opts->trunk_enable != 1 || opts->trunk_is_tuned == 1 || ctx->cc_retry_after_m > now_m
+        || (opts->trunk_scan_enabled && !dsd_trunk_scan_hook_dmr_ctx())) {
+        return;
+    }
+    ctx->cc_retry_after_m = now_m + 2.0;
+    const long freq = dmr_cc_next_candidate(ctx, opts, state);
+    if (freq <= 0) {
+        return;
+    }
+    const long anchor = state->trunk_cc_freq;
+    uint64_t request_id = 0U;
+    const dsd_trunk_tune_result result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, 0, &request_id);
+    /* The shared tune helper stages a CC frequency for legacy callers. DMR
+     * probes retain their return destination until a control message proves it. */
+    state->trunk_cc_freq = anchor;
+    if (!dsd_trunk_tune_result_is_ok(result)) {
+        sm_log(opts, "cc-probe-deferred-or-failed");
+        return;
+    }
+    ctx->cc_probe_freq_hz = freq;
+    ctx->cc_acquiring = 1;
+    ctx->cc_acquire_start_m = dsd_time_now_monotonic_s();
+    ctx->cc_tune_request_id = request_id;
+    set_state(ctx, opts, DMR_SM_ON_CC, "cc-probe");
+    (void)dmr_cc_resolve_pending(ctx, opts, ctx->cc_acquire_start_m);
+    if (sm_status_log_enabled(opts)) {
+        DSD_FPRINTF(stderr, "\n[DMR SM] CC probe %.6lf MHz; acquisition %.2f s\n", (double)freq / 1000000.0,
+                    ctx->cc_grace_s);
+    }
+}
+
 /* ============================================================================
  * Release to CC
  * ============================================================================ */
@@ -99,7 +277,8 @@ do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
 
     sm_log(opts, reason);
 
-    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state, NULL);
+    uint64_t request_id = 0U;
+    dsd_trunk_tune_result tune_result = dsd_trunk_tuning_hook_return_to_cc(opts, state, &request_id);
     if (!dsd_trunk_tune_result_is_ok(tune_result)) {
         sm_log(opts, "release-tune-deferred");
         if (state && had_force_release) {
@@ -136,12 +315,15 @@ do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
     }
 
     set_state(ctx, opts, DMR_SM_ON_CC, reason);
+    if (state) {
+        dmr_sm_begin_cc_acquisition(ctx, opts, state, state->trunk_cc_freq, request_id);
+    }
 }
 
 static int
 dmr_sm_resolve_tunable_grant(const dmr_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state, const dmr_sm_event_t* ev,
                              long* out_freq) {
-    if (opts->trunk_enable != 1 || state->trunk_cc_freq == 0) {
+    if (opts->trunk_enable != 1 || state->trunk_cc_freq == 0 || ctx->cc_tune_request_id != 0U) {
         return 0;
     }
 
@@ -198,6 +380,8 @@ handle_grant(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const dmr_sm_e
     ctx->vc_identity_published = 0;
     ctx->t_tune_m = now_m;
     ctx->t_voice_m = 0.0;
+    ctx->cc_acquiring = 0;
+    ctx->cc_tune_request_id = 0U;
     state->dmr_mono_slot = ctx->vc_slot;
 
     for (int s = 0; s < 2; s++) {
@@ -322,12 +506,18 @@ handle_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int slot) {
 }
 
 static void
-handle_cc_sync(dmr_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
+handle_cc_sync(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state) {
     if (!ctx) {
         return;
     }
-    UNUSED(state);
-
+    if (opts && opts->trunk_is_tuned == 1) {
+        return;
+    }
+    if (state) {
+        ctx->cc_freq_hz = state->trunk_cc_freq;
+    }
+    ctx->cc_acquiring = 0;
+    ctx->cc_confirmed = 1;
     ctx->t_cc_sync_m = dsd_time_now_monotonic_s();
 
     if (ctx->state == DMR_SM_IDLE || ctx->state == DMR_SM_HUNTING) {
@@ -340,7 +530,8 @@ tick_on_cc(dmr_sm_ctx_t* ctx, const dsd_opts* opts, double now_m, double cc_grac
     if (ctx->t_cc_sync_m <= 0.0) {
         return;
     }
-    if ((now_m - ctx->t_cc_sync_m) > cc_grace) {
+    const double since = ctx->cc_acquiring ? ctx->cc_acquire_start_m : ctx->t_cc_sync_m;
+    if ((now_m - since) > cc_grace) {
         set_state(ctx, opts, DMR_SM_HUNTING, "cc-lost");
     }
 }
@@ -448,6 +639,8 @@ dmr_sm_init_ctx(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state)
     if (state && state->trunk_cc_freq != 0) {
         ctx->state = DMR_SM_ON_CC;
         ctx->t_cc_sync_m = dsd_time_now_monotonic_s();
+        ctx->cc_freq_hz = state->trunk_cc_freq;
+        ctx->cc_probe_freq_hz = state->trunk_cc_freq;
     } else {
         ctx->state = DMR_SM_IDLE;
     }
@@ -489,15 +682,22 @@ dmr_sm_tick_ctx(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
     double hangtime = ctx->hangtime_s;
     double grant_timeout = ctx->grant_timeout_s;
     double cc_grace = ctx->cc_grace_s;
+    if (!dmr_cc_resolve_pending(ctx, opts, now_m)) {
+        return;
+    }
 
     switch (ctx->state) {
         case DMR_SM_IDLE: break;
 
-        case DMR_SM_ON_CC: tick_on_cc(ctx, opts, now_m, cc_grace); break;
+        case DMR_SM_ON_CC:
+            if (!opts || opts->trunk_is_tuned != 1) {
+                tick_on_cc(ctx, opts, now_m, cc_grace);
+            }
+            break;
 
         case DMR_SM_TUNED: tick_tuned(ctx, opts, state, now_m, hangtime, grant_timeout); break;
 
-        case DMR_SM_HUNTING: break;
+        case DMR_SM_HUNTING: dmr_cc_hunt(ctx, opts, state, now_m); break;
     }
 }
 

--- a/src/protocol/p25/p25_sm_watchdog.c
+++ b/src/protocol/p25/p25_sm_watchdog.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/exitflag.h>
 #include <dsd-neo/runtime/telemetry.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <stddef.h>
 
 #include "dsd-neo/core/opts_fwd.h"
@@ -51,7 +52,7 @@ p25_sm_try_tick(dsd_opts* opts, dsd_state* state) {
         return;
     }
     if (p25_sm_tick_guard_try_enter()) {
-        if (p25_sm_recovery_allowed(p25_sm_get_ctx(), opts, state)) {
+        if (dsd_trunk_p25_recovery_allowed(opts, state)) {
             /* Only one tick runs at a time across all callers. */
             atomic_store(&g_p25_sm_in_tick, 1);
             // Drive the high-level trunk SM tick

--- a/src/protocol/p25/p25_sm_watchdog.c
+++ b/src/protocol/p25/p25_sm_watchdog.c
@@ -3,7 +3,6 @@
  * Copyright (C) 2025 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
-#include <dsd-neo/core/opts.h>
 #include <dsd-neo/platform/atomic_compat.h>
 #include <dsd-neo/platform/threading.h>
 #include <dsd-neo/platform/timing.h>
@@ -52,7 +51,7 @@ p25_sm_try_tick(dsd_opts* opts, dsd_state* state) {
         return;
     }
     if (p25_sm_tick_guard_try_enter()) {
-        if (opts->trunk_enable == 1) {
+        if (p25_sm_recovery_allowed(p25_sm_get_ctx(), opts, state)) {
             /* Only one tick runs at a time across all callers. */
             atomic_store(&g_p25_sm_in_tick, 1);
             // Drive the high-level trunk SM tick

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -2457,6 +2457,8 @@ handle_grant(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
         return;
     }
 
+    dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_P25);
+
     // Check grant policy
     if (!grant_allowed(ctx, opts, state, ev, &decision, &eval_ctx, 1)) {
         return;
@@ -4367,6 +4369,7 @@ handle_cc_sync(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
     if (!ctx) {
         return;
     }
+    dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_P25);
     const double now_m = dsd_time_now_monotonic_s();
     if (state) {
         state->last_cc_sync_time = time(NULL);
@@ -6106,30 +6109,6 @@ p25_sm_event(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     if (handler) {
         handler(ctx, opts, state, ev);
     }
-}
-
-static int
-p25_sm_retained_recovery_context(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state) {
-    /* A traffic grant can precede NET_STS (and its CC-format hint). Preserve
-     * that real P25 owner through noCarrier, without mistaking generic shared
-     * frequency/tuned flags for a P25 call. */
-    if (ctx->state == P25_SM_TUNED && opts->trunk_is_tuned == 1 && ctx->vc_freq_hz > 0) {
-        return state->p25_vc_freq[0] == ctx->vc_freq_hz || state->p25_vc_freq[1] == ctx->vc_freq_hz;
-    }
-    return ctx->state == P25_SM_ON_CC && (ctx->cc_sync_pending || ctx->cc_tune_pending);
-}
-
-int
-p25_sm_recovery_allowed(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state) {
-    if (dsd_trunk_p25_recovery_allowed(opts, state)) {
-        return 1;
-    }
-    if (!ctx || !opts || !state || opts->trunk_enable != 1 || opts->trunk_scan_enabled == 1
-        || (!opts->frame_p25p1 && !opts->frame_p25p2) || state->synctype != DSD_SYNC_NONE
-        || state->lastsynctype != DSD_SYNC_NONE || state->p25_cc_freq <= 0) {
-        return 0;
-    }
-    return p25_sm_retained_recovery_context(ctx, opts, state);
 }
 
 void

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -4369,7 +4369,6 @@ handle_cc_sync(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
     if (!ctx) {
         return;
     }
-    dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_P25);
     const double now_m = dsd_time_now_monotonic_s();
     if (state) {
         state->last_cc_sync_time = time(NULL);
@@ -6130,7 +6129,15 @@ p25_sm_tick_ctx(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
 
     switch (ctx->state) {
         case P25_SM_IDLE:
-            // Nothing to do
+            /* Control blocks can establish a CC before the first voice grant.
+             * Use their actual decode time so sync loss still expires normally. */
+            if (state && state->trunk_recovery_protocol == DSD_TRUNK_RECOVERY_P25 && state->p25_cc_freq > 0
+                && state->p25_last_cc_msg_time_m > 0.0) {
+                ctx->t_cc_sync_m = state->p25_last_cc_msg_time_m;
+                p25_sm_set_expected_cc_nac(ctx, state, 0);
+                set_state(ctx, opts, state, P25_SM_ON_CC, "decoded-cc");
+                p25_sm_tick_on_cc(ctx, opts, state, now_m, ctx->config.cc_grace_s);
+            }
             break;
 
         case P25_SM_ON_CC: p25_sm_tick_on_cc(ctx, opts, state, now_m, ctx->config.cc_grace_s); break;

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -6108,6 +6108,30 @@ p25_sm_event(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_e
     }
 }
 
+static int
+p25_sm_retained_recovery_context(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state) {
+    /* A traffic grant can precede NET_STS (and its CC-format hint). Preserve
+     * that real P25 owner through noCarrier, without mistaking generic shared
+     * frequency/tuned flags for a P25 call. */
+    if (ctx->state == P25_SM_TUNED && opts->trunk_is_tuned == 1 && ctx->vc_freq_hz > 0) {
+        return state->p25_vc_freq[0] == ctx->vc_freq_hz || state->p25_vc_freq[1] == ctx->vc_freq_hz;
+    }
+    return ctx->state == P25_SM_ON_CC && (ctx->cc_sync_pending || ctx->cc_tune_pending);
+}
+
+int
+p25_sm_recovery_allowed(const p25_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state) {
+    if (dsd_trunk_p25_recovery_allowed(opts, state)) {
+        return 1;
+    }
+    if (!ctx || !opts || !state || opts->trunk_enable != 1 || opts->trunk_scan_enabled == 1
+        || (!opts->frame_p25p1 && !opts->frame_p25p2) || state->synctype != DSD_SYNC_NONE
+        || state->lastsynctype != DSD_SYNC_NONE || state->p25_cc_freq <= 0) {
+        return 0;
+    }
+    return p25_sm_retained_recovery_context(ctx, opts, state);
+}
+
 void
 p25_sm_tick_ctx(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
     if (!ctx) {

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -405,10 +405,13 @@ dsd_cli_usage_section_trunking_and_tools(void) {
     printf(
         "      --trunk-scan-activity-hold-ms <ms>  Set conventional DMR/P25/NXDN activity hold (250..600000, default "
         "1200).\n");
-    printf("      --scan-voice-only  Only stop scan on channels carrying voice.\n");
+    printf("      --scan-voice-only  Conventional scan/targets: hold only for decoded voice.\n");
+    printf("                 Trunked targets use idle dwell and protocol call-following timers.\n");
     printf("      --scan-voice-qualify-ms <ms>  Window after sync in which voice must appear or the scan moves on "
            "(100..600000, default 1000).\n");
     printf("      --scan-voice-hold-ms <ms>  Time to stay after the last voice frame (100..600000, default 2000).\n");
+    printf("                 Global qualify/hold timings apply to -Y; trunk-scan conventional rows use\n");
+    printf("                 dwell_ms/activity_hold_ms, or their own row options.\n");
     printf("  -W            Use Imported Group List as a Trunking Allow/White List -- Only Tune with Mode A\n");
     printf("  -p            Disable Tune to Private Calls (DMR TIII, P25, NXDN Type-C and Type-D)\n");
     printf("  -E            Disable Tune to Group Calls (DMR TIII, Con+, Cap+, P25, NXDN Type-C, and Type-D)\n");
@@ -422,7 +425,8 @@ dsd_cli_usage_section_trunking_and_tools(void) {
     printf("  -B <Hertz>    Set RIGCTL Setmod Bandwidth in Hertz (0 - default - Off)\n");
     printf("                 P25 - 12000; NXDN48 - 7000; NXDN96: 12000; DMR - 7000-12000; EDACS/PV - 12000-24000;\n");
     printf("                 May vary based on system stregnth, etc.\n");
-    printf("  -t <secs>     Set Trunking or Scan Speed VC/sync loss hangtime in seconds. (default = 2 seconds)\n");
+    printf("  -t <secs>     Voice/sync-loss hangtime in seconds (default 2); also conventional -Y scan speed.\n");
+    printf("                 Does not set --trunk-scan target dwell or DMR control-channel acquisition time.\n");
     printf("\n");
     printf(" Trunking Example TCP: dsd-neo -fs -i tcp -U 4532 -T -C dmr_t3_chan.csv -G group.csv --frontend terminal "
            "2> log.txt\n");

--- a/src/runtime/trunk_scan_hooks.c
+++ b/src/runtime/trunk_scan_hooks.c
@@ -5,7 +5,6 @@
 
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
-#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -14,9 +13,11 @@
 
 static dsd_trunk_scan_hooks g_trunk_scan_hooks = {0};
 
-static int
-trunk_sync_is_non_p25(int sync) {
-    return DSD_SYNC_IS_DMR(sync) || DSD_SYNC_IS_NXDN(sync) || DSD_SYNC_IS_EDACS(sync) || DSD_SYNC_IS_X2TDMA(sync);
+void
+dsd_trunk_recovery_note_protocol(dsd_state* state, dsd_trunk_recovery_protocol protocol) {
+    if (state) {
+        state->trunk_recovery_protocol = (int)protocol;
+    }
 }
 
 int
@@ -30,15 +31,9 @@ dsd_trunk_p25_recovery_allowed(const dsd_opts* opts, const dsd_state* state) {
     if (!opts->frame_p25p1 && !opts->frame_p25p2) {
         return 0;
     }
-    const int sync = state->synctype != DSD_SYNC_NONE ? state->synctype : state->lastsynctype;
-    if (trunk_sync_is_non_p25(sync)) {
-        return 0;
-    }
-    /* Generic trunk return hints can outlive their protocol. A known P25
-     * channel format, or an explicitly P25-only trunk decoder, can bridge sync
-     * loss; the shared frequency cache alone cannot do that in AUTO. */
-    const int known_p25_cc = state->p25_cc_is_tdma == 0 || state->p25_cc_is_tdma == 1;
-    return DSD_SYNC_IS_P25(sync) || (state->p25_cc_freq > 0 && (known_p25_cc || !opts->frame_dmr));
+    return state->trunk_recovery_protocol == DSD_TRUNK_RECOVERY_P25
+           || (state->trunk_recovery_protocol == DSD_TRUNK_RECOVERY_UNKNOWN && !opts->frame_dmr && !opts->frame_nxdn48
+               && !opts->frame_nxdn96 && !opts->frame_provoice);
 }
 
 int
@@ -52,11 +47,9 @@ dsd_trunk_dmr_recovery_allowed(const dsd_opts* opts, const dsd_state* state) {
     if (!opts->frame_dmr) {
         return 0;
     }
-    const int sync = state->synctype != DSD_SYNC_NONE ? state->synctype : state->lastsynctype;
-    if (sync != DSD_SYNC_NONE) {
-        return DSD_SYNC_IS_DMR(sync);
-    }
-    return !opts->frame_p25p1 && !opts->frame_p25p2 && state->rf_mod == 2 && state->trunk_cc_freq > 0;
+    return state->trunk_recovery_protocol == DSD_TRUNK_RECOVERY_DMR
+           || (state->trunk_recovery_protocol == DSD_TRUNK_RECOVERY_UNKNOWN && !opts->frame_p25p1 && !opts->frame_p25p2
+               && !opts->frame_nxdn48 && !opts->frame_nxdn96 && !opts->frame_provoice);
 }
 
 void

--- a/src/runtime/trunk_scan_hooks.c
+++ b/src/runtime/trunk_scan_hooks.c
@@ -3,12 +3,61 @@
  * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
  */
 
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <stddef.h>
+#include <stdint.h>
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/state_fwd.h"
 
 static dsd_trunk_scan_hooks g_trunk_scan_hooks = {0};
+
+static int
+trunk_sync_is_non_p25(int sync) {
+    return DSD_SYNC_IS_DMR(sync) || DSD_SYNC_IS_NXDN(sync) || DSD_SYNC_IS_EDACS(sync) || DSD_SYNC_IS_X2TDMA(sync);
+}
+
+int
+dsd_trunk_p25_recovery_allowed(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state || opts->trunk_enable != 1) {
+        return 0;
+    }
+    if (opts->trunk_scan_enabled == 1) {
+        return dsd_trunk_scan_hook_p25_ctx() != NULL;
+    }
+    if (!opts->frame_p25p1 && !opts->frame_p25p2) {
+        return 0;
+    }
+    const int sync = state->synctype != DSD_SYNC_NONE ? state->synctype : state->lastsynctype;
+    if (trunk_sync_is_non_p25(sync)) {
+        return 0;
+    }
+    /* Generic trunk return hints can outlive their protocol. A known P25
+     * channel format, or an explicitly P25-only trunk decoder, can bridge sync
+     * loss; the shared frequency cache alone cannot do that in AUTO. */
+    const int known_p25_cc = state->p25_cc_is_tdma == 0 || state->p25_cc_is_tdma == 1;
+    return DSD_SYNC_IS_P25(sync) || (state->p25_cc_freq > 0 && (known_p25_cc || !opts->frame_dmr));
+}
+
+int
+dsd_trunk_dmr_recovery_allowed(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state || opts->trunk_enable != 1) {
+        return 0;
+    }
+    if (opts->trunk_scan_enabled == 1) {
+        return dsd_trunk_scan_hook_dmr_ctx() != NULL;
+    }
+    if (!opts->frame_dmr) {
+        return 0;
+    }
+    const int sync = state->synctype != DSD_SYNC_NONE ? state->synctype : state->lastsynctype;
+    if (sync != DSD_SYNC_NONE) {
+        return DSD_SYNC_IS_DMR(sync);
+    }
+    return !opts->frame_p25p1 && !opts->frame_p25p2 && state->rf_mod == 2 && state->trunk_cc_freq > 0;
+}
 
 void
 dsd_trunk_scan_hooks_set(dsd_trunk_scan_hooks hooks) {

--- a/src/ui/qt/call_history_model.cpp
+++ b/src/ui/qt/call_history_model.cpp
@@ -6,6 +6,7 @@
 #include "call_history_model.h"
 
 #include <QByteArray>
+#include <QChar>
 #include <QDateTime>
 #include <QJsonArray>
 #include <QJsonObject>

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -16,7 +16,6 @@
 #include <dsd-neo/core/power.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
-#include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/scan_mode.h>
 
 #include "dsd-neo/core/opts_fwd.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4679,6 +4679,29 @@ target_link_libraries(
 add_test(NAME ENGINE_TRUNK_SCAN COMMAND dsd-neo_test_engine_trunk_scan)
 
 add_executable(
+    dsd-neo_test_engine_dmr_cc_recovery
+    engine/test_engine_dmr_cc_recovery.c
+    ${PROJECT_SOURCE_DIR}/src/dsp/dsd_frame_sync.c
+    ${PROJECT_SOURCE_DIR}/src/engine/trunk_scan.c
+)
+target_include_directories(
+    dsd-neo_test_engine_dmr_cc_recovery
+    PRIVATE ${PROJECT_SOURCE_DIR}/src/dsp ${PROJECT_SOURCE_DIR}/src/engine
+)
+target_compile_definitions(
+    dsd-neo_test_engine_dmr_cc_recovery
+    PRIVATE DSD_NEO_TEST_HOOKS DSD_TRUNK_SCAN_TEST_CLOCK=1
+)
+target_link_libraries(
+    dsd-neo_test_engine_dmr_cc_recovery
+    PRIVATE dsd-neo_engine ${LIBS} dsd-neo_test_support
+)
+add_test(
+    NAME ENGINE_DMR_CC_RECOVERY
+    COMMAND dsd-neo_test_engine_dmr_cc_recovery
+)
+
+add_executable(
     dsd-neo_test_engine_scan_voice_gate
     engine/test_engine_scan_voice_gate.c
     ${PROJECT_SOURCE_DIR}/src/engine/scan_voice_gate.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4406,6 +4406,10 @@ add_test(
     NAME ENGINE_PROTOCOL_DISPATCH
     COMMAND dsd-neo_test_engine_protocol_dispatch
 )
+target_link_libraries(
+    dsd-neo_test_engine_protocol_dispatch
+    PRIVATE dsd-neo_runtime
+)
 
 add_executable(
     dsd-neo_test_engine_no_carrier_reset

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6514,7 +6514,9 @@ add_test(NAME M17_CONFIRM COMMAND dsd-neo_test_m17_confirm)
 add_executable(
     dsd-neo_test_dmr_t3_sm_clamp
     protocol/dmr/test_dmr_t3_sm_clamp.c
+    test_support/scan_group_stubs.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_trunk_sm.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
 )
 target_include_directories(
     dsd-neo_test_dmr_t3_sm_clamp
@@ -6532,7 +6534,9 @@ add_test(NAME DMR_T3_SM_CLAMP COMMAND dsd-neo_test_dmr_t3_sm_clamp)
 add_executable(
     dsd-neo_test_dmr_t3_sm_release
     protocol/dmr/test_dmr_t3_sm_release.c
+    test_support/scan_group_stubs.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_trunk_sm.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
 )
 target_include_directories(
     dsd-neo_test_dmr_t3_sm_release
@@ -6550,7 +6554,9 @@ add_test(NAME DMR_T3_SM_RELEASE COMMAND dsd-neo_test_dmr_t3_sm_release)
 add_executable(
     dsd-neo_test_dmr_t3_sm_return_to_cc_matrix
     protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
+    test_support/scan_group_stubs.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_trunk_sm.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
 )
 target_include_directories(
     dsd-neo_test_dmr_t3_sm_return_to_cc_matrix
@@ -6572,7 +6578,9 @@ add_test(
 add_executable(
     dsd-neo_test_dmr_t3_shim
     protocol/dmr/test_dmr_t3_shim.c
+    test_support/scan_group_stubs.c
     ${PROJECT_SOURCE_DIR}/src/protocol/dmr/dmr_trunk_sm.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
 )
 target_include_directories(
     dsd-neo_test_dmr_t3_shim

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5226,7 +5226,7 @@ target_include_directories(
 )
 target_link_libraries(
     dsd-neo_test_p25_p1_tsbk_handlers
-    PRIVATE dsd-neo_test_call_state_support dsd-neo_test_support
+    PRIVATE dsd-neo_test_call_state_support dsd-neo_test_support dsd-neo_runtime
 )
 target_compile_options(
     dsd-neo_test_p25_p1_tsbk_handlers
@@ -5593,6 +5593,7 @@ target_include_directories(
     PRIVATE ${PROJECT_SOURCE_DIR}/include
 )
 add_test(NAME P25_P2_XCCH_HELPERS COMMAND dsd-neo_test_p25_p2_xcch_helpers)
+target_link_libraries(dsd-neo_test_p25_p2_xcch_helpers PRIVATE dsd-neo_runtime)
 
 # Core synthesized-audio playback dispatch matrix
 add_executable(
@@ -5682,6 +5683,7 @@ target_link_libraries(
     PRIVATE dsd-neo_test_call_state_support
 )
 add_test(NAME P25_P1_TSBK_SEQUENCE COMMAND dsd-neo_test_p25_p1_tsbk_sequence)
+target_link_libraries(dsd-neo_test_p25_p1_tsbk_sequence PRIVATE dsd-neo_runtime)
 
 # P25 P1 TDU state cleanup and status-symbol handoff
 add_executable(
@@ -8150,7 +8152,7 @@ target_include_directories(
 )
 target_link_libraries(
     dsd-neo_test_p25_p1_pdu_private_allowlist
-    PRIVATE dsd-neo_test_call_state_support dsd-neo_platform
+    PRIVATE dsd-neo_test_call_state_support dsd-neo_platform dsd-neo_runtime
 )
 add_test(
     NAME P25_P1_PDU_PRIVATE_ALLOWLIST

--- a/tests/engine/test_engine_dmr_cc_recovery.c
+++ b/tests/engine/test_engine_dmr_cc_recovery.c
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+/* Real scan coordinator, control-message parser and sync-loss callbacks, with
+ * only the tuner replaced. In particular, neither protocol SM is stubbed. */
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/frame.h>
+#include <dsd-neo/core/init.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/trunk_scan.h>
+#include <dsd-neo/protocol/dmr/dmr.h>
+#include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/frame_sync_hooks.h>
+#include <dsd-neo/runtime/rigctl_query_hooks.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "dsd-neo/core/opts_fwd.h"
+#include "dsd-neo/core/state_fwd.h"
+#include "dsd-neo/platform/file_compat.h"
+#include "dsd-neo/platform/platform.h"
+#if DSD_PLATFORM_WIN_NATIVE
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+#include "engine_hooks_install.h"
+#include "frame_sync_test_support.h"
+#include "test_support.h"
+#include "trunk_scan_internal.h"
+
+void
+printFrameInfo(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+static dsd_opts g_opts;
+static dsd_state g_state;
+static char g_dir[DSD_TEST_PATH_MAX];
+static char g_targets[DSD_TEST_PATH_MAX];
+static char g_channels[DSD_TEST_PATH_MAX];
+static long g_frequency;
+static int g_cc_tunes;
+static int g_returns;
+static uint64_t g_request;
+static dsd_trunk_tune_result g_result;
+
+static int
+expect(int condition, const char* message) {
+    if (!condition) {
+        DSD_FPRINTF(stderr, "FAIL: %s\n", message);
+        return 1;
+    }
+    return 0;
+}
+
+static long
+current_frequency(const dsd_opts* opts) {
+    (void)opts;
+    return g_frequency;
+}
+
+static dsd_trunk_tune_result
+cc_tune(dsd_opts* opts, dsd_state* state, long freq, int sps, uint64_t request_id) {
+    (void)sps;
+    ++g_cc_tunes;
+    g_request = request_id;
+    if (dsd_trunk_tune_result_is_ok(g_result)) {
+        g_frequency = freq;
+        opts->rtlsdr_center_freq = (uint32_t)freq;
+        state->trunk_cc_freq = freq; // The real shared tune helper stages this field.
+        dsd_mark_cc_sync(state);
+    }
+    return g_result;
+}
+
+static dsd_trunk_tune_result
+vc_tune(dsd_opts* opts, dsd_state* state, long freq, int sps, uint64_t request_id) {
+    (void)sps;
+    (void)request_id;
+    g_frequency = freq;
+    opts->rtlsdr_center_freq = (uint32_t)freq;
+    opts->trunk_is_tuned = 1;
+    state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = freq;
+    return DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+static dsd_trunk_tune_result
+return_to_cc(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
+    ++g_returns;
+    g_request = request_id;
+    if (dsd_trunk_tune_result_is_ok(g_result)) {
+        g_frequency = state->trunk_cc_freq;
+        opts->rtlsdr_center_freq = (uint32_t)g_frequency;
+        opts->trunk_is_tuned = 0;
+        state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = 0;
+        dsd_mark_cc_sync(state);
+    }
+    return g_result;
+}
+
+static int
+write_file(const char* path, const char* content) {
+    FILE* fp = dsd_fopen_private(path, "wb");
+    if (!fp) {
+        return 1;
+    }
+    const size_t len = strlen(content);
+    const int failed = fwrite(content, 1, len, fp) != len;
+    return fclose(fp) != 0 || failed;
+}
+
+static void
+cleanup(void) {
+    dsd_engine_trunk_scan_shutdown(&g_opts, &g_state);
+    dsd_frame_sync_hooks_set((dsd_frame_sync_hooks){0});
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){0});
+    dsd_trunk_tuning_requests_reset();
+    trunk_scan_test_clear_now();
+    freeState(&g_state);
+    (void)remove(g_targets);
+    (void)remove(g_channels);
+#if DSD_PLATFORM_WIN_NATIVE
+    (void)_rmdir(g_dir);
+#else
+    (void)rmdir(g_dir);
+#endif
+}
+
+static int
+setup(float hangtime) {
+    DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
+    DSD_MEMSET(&g_state, 0, sizeof(g_state));
+    initOpts(&g_opts);
+    initState(&g_state);
+    g_opts.verbose = 0;
+    g_opts.audio_in_type = AUDIO_IN_NULL;
+    g_opts.audio_out_type = 9;
+    g_opts.use_rigctl = 1;
+    g_opts.trunk_scan_enabled = 1;
+    g_opts.trunk_hangtime = hangtime;
+    g_cc_tunes = g_returns = 0;
+    g_request = 0U;
+    g_result = DSD_TRUNK_TUNE_RESULT_OK;
+    dsd_trunk_tuning_requests_reset();
+    p25_sm_init_ctx(p25_sm_get_ctx(), &g_opts, &g_state);
+    dsd_engine_frame_sync_hooks_install();
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){
+        .tune_to_freq_request = vc_tune, .tune_to_cc_request = cc_tune, .return_to_cc_request = return_to_cc});
+    dsd_rigctl_query_hooks_set((dsd_rigctl_query_hooks){.get_current_freq_hz = current_frequency});
+    if (!dsd_test_mkdtemp(g_dir, sizeof(g_dir), "dsdneo_dmr_cc")
+        || dsd_test_path_join(g_targets, sizeof(g_targets), g_dir, "targets.csv") != 0
+        || dsd_test_path_join(g_channels, sizeof(g_channels), g_dir, "channels.csv") != 0
+        || write_file(g_channels, "channel,frequency\n1,451000000\n2,452000000\n3,452000000\n4,453000000\n")
+        || write_file(g_targets, "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes\n"
+                                 "tiii,dmr-trunk,451000000,channels.csv,250,1200,\n"
+                                 "p25,p25-trunk,851000000,,250,1200,\n"
+                                 "nxdn,nxdn-trunk,454000000,,250,1200,\n")) {
+        return 1;
+    }
+    DSD_SNPRINTF(g_opts.trunk_scan_targets_csv, sizeof(g_opts.trunk_scan_targets_csv), "%s", g_targets);
+    trunk_scan_test_set_now(0.0);
+    char error[256] = {0};
+    const int rc = dsd_engine_trunk_scan_init(&g_opts, &g_state, error, sizeof(error));
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "scan init: %s\n", error);
+        return 1;
+    }
+    return expect(dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE) == 1,
+                  "hold enabled");
+}
+
+static void
+aloha(int crc_ok) {
+    uint8_t bits[196] = {0};
+    uint8_t bytes[24] = {0};
+    bytes[0] = 25;
+    for (int i = 0; i < 8; ++i) {
+        bits[i] = (uint8_t)((bytes[0] >> (7 - i)) & 1);
+    }
+    g_state.synctype = g_state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    dmr_cspdu(&g_opts, &g_state, bits, bytes, (uint32_t)crc_ok, 0);
+}
+
+static void
+expire_acquisition(dmr_sm_ctx_t* ctx) {
+    ctx->cc_acquire_start_m = ctx->t_cc_sync_m = dsd_time_now_monotonic_s() - 3.0;
+    ctx->cc_retry_after_m = 0.0;
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+}
+
+static int
+held_call_return(float hangtime) {
+    if (setup(hangtime)) {
+        cleanup();
+        return 1;
+    }
+    int rc = 0;
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    p25_sm_ctx_t* p25 = p25_sm_get_ctx();
+    ctx->t_cc_sync_m -= 3.0;
+    aloha(1);
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(ctx->state == DMR_SM_ON_CC && ctx->cc_confirmed, "decoded ALOHA keeps DMR on CC");
+    rc |= expect(!g_opts.frame_p25p1 && !g_opts.frame_p25p2, "DMR row excludes P25");
+    dmr_sm_emit_group_grant_slot(&g_opts, &g_state, 452000000L, 2, 0, 1001, 2001);
+    aloha(1);
+    rc |= expect(g_state.trunk_cc_freq == 451000000L, "control-like messages on a followed VC cannot replace CC");
+    dmr_sm_emit_voice_sync(&g_opts, &g_state, 0);
+    ctx->slots[0].last_active_m -= 3.0;
+    ctx->t_voice_m -= 3.0;
+    g_state.last_vc_sync_time = time(NULL) - 3;
+    g_state.last_vc_sync_time_m = dsd_time_now_monotonic_s() - 3.0;
+    g_state.p25_last_vc_tune_time_m = dsd_time_now_monotonic_s() - 4.0;
+    dsd_frame_sync_test_handle_no_sync_timeout(&g_opts, &g_state, 1800);
+    rc |= expect(g_returns == 1 && g_frequency == 451000000L, "DMR returned to original control channel");
+    rc |= expect(p25->state == P25_SM_IDLE && !p25->cc_sync_pending && !g_state.p25_sm_force_release,
+                 "DMR loss did not start P25 recovery or leave a forced-release latch");
+    const int tunes = g_cc_tunes;
+    for (int i = 0; i < 3; ++i) {
+        ctx->cc_acquire_start_m -= 6.0;
+        aloha(1);
+        p25_sm_try_tick(&g_opts, &g_state);
+        trunk_scan_test_set_now(10.0 + i);
+        dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    }
+    rc |= expect(g_cc_tunes == tunes && g_state.trunk_cc_freq == 451000000L && g_state.trunk_scan_hold,
+                 "held target stays on decoded idle CC");
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE);
+    trunk_scan_test_set_now(20.0);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    trunk_scan_test_set_now(20.26);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    rc |= expect(dsd_engine_trunk_scan_active_p25_ctx() != NULL, "idle dwell rotates after hold release");
+    rc |= expect(dsd_trunk_p25_recovery_allowed(&g_opts, &g_state), "P25 target retains its recovery owner");
+    cleanup();
+    return rc;
+}
+
+static int
+hunt_and_reacquire(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    int rc = 0;
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    aloha(1);
+    expire_acquisition(ctx);
+    rc |= expect(g_frequency == 452000000L && g_state.trunk_cc_freq == 451000000L,
+                 "probe moved tuner without replacing CC anchor");
+    g_opts.dmr_crc_relaxed_default = 1;
+    aloha(0);
+    rc |= expect(ctx->cc_acquiring && g_state.trunk_cc_freq == 451000000L,
+                 "relaxed heartbeat cannot validate a new candidate");
+    expire_acquisition(ctx);
+    rc |= expect(g_frequency == 453000000L, "hunt skips duplicate channel frequencies");
+    aloha(1);
+    rc |= expect(!ctx->cc_acquiring && ctx->cc_confirmed && g_state.trunk_cc_freq == 453000000L,
+                 "decoded control channel replaces the old anchor");
+    ctx->t_cc_sync_m -= 3.0;
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(ctx->state == DMR_SM_HUNTING, "expired heartbeat enters recovery");
+    aloha(0);
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(ctx->state == DMR_SM_ON_CC, "relaxed heartbeat retains an established CC");
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_ADVANCE);
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_ADVANCE);
+    rc |= expect(!dsd_trunk_p25_recovery_allowed(&g_opts, &g_state), "NXDN row has no P25 recovery");
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_ADVANCE);
+    rc |= expect(g_frequency == 453000000L, "revisit starts on learned CC");
+    ctx = dmr_sm_get_ctx();
+    rc |= expect(ctx->cc_acquiring && ctx->state == DMR_SM_ON_CC && !ctx->vc_freq_hz,
+                 "revisit starts fresh acquisition without stale call state");
+    cleanup();
+    return rc;
+}
+
+static int
+pending_and_failed_probes(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    int rc = 0;
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    aloha(1);
+    g_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    expire_acquisition(ctx);
+    const uint64_t pending = g_request;
+    const int count = g_cc_tunes;
+    rc |= expect(pending != 0U && ctx->cc_tune_request_id == pending, "probe tracks pending request");
+    expire_acquisition(ctx);
+    aloha(1);
+    rc |= expect(ctx->cc_tune_request_id == pending && g_cc_tunes == count && ctx->cc_acquiring,
+                 "pending tune neither times out nor accepts old-frequency control messages");
+    dsd_trunk_tuning_request_publish(pending, DSD_TRUNK_TUNE_RESULT_OK);
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(ctx->cc_tune_request_id == 0U && g_cc_tunes == count
+                     && dsd_time_now_monotonic_s() - ctx->cc_acquire_start_m < 1.0,
+                 "acquisition grace begins at backend completion");
+    aloha(1);
+    rc |= expect(g_state.trunk_cc_freq == 452000000L, "completed probe accepts decoded CC");
+    g_result = DSD_TRUNK_TUNE_RESULT_DEFERRED;
+    expire_acquisition(ctx);
+    rc |= expect(g_frequency == 452000000L && g_state.trunk_cc_freq == 452000000L,
+                 "deferred probe preserves tuner and anchor");
+    const int deferred_count = g_cc_tunes;
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(g_cc_tunes == deferred_count, "failed/deferred probes are paced");
+    g_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    ctx->cc_retry_after_m = 0.0;
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    const uint64_t failed = g_request;
+    dsd_trunk_tuning_request_publish(failed, DSD_TRUNK_TUNE_RESULT_FAILED);
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(ctx->state == DMR_SM_HUNTING && !ctx->cc_tune_request_id && g_state.trunk_cc_freq == 452000000L,
+                 "backend failure enters paced recovery without changing anchor");
+    g_result = DSD_TRUNK_TUNE_RESULT_OK;
+    ctx->cc_retry_after_m = 0.0;
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()),
+                 "successful replacement clears the failed frame gate");
+    cleanup();
+    return rc;
+}
+
+static void
+cap_plus_idle(unsigned int rest) {
+    uint8_t bits[196] = {0};
+    uint8_t bytes[24] = {0};
+    bytes[0] = 0x3e;
+    bytes[1] = 0x10;
+    bytes[2] = (uint8_t)(0xc0U | rest); // Single complete status, all channel banks idle.
+    for (int i = 0; i < 24; ++i) {
+        bits[i] = (uint8_t)((bytes[i / 8] >> (7 - (i % 8))) & 1);
+    }
+    g_state.synctype = g_state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    dmr_cspdu(&g_opts, &g_state, bits, bytes, 1, 0);
+}
+
+static int
+cap_plus_rest_recovery(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    int rc = 0;
+    cap_plus_idle(1U);
+    rc |= expect(!g_opts.trunk_is_tuned && dmr_sm_get_ctx()->cc_confirmed,
+                 "idle CAP+ status confirms rest channel without claiming a followed call");
+    g_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    cap_plus_idle(2U);
+    rc |= expect(g_frequency == 451000000L && g_state.trunk_cc_freq == 451000000L,
+                 "failed CAP+ rest move retains the previous anchor");
+    g_result = DSD_TRUNK_TUNE_RESULT_OK;
+    cap_plus_idle(2U);
+    rc |= expect(g_frequency == 452000000L && g_state.trunk_cc_freq == 452000000L && dmr_sm_get_ctx()->cc_acquiring,
+                 "idle CAP+ rest announcement actually retunes and starts acquisition");
+    cap_plus_idle(2U);
+    rc |= expect(dmr_sm_get_ctx()->cc_confirmed && !dmr_sm_get_ctx()->cc_acquiring,
+                 "received CAP+ rest status completes acquisition");
+    trunk_scan_test_set_now(0.5);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE);
+    trunk_scan_test_set_now(1.0);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    trunk_scan_test_set_now(1.26);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    rc |= expect(dsd_engine_trunk_scan_active_p25_ctx() != NULL, "idle CAP+ allows target rotation");
+    cleanup();
+    return rc;
+}
+
+static int
+switch_while_probe_pending(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    aloha(1);
+    g_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    expire_acquisition(dmr_sm_get_ctx());
+    const uint64_t old_request = g_request;
+    g_result = DSD_TRUNK_TUNE_RESULT_OK;
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_ADVANCE);
+    dsd_trunk_tuning_request_publish(old_request, DSD_TRUNK_TUNE_RESULT_OK);
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_ADVANCE);
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_ADVANCE);
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    int rc = expect(g_frequency == 451000000L && ctx->cc_probe_freq_hz == 451000000L && ctx->cc_tune_request_id == 0U
+                        && ctx->cc_acquiring,
+                    "late completion from a parked target cannot restore its old probe");
+    uint8_t bits[196] = {0};
+    uint8_t bytes[24] = {0};
+    dmr_cspdu(&g_opts, &g_state, bits, bytes, 1, 0);
+    rc |= expect(ctx->cc_acquiring && !ctx->cc_confirmed, "arbitrary valid CSBK is not CC acquisition proof");
+    g_opts.trunk_enable = 0;
+    g_state.trunk_cc_freq = 0;
+    aloha(1);
+    rc |= expect(g_state.trunk_cc_freq == 451000000L && ctx->cc_acquiring,
+                 "monitor mode retains decoded CC attribution without starting recovery");
+    cleanup();
+    return rc;
+}
+
+int
+main(void) {
+    (void)dsd_test_unsetenv("DSD_NEO_DMR_HANGTIME");
+    (void)dsd_test_unsetenv("DSD_NEO_DMR_GRANT_TIMEOUT");
+    dsd_neo_config_init();
+    int rc = held_call_return(0.0f);
+    rc |= held_call_return(2.0f);
+    rc |= hunt_and_reacquire();
+    rc |= pending_and_failed_probes();
+    rc |= cap_plus_rest_recovery();
+    rc |= switch_while_probe_pending();
+    return rc;
+}

--- a/tests/engine/test_engine_dmr_cc_recovery.c
+++ b/tests/engine/test_engine_dmr_cc_recovery.c
@@ -10,7 +10,9 @@
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/trunk_scan.h>
+#include <dsd-neo/platform/timing.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
@@ -20,6 +22,7 @@
 #include <dsd-neo/runtime/rigctl_query_hooks.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -53,6 +56,8 @@ static char g_channels[DSD_TEST_PATH_MAX];
 static long g_frequency;
 static int g_cc_tunes;
 static int g_returns;
+static int g_queries;
+static int g_query_failed;
 static uint64_t g_request;
 static dsd_trunk_tune_result g_result;
 
@@ -68,7 +73,8 @@ expect(int condition, const char* message) {
 static long
 current_frequency(const dsd_opts* opts) {
     (void)opts;
-    return g_frequency;
+    ++g_queries;
+    return g_query_failed ? 0 : g_frequency;
 }
 
 static dsd_trunk_tune_result
@@ -101,7 +107,7 @@ return_to_cc(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
     ++g_returns;
     g_request = request_id;
     if (dsd_trunk_tune_result_is_ok(g_result)) {
-        g_frequency = state->trunk_cc_freq;
+        g_frequency = state->p25_cc_freq > 0 ? state->p25_cc_freq : state->trunk_cc_freq;
         opts->rtlsdr_center_freq = (uint32_t)g_frequency;
         opts->trunk_is_tuned = 0;
         state->trunk_vc_freq[0] = state->trunk_vc_freq[1] = 0;
@@ -151,7 +157,7 @@ setup(float hangtime) {
     g_opts.use_rigctl = 1;
     g_opts.trunk_scan_enabled = 1;
     g_opts.trunk_hangtime = hangtime;
-    g_cc_tunes = g_returns = 0;
+    g_cc_tunes = g_returns = g_queries = g_query_failed = 0;
     g_request = 0U;
     g_result = DSD_TRUNK_TUNE_RESULT_OK;
     dsd_trunk_tuning_requests_reset();
@@ -220,13 +226,21 @@ held_call_return(float hangtime) {
     aloha(1);
     rc |= expect(g_state.trunk_cc_freq == 451000000L, "control-like messages on a followed VC cannot replace CC");
     dmr_sm_emit_voice_sync(&g_opts, &g_state, 0);
-    ctx->slots[0].last_active_m -= 3.0;
-    ctx->t_voice_m -= 3.0;
+    ctx->slots[0].last_active_m -= 1.0;
+    ctx->t_voice_m -= 1.0;
+    g_state.is_con_plus = 1;
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(g_returns == (hangtime == 0.0f ? 1 : 0), "one-second gap distinguishes zero and two-second hangtime");
+    if (hangtime > 0.0f) {
+        ctx->slots[0].last_active_m -= 2.0;
+        ctx->t_voice_m -= 2.0;
+    }
     g_state.last_vc_sync_time = time(NULL) - 3;
     g_state.last_vc_sync_time_m = dsd_time_now_monotonic_s() - 3.0;
     g_state.p25_last_vc_tune_time_m = dsd_time_now_monotonic_s() - 4.0;
     dsd_frame_sync_test_handle_no_sync_timeout(&g_opts, &g_state, 1800);
     rc |= expect(g_returns == 1 && g_frequency == 451000000L, "DMR returned to original control channel");
+    rc |= expect(!g_state.is_con_plus, "DMR-owned release clears Con+ follow latch");
     rc |= expect(p25->state == P25_SM_IDLE && !p25->cc_sync_pending && !g_state.p25_sm_force_release,
                  "DMR loss did not start P25 recovery or leave a forced-release latch");
     const int tunes = g_cc_tunes;
@@ -305,6 +319,8 @@ pending_and_failed_probes(void) {
     rc |= expect(pending != 0U && ctx->cc_tune_request_id == pending, "probe tracks pending request");
     expire_acquisition(ctx);
     aloha(1);
+    dmr_sm_emit_group_grant_slot(&g_opts, &g_state, 453000000L, 4, 0, 1001, 2001);
+    rc |= expect(!g_opts.trunk_is_tuned, "grant cannot interrupt an unresolved CC tune");
     rc |= expect(ctx->cc_tune_request_id == pending && g_cc_tunes == count && ctx->cc_acquiring,
                  "pending tune neither times out nor accepts old-frequency control messages");
     dsd_trunk_tuning_request_publish(pending, DSD_TRUNK_TUNE_RESULT_OK);
@@ -339,17 +355,24 @@ pending_and_failed_probes(void) {
 }
 
 static void
-cap_plus_idle(unsigned int rest) {
+cap_plus_status(unsigned int rest, int busy) {
     uint8_t bits[196] = {0};
     uint8_t bytes[24] = {0};
     bytes[0] = 0x3e;
     bytes[1] = 0x10;
-    bytes[2] = (uint8_t)(0xc0U | rest); // Single complete status, all channel banks idle.
-    for (int i = 0; i < 24; ++i) {
+    bytes[2] = (uint8_t)(0xc0U | rest); // Single complete status.
+    bytes[3] = busy ? 0x80 : 0;         // LSN 1 carries a group call when busy.
+    bytes[4] = busy ? 42 : 0;
+    for (int i = 0; i < 80; ++i) {
         bits[i] = (uint8_t)((bytes[i / 8] >> (7 - (i % 8))) & 1);
     }
     g_state.synctype = g_state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
     dmr_cspdu(&g_opts, &g_state, bits, bytes, 1, 0);
+}
+
+static void
+cap_plus_idle(unsigned int rest) {
+    cap_plus_status(rest, 0);
 }
 
 static int
@@ -362,13 +385,15 @@ cap_plus_rest_recovery(void) {
     cap_plus_idle(1U);
     rc |= expect(!g_opts.trunk_is_tuned && dmr_sm_get_ctx()->cc_confirmed,
                  "idle CAP+ status confirms rest channel without claiming a followed call");
+    g_state.p25_cc_freq = 451000000L; // A stale generic alias must not override the announcement.
     g_result = DSD_TRUNK_TUNE_RESULT_FAILED;
     cap_plus_idle(2U);
     rc |= expect(g_frequency == 451000000L && g_state.trunk_cc_freq == 451000000L,
                  "failed CAP+ rest move retains the previous anchor");
     g_result = DSD_TRUNK_TUNE_RESULT_OK;
     cap_plus_idle(2U);
-    rc |= expect(g_frequency == 452000000L && g_state.trunk_cc_freq == 452000000L && dmr_sm_get_ctx()->cc_acquiring,
+    rc |= expect(g_frequency == 452000000L && g_state.trunk_cc_freq == 452000000L
+                     && dmr_sm_get_ctx()->cc_probe_freq_hz == g_frequency && dmr_sm_get_ctx()->cc_acquiring,
                  "idle CAP+ rest announcement actually retunes and starts acquisition");
     cap_plus_idle(2U);
     rc |= expect(dmr_sm_get_ctx()->cc_confirmed && !dmr_sm_get_ctx()->cc_acquiring,
@@ -417,6 +442,208 @@ switch_while_probe_pending(void) {
     return rc;
 }
 
+static int
+standalone_recovery(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    dsd_engine_trunk_scan_shutdown(&g_opts, &g_state);
+    g_opts.trunk_scan_enabled = 0;
+    g_opts.trunk_enable = 1;
+    g_opts.frame_dmr = g_opts.frame_p25p1 = g_opts.frame_p25p2 = 1;
+    g_state.trunk_cc_freq = 451000000L;
+    g_state.trunk_lcn_freq[0] = 451000000L;
+    g_state.trunk_lcn_freq[1] = 452000000L;
+    g_state.lcn_freq_count = 2;
+    DSD_SNPRINTF(g_opts.chan_in_file, sizeof(g_opts.chan_in_file), "%s", g_channels);
+    dmr_sm_ctx_t* dmr = dmr_sm_get_ctx();
+    dmr_sm_init_ctx(dmr, &g_opts, &g_state);
+    aloha(1);
+    g_state.synctype = DSD_SYNC_NONE;
+    noCarrier(&g_opts, &g_state);
+    int rc = expect(dsd_trunk_dmr_recovery_allowed(&g_opts, &g_state), "standalone AUTO retains decoded DMR owner");
+    if (dsd_trunk_dmr_recovery_allowed(&g_opts, &g_state)) {
+        expire_acquisition(dmr);
+    }
+    rc |= expect(g_frequency == 452000000L, "standalone AUTO hunts after complete sync loss");
+
+    p25_sm_ctx_t* p25 = p25_sm_get_ctx();
+    g_state.p25_cc_freq = 851000000L;
+    p25_sm_init_ctx(p25, &g_opts, &g_state);
+    p25->state = P25_SM_HUNTING;
+    const double old_try = dsd_time_now_monotonic_s() - 20.0;
+    p25->t_hunt_try_m = old_try;
+    const int tunes = g_cc_tunes;
+    p25_sm_try_tick(&g_opts, &g_state);
+    rc |= expect(fabs(p25->t_hunt_try_m - old_try) < 1e-9 && g_cc_tunes == tunes,
+                 "watchdog cannot hunt on a DMR owner even with P25 enabled and stale P25 context");
+
+    g_state.trunk_cc_freq = g_state.p25_cc_freq = g_frequency = 851000000L;
+    g_state.trunk_lcn_freq[0] = 851000000L;
+    g_state.trunk_lcn_freq[1] = 852000000L;
+    g_state.p25_cc_is_tdma = 0;
+    g_state.synctype = g_state.lastsynctype = DSD_SYNC_P25P1_POS;
+    p25_sm_init_ctx(p25, &g_opts, &g_state);
+    p25_sm_event(p25, &g_opts, &g_state, &(p25_sm_event_t){.type = P25_SM_EV_CC_SYNC});
+    p25->t_cc_sync_m = g_state.last_cc_sync_time_m = old_try;
+    p25->t_hunt_try_m = old_try;
+    g_state.synctype = DSD_SYNC_NONE;
+    g_state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    noCarrier(&g_opts, &g_state);
+    rc |= expect(g_state.p25_cc_is_tdma == 0 && dsd_trunk_p25_recovery_allowed(&g_opts, &g_state),
+                 "stray non-P25 sync and noCarrier preserve the established P25 owner and format");
+    p25_sm_try_tick(&g_opts, &g_state);
+    rc |= expect(p25->t_hunt_try_m > old_try && g_cc_tunes > tunes,
+                 "watchdog advances P25 CC recovery after stray sync and noCarrier");
+    cleanup();
+    return rc;
+}
+
+static int
+heartbeat_and_single_candidate(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    aloha(1);
+    int rc = 0;
+    const int queries = g_queries;
+    g_query_failed = 1;
+    ctx->t_cc_sync_m -= 3.0;
+    for (int i = 0; i < 30; ++i) {
+        dmr_sm_note_cc_heartbeat(&g_opts, &g_state);
+    }
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(g_queries == queries && ctx->state == DMR_SM_ON_CC,
+                 "established heartbeats use completed tune attribution without rigctl queries");
+    dsd_trunk_tuning_generation_advance();
+    ctx->t_cc_sync_m -= 3.0;
+    dmr_sm_note_cc_heartbeat(&g_opts, &g_state);
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(ctx->state == DMR_SM_HUNTING, "heartbeat from a different tune generation cannot retain CC");
+
+    g_query_failed = 0;
+    g_state.lcn_freq_count = 1;
+    g_state.trunk_cc_freq = 0;
+    g_state.p25_cc_freq = 451000000L;
+    dmr_sm_begin_cc_acquisition(ctx, &g_opts, &g_state, 451000000L, 0U);
+    ctx->cc_acquire_start_m -= 3.0;
+    dmr_sm_event(ctx, &g_opts, &g_state, &(dmr_sm_event_t){.type = DMR_SM_EV_CC_SYNC});
+    rc |= expect(ctx->cc_acquiring && !ctx->cc_confirmed, "raw CC_SYNC event cannot confirm acquisition");
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(ctx->state == DMR_SM_HUNTING, "acquisition deadline works without a prior CC sync timestamp");
+    const int tunes = g_cc_tunes;
+    for (int i = 0; i < 3; ++i) {
+        dmr_sm_note_cc_heartbeat(&g_opts, &g_state);
+        expire_acquisition(ctx);
+    }
+    rc |= expect(g_cc_tunes == tunes && ctx->cc_acquiring && !ctx->cc_confirmed,
+                 "single-candidate acquisition keeps listening without repeated retunes or false confirmation");
+    aloha(1);
+    rc |= expect(ctx->cc_confirmed && !ctx->cc_acquiring, "decoded CC evidence completes uninterrupted acquisition");
+    cleanup();
+    return rc;
+}
+
+static int
+watchdog_ownership_thread(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    dsd_engine_trunk_scan_shutdown(&g_opts, &g_state);
+    g_opts.trunk_scan_enabled = 0;
+    g_opts.trunk_enable = 1;
+    g_opts.frame_dmr = g_opts.frame_p25p1 = g_opts.frame_p25p2 = 1;
+    g_state.trunk_cc_freq = g_state.p25_cc_freq = 851000000L;
+    g_state.trunk_lcn_freq[0] = 851000000L;
+    g_state.trunk_lcn_freq[1] = 852000000L;
+    g_state.lcn_freq_count = 2;
+    DSD_SNPRINTF(g_opts.chan_in_file, sizeof(g_opts.chan_in_file), "%s", g_channels);
+    p25_sm_ctx_t* p25 = p25_sm_get_ctx();
+    p25_sm_init_ctx(p25, &g_opts, &g_state);
+    p25->state = P25_SM_HUNTING;
+    const double old_try = dsd_time_now_monotonic_s() - 20.0;
+    p25->t_hunt_try_m = old_try;
+    dsd_trunk_recovery_note_protocol(&g_state, DSD_TRUNK_RECOVERY_DMR);
+    p25_sm_watchdog_start(&g_opts, &g_state);
+    /* Acquisition owns these volatile fields outside the SM guard. TSan must
+     * see no watchdog read of them while a DMR owner excludes P25 recovery. */
+    for (int i = 0; i < 450; ++i) {
+        g_state.synctype = (i & 1) ? DSD_SYNC_P25P1_POS : DSD_SYNC_DMR_BS_DATA_POS;
+        g_state.lastsynctype = g_state.synctype;
+        g_state.p25_cc_is_tdma = i & 1;
+        dsd_sleep_ms(1U);
+    }
+    p25_sm_watchdog_stop();
+    int rc =
+        expect(fabs(p25->t_hunt_try_m - old_try) < 1e-9, "background watchdog excludes DMR despite changing raw hints");
+    g_state.synctype = g_state.lastsynctype = DSD_SYNC_NONE;
+    g_state.p25_cc_is_tdma = 0;
+    dsd_trunk_recovery_note_protocol(&g_state, DSD_TRUNK_RECOVERY_P25);
+    p25_sm_watchdog_start(&g_opts, &g_state);
+    dsd_sleep_ms(50U);
+    p25_sm_watchdog_stop();
+    rc |= expect(p25->t_hunt_try_m > old_try, "background watchdog positive control drives P25 recovery");
+    cleanup();
+    return rc;
+}
+
+static int
+pending_probe_dwell(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    aloha(1);
+    trunk_scan_test_set_now(1.0);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE);
+    trunk_scan_test_set_now(1.0);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    g_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    expire_acquisition(dmr_sm_get_ctx());
+    const uint64_t request = g_request;
+    trunk_scan_test_set_now(10.0);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    int rc =
+        expect(dsd_engine_trunk_scan_active_dmr_ctx() != NULL, "unresolved DMR probe holds the target past idle dwell");
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
+    g_result = DSD_TRUNK_TUNE_RESULT_OK;
+    trunk_scan_test_set_now(10.1);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    rc |= expect(dsd_engine_trunk_scan_active_dmr_ctx() != NULL, "probe completion starts a fresh idle dwell");
+    trunk_scan_test_set_now(10.36);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    rc |= expect(dsd_engine_trunk_scan_active_p25_ctx() != NULL,
+                 "decoded acquisition wait does not extend idle dwell after tune completion");
+    cleanup();
+    return rc;
+}
+
+static int
+busy_cap_plus_rest(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    cap_plus_idle(1U);
+    g_opts.trunk_tune_group_calls = 0;
+    cap_plus_status(4U, 1);
+    int rc = expect(g_frequency == 453000000L && !g_opts.trunk_is_tuned && dmr_sm_get_ctx()->cc_acquiring,
+                    "busy CAP+ follows an announced rest channel when no allowed call owns the tuner");
+    cap_plus_status(4U, 1);
+    rc |= expect(dmr_sm_get_ctx()->cc_confirmed, "busy CAP+ rest signalling confirms acquisition");
+    g_opts.trunk_is_tuned = 1;
+    g_frequency = 452000000L;
+    cap_plus_status(1U, 1);
+    rc |= expect(g_frequency == 452000000L, "busy CAP+ rest following preserves an active followed call");
+    cleanup();
+    return rc;
+}
+
 int
 main(void) {
     (void)dsd_test_unsetenv("DSD_NEO_DMR_HANGTIME");
@@ -428,5 +655,10 @@ main(void) {
     rc |= pending_and_failed_probes();
     rc |= cap_plus_rest_recovery();
     rc |= switch_while_probe_pending();
+    rc |= standalone_recovery();
+    rc |= heartbeat_and_single_candidate();
+    rc |= busy_cap_plus_rest();
+    rc |= pending_probe_dwell();
+    rc |= watchdog_ownership_thread();
     return rc;
 }

--- a/tests/engine/test_engine_dmr_cc_recovery.c
+++ b/tests/engine/test_engine_dmr_cc_recovery.c
@@ -3,6 +3,7 @@
 
 /* Real scan coordinator, control-message parser and sync-loss callbacks, with
  * only the tuner replaced. In particular, neither protocol SM is stubbed. */
+#include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/frame.h>
 #include <dsd-neo/core/init.h>
@@ -203,7 +204,7 @@ aloha(int crc_ok) {
 
 static void
 expire_acquisition(dmr_sm_ctx_t* ctx) {
-    ctx->cc_acquire_start_m = ctx->t_cc_sync_m = dsd_time_now_monotonic_s() - 3.0;
+    ctx->cc_acquire_start_m = ctx->t_cc_sync_m = dsd_time_now_monotonic_s() - ctx->cc_grace_s - 1.0;
     ctx->cc_retry_after_m = 0.0;
     dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
     dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
@@ -218,7 +219,7 @@ held_call_return(float hangtime) {
     int rc = 0;
     dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
     p25_sm_ctx_t* p25 = p25_sm_get_ctx();
-    ctx->t_cc_sync_m -= 3.0;
+    ctx->t_cc_sync_m -= ctx->cc_grace_s + 1.0;
     aloha(1);
     dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
     rc |= expect(ctx->state == DMR_SM_ON_CC && ctx->cc_confirmed, "decoded ALOHA keeps DMR on CC");
@@ -282,11 +283,13 @@ hunt_and_reacquire(void) {
     rc |= expect(ctx->cc_acquiring && g_state.trunk_cc_freq == 451000000L,
                  "relaxed heartbeat cannot validate a new candidate");
     expire_acquisition(ctx);
-    rc |= expect(g_frequency == 453000000L, "hunt skips duplicate channel frequencies");
+    rc |= expect(g_frequency == 451000000L, "hunt revisits the anchor between alternate probes");
+    expire_acquisition(ctx);
+    rc |= expect(g_frequency == 453000000L, "hunt skips adjacent duplicate channel frequencies");
     aloha(1);
     rc |= expect(!ctx->cc_acquiring && ctx->cc_confirmed && g_state.trunk_cc_freq == 453000000L,
                  "decoded control channel replaces the old anchor");
-    ctx->t_cc_sync_m -= 3.0;
+    ctx->t_cc_sync_m -= ctx->cc_grace_s + 1.0;
     dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
     rc |= expect(ctx->state == DMR_SM_HUNTING, "expired heartbeat enters recovery");
     aloha(0);
@@ -323,7 +326,7 @@ pending_and_failed_probes(void) {
     dmr_sm_emit_group_grant_slot(&g_opts, &g_state, 453000000L, 4, 0, 1001, 2001);
     rc |= expect(!g_opts.trunk_is_tuned, "grant cannot interrupt an unresolved CC tune");
     rc |= expect(ctx->cc_tune_request_id == pending && g_cc_tunes == count && ctx->cc_acquiring,
-                 "pending tune neither times out nor accepts old-frequency control messages");
+                 "pending tune waits within its backend deadline and rejects old-frequency control messages");
     dsd_trunk_tuning_request_publish(pending, DSD_TRUNK_TUNE_RESULT_OK);
     dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
     rc |= expect(ctx->cc_tune_request_id == 0U && g_cc_tunes == count
@@ -500,6 +503,15 @@ standalone_recovery(void) {
     noCarrier(&g_opts, &g_state);
     rc |= expect(g_state.p25_cc_is_tdma == 0 && dsd_trunk_p25_recovery_allowed(&g_opts, &g_state),
                  "stray non-P25 sync and noCarrier preserve the established P25 owner and format");
+    const int before_dmr = g_cc_tunes;
+    /* Decoder-side ticks used to bypass the engine ownership gate. Exercise
+     * both the transition out of ON_CC and an already-hunting stale context. */
+    expire_acquisition(dmr);
+    dmr->state = DMR_SM_HUNTING;
+    dmr->cc_retry_after_m = 0.0;
+    dmr_sm_tick_ctx(dmr, &g_opts, &g_state);
+    rc |= expect(g_cc_tunes == before_dmr && g_frequency == 851000000L,
+                 "decoder-side DMR ticks cannot retune a P25-owned receiver");
     p25_sm_try_tick(&g_opts, &g_state);
     rc |= expect(p25->t_hunt_try_m > old_try && g_cc_tunes > tunes,
                  "watchdog advances P25 CC recovery after stray sync and noCarrier");
@@ -518,7 +530,7 @@ heartbeat_and_single_candidate(void) {
     int rc = 0;
     const int queries = g_queries;
     g_query_failed = 1;
-    ctx->t_cc_sync_m -= 3.0;
+    ctx->t_cc_sync_m -= ctx->cc_grace_s + 1.0;
     for (int i = 0; i < 30; ++i) {
         dmr_sm_note_cc_heartbeat(&g_opts, &g_state);
     }
@@ -526,7 +538,7 @@ heartbeat_and_single_candidate(void) {
     rc |= expect(g_queries == queries && ctx->state == DMR_SM_ON_CC,
                  "established heartbeats use completed tune attribution without rigctl queries");
     dsd_trunk_tuning_generation_advance();
-    ctx->t_cc_sync_m -= 3.0;
+    ctx->t_cc_sync_m -= ctx->cc_grace_s + 1.0;
     dmr_sm_note_cc_heartbeat(&g_opts, &g_state);
     dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
     rc |= expect(ctx->state == DMR_SM_HUNTING, "heartbeat from a different tune generation cannot retain CC");
@@ -651,6 +663,175 @@ busy_cap_plus_rest(void) {
     return rc;
 }
 
+static int
+probe_grant_and_missing_anchor(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    aloha(1);
+    expire_acquisition(ctx);
+    dmr_sm_emit_group_grant_slot(&g_opts, &g_state, 453000000L, 4, 0, 1001, 2001);
+    int rc = expect(g_opts.trunk_is_tuned && g_frequency == 453000000L && g_state.trunk_cc_freq == 452000000L,
+                    "validated grant on a probe establishes its return anchor before following");
+    g_state.trunk_sm_force_release = 1;
+    dmr_sm_emit_release(&g_opts, &g_state, -1);
+    rc |= expect(g_frequency == 452000000L && !g_opts.trunk_is_tuned,
+                 "probe grant releases to the channel that carried the grant");
+    aloha(1);
+    dmr_sm_emit_group_grant_slot(&g_opts, &g_state, 453000000L, 4, 0, 1001, 2001);
+    g_state.trunk_cc_freq = 0;
+    g_state.trunk_sm_force_release = 1;
+    dmr_sm_emit_release(&g_opts, &g_state, -1);
+    rc |= expect(g_frequency == 452000000L && !g_opts.trunk_is_tuned,
+                 "release recovers a cleared shared anchor from the DMR context");
+    aloha(1);
+    dmr_sm_emit_group_grant_slot(&g_opts, &g_state, 453000000L, 4, 0, 1001, 2001);
+    dmr_sm_emit_voice_sync(&g_opts, &g_state, 0);
+    dsd_call_snapshot call;
+    rc |= expect(dsd_call_state_get(&g_state, 0U, &call) > 0 && call.phase == DSD_CALL_PHASE_ACTIVE,
+                 "missing-anchor release starts with an active canonical call");
+    g_state.trunk_cc_freq = ctx->cc_freq_hz = 0;
+    g_state.p25_cc_freq = 851000000L;
+    g_state.trunk_sm_force_release = 1;
+    const int returns = g_returns;
+    dmr_sm_emit_release(&g_opts, &g_state, -1);
+    rc |= expect(g_returns == returns && !g_opts.trunk_is_tuned && ctx->state == DMR_SM_HUNTING && !ctx->vc_freq_hz
+                     && !g_state.trunk_vc_freq[0] && !g_state.trunk_sm_force_release,
+                 "missing DMR anchor clears the call and enters recovery without using a stale P25 alias");
+    rc |= expect(dsd_call_state_get(&g_state, 0U, &call) > 0 && call.phase != DSD_CALL_PHASE_ACTIVE,
+                 "missing-anchor release ends canonical call activity");
+    ctx->cc_retry_after_m = 0.0;
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(g_frequency == 451000000L && ctx->cc_acquiring, "missing-anchor release can recover from the map");
+    cleanup();
+    return rc;
+}
+
+static int
+cap_plus_idle_preserves_hangtime(void) {
+    if (setup(2.0f)) {
+        cleanup();
+        return 1;
+    }
+    cap_plus_idle(1U);
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    dmr_sm_emit_group_grant_slot(&g_opts, &g_state, 452000000L, 2, 0, 1001, 2001);
+    dmr_sm_emit_voice_sync(&g_opts, &g_state, 0);
+    ctx->slots[0].last_active_m -= 1.0;
+    ctx->t_voice_m -= 1.0;
+    cap_plus_idle(1U);
+    cap_plus_idle(4U);
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    int rc = expect(g_returns == 0 && g_opts.trunk_is_tuned && g_frequency == 452000000L,
+                    "idle CAP+ rest announcements preserve the followed call's hangtime");
+    ctx->t_voice_m -= 2.0;
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(g_returns == 1 && !g_opts.trunk_is_tuned && g_frequency == 453000000L,
+                 "CAP+ call releases to the announced rest channel when hangtime expires");
+    cleanup();
+    return rc;
+}
+
+static int
+hunt_fade_and_avoids(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    aloha(1);
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    const int tunes = g_cc_tunes;
+    ctx->t_cc_sync_m = dsd_time_now_monotonic_s() - 3.0;
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    int rc =
+        expect(g_cc_tunes == tunes && ctx->state == DMR_SM_ON_CC, "three-second control fade retains the confirmed CC");
+    for (int i = 0; i < g_state.lcn_freq_count; ++i) {
+        if (*dsd_state_trunk_lcn_slot_const(&g_state, i) == 452000000L) {
+            rc |= expect(dsd_state_trunk_lcn_avoid_set(&g_state, (size_t)i, 1) == 0, "avoid first alternate");
+        }
+    }
+    expire_acquisition(ctx);
+    rc |= expect(g_frequency == 453000000L, "hunt skips avoided channel rows");
+    expire_acquisition(ctx);
+    rc |= expect(g_frequency == 451000000L, "hunt returns to the anchor after one probe");
+    aloha(1);
+    const int recovered_tunes = g_cc_tunes;
+    dmr_sm_tick_ctx(ctx, &g_opts, &g_state);
+    rc |= expect(g_cc_tunes == recovered_tunes && ctx->cc_confirmed && !ctx->cc_acquiring,
+                 "control recovered on the anchor ends hunting");
+    for (int i = 0; i < g_state.lcn_freq_count; ++i) {
+        rc |= expect(dsd_state_trunk_lcn_avoid_set(&g_state, (size_t)i, 1) == 0, "avoid remaining rows");
+    }
+    expire_acquisition(ctx);
+    rc |= expect(g_cc_tunes == recovered_tunes, "all-avoided map does not tune an avoided fallback");
+    cleanup();
+    return rc;
+}
+
+static int
+pending_probe_timeout(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    aloha(1);
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE);
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    g_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    expire_acquisition(ctx);
+    const uint64_t request = g_request;
+    trunk_scan_test_set_now(9.0);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    ctx->cc_tune_deadline_m = dsd_time_now_monotonic_s() - 1.0;
+    trunk_scan_test_set_now(10.0);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    int rc = expect(!ctx->cc_tune_request_id && ctx->state == DMR_SM_HUNTING
+                        && dsd_trunk_tuning_request_status(request, NULL) == DSD_TRUNK_TUNE_RESULT_FAILED,
+                    "unanswered probe expires and releases the scan hold");
+    dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
+    rc |= expect(dsd_trunk_tuning_request_status(request, NULL) == DSD_TRUNK_TUNE_RESULT_FAILED
+                     && !dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()),
+                 "late success cannot revive an expired request or open the frame gate");
+    g_result = DSD_TRUNK_TUNE_RESULT_OK;
+    trunk_scan_test_set_now(10.26);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    rc |= expect(dsd_engine_trunk_scan_active_p25_ctx() != NULL
+                     && dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()),
+                 "scan advances after timeout and replacement tune reopens the frame gate");
+    cleanup();
+    return rc;
+}
+
+static int
+pending_park_timeout(void) {
+    if (setup(0.0f)) {
+        cleanup();
+        return 1;
+    }
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_ADVANCE);
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_ADVANCE);
+    g_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+    (void)dsd_engine_trunk_scan_control(&g_opts, &g_state, DSD_TRUNK_SCAN_CONTROL_ADVANCE);
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    const uint64_t request = ctx->cc_tune_request_id;
+    int rc = expect(request != 0U, "initial DMR park tracks its backend request");
+    ctx->cc_tune_deadline_m = dsd_time_now_monotonic_s() - 1.0;
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    rc |= expect(!ctx->cc_tune_request_id
+                     && dsd_trunk_tuning_request_status(request, NULL) == DSD_TRUNK_TUNE_RESULT_FAILED,
+                 "coordinator resolves the DMR deadline while awaiting the initial park");
+    g_result = DSD_TRUNK_TUNE_RESULT_OK;
+    trunk_scan_test_set_now(3.0);
+    dsd_engine_trunk_scan_tick(&g_opts, &g_state);
+    rc |= expect(dsd_trunk_tuning_frame_is_current(dsd_trunk_tuning_generation()),
+                 "held DMR target retries an expired initial park");
+    cleanup();
+    return rc;
+}
+
 int
 main(void) {
     (void)dsd_test_unsetenv("DSD_NEO_DMR_HANGTIME");
@@ -667,5 +848,10 @@ main(void) {
     rc |= busy_cap_plus_rest();
     rc |= pending_probe_dwell();
     rc |= watchdog_ownership_thread();
+    rc |= probe_grant_and_missing_anchor();
+    rc |= cap_plus_idle_preserves_hangtime();
+    rc |= hunt_fade_and_avoids();
+    rc |= pending_probe_timeout();
+    rc |= pending_park_timeout();
     return rc;
 }

--- a/tests/engine/test_engine_dmr_cc_recovery.c
+++ b/tests/engine/test_engine_dmr_cc_recovery.c
@@ -15,6 +15,7 @@
 #include <dsd-neo/platform/timing.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/protocol/p25/p25_cc_activity.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/config.h>
@@ -484,8 +485,14 @@ standalone_recovery(void) {
     g_state.trunk_lcn_freq[1] = 852000000L;
     g_state.p25_cc_is_tdma = 0;
     g_state.synctype = g_state.lastsynctype = DSD_SYNC_P25P1_POS;
+    g_state.p25_cc_freq = 0;
     p25_sm_init_ctx(p25, &g_opts, &g_state);
-    p25_sm_event(p25, &g_opts, &g_state, &(p25_sm_event_t){.type = P25_SM_EV_CC_SYNC});
+    g_state.p25_cc_freq = 851000000L;
+    p25_sm_note_cc_activity(&g_state); // Actual TSBK/MBT/LCCH production activity boundary.
+    p25_sm_try_tick(&g_opts, &g_state);
+    rc |= expect(p25->state == P25_SM_ON_CC && dsd_trunk_p25_recovery_allowed(&g_opts, &g_state),
+                 "decoded P25 control activity starts standalone recovery before the first voice grant");
+    g_state.p25_last_cc_msg_time_m = old_try;
     p25->t_cc_sync_m = g_state.last_cc_sync_time_m = old_try;
     p25->t_hunt_try_m = old_try;
     g_state.synctype = DSD_SYNC_NONE;

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -16,13 +16,16 @@
 #include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
+#include <dsd-neo/engine/trunk_tuning.h>
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
 #include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/rtl_stream_metrics_hooks.h>
 #include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <math.h>
 #include <stdbool.h>
@@ -285,6 +288,42 @@ free_test_runtime(dsd_opts* opts, dsd_state* state) {
 }
 
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
+static int
+test_dmr_explicit_return_destination(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+    opts->trunk_enable = opts->use_rigctl = 1;
+    opts->audio_in_type = AUDIO_IN_NULL;
+    opts->audio_out_type = 9;
+    opts->setmod_bw = 0;
+    state->trunk_cc_freq = 451000000L;
+    state->p25_cc_freq = 450000000L;
+    dmr_sm_ctx_t ctx;
+    dmr_sm_init_ctx(&ctx, opts, state);
+    dsd_trunk_tuning_requests_reset();
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){.return_to_cc_request = dsd_engine_return_to_cc_request});
+    g_rigctl_setfreq_ok = 0;
+    int rc = expect_true("dmr-return-failure",
+                         dmr_sm_return_to_cc(&ctx, opts, state, 452000000L) == DSD_TRUNK_TUNE_RESULT_FAILED);
+    rc |= expect_true("dmr-failed-return-keeps-aliases",
+                      state->trunk_cc_freq == 451000000L && state->p25_cc_freq == 450000000L);
+    g_rigctl_setfreq_ok = 1;
+    rc |= expect_true("dmr-return-success",
+                      dmr_sm_return_to_cc(&ctx, opts, state, 452000000L) == DSD_TRUNK_TUNE_RESULT_OK);
+    rc |= expect_true("dmr-return-actual-frequency",
+                      g_rigctl_setfreq_freq == 452000000L && state->trunk_cc_freq == 452000000L
+                          && ctx.cc_probe_freq_hz == 452000000L && ctx.cc_rx_freq_hz == 452000000L && ctx.cc_acquiring);
+    rc |= expect_true("dmr-return-clears-obsolete-alias", state->p25_cc_freq == 0);
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    dsd_trunk_tuning_requests_reset();
+    g_rigctl_setfreq_ok = 0;
+    free_test_runtime(opts, state);
+    return rc;
+}
+
 static int
 test_trunk_cache_with_mode_metadata(void) {
     dsd_opts* opts = NULL;
@@ -567,6 +606,7 @@ main(void) {
 
     p25_sm_ctx_t* recovery_ctx = p25_sm_get_ctx();
     p25_sm_init_ctx(recovery_ctx, opts, state);
+    dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_P25);
     recovery_ctx->state = P25_SM_TUNED;
     recovery_ctx->vc_freq_hz = 851012500;
     recovery_ctx->vc_channel = (2 << 12) | 2;
@@ -588,6 +628,7 @@ main(void) {
     rc |= expect_true("p25-vc-reacquire-hold-preserves-sync-deadline",
                       fabs(state->last_vc_sync_time_m - (recovery_now_m - 11.0)) <= 1.0e-9);
 
+    dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_UNKNOWN);
     recovery_ctx->t_vc_reacquire_m = 0.0;
     opts->audio_in_type = saved_audio_in_type;
     p25_sm_init_ctx(recovery_ctx, opts, state);
@@ -2066,6 +2107,7 @@ main(void) {
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
     rc |= test_typed_scan_tune_boundaries();
     rc |= test_trunk_cache_with_mode_metadata();
+    rc |= test_dmr_explicit_return_destination();
 #endif
 
     if (rc == 0) {

--- a/tests/engine/test_engine_protocol_dispatch.c
+++ b/tests/engine/test_engine_protocol_dispatch.c
@@ -205,9 +205,8 @@ run_dispatch_case_verdict(int synctype, int expected_handler, dsd_frame_verdict 
      * either way a verdict left over from the previous frame must not survive. */
     assert(state->sps_hunt_last_frame_verdict
            == (expected_handler == TEST_HANDLER_NONE ? DSD_FRAME_VERDICT_PRODUCTIVE : (int)verdict));
-    const int validated_other = (DSD_SYNC_IS_NXDN(synctype) || DSD_SYNC_IS_EDACS(synctype))
-                                && verdict == DSD_FRAME_VERDICT_PRODUCTIVE && !g_retune_during_handler;
-    assert(state->trunk_recovery_protocol == (validated_other ? DSD_TRUNK_RECOVERY_OTHER : DSD_TRUNK_RECOVERY_P25));
+    /* Productivity (including sticky NXDN call confirmation) is not recovery ownership. */
+    assert(state->trunk_recovery_protocol == DSD_TRUNK_RECOVERY_P25);
     g_handler_verdict = DSD_FRAME_VERDICT_PRODUCTIVE;
     free(state);
     free(opts);

--- a/tests/engine/test_engine_protocol_dispatch.c
+++ b/tests/engine/test_engine_protocol_dispatch.c
@@ -9,6 +9,8 @@
 #include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/engine/frame_processing.h>
 #include <dsd-neo/engine/protocol_dispatch.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -34,11 +36,15 @@ enum {
 static int g_called_handler = TEST_HANDLER_NONE;
 /* The verdict every stub reports, so one case can drive the whole table. */
 static dsd_frame_verdict g_handler_verdict = DSD_FRAME_VERDICT_PRODUCTIVE;
+static int g_retune_during_handler = 0;
 
 static dsd_frame_verdict
 record_handler(int handler_id) {
     assert(g_called_handler == TEST_HANDLER_NONE);
     g_called_handler = handler_id;
+    if (g_retune_during_handler) {
+        dsd_trunk_tuning_generation_advance();
+    }
     return g_handler_verdict;
 }
 
@@ -181,6 +187,7 @@ run_dispatch_case_verdict(int synctype, int expected_handler, dsd_frame_verdict 
     assert(opts != NULL);
     assert(state != NULL);
     state->synctype = synctype;
+    dsd_trunk_recovery_note_protocol(state, DSD_TRUNK_RECOVERY_P25);
     state->rf_mod = 1;
     state->max = 100.0F;
     state->min = -50.0F;
@@ -198,6 +205,9 @@ run_dispatch_case_verdict(int synctype, int expected_handler, dsd_frame_verdict 
      * either way a verdict left over from the previous frame must not survive. */
     assert(state->sps_hunt_last_frame_verdict
            == (expected_handler == TEST_HANDLER_NONE ? DSD_FRAME_VERDICT_PRODUCTIVE : (int)verdict));
+    const int validated_other = (DSD_SYNC_IS_NXDN(synctype) || DSD_SYNC_IS_EDACS(synctype))
+                                && verdict == DSD_FRAME_VERDICT_PRODUCTIVE && !g_retune_during_handler;
+    assert(state->trunk_recovery_protocol == (validated_other ? DSD_TRUNK_RECOVERY_OTHER : DSD_TRUNK_RECOVERY_P25));
     g_handler_verdict = DSD_FRAME_VERDICT_PRODUCTIVE;
     free(state);
     free(opts);
@@ -237,6 +247,11 @@ int
 main(void) {
     check_public_handler_table();
     check_verdict_default_is_productive();
+    run_dispatch_case(DSD_SYNC_NXDN_POS, TEST_HANDLER_NXDN);
+    run_dispatch_case_verdict(DSD_SYNC_NXDN_POS, TEST_HANDLER_NXDN, DSD_FRAME_VERDICT_UNPRODUCTIVE, 0);
+    g_retune_during_handler = 1;
+    run_dispatch_case(DSD_SYNC_NXDN_POS, TEST_HANDLER_NXDN);
+    g_retune_during_handler = 0;
     run_dispatch_case(DSD_SYNC_DMR_BS_VOICE_POS, TEST_HANDLER_DMR);
     run_dispatch_case(DSD_SYNC_DPMR_FS1_POS, TEST_HANDLER_DPMR);
     run_dispatch_case(DSD_SYNC_P25P1_POS, TEST_HANDLER_P25P1);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -168,6 +168,14 @@ dmr_sm_init_ctx(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state)
 }
 
 void
+dmr_sm_begin_cc_acquisition(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const dsd_state* state, long freq_hz,
+                            uint64_t request_id) {
+    (void)freq_hz;
+    (void)request_id;
+    dmr_sm_init_ctx(ctx, opts, state);
+}
+
+void
 dmr_sm_tick_ctx(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
     g_dmr_tick_calls++;
     if (!ctx || !g_dmr_tick_release_tuned || ctx->state != DMR_SM_TUNED) {

--- a/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
+++ b/tests/protocol/dmr/test_dmr_flco_privacy_modes.c
@@ -2325,6 +2325,37 @@ test_completed_slco_capacity_plus_hold_returns_to_rest_channel(void) {
     dsd_state_ext_free_all(&state);
 }
 
+static void
+test_completed_slco_xpt_hold_does_not_start_cc_hunt(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    uint8_t slco[36] = {0};
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.trunk_enable = opts.frame_dmr = 1;
+    opts.trunk_is_tuned = 1;
+    state.tg_hold = 99U;
+    state.dmrburstL = state.dmrburstR = 16;
+    state.trunk_cc_freq = 851000000L;
+    state.trunk_chan_map[11] = 852000000L; // Free LCN 6 maps to LSN 11.
+    dmr_sm_init(&opts, &state);
+    dsd_trunk_recovery_note_protocol(&state, DSD_TRUNK_RECOVERY_DMR);
+    s_tune_to_cc_calls = 0;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){.tune_to_cc_request = capture_tune_to_cc});
+    write_bits_u64(slco, 0U, 0x8U, 4U);
+    write_bits_u64(slco, 12U, 6U, 4U);
+    run_completed_slco(&opts, &state, slco);
+    assert(s_tune_to_cc_calls == 1 && s_tune_to_cc_freq == 852000000L);
+    dmr_sm_ctx_t* ctx = dmr_sm_get_ctx();
+    assert(ctx->state == DMR_SM_IDLE && !ctx->cc_acquiring && !ctx->cc_freq_hz);
+    ctx->cc_acquire_start_m = ctx->t_cc_sync_m = dsd_time_now_monotonic_s() - 10.0;
+    dmr_sm_tick_ctx(ctx, &opts, &state);
+    dmr_sm_tick_ctx(ctx, &opts, &state);
+    assert(s_tune_to_cc_calls == 1 && ctx->state == DMR_SM_IDLE);
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    dsd_state_ext_free_all(&state);
+}
+
 // The voice LC header repeats through the start of a transmission for late
 // entry, always before the first voice superframe. Repeats that re-describe the
 // running call stay in its epoch; a second epoch would commit the first one's
@@ -2575,6 +2606,7 @@ main(void) {
     test_completed_slco_activity_uses_each_slot_value();
     test_completed_slco_connect_plus_and_xpt_update_site_state();
     test_completed_slco_capacity_plus_hold_returns_to_rest_channel();
+    test_completed_slco_xpt_hold_does_not_start_cc_hunt();
     printf("DMR FLCO privacy modes: OK\n");
     return 0;
 }

--- a/tests/protocol/dmr/test_dmr_t3_shim.c
+++ b/tests/protocol/dmr/test_dmr_t3_shim.c
@@ -68,6 +68,7 @@ init_env(dsd_opts* opts, dsd_state* state) {
     DSD_MEMSET(opts, 0, sizeof(*opts));
     DSD_MEMSET(state, 0, sizeof(*state));
     opts->trunk_enable = 1;
+    opts->frame_dmr = 1;
     opts->use_rigctl = 0;
     opts->audio_in_type = AUDIO_IN_PULSE;
     state->trunk_cc_freq = 851000000; // mock CC

--- a/tests/protocol/dmr/test_dmr_t3_sm_release.c
+++ b/tests/protocol/dmr/test_dmr_t3_sm_release.c
@@ -73,6 +73,7 @@ main(int argc, char** argv) {
     DSD_MEMSET(&opts, 0, sizeof opts);
     DSD_MEMSET(&state, 0, sizeof state);
     opts.trunk_enable = 1;
+    opts.frame_dmr = 1;
     opts.trunk_hangtime = 0.5f;
     state.trunk_cc_freq = 851000000;
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){

--- a/tests/protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
+++ b/tests/protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
@@ -201,6 +201,7 @@ dmr_setup_fixture(const dmr_grant_case* grant) {
     DSD_MEMSET(&g_ctx, 0, sizeof(g_ctx));
 
     g_opts.trunk_enable = 1;
+    g_opts.frame_dmr = 1;
     g_opts.trunk_hangtime = 0.1f;
     g_opts.trunk_tune_data_calls = 1;
     g_state.trunk_cc_freq = 851012500L;
@@ -697,6 +698,7 @@ dmr_run_rejected_grant_contracts(void) {
                      "disabled trunking stayed on control channel");
 
     g_opts.trunk_enable = 1;
+    g_opts.frame_dmr = 1;
     g_state.trunk_cc_freq = 0;
     ev = dmr_sm_ev_group_grant(grant.freq_hz, 0, 1202, 7202);
     dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
@@ -762,6 +764,7 @@ dmr_run_global_emit_and_scan_hook_case(void) {
     dmr_setup_blank_fixture();
     dmr_install_hooks();
     g_opts.trunk_enable = 1;
+    g_opts.frame_dmr = 1;
     g_opts.trunk_tune_data_calls = 1;
     g_state.trunk_cc_freq = 851012500L;
     dmr_sm_init_ctx(&g_ctx, &g_opts, &g_state);

--- a/tests/protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
+++ b/tests/protocol/dmr/test_dmr_t3_sm_return_to_cc_matrix.c
@@ -610,7 +610,12 @@ dmr_run_cc_loss_reacquire_case(void) {
 
     dmr_sm_event_t ev = dmr_sm_ev_cc_sync();
     dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
-    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC, grant.name, flow, script, "cc sync returns ON_CC");
+    rc |= dmr_expect(g_ctx.state == DMR_SM_HUNTING, grant.name, flow, script, "raw sync cannot acquire CC");
+    dsd_trunk_scan_hooks_set((dsd_trunk_scan_hooks){.dmr_ctx = dmr_hook_scan_ctx});
+    dmr_sm_note_cc_activity(&g_opts, &g_state, g_state.trunk_cc_freq);
+    dsd_trunk_scan_hooks_set((dsd_trunk_scan_hooks){0});
+    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC && g_ctx.cc_confirmed, grant.name, flow, script,
+                     "decoded control evidence returns ON_CC");
     return rc;
 }
 
@@ -663,8 +668,9 @@ dmr_run_auto_init_and_idle_hunting_case(void) {
 
     ev = dmr_sm_ev_cc_sync();
     dmr_sm_event(&g_ctx, &g_opts, &g_state, &ev);
-    rc |= dmr_expect(g_ctx.state == DMR_SM_ON_CC && g_ctx.t_cc_sync_m > 0.0, grant, flow, script,
-                     "cc sync reacquires from hunting");
+    rc |= dmr_expect(g_ctx.state == DMR_SM_HUNTING && g_ctx.t_cc_sync_m == 0.0, grant, flow, script,
+                     "raw sync cannot invent a confirmed CC");
+    g_ctx.state = DMR_SM_ON_CC;
 
     g_ctx.t_cc_sync_m = 0.0;
     dmr_sm_tick_ctx(&g_ctx, &g_opts, &g_state);

--- a/tests/protocol/p25/test_p25_p2_xcch_helpers.c
+++ b/tests/protocol/p25/test_p25_p2_xcch_helpers.c
@@ -22,6 +22,7 @@
 #include <dsd-neo/protocol/p25/p25_vpdu.h>
 #include <dsd-neo/protocol/p25/p25p2_mac_parse.h>
 #include <dsd-neo/runtime/p25_p2_audio_ring.h>
+#include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "../../../src/protocol/p25/p25_trunk_sm_internal.h"
@@ -961,6 +962,7 @@ test_sacch_dispatch_and_lcch_crc_abort(void) {
     state.p25_p2_audio_allowed[1] = 1;
     state.p25_p2_audio_ring_count[1] = 4;
     g_crc16_result = 1;
+    dsd_trunk_recovery_note_protocol(&state, DSD_TRUNK_RECOVERY_DMR);
     mac[1] = 0x55;
     pack_payload_from_mac(payload, 180, mac, 0x0, 0, 0);
 
@@ -969,6 +971,12 @@ test_sacch_dispatch_and_lcch_crc_abort(void) {
     rc |= expect_int("lcch crc abort clears gate", state.p25_p2_audio_allowed[1], 0);
     rc |= expect_int("lcch crc abort resets ring", g_ring_reset_count[1], 1);
     rc |= expect_int("lcch crc abort no vpdu", g_vpdu_count, 0);
+    rc |= expect_int("invalid lcch preserves recovery owner", state.trunk_recovery_protocol, DSD_TRUNK_RECOVERY_DMR);
+
+    reset_stubs();
+    state.p2_is_lcch = 1;
+    process_SACCH_MAC_PDU(&opts, &state, payload);
+    rc |= expect_int("validated lcch claims P25 recovery", state.trunk_recovery_protocol, DSD_TRUNK_RECOVERY_P25);
 
     return rc;
 }

--- a/tests/runtime/test_runtime_trunk_scan_hooks.c
+++ b/tests/runtime/test_runtime_trunk_scan_hooks.c
@@ -81,9 +81,6 @@ test_recovery_ownership(void) {
     assert(!dsd_trunk_dmr_recovery_allowed(&opts, &state));
     state.synctype = state.lastsynctype = DSD_SYNC_NONE;
     assert(dsd_trunk_p25_recovery_allowed(&opts, &state));
-    dsd_trunk_recovery_note_protocol(&state, DSD_TRUNK_RECOVERY_OTHER);
-    assert(!dsd_trunk_p25_recovery_allowed(&opts, &state));
-    assert(!dsd_trunk_dmr_recovery_allowed(&opts, &state));
     opts.trunk_scan_enabled = 1;
     assert(!dsd_trunk_p25_recovery_allowed(&opts, &state)); // No installed owner during startup/shutdown.
     opts.trunk_scan_enabled = 0;

--- a/tests/runtime/test_runtime_trunk_scan_hooks.c
+++ b/tests/runtime/test_runtime_trunk_scan_hooks.c
@@ -67,19 +67,23 @@ test_recovery_ownership(void) {
     opts.frame_dmr = opts.frame_p25p1 = opts.frame_p25p2 = 1;
     state.p25_cc_freq = state.trunk_cc_freq = 451000000L;
     state.synctype = state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    assert(!dsd_trunk_dmr_recovery_allowed(&opts, &state)); // Raw sync cannot claim ownership.
+    dsd_trunk_recovery_note_protocol(&state, DSD_TRUNK_RECOVERY_DMR);
     assert(dsd_trunk_dmr_recovery_allowed(&opts, &state));
     assert(!dsd_trunk_p25_recovery_allowed(&opts, &state));
-    state.synctype = DSD_SYNC_NONE;
-    assert(!dsd_trunk_p25_recovery_allowed(&opts, &state));
-    state.lastsynctype = DSD_SYNC_NONE;
+    state.synctype = state.lastsynctype = DSD_SYNC_NONE;
     state.p25_cc_is_tdma = 2;
+    assert(dsd_trunk_dmr_recovery_allowed(&opts, &state));
     assert(!dsd_trunk_p25_recovery_allowed(&opts, &state));
-    state.synctype = DSD_SYNC_P25P1_POS;
-    assert(dsd_trunk_p25_recovery_allowed(&opts, &state));
+    dsd_trunk_recovery_note_protocol(&state, DSD_TRUNK_RECOVERY_P25);
+    state.synctype = state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    assert(dsd_trunk_p25_recovery_allowed(&opts, &state)); // Stray sync cannot evict P25.
     assert(!dsd_trunk_dmr_recovery_allowed(&opts, &state));
-    state.synctype = DSD_SYNC_NONE;
-    state.p25_cc_is_tdma = 0;
+    state.synctype = state.lastsynctype = DSD_SYNC_NONE;
     assert(dsd_trunk_p25_recovery_allowed(&opts, &state));
+    dsd_trunk_recovery_note_protocol(&state, DSD_TRUNK_RECOVERY_OTHER);
+    assert(!dsd_trunk_p25_recovery_allowed(&opts, &state));
+    assert(!dsd_trunk_dmr_recovery_allowed(&opts, &state));
     opts.trunk_scan_enabled = 1;
     assert(!dsd_trunk_p25_recovery_allowed(&opts, &state)); // No installed owner during startup/shutdown.
     opts.trunk_scan_enabled = 0;

--- a/tests/runtime/test_runtime_trunk_scan_hooks.c
+++ b/tests/runtime/test_runtime_trunk_scan_hooks.c
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/synctype_ids.h>
 #include <dsd-neo/runtime/trunk_scan_hooks.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -56,6 +57,37 @@ fake_p25_activity(const dsd_opts* opts, const dsd_state* state, uint32_t target,
     assert(target == 1001U && source == 2002U);
     assert(is_private == 1 && encrypted == 1 && data_call == 0);
     g_activity_calls++;
+}
+
+static void
+test_recovery_ownership(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    opts.trunk_enable = 1;
+    opts.frame_dmr = opts.frame_p25p1 = opts.frame_p25p2 = 1;
+    state.p25_cc_freq = state.trunk_cc_freq = 451000000L;
+    state.synctype = state.lastsynctype = DSD_SYNC_DMR_BS_DATA_POS;
+    assert(dsd_trunk_dmr_recovery_allowed(&opts, &state));
+    assert(!dsd_trunk_p25_recovery_allowed(&opts, &state));
+    state.synctype = DSD_SYNC_NONE;
+    assert(!dsd_trunk_p25_recovery_allowed(&opts, &state));
+    state.lastsynctype = DSD_SYNC_NONE;
+    state.p25_cc_is_tdma = 2;
+    assert(!dsd_trunk_p25_recovery_allowed(&opts, &state));
+    state.synctype = DSD_SYNC_P25P1_POS;
+    assert(dsd_trunk_p25_recovery_allowed(&opts, &state));
+    assert(!dsd_trunk_dmr_recovery_allowed(&opts, &state));
+    state.synctype = DSD_SYNC_NONE;
+    state.p25_cc_is_tdma = 0;
+    assert(dsd_trunk_p25_recovery_allowed(&opts, &state));
+    opts.trunk_scan_enabled = 1;
+    assert(!dsd_trunk_p25_recovery_allowed(&opts, &state)); // No installed owner during startup/shutdown.
+    opts.trunk_scan_enabled = 0;
+    opts.trunk_enable = 0;
+    assert(!dsd_trunk_p25_recovery_allowed(&opts, &state));
+    assert(!dsd_trunk_dmr_recovery_allowed(&opts, &state));
+    assert(!dsd_trunk_p25_recovery_allowed(NULL, &state));
+    assert(!dsd_trunk_dmr_recovery_allowed(&opts, NULL));
 }
 
 int
@@ -110,5 +142,6 @@ main(void) {
     assert(g_control_calls == 4);
     dsd_trunk_scan_hook_p25_conventional_activity(&opts, &state, 1001U, 2002U, 1, 1, 0);
     assert(g_activity_calls == 1);
+    test_recovery_ownership();
     return 0;
 }


### PR DESCRIPTION
## Summary

A held DMR target could lose voice sync and enter P25 recovery, then keep hunting despite valid control messages. Standalone auto decoding also needs to retain the correct recovery owner after sync disappears. Recovery now follows the parked scan target or validated protocol evidence that survives no-carrier resets; a stray sync cannot evict an established owner.

- Check ownership at the watchdog and engine frame-sync callbacks. The DSP callback delegates the force-release latch to the engine adapter. The watchdog predicate no longer reads volatile sync or CC-format hints.
- Establish P25 ownership from validated TSBK, MBT, and LCCH activity and start the idle state machine on a decoded CC before the first voice grant.
- Drive DMR recovery from the standalone main loop as well as trunk scan. Keep confirmed CC frequencies separate from probes, attribute heartbeats to completed tuning generations without per-CSBK rigctl queries, and start acquisition deadlines at the matching backend completion.
- Route DMR releases and CAP+/TSCC moves through an explicit return destination so a stale P25 frequency alias cannot override the tuner or acquisition frequency. Preserve destinations on failed returns and clear the Con+ follow latch on accepted releases.
- Require decoded control evidence to confirm acquisition; raw `CC_SYNC` and relaxed heartbeats only retain established channels. Fix acquisition without an earlier sync timestamp and keep listening when the only candidate is already tuned instead of resetting demodulation every two seconds.
- Ignore grants while a CC tune is unresolved. A pending backend probe holds its target past idle dwell; completion starts a fresh dwell, which includes the subsequent acquisition wait.
- Follow busy Capacity Plus rest announcements when no followed call owns the tuner, including when advertised calls are blocked. Preserve active calls and allow idle targets to rotate.
- Correct the dwell/candidate documentation and make recovery diagnostics consistently available at verbosity 1, including acquisition confirmation while already in the CC state.

Addresses the [September 10 follow-up on #487](https://github.com/arancormonk/dsd-neo/pull/487#issuecomment-5618555125). No new flags, CSV columns, timer controls, or UI countdowns.

## Review

- [x] Changes reviewed against surrounding module design, state ownership, and failure modes.
- [ ] Human review of the final behavior and ownership boundaries.
- [ ] Follow-up outside review of the revised implementation.
- [x] High-risk areas identified: protocol recovery, runtime ownership, control-message handling, and retune ordering. No dependency, workflow, or crypto algorithm changes.
- [x] Generated code read and adapted to project conventions; no added static-analysis suppressions.
- [x] DCO sign-off included.

## Quality Review

- [x] Regressions cover standalone AUTO P25/DMR recovery after no-carrier reset, stray sync, watchdog exclusion with P25 enabled, actual watchdog threading, stale return aliases through the real helper, pending/deferred/failed probes, target dwell, raw versus decoded evidence, single-candidate acquisition, busy CAP+, and distinct expired/unexpired hangtime.
- [x] The expanded integration regression fails when linked against the original unconditional watchdog. The original frame-sync callback mutation also fails.
- [x] Existing protocol, scan, replay, and retune tests pass. No changes to demodulation algorithms or audio policy.
- [x] No new raw memory/string/formatting APIs or subprocess execution in production code.

## Tests And Guardrails

- [x] Full `dev-debug` build and CTest: **628 passed**, including **30 IQ decode replays**.
- [x] Radio-disabled/headless build and CTest: **536 passed**.
- [x] ASan/UBSan: `ENGINE_DMR_CC_RECOVERY`, `ENGINE_NO_CARRIER_RESET`, `RUNTIME_TRUNK_SCAN_HOOKS`, `DMR_T3_SM_RETURN_TO_CC_MATRIX`, and `P25_P2_XCCH_HELPERS` passed.
- [x] TSan: `ENGINE_DMR_CC_RECOVERY` (including the background watchdog) and `RUNTIME_TRUNK_SCAN_HOOKS` passed.
- [x] Strict preflight passed, including architecture, formatting, complexity, Semgrep, clang-tidy, IWYU, cppcheck, GCC fanalyzer, and Clang scan-build. Scan-build reused its build tree for the final incremental analysis.
- [x] `DSD_HOOK_JOBS=12 DSD_HOOK_SCAN_BUILD_REUSE=1 tools/quality_preflight.sh --base origin/main` passed, including whole-tree checks and **7 fuzz targets at 1,000 runs each**.
- [x] CMake formatting and CLI help smoke passed.

## Risk

- Correctness impact: recovery ownership, acquisition, and retune ordering change. Retained ownership is stored with each scan snapshot; pending requests retain frame-dispatch gating.
- CLI/UI impact: busy rest-channel following and idle dwell behave as documented; no new options. Two Qt include corrections were required by the expanded header analysis.
- Compatibility: native Linux, radio-disabled/headless, ASan/UBSan, and TSan were exercised. The reporter's exact Windows/RF trigger has not been replayed on live hardware.
