### PR TITLE
feat(qt): add hang time settings and history holds

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -773,7 +773,12 @@ imports' exclusion behavior). Supplying keys never silently unblocks a talkgroup
 Android Back dismisses input, then the top dialog, then the pushed screen or
 wizard step. Root Back follows the background-listening preference. Monitor's
 More menu reaches History, Settings and Diagnostics without stopping the session.
-Preferences identify changes that apply at the next start.
+Preferences identify changes that apply at the next start. **Decoding → Voice hang time**
+defaults to 2.0 seconds (0.0–30.0); a saved system can override it under Advanced,
+or leave its field empty to follow the app default. Extra decoder arguments containing
+`-t` take precedence. To check P25 timing on-device, enable `--p25-sm-log` in Extra
+decoder arguments and inspect the effective hang time and carrier-release events in
+Diagnostics; argument construction is covered by the host tests.
 
 Controls expose named accessibility actions, keyboard focus and 48 dp targets.
 Text uses Android's per-size SP conversion, including nonlinear large-text scaling.
@@ -799,7 +804,9 @@ Home → **Scan lists** combines saved systems and bare P25/DMR/NXDN frequencies
 into a single trunk-scan session. Use the visible Edit action (or long-press) to edit entries, order, timing,
 modulation and gain. Choose one USB or RTL-TCP tuner for the list; it replaces
 individual systems' source, endpoint, PPM, bandwidth and bias-tee settings.
-The list editor can select imported group/source CSVs from the existing library.
+Scan lists use the app's voice hang time; per-system hang-time overrides do not apply.
+`-t` is separate from idle dwell on every target and the activity hold on conventional
+targets. The list editor can select imported group/source CSVs from the existing library.
 Per-system groups and keys remain isolated on rotation; source aliases are global
 and differing system alias files produce a warning. Unsupported settings are
 refused rather than dropped. See [scan-list rules](../docs/trunk-scan.md#qt-and-android-scan-lists).

--- a/android/README.md
+++ b/android/README.md
@@ -798,6 +798,14 @@ File details show the basename, size and modification time. Replay completion is
 retained with a Play again action. Progress is not invented when the input backend
 cannot report it. History rows open full details, including timestamps and messages.
 
+Tap a row in History or Monitor's Recent calls to **Hold TG** while listening to
+the same saved system. The held talkgroup follows the decoder's state; release it
+from the details or Monitor. Explore sessions and scans (including scans enabled
+through Extra decoder arguments) cannot start a history hold. Rows heard during
+those sessions or saved before system identities were recorded remain ineligible,
+even after starting a single saved system. A running session can still release an
+existing hold.
+
 ### Scan lists
 
 Home → **Scan lists** combines saved systems and bare P25/DMR/NXDN frequencies

--- a/android/README.md
+++ b/android/README.md
@@ -776,9 +776,18 @@ More menu reaches History, Settings and Diagnostics without stopping the session
 Preferences identify changes that apply at the next start. **Decoding → Voice hang time**
 defaults to 2.0 seconds (0.0–30.0); a saved system can override it under Advanced,
 or leave its field empty to follow the app default. Extra decoder arguments containing
-`-t` take precedence. To check P25 timing on-device, enable `--p25-sm-log` in Extra
-decoder arguments and inspect the effective hang time and carrier-release events in
-Diagnostics; argument construction is covered by the host tests.
+`-t` take precedence. Channel scanning enabled with `-Y` also uses this value as
+its dwell timer; scan lists have separate dwell settings.
+
+To check P25 timing, Extra decoder arguments must include a writable filename,
+for example `--p25-sm-log /data/user/0/io.github.arancormonk.dsdneo/files/p25-sm.log`.
+Effective hang time and carrier-release events are appended to that file, not
+the Diagnostics screen. Stop listening before retrieving it. On a rooted test
+emulator, use `adb root` followed by `adb pull` with that path; a debuggable build
+can use `adb exec-out run-as io.github.arancormonk.dsdneo cat files/p25-sm.log > p25-sm.log`.
+Production builds on non-rooted devices do not expose app-private files through
+adb. Remove the argument after testing to stop the log growing. Argument
+construction is also covered by the host tests.
 
 Controls expose named accessibility actions, keyboard focus and 48 dp targets.
 Text uses Android's per-size SP conversion, including nonlinear large-text scaling.
@@ -801,10 +810,11 @@ cannot report it. History rows open full details, including timestamps and messa
 Tap a row in History or Monitor's Recent calls to **Hold TG** while listening to
 the same saved system. The held talkgroup follows the decoder's state; release it
 from the details or Monitor. Explore sessions and scans (including scans enabled
-through Extra decoder arguments) cannot start a history hold. Rows heard during
+through Extra decoder arguments) cannot start a history hold. Hold waits for
+the effective session settings to arrive after startup. Rows heard during
 those sessions or saved before system identities were recorded remain ineligible,
 even after starting a single saved system. A running session can still release an
-existing hold.
+existing hold, including from a different system's row with the same talkgroup ID.
 
 ### Scan lists
 

--- a/docs/radioreference-import.md
+++ b/docs/radioreference-import.md
@@ -117,9 +117,10 @@ site; the other sites retain their individual import settings. A single-site imp
 site identity. Identity uses RadioReference's database site ID, not the RF site number.
 
 Home groups sibling sites under one card with an **n sites ›** chooser. **Use my location** requests a
-foreground fix; valid site distances appear in kilometers. **Nearest site** skips avoided sites and
-sites without valid coordinates. Missing `(0, 0)` coordinates and nonfinite or out-of-range values never
-participate in distance calculations. The avoid switch is saved locally.
+foreground fix; valid site distances appear in miles by default. Enable **Settings → Units → Use metric
+units** to display kilometers. The preference is saved locally and updates displayed distances immediately.
+**Nearest site** skips avoided sites and sites without valid coordinates. Missing `(0, 0)` coordinates and
+nonfinite or out-of-range values never participate in distance calculations. The avoid switch is saved locally.
 
 Site buttons and **Nearest site** start only while Idle. While listening, open **Sites ›**, then use
 **Stop and switch** for the desired site. It stops the session, waits for confirmed Idle, and starts the

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -492,7 +492,9 @@ System source, host, port, PPM, bandwidth and bias-tee settings are replaced by 
 list's settings. Entry gain overrides system gain; otherwise system gain overrides
 the list's default. Zero dwell/hold, negative-one gain/bandwidth/bias-tee and blank
 PPM/modulation inherit their corresponding defaults. Nonzero dwell/hold must be
-250–600000 ms.
+250–600000 ms. Lists use the app's voice hang time, not per-system hang-time overrides;
+Extra decoder arguments containing `-t` still take precedence. Voice/sync-loss hang time
+is separate from idle dwell on every target and the activity hold on conventional targets.
 
 Lists persist in `scan_lists.json`. Lists and entries have stable UIDs; system
 entries reference saved-system UIDs, so deleting or reordering a saved system

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -495,6 +495,9 @@ PPM/modulation inherit their corresponding defaults. Nonzero dwell/hold must be
 250–600000 ms. Lists use the app's voice hang time, not per-system hang-time overrides;
 Extra decoder arguments containing `-t` still take precedence. Voice/sync-loss hang time
 is separate from idle dwell on every target and the activity hold on conventional targets.
+The older channel-scanning mode enabled with `-Y` instead uses `-t` as its dwell
+timer, so changing the app default or a saved-system hang-time override also
+changes that mode's rotation timing.
 
 Lists persist in `scan_lists.json`. Lists and entries have stable UIDs; system
 entries reference saved-system UIDs, so deleting or reordering a saved system

--- a/src/ui/qt/app_prefs.cpp
+++ b/src/ui/qt/app_prefs.cpp
@@ -8,6 +8,7 @@
 #include <QDateTime>
 #include <QLatin1String>
 #include <QVariant>
+#include <cmath>
 
 namespace dsd_qt {
 
@@ -20,6 +21,7 @@ constexpr const char kOnboardingDone[] = "ui/onboardingDone";
 constexpr const char kBackgroundListening[] = "listen/background";
 constexpr const char kKeepScreenAwake[] = "listen/keepAwake";
 constexpr const char kSkipEncrypted[] = "decode/skipEncrypted";
+constexpr const char kHangtimeSec[] = "decode/hangtimeSec";
 constexpr const char kAutoPpm[] = "decode/autoPpm";
 constexpr const char kGainDb[] = "tuner/gainDb";
 constexpr const char kPpm[] = "tuner/ppm";
@@ -39,12 +41,21 @@ constexpr const char kExplorePort[] = "explore/port";
 constexpr const char kExploreFreqMhz[] = "explore/freqMhz";
 
 /*
- * Three preferences are range-checked on the way out. They are checked on the way
+ * Preferences are range-checked on the way out. They are checked on the way
  * in as well, and the setters below compare against what is *stored* rather than
  * against the checked reading — otherwise an out-of-range write persists (the
  * getter hides it) and the corrective write that follows looks like a no-op and is
  * dropped, leaving the file permanently disagreeing with the app.
  */
+
+/** @brief Finite seconds in the UI range, rounded to the displayed precision. */
+double
+sane_hangtime(double seconds) {
+    if (!std::isfinite(seconds)) {
+        return 2.0;
+    }
+    return std::round(qBound(0.0, seconds, 30.0) * 10.0) / 10.0;
+}
 
 /** @brief @p mode if it names an appearance, else the default. */
 int
@@ -201,6 +212,21 @@ AppPrefs::setSkipEncrypted(bool on) {
     }
     m_settings.setValue(QLatin1String(kSkipEncrypted), on);
     Q_EMIT skipEncryptedChanged();
+}
+
+double
+AppPrefs::hangtimeSec() const {
+    return sane_hangtime(m_settings.value(QLatin1String(kHangtimeSec), 2.0).toDouble());
+}
+
+void
+AppPrefs::setHangtimeSec(double seconds) {
+    const double value = sane_hangtime(seconds);
+    if (value == m_settings.value(QLatin1String(kHangtimeSec), 2.0).toDouble()) {
+        return;
+    }
+    m_settings.setValue(QLatin1String(kHangtimeSec), value);
+    Q_EMIT hangtimeSecChanged();
 }
 
 bool

--- a/src/ui/qt/app_prefs.cpp
+++ b/src/ui/qt/app_prefs.cpp
@@ -17,6 +17,7 @@ namespace {
 // Keys are flat and stable: renaming one silently resets that preference for
 // every existing install, so treat them as a persistence format.
 constexpr const char kAppearance[] = "ui/appearance";
+constexpr const char kMetricUnits[] = "ui/metricUnits";
 constexpr const char kOnboardingDone[] = "ui/onboardingDone";
 constexpr const char kBackgroundListening[] = "listen/background";
 constexpr const char kKeepScreenAwake[] = "listen/keepAwake";
@@ -139,6 +140,20 @@ AppPrefs::setAppearance(int mode) {
     }
     m_settings.setValue(QLatin1String(kAppearance), next);
     Q_EMIT appearanceChanged();
+}
+
+bool
+AppPrefs::metricUnits() const {
+    return m_settings.value(QLatin1String(kMetricUnits), false).toBool();
+}
+
+void
+AppPrefs::setMetricUnits(bool on) {
+    if (on == metricUnits()) {
+        return;
+    }
+    m_settings.setValue(QLatin1String(kMetricUnits), on);
+    Q_EMIT metricUnitsChanged();
 }
 
 bool

--- a/src/ui/qt/app_prefs.h
+++ b/src/ui/qt/app_prefs.h
@@ -34,6 +34,7 @@ class AppPrefs : public QObject {
     Q_PROPERTY(qint64 lastFixAt READ lastFixAt NOTIFY locationChanged)
 
     Q_PROPERTY(int appearance READ appearance WRITE setAppearance NOTIFY appearanceChanged)
+    Q_PROPERTY(bool metricUnits READ metricUnits WRITE setMetricUnits NOTIFY metricUnitsChanged)
     Q_PROPERTY(bool onboardingDone READ onboardingDone WRITE setOnboardingDone NOTIFY onboardingDoneChanged)
     Q_PROPERTY(bool notificationExplained READ notificationExplained WRITE setNotificationExplained NOTIFY
                    notificationExplainedChanged)
@@ -88,6 +89,10 @@ class AppPrefs : public QObject {
 
     int appearance() const;
     void setAppearance(int mode);
+
+    /** @brief Display metric units when enabled; imperial is the default. */
+    bool metricUnits() const;
+    void setMetricUnits(bool on);
 
     bool onboardingDone() const;
     void setOnboardingDone(bool done);
@@ -155,6 +160,7 @@ class AppPrefs : public QObject {
     void locationChanged();
 
     void appearanceChanged();
+    void metricUnitsChanged();
     void onboardingDoneChanged();
     void notificationExplainedChanged();
     void backgroundListeningChanged();

--- a/src/ui/qt/app_prefs.h
+++ b/src/ui/qt/app_prefs.h
@@ -41,6 +41,7 @@ class AppPrefs : public QObject {
                    backgroundListeningChanged)
     Q_PROPERTY(bool keepScreenAwake READ keepScreenAwake WRITE setKeepScreenAwake NOTIFY keepScreenAwakeChanged)
     Q_PROPERTY(bool skipEncrypted READ skipEncrypted WRITE setSkipEncrypted NOTIFY skipEncryptedChanged)
+    Q_PROPERTY(double hangtimeSec READ hangtimeSec WRITE setHangtimeSec NOTIFY hangtimeSecChanged)
     Q_PROPERTY(bool autoPpm READ autoPpm WRITE setAutoPpm NOTIFY autoPpmChanged)
     Q_PROPERTY(int gainDb READ gainDb WRITE setGainDb NOTIFY gainDbChanged)
     Q_PROPERTY(int ppm READ ppm WRITE setPpm NOTIFY ppmChanged)
@@ -102,6 +103,9 @@ class AppPrefs : public QObject {
     bool skipEncrypted() const;
     void setSkipEncrypted(bool on);
 
+    double hangtimeSec() const;
+    void setHangtimeSec(double seconds);
+
     bool autoPpm() const;
     void setAutoPpm(bool on);
 
@@ -156,6 +160,7 @@ class AppPrefs : public QObject {
     void backgroundListeningChanged();
     void keepScreenAwakeChanged();
     void skipEncryptedChanged();
+    void hangtimeSecChanged();
     void autoPpmChanged();
     void gainDbChanged();
     void ppmChanged();

--- a/src/ui/qt/call_history_model.cpp
+++ b/src/ui/qt/call_history_model.cpp
@@ -18,6 +18,8 @@
 #include <QVariant>
 #include <QtGlobal>
 #include <algorithm>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
 #include <iterator>
 #include <stdint.h>
@@ -33,6 +35,7 @@ namespace {
 
 constexpr const char kStoreFileName[] = "call_history.json";
 constexpr const char kSeenStoreFileName[] = "call_history_seen.json";
+constexpr const char kSessionUidKey[] = "callHistory/sessionUid";
 constexpr const char kSessionLabelKey[] = "callHistory/sessionLabel";
 constexpr const char kClearedThroughKey[] = "callHistory/clearedThrough";
 constexpr int kMaxRows = 1000;
@@ -84,6 +87,7 @@ CallHistoryModel::CallHistoryModel(QObject* parent) : QAbstractListModel(parent)
      * session is still decoding, and its backlog lands before any start button is
      * pressed. Without the persisted label those rows would be attributed to "". */
     m_sessionLabel = m_settings.value(QLatin1String(kSessionLabelKey)).toString();
+    m_sessionUid = m_settings.value(QLatin1String(kSessionUidKey)).toString();
     /* Restored for the same reason: Clear must survive an Activity restart while
      * the service's ring still holds the cleared rows. */
     m_clearedThrough = m_settings.value(QLatin1String(kClearedThroughKey)).toLongLong();
@@ -135,26 +139,35 @@ CallHistoryModel::rowCount(const QModelIndex& parent) const {
 
 namespace {
 
-/** @brief One row's value for @p role; an unknown role reads as null. */
+/** Identity roles shared by the history views and their saved row details. */
 QVariant
-row_role_value(const CallHistoryModel::Row& row, int role) {
+row_identity_value(const CallHistoryModel::Row& row, int role) {
     switch (role) {
         case CallHistoryModel::NameRole: return row.name;
         case CallHistoryModel::TgRole: return row.tg;
         case CallHistoryModel::SrcRole: return row.src;
         case CallHistoryModel::SourceNameRole: return row.sourceName;
+        case CallHistoryModel::SystemNameRole: return row.systemName;
+        case CallHistoryModel::SystemUidRole: return row.systemUid;
+        default: return QVariant();
+    }
+}
+
+/** @brief One row's value for @p role; an unknown role reads as null. */
+QVariant
+row_role_value(const CallHistoryModel::Row& row, int role) {
+    switch (role) {
         case CallHistoryModel::EmergencyRole: return row.emergency;
         case CallHistoryModel::EncRole: return row.enc;
         case CallHistoryModel::WhenRole: return row.when;
         case CallHistoryModel::DurationSecsRole: return row.durationSecs;
-        case CallHistoryModel::SystemNameRole: return row.systemName;
         case CallHistoryModel::DayLabelRole: return day_label(row.when);
         case CallHistoryModel::TimeTextRole:
             return QDateTime::fromSecsSinceEpoch(row.when).toString(QStringLiteral("HH:mm"));
         case CallHistoryModel::KindRole: return row.kind;
         case CallHistoryModel::DetailRole: return row.detail;
         case CallHistoryModel::ChannelRole: return row.channel;
-        default: return QVariant();
+        default: return row_identity_value(row, role);
     }
 }
 
@@ -180,6 +193,7 @@ CallHistoryModel::roleNames() const {
     roles.insert(WhenRole, QByteArrayLiteral("when"));
     roles.insert(DurationSecsRole, QByteArrayLiteral("durationSecs"));
     roles.insert(SystemNameRole, QByteArrayLiteral("systemName"));
+    roles.insert(SystemUidRole, QByteArrayLiteral("systemUid"));
     roles.insert(DayLabelRole, QByteArrayLiteral("dayLabel"));
     roles.insert(TimeTextRole, QByteArrayLiteral("timeText"));
     roles.insert(KindRole, QByteArrayLiteral("kind"));
@@ -196,6 +210,16 @@ CallHistoryModel::setSessionLabel(const QString& label) {
     m_sessionLabel = label;
     m_settings.setValue(QLatin1String(kSessionLabelKey), label);
     Q_EMIT sessionLabelChanged();
+}
+
+void
+CallHistoryModel::setSessionUid(const QString& uid) {
+    if (uid == m_sessionUid) {
+        return;
+    }
+    m_sessionUid = uid;
+    m_settings.setValue(QLatin1String(kSessionUidKey), uid);
+    Q_EMIT sessionUidChanged();
 }
 
 QStringList
@@ -259,7 +283,8 @@ notice_summary(const Event_History* item) {
 
 /** @brief One committed ring item as a display row. */
 CallHistoryModel::Row
-row_from_item(const Event_History* item, const QString& sessionLabel, int slot, qulonglong seq) {
+row_from_item(const Event_History* item, const QString& sessionLabel, const QString& systemUid, int slot,
+              qulonglong seq) {
     CallHistoryModel::Row row;
     row.slot = slot;
     row.seq = seq;
@@ -299,6 +324,8 @@ row_from_item(const Event_History* item, const QString& sessionLabel, int slot, 
      * role: the row's meta line shows it, search matches it, and a talkgroup heard
      * on two channels stays two rows. */
     row.systemName = sessionLabel;
+    // Retained scan rows remain ineligible even if rotation has since stopped.
+    row.systemUid = item->channel_label[0] == '\0' ? systemUid : QString();
     row.channel = QString::fromUtf8(item->channel_label);
     /* The ring stamps both ends of the transmission: event_start_time when the
      * epoch began, event_time as its last render (its end, once committed). Their
@@ -352,7 +379,7 @@ CallHistoryModel::noteSeen(const QString& key, qint64 when, qint64 end, qulonglo
 }
 
 QList<CallHistoryModel::FreshRow>
-CallHistoryModel::collectFresh(const dsd_state* snapshot, const bool scan[2]) {
+CallHistoryModel::collectFresh(const dsd_state* snapshot, const bool scan[2], const QString& systemUid) {
     QList<FreshRow> fresh;
     for (int slot = 0; slot < 2; slot++) {
         if (!scan[slot]) {
@@ -391,7 +418,7 @@ CallHistoryModel::collectFresh(const dsd_state* snapshot, const bool scan[2]) {
             if (verdict == SeenUnchanged) {
                 continue;
             }
-            fresh.append(FreshRow{row_from_item(item, m_sessionLabel, slot, seq), verdict == SeenAdvanced});
+            fresh.append(FreshRow{row_from_item(item, m_sessionLabel, systemUid, slot, seq), verdict == SeenAdvanced});
         }
     }
     return fresh;
@@ -410,7 +437,7 @@ rows_mergeable(const CallHistoryModel::Row& existing, const CallHistoryModel::Ro
     // them would leave one conversation split across two rows.
     const bool srcCompatible = existing.src == row.src || existing.src == 0 || row.src == 0;
     if (existing.tg != row.tg || !srcCompatible || existing.systemName != row.systemName
-        || existing.channel != row.channel) {
+        || existing.systemUid != row.systemUid || existing.channel != row.channel) {
         return false;
     }
     // Textual targets (M17/D-STAR/YSF callsigns, dPMR dial strings) all share
@@ -545,7 +572,7 @@ CallHistoryModel::ingestRow(const Row& row, bool isUpdate) {
 }
 
 void
-CallHistoryModel::refresh(const dsd_state* snapshot) {
+CallHistoryModel::refresh(const dsd_state* snapshot, const dsd_opts* opts_snapshot) {
     if (snapshot == nullptr || snapshot->event_history_s == nullptr) {
         return;
     }
@@ -567,7 +594,10 @@ CallHistoryModel::refresh(const dsd_state* snapshot) {
         return;
     }
 
-    const QList<FreshRow> fresh = collectFresh(snapshot, scan);
+    // The effective options cover scans started from a saved system's extra
+    // arguments as well as the list UI. Unknown options cannot establish identity.
+    const bool singleSystem = opts_snapshot && !opts_snapshot->scanner_mode && !opts_snapshot->trunk_scan_enabled;
+    const QList<FreshRow> fresh = collectFresh(snapshot, scan, singleSystem ? m_sessionUid : QString());
 
     if (fresh.isEmpty()) {
         return;
@@ -656,6 +686,7 @@ CallHistoryModel::load() {
         row.emergency = obj.value(QLatin1String("em")).toBool();
         row.durationSecs = obj.value(QLatin1String("durationSecs")).toInt(-1);
         row.systemName = obj.value(QLatin1String("systemName")).toString();
+        row.systemUid = obj.value(QLatin1String("systemUid")).toString();
         row.kind = obj.value(QLatin1String("kind")).toInt(KindVoice);
         row.detail = obj.value(QLatin1String("detail")).toString();
         row.channel = obj.value(QLatin1String("channel")).toString();
@@ -737,6 +768,7 @@ CallHistoryModel::rowsToJson() const {
         }
         obj.insert(QLatin1String("durationSecs"), row.durationSecs);
         obj.insert(QLatin1String("systemName"), row.systemName);
+        obj.insert(QLatin1String("systemUid"), row.systemUid);
         obj.insert(QLatin1String("kind"), row.kind);
         if (!row.detail.isEmpty()) {
             obj.insert(QLatin1String("detail"), row.detail);

--- a/src/ui/qt/call_history_model.h
+++ b/src/ui/qt/call_history_model.h
@@ -33,6 +33,7 @@
 #include <QTimer>
 #include <Qt>
 #include <QtGlobal>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state_fwd.h>
 
 namespace dsd_qt {
@@ -41,6 +42,7 @@ class CallHistoryModel : public QAbstractListModel {
     Q_OBJECT
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(QString sessionLabel READ sessionLabel WRITE setSessionLabel NOTIFY sessionLabelChanged)
+    Q_PROPERTY(QString sessionUid READ sessionUid WRITE setSessionUid NOTIFY sessionUidChanged)
     Q_PROPERTY(QStringList systemLabels READ systemLabels NOTIFY countChanged)
 
   public:
@@ -53,6 +55,7 @@ class CallHistoryModel : public QAbstractListModel {
         WhenRole,         // call start, seconds since epoch
         DurationSecsRole, // -1 when unknown
         SystemNameRole,
+        SystemUidRole,
         DayLabelRole,  // "TODAY" / "YESTERDAY" / "MON 3 AUG" — drives list sections
         TimeTextRole,  // "12:04"
         KindRole,      // RowKind: voice call or data/control notice
@@ -91,6 +94,14 @@ class CallHistoryModel : public QAbstractListModel {
 
     void setSessionLabel(const QString& label);
 
+    /** Saved-system identity of the session; empty for exploring and scan lists. */
+    QString
+    sessionUid() const {
+        return m_sessionUid;
+    }
+
+    void setSessionUid(const QString& uid);
+
     /** @brief Distinct system names present in the log, for the filter pill. */
     QStringList systemLabels() const;
 
@@ -102,14 +113,18 @@ class CallHistoryModel : public QAbstractListModel {
      * not its index, which shifts on every push. Updates are granular
      * (insert/change/remove), never a model reset — a reset would destroy every
      * delegate and the reader's scroll position per ingest.
+     *
+     * Options must accompany the snapshot to attribute hold-eligible rows.
+     * Scanning enabled through extra arguments also excludes that attribution.
      */
-    void refresh(const dsd_state* snapshot);
+    void refresh(const dsd_state* snapshot, const dsd_opts* opts_snapshot = nullptr);
 
     Q_INVOKABLE void clearAll();
 
   Q_SIGNALS:
     void countChanged();
     void sessionLabelChanged();
+    void sessionUidChanged();
 
   public:
     /** @brief One logged call or notice. Public only so file-local helpers can build one. */
@@ -129,6 +144,7 @@ class CallHistoryModel : public QAbstractListModel {
         bool enc = false;
         int durationSecs = -1;
         QString systemName;
+        QString systemUid;
         int kind = KindVoice;
         QString detail;
         /* The scan channel the row was heard on: a -Y row name or a trunk-scan
@@ -186,7 +202,7 @@ class CallHistoryModel : public QAbstractListModel {
                  const QString& sourceName);
 
     /** @brief Scan the flagged slots' rings for rows not seen before, or seen but advanced. */
-    QList<FreshRow> collectFresh(const dsd_state* snapshot, const bool scan[2]);
+    QList<FreshRow> collectFresh(const dsd_state* snapshot, const bool scan[2], const QString& systemUid);
 
     /**
      * @brief Absorb @p row into a recent same-target row when the two overlap
@@ -229,6 +245,7 @@ class CallHistoryModel : public QAbstractListModel {
     QList<Row> m_rows; // newest first
     QHash<QString, SeenState> m_seen;
     QString m_sessionLabel;
+    QString m_sessionUid;
     /* Rows starting at or before this stamp were cleared by the user; persisted so
      * the still-populated ring cannot resurrect them after an Activity restart. */
     qint64 m_clearedThrough = 0;

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -679,6 +679,10 @@ MetricsModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) 
      * the last one costs no binding re-evaluation. See MetricsModel::View. */
     View next;
 
+    // Published atomically with the scan flags. Until this first valid snapshot,
+    // a cleared model cannot prove that a new session is not scanning.
+    next.options_known = true;
+
     /* Drives whether the tuner-facing rows are shown at all. Taken from the options
      * the running session was configured with, which is the same authority the
      * metrics fetch above uses to decide whether any of them mean anything. */

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -129,6 +129,7 @@ class MetricsModel : public QObject {
     Q_PROPERTY(bool tunerControlled READ tunerControlled NOTIFY controlChanged)
     Q_PROPERTY(bool trunkingEnabled READ trunkingEnabled NOTIFY controlChanged)
     Q_PROPERTY(bool scannerMode READ scannerMode NOTIFY controlChanged)
+    Q_PROPERTY(bool optionsKnown READ optionsKnown NOTIFY controlChanged)
     Q_PROPERTY(bool scanRotationActive READ scanRotationActive NOTIFY controlChanged)
     Q_PROPERTY(int configuredForce READ configuredForce NOTIFY controlChanged)
     Q_PROPERTY(int effectiveForce READ effectiveForce NOTIFY controlChanged)
@@ -681,6 +682,12 @@ class MetricsModel : public QObject {
         return m_view.scan_rotation_active;
     }
 
+    /** @brief Effective options have arrived; cleared scan flags alone are not authoritative. */
+    bool
+    optionsKnown() const {
+        return m_view.options_known;
+    }
+
     /** @brief The operator hold on the channel or target on air, read from the engine. */
     bool
     scanHold() const {
@@ -1011,6 +1018,7 @@ class MetricsModel : public QObject {
         bool tuner_controlled = false;
         bool trunking_enabled = false;
         bool scanner_mode = false;
+        bool options_known = false;
         bool scan_rotation_active = false;
         QString scan_target_id;
         int scan_target_ordinal = 0;
@@ -1036,10 +1044,10 @@ class MetricsModel : public QObject {
            neither comparison outgrows the complexity ceiling as readings are added. */
         bool
         scanControlEquals(const View& other) const {
-            return scan_target_id == other.scan_target_id && scan_target_ordinal == other.scan_target_ordinal
-                   && scan_target_count == other.scan_target_count && scan_rotation_active == other.scan_rotation_active
-                   && scan_hold == other.scan_hold && scan_avoid_count == other.scan_avoid_count
-                   && scan_target_avoided == other.scan_target_avoided;
+            return options_known == other.options_known && scan_target_id == other.scan_target_id
+                   && scan_target_ordinal == other.scan_target_ordinal && scan_target_count == other.scan_target_count
+                   && scan_rotation_active == other.scan_rotation_active && scan_hold == other.scan_hold
+                   && scan_avoid_count == other.scan_avoid_count && scan_target_avoided == other.scan_target_avoided;
         }
 
         bool

--- a/src/ui/qt/qml/HistoryDetailSheet.qml
+++ b/src/ui/qt/qml/HistoryDetailSheet.qml
@@ -6,7 +6,7 @@ ModalSheet {
     property var record: ({})
     readonly property string rowUid: record.systemUid || ""
     readonly property double rowTg: record.tg || 0
-    readonly property bool canHold: decoderHost.running && !metrics.scanRotationActive && rowTg > 0 && rowUid.length > 0 && rowUid === callHistory.sessionUid
+    readonly property bool canHold: decoderHost.running && metrics.optionsKnown && !metrics.scanRotationActive && rowTg > 0 && rowUid.length > 0 && rowUid === callHistory.sessionUid
     readonly property bool heldHere: metrics.heldTg > 0 && metrics.heldTg === rowTg
     accessibleName: qsTr("Activity details")
     function open(value) {
@@ -48,7 +48,7 @@ ModalSheet {
         width: parent.width
         wrapMode: Text.Wrap
         visible: holdButton.visible && !holdButton.enabled
-        text: !decoderHost.running ? qsTr("Start this system to hold") : metrics.scanRotationActive || callHistory.sessionUid.length === 0 ? qsTr("Hold needs a single saved system") : qsTr("Heard on another system")
+        text: !decoderHost.running ? qsTr("Start this system to hold") : !metrics.optionsKnown ? qsTr("Waiting for session settings") : metrics.scanRotationActive || callHistory.sessionUid.length === 0 ? qsTr("Hold needs a single saved system") : qsTr("Heard on another system")
     }
     OutlineButton {
         width: parent.width

--- a/src/ui/qt/qml/HistoryDetailSheet.qml
+++ b/src/ui/qt/qml/HistoryDetailSheet.qml
@@ -4,6 +4,10 @@ import QtQuick
 ModalSheet {
     id: sheet
     property var record: ({})
+    readonly property string rowUid: record.systemUid || ""
+    readonly property double rowTg: record.tg || 0
+    readonly property bool canHold: decoderHost.running && !metrics.scanRotationActive && rowTg > 0 && rowUid.length > 0 && rowUid === callHistory.sessionUid
+    readonly property bool heldHere: metrics.heldTg > 0 && metrics.heldTg === rowTg
     accessibleName: qsTr("Activity details")
     function open(value) {
         record = value;
@@ -26,6 +30,25 @@ ModalSheet {
             font.family: Theme.sans
             font.pixelSize: Theme.fontSize(15)
         }
+    }
+    OutlineButton {
+        id: holdButton
+        objectName: "historyHoldButton"
+        width: parent.width
+        visible: sheet.rowTg > 0
+        text: sheet.heldHere ? qsTr("Release hold") : qsTr("Hold TG %1").arg(sheet.rowTg)
+        enabled: decoderHost.running && (sheet.canHold || sheet.heldHere)
+        onClicked: {
+            if (commands.holdTalkgroup(sheet.heldHere ? 0 : sheet.rowTg))
+                sheet.visible = false;
+        }
+    }
+    MicroLabel {
+        objectName: "historyHoldReason"
+        width: parent.width
+        wrapMode: Text.Wrap
+        visible: holdButton.visible && !holdButton.enabled
+        text: !decoderHost.running ? qsTr("Start this system to hold") : metrics.scanRotationActive || callHistory.sessionUid.length === 0 ? qsTr("Hold needs a single saved system") : qsTr("Heard on another system")
     }
     OutlineButton {
         width: parent.width

--- a/src/ui/qt/qml/HistoryScreen.qml
+++ b/src/ui/qt/qml/HistoryScreen.qml
@@ -181,6 +181,7 @@ Item {
                 name: model.name,
                 when: model.when,
                 systemName: model.systemName,
+                systemUid: model.systemUid,
                 channel: model.channel,
                 tg: model.tg,
                 src: model.src,

--- a/src/ui/qt/qml/HomeScreen.qml
+++ b/src/ui/qt/qml/HomeScreen.qml
@@ -571,6 +571,7 @@ Item {
                     name: model.name,
                     when: model.when,
                     systemName: model.systemName,
+                    systemUid: model.systemUid,
                     channel: model.channel,
                     tg: model.tg,
                     src: model.src,

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -539,6 +539,7 @@ Window {
         // or its tail calls read as the new system's.
         uiController.flushHistory();
         callHistory.sessionLabel = sys.name;
+        callHistory.sessionUid = (!scan && sys.uid) ? sys.uid : "";
         // The monitor's recent-calls pane shows this session, not the whole log.
         monitorView.minWhen = Math.floor(Date.now() / 1000);
         talkgroups.sinceWhen = monitorView.minWhen;
@@ -847,6 +848,7 @@ Window {
         id: spectrumScreen
 
         SpectrumScreen {
+            objectName: "spectrumScreen"
             exploring: mainRoot.exploring
 
             onClosed: mainRoot.spectrumOpen = false
@@ -879,6 +881,7 @@ Window {
                 mainRoot.sessionRow = -1;
                 uiController.flushHistory();
                 callHistory.sessionLabel = qsTr("Exploring");
+                callHistory.sessionUid = "";
             }
             onSaveAsSystem: function (freqHz) {
                 wizard.openForFound(mainRoot.sessionSystem, Util.mhzText(freqHz));

--- a/src/ui/qt/qml/Main.qml
+++ b/src/ui/qt/qml/Main.qml
@@ -498,6 +498,8 @@ Window {
                 mainRoot.startError = qsTr("“%1” has no valid frequency. Edit the source to correct it.").arg(sys.name);
             } else if (built.error === "ppm") {
                 mainRoot.startError = qsTr("“%1” has an invalid PPM correction. Edit the source to correct it.").arg(sys.name);
+            } else if (built.error === "hangtime") {
+                mainRoot.startError = qsTr("Enter hang time in seconds from 0 to 30.");
             } else if (built.error === "encryption") {
                 mainRoot.startError = qsTr("“%1” has an invalid decryption configuration. Edit the source to correct it.").arg(sys.name);
             } else if (built.error === "unsafe-option") {

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -52,6 +52,8 @@ Item {
     readonly property string heroTg: heroSlot === 1 ? metrics.slot1TgText : heroSlot === 2 ? metrics.slot2TgText : ""
     readonly property string heroSrc: heroSlot === 1 ? metrics.slot1SrcText : heroSlot === 2 ? metrics.slot2SrcText : ""
     readonly property double heroTgId: heroSlot === 1 ? metrics.slot1TgId : heroSlot === 2 ? metrics.slot2TgId : 0
+    readonly property bool heroDuplicate: heroTgId > 0 && heroName === heroTg
+    readonly property string heroHeadline: Util.talkgroupHeadline(heroName, heroTg, heroTgId)
     readonly property bool heroEmergency: heroSlot === 1 ? metrics.slot1CallEmergency : heroSlot === 2 ? metrics.slot2CallEmergency : false
     readonly property bool otherEmergency: otherSlot === 1 ? metrics.slot1CallEmergency : otherSlot === 2 ? metrics.slot2CallEmergency : false
     readonly property bool heroEnc: heroSlot === 1 ? metrics.slot1CallEnc : heroSlot === 2 ? metrics.slot2CallEnc : false
@@ -65,6 +67,7 @@ Item {
     readonly property bool otherActive: otherSlot === 1 ? metrics.slot1CallState === 2 : otherSlot === 2 ? metrics.slot2CallState === 2 : false
     readonly property string otherName: otherSlot === 1 ? metrics.slot1CallName : otherSlot === 2 ? metrics.slot2CallName : ""
     readonly property string otherTg: otherSlot === 1 ? metrics.slot1TgText : otherSlot === 2 ? metrics.slot2TgText : ""
+    readonly property double otherTgId: otherSlot === 1 ? metrics.slot1TgId : otherSlot === 2 ? metrics.slot2TgId : 0
     readonly property bool otherEnc: otherSlot === 1 ? metrics.slot1CallEnc : otherSlot === 2 ? metrics.slot2CallEnc : false
 
     // Ticks the recent-calls age labels ("now", "1m", "2h") once a minute:
@@ -88,7 +91,7 @@ Item {
     readonly property bool holding: metrics ? metrics.heldTg > 0 : false
     readonly property bool scanHeld: metrics ? metrics.scanHold : false
 
-    onHeroNameChanged: heroText.requestPaint()
+    onHeroHeadlineChanged: heroText.requestPaint()
 
     Rectangle {
         anchors.fill: parent
@@ -320,7 +323,7 @@ Item {
                 onPaint: {
                     var ctx = getContext("2d");
                     ctx.reset();
-                    var label = screen.heroName.length > 0 ? screen.heroName : screen.heroTg;
+                    var label = screen.heroHeadline;
                     ctx.font = "bold " + Theme.fontSize(screen.compactHeight ? 25 : 31) + "px \"" + Theme.sans + "\"";
                     ctx.textBaseline = "middle";
                     var gradient = ctx.createLinearGradient(0, 0, Math.max(ctx.measureText(label).width, 1), 0);
@@ -371,7 +374,7 @@ Item {
                     elide: Text.ElideRight
                     text: {
                         var parts = [];
-                        if (screen.heroTg.length > 0 && screen.heroTg !== "0")
+                        if (!screen.heroDuplicate && screen.heroTg.length > 0 && screen.heroTg !== "0")
                             parts.push("TG " + screen.heroTg);
                         if (screen.heroSrc.length > 0 && screen.heroSrc !== "0")
                             parts.push("SRC " + screen.heroSrc);
@@ -594,12 +597,13 @@ Item {
                 }
 
                 Text {
+                    objectName: "otherSlotIdentity"
                     anchors.left: otherSlotLabel.right
                     anchors.leftMargin: 10
                     anchors.right: otherEmergencyTag.visible ? otherEmergencyTag.left : otherEncTag.visible ? otherEncTag.left : otherSkip.left
                     anchors.rightMargin: 10
                     anchors.verticalCenter: parent.verticalCenter
-                    text: screen.otherName.length > 0 ? screen.otherName + " · TG " + screen.otherTg : "TG " + screen.otherTg
+                    text: screen.otherTgId > 0 && screen.otherName === screen.otherTg ? Util.talkgroupHeadline(screen.otherName, screen.otherTg, screen.otherTgId) : screen.otherName.length > 0 ? screen.otherName + " · TG " + screen.otherTg : "TG " + screen.otherTg
                     font.family: Theme.sans
                     font.pixelSize: Theme.fontSize(14)
                     font.weight: Font.DemiBold

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -14,6 +14,7 @@ Item {
             keySheet.visible = false;
             siteSheet.visible = false;
             networkSheet.visible = false;
+            historyDetail.visible = false;
         }
     }
 
@@ -876,6 +877,21 @@ Item {
                     model: monitorView
 
                     delegate: CallRow {
+                        interactive: true
+                        onActivated: historyDetail.open({
+                            name: model.name,
+                            when: model.when,
+                            systemName: model.systemName,
+                            systemUid: model.systemUid,
+                            channel: model.channel,
+                            tg: model.tg,
+                            src: model.src,
+                            sourceName: model.srcName,
+                            emergency: model.emergency,
+                            enc: model.enc,
+                            durationSecs: model.durationSecs,
+                            detail: model.detail
+                        })
                         width: ListView.view.width
                         name: model.name
                         metaText: {
@@ -925,6 +941,11 @@ Item {
                 }
             }
         }
+    }
+
+    HistoryDetailSheet {
+        id: historyDetail
+        objectName: "monitorHistoryDetail"
     }
 
     // WP-D2: the modal consumes input above every monitor control.

--- a/src/ui/qt/qml/ScanListScreen.qml
+++ b/src/ui/qt/qml/ScanListScreen.qml
@@ -225,7 +225,7 @@ Rectangle {
             Text {
                 width: parent.width
                 wrapMode: Text.Wrap
-                text: qsTr("The list's tuner replaces each system's source, host, port, PPM, bandwidth and bias tee. System groups and keys stay isolated. 0 timing, -1 gain/bandwidth and blank PPM inherit defaults.")
+                text: qsTr("The list's tuner replaces each system's source, host, port, PPM, bandwidth and bias tee. System groups and keys stay isolated. Voice hang time uses the app default, including when a system has an override. 0 timing, -1 gain/bandwidth and blank PPM inherit defaults.")
                 color: Theme.textSecondary
                 font.family: Theme.sans
             }

--- a/src/ui/qt/qml/SettingsScreen.qml
+++ b/src/ui/qt/qml/SettingsScreen.qml
@@ -3,7 +3,7 @@
 
 import QtQuick
 
-// Settings: appearance, listening, decoding, and the advanced tuner defaults
+// Settings: appearance, units, listening, decoding, and the advanced tuner defaults
 // folded shut. Every row writes straight through to the persisted preference.
 Item {
     id: screen
@@ -133,6 +133,40 @@ Item {
                         font.pixelSize: Theme.fontSize(12)
                         color: Theme.textSubdued
                         wrapMode: Text.Wrap
+                    }
+                }
+            }
+
+            // UNITS
+            UiPanel {
+                width: parent.width
+                height: unitsColumn.height + Theme.cardPadding + 4
+
+                Column {
+                    id: unitsColumn
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.topMargin: Theme.cardPadding
+                    spacing: 0
+
+                    MicroLabel {
+                        width: parent.width
+                        wrapMode: Text.Wrap
+                        text: qsTr("Units")
+                        leftPadding: Theme.cardPadding
+                        bottomPadding: 6
+                    }
+
+                    ToggleRow {
+                        objectName: "metricUnitsToggle"
+                        title: qsTr("Use metric units")
+                        subtitle: prefs.metricUnits ? qsTr("Distances in kilometers (km)") : qsTr("Distances in miles (mi)")
+                        checked: prefs.metricUnits
+                        onToggled: function (state) {
+                            prefs.metricUnits = state;
+                        }
                     }
                 }
             }

--- a/src/ui/qt/qml/SettingsScreen.qml
+++ b/src/ui/qt/qml/SettingsScreen.qml
@@ -263,7 +263,7 @@ Item {
 
                     DecimalRow {
                         title: qsTr("Voice hang time")
-                        subtitle: qsTr("Keeps a call's channel this long after voice stops before returning to the control channel")
+                        subtitle: qsTr("Keeps a call's channel after voice stops. Also sets channel-scanning dwell (-Y); scan lists have separate dwell settings.")
                         unit: "s"
                         text: prefs.hangtimeSec.toFixed(1)
                         onEdited: function (value) {

--- a/src/ui/qt/qml/SettingsScreen.qml
+++ b/src/ui/qt/qml/SettingsScreen.qml
@@ -46,6 +46,34 @@ Item {
         }
     }
 
+    component DecimalRow: Item {
+        id: decimalRow
+        property string title: ""
+        property string subtitle: ""
+        property string unit: ""
+        property alias text: decimalInput.text
+        signal edited(string text)
+        width: parent ? parent.width : 0
+        height: decimalInput.implicitHeight + 16
+        PlexTextField {
+            id: decimalInput
+            objectName: "hangtimePreferenceField"
+            x: Theme.cardPadding
+            y: 8
+            width: parent.width - 2 * Theme.cardPadding
+            label: decimalRow.title
+            hint: decimalRow.subtitle
+            unit: decimalRow.unit
+            mono: true
+            inputMethodHints: Qt.ImhFormattedNumbersOnly
+            error: /^\d{1,2}(\.\d)?$/.test(text) && Number(text) <= 30 ? "" : qsTr("Enter seconds from 0 to 30, e.g. 2.0.")
+            onEditingFinished: {
+                if (!error.length)
+                    decimalRow.edited(text);
+            }
+        }
+    }
+
     PlexFlickable {
         anchors.fill: parent
         contentHeight: content.height + 2 * Theme.screenPadding
@@ -230,6 +258,16 @@ Item {
                         checked: prefs.autoPpm
                         onToggled: function (state) {
                             prefs.autoPpm = state;
+                        }
+                    }
+
+                    DecimalRow {
+                        title: qsTr("Voice hang time")
+                        subtitle: qsTr("Keeps a call's channel this long after voice stops before returning to the control channel")
+                        unit: "s"
+                        text: prefs.hangtimeSec.toFixed(1)
+                        onEdited: function (value) {
+                            prefs.hangtimeSec = Number(value);
                         }
                     }
                 }

--- a/src/ui/qt/qml/SiteChooserSheet.qml
+++ b/src/ui/qt/qml/SiteChooserSheet.qml
@@ -2,6 +2,7 @@
 import QtQuick
 import QtQuick.Controls
 import DsdNeo 1.0
+import "Util.js" as Util
 
 ModalSheet {
     id: sheet
@@ -142,9 +143,11 @@ ModalSheet {
             width: parent.width
             property var site: (sheet.revision, savedSystems.get(modelData))
             property real distance: (sheet.revision, prefs.lastFixAt > 0 ? savedSystems.distanceKm(modelData, prefs.lastLat, prefs.lastLon) : -1)
+            readonly property string distanceText: Util.fmtDistanceKm(distance, prefs.metricUnits)
             OutlineButton {
+                objectName: "siteChoice" + siteRow.modelData
                 width: parent.width
-                text: (siteRow.site.siteName || siteRow.site.name) + (siteRow.distance >= 0 ? " · " + siteRow.distance.toFixed(1) + " km" : "")
+                text: (siteRow.site.siteName || siteRow.site.name) + (siteRow.distanceText.length > 0 ? " · " + siteRow.distanceText : "")
                 enabled: sheet.sessionState === 0 && !siteRow.site.avoidSite
                 onClicked: sheet.choose(siteRow.modelData)
             }

--- a/src/ui/qt/qml/Util.js
+++ b/src/ui/qt/qml/Util.js
@@ -148,6 +148,14 @@ function fmtMhz(hz) {
     return mhzText(hz) + " MHz"
 }
 
+// Site calculations stay in kilometers; convert only the displayed distance.
+function fmtDistanceKm(km, metricUnits) {
+    if (typeof km !== "number" || !isFinite(km) || km < 0)
+        return ""
+    return metricUnits ? qsTr("%1 km").arg(km.toFixed(1))
+                       : qsTr("%1 mi").arg((km / 1.609344).toFixed(1))
+}
+
 // The catalog entry a chip flag names, or null. One lookup for every question
 // asked of the catalog, so a flag that has to be matched some other way — the
 // importer's composite forms are already the reason LEGACY_DECODE_LABELS exists

--- a/src/ui/qt/qml/Util.js
+++ b/src/ui/qt/qml/Util.js
@@ -2,6 +2,11 @@
 // Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
 .pragma library
 
+// Only numeric talkgroups get the TG prefix; callsigns remain names in their own right.
+function talkgroupHeadline(name, tgText, tgId) {
+    return tgId > 0 && name === tgText ? "TG " + tgText : name.length > 0 ? name : tgText;
+}
+
 // Decode chip catalog: label ↔ CLI flags. The empty flag is the engine's own
 // default (P25 Phase 1+2, DMR and YSF enabled together), so "Auto" passes
 // nothing. Each entry carries the whole flag set its system type needs — the

--- a/src/ui/qt/qml/WizardScreen.qml
+++ b/src/ui/qt/qml/WizardScreen.qml
@@ -1264,7 +1264,7 @@ Item {
                             unit: "s"
                             mono: true
                             placeholderText: prefs.hangtimeSec.toFixed(1)
-                            hint: qsTr("Leave empty to follow the app default · next start")
+                            hint: qsTr("Leave empty to follow the app default · next start. Scan lists always use the app default.")
                             inputMethodHints: Qt.ImhFormattedNumbersOnly
                             error: wizard.hangtimeValid() ? "" : qsTr("Enter hang time in seconds from 0 to 30.")
                         }

--- a/src/ui/qt/qml/WizardScreen.qml
+++ b/src/ui/qt/qml/WizardScreen.qml
@@ -34,7 +34,7 @@ Item {
         }
     }
     function draftFingerprint() {
-        return JSON.stringify([sourceType, hostText, portText, fileText, freqText, decodeFlag, trunking, gainText, ppmText, bwText, biasTee, extraText, nameText, chanCsvPath, groupCsvPath, keyCsvPath, keyCsvHex, encKeyType, encForceKey, p25BandplanCsvPath, srcCsvPath, decryptionProfileUid]);
+        return JSON.stringify([sourceType, hostText, portText, fileText, freqText, decodeFlag, trunking, gainText, ppmText, hangtimeText, bwText, biasTee, extraText, nameText, chanCsvPath, groupCsvPath, keyCsvPath, keyCsvHex, encKeyType, encForceKey, p25BandplanCsvPath, srcCsvPath, decryptionProfileUid]);
     }
     function requestBack() {
         Navigation.clearInput(wizard.Window.window);
@@ -77,6 +77,7 @@ Item {
     property bool advancedOpen: false
     property alias gainText: gainField.text
     property alias ppmText: ppmField.text
+    property alias hangtimeText: hangtimeField.text
     property alias bwText: bwField.text
     // Tri-state: -1 follows the app-wide Settings pref, 0 forces off, 1 forces
     // on. An explicit Off must survive a global On — it means this dongle or
@@ -176,6 +177,7 @@ Item {
         advancedOpen = false;
         gainField.text = "";
         ppmField.text = "";
+        hangtimeField.text = "";
         bwField.text = "";
         biasTee = -1;
         extraField.text = "";
@@ -221,6 +223,7 @@ Item {
         advancedOpen = false;
         gainField.text = "";
         ppmField.text = "";
+        hangtimeField.text = "";
         bwField.text = "";
         biasTee = -1;
         extraField.text = "";
@@ -256,6 +259,7 @@ Item {
         advancedOpen = false;
         gainField.text = sys.gainDb >= 0 ? String(sys.gainDb) : "";
         ppmField.text = sys.ppm;
+        hangtimeField.text = sys.hangtime || "";
         bwField.text = sys.bandwidthKhz > 0 ? String(sys.bandwidthKhz) : "";
         biasTee = sys.biasTee;
         extraField.text = sys.extraArgs;
@@ -333,6 +337,10 @@ Item {
         return /^[0-9]+$/.test(portText) && p >= 1 && p <= 65535;
     }
 
+    function hangtimeValid() {
+        return hangtimeText.length === 0 || (/^\d{1,2}(\.\d)?$/.test(hangtimeText) && Number(hangtimeText) <= 30);
+    }
+
     function stepValid() {
         if (step === 0) {
             if (sourceType === "rtltcp" || sourceType === "tcp")
@@ -344,12 +352,12 @@ Item {
             return true;
         }
         if (step === 1)
-            return encryptionValid && (!radioSource || sessionArgs.freqValid(freqText));
-        return encryptionValid && nameText.trim().length > 0;
+            return hangtimeValid() && encryptionValid && (!radioSource || sessionArgs.freqValid(freqText));
+        return hangtimeValid() && encryptionValid && nameText.trim().length > 0;
     }
 
     function commit() {
-        if (!encryptionValid)
+        if (!hangtimeValid() || !encryptionValid)
             return;
         var sys = {
             name: nameText.trim(),
@@ -361,6 +369,7 @@ Item {
             trunking: trunking,
             gainDb: gainText.length > 0 ? intOr(gainText, -1) : -1,
             ppm: ppmText,
+            hangtime: hangtimeText,
             bandwidthKhz: bwText.length > 0 ? intOr(bwText, -1) : -1,
             biasTee: biasTee,
             extraArgs: extraText.trim(),
@@ -1245,6 +1254,19 @@ Item {
                                     }
                                 }
                             }
+                        }
+
+                        PlexTextField {
+                            id: hangtimeField
+                            objectName: "systemHangtimeField"
+                            width: parent.width
+                            label: qsTr("Voice hang time")
+                            unit: "s"
+                            mono: true
+                            placeholderText: prefs.hangtimeSec.toFixed(1)
+                            hint: qsTr("Leave empty to follow the app default · next start")
+                            inputMethodHints: Qt.ImhFormattedNumbersOnly
+                            error: wizard.hangtimeValid() ? "" : qsTr("Enter hang time in seconds from 0 to 30.")
                         }
 
                         Column {

--- a/src/ui/qt/saved_systems_model.cpp
+++ b/src/ui/qt/saved_systems_model.cpp
@@ -105,6 +105,7 @@ SavedSystemsModel::tuningRoleValue(const Row& row, int role) {
         case TrunkingRole: return row.trunking;
         case GainDbRole: return row.gainDb;
         case PpmRole: return row.ppm;
+        case HangtimeRole: return row.hangtime;
         case BandwidthKhzRole: return row.bandwidthKhz;
         case BiasTeeRole: return row.biasTee;
         case ExtraArgsRole: return row.extraArgs;
@@ -145,6 +146,7 @@ SavedSystemsModel::roleNames() const {
     roles.insert(TrunkingRole, QByteArrayLiteral("trunking"));
     roles.insert(GainDbRole, QByteArrayLiteral("gainDb"));
     roles.insert(PpmRole, QByteArrayLiteral("ppm"));
+    roles.insert(HangtimeRole, QByteArrayLiteral("hangtime"));
     roles.insert(BandwidthKhzRole, QByteArrayLiteral("bandwidthKhz"));
     roles.insert(BiasTeeRole, QByteArrayLiteral("biasTee"));
     roles.insert(ExtraArgsRole, QByteArrayLiteral("extraArgs"));
@@ -283,6 +285,7 @@ SavedSystemsModel::rowFromMap(const QVariantMap& map, const Row& base) {
     map_take_bool(map, QStringLiteral("trunking"), &row.trunking);
     map_take_int(map, QStringLiteral("gainDb"), &row.gainDb);
     map_take_string(map, QStringLiteral("ppm"), &row.ppm);
+    map_take_string(map, QStringLiteral("hangtime"), &row.hangtime);
     map_take_int(map, QStringLiteral("bandwidthKhz"), &row.bandwidthKhz);
     if (map.contains(QStringLiteral("biasTee"))) {
         row.biasTee = bias_tee_from_stored(map.value(QStringLiteral("biasTee")));
@@ -327,6 +330,7 @@ SavedSystemsModel::mapFromRow(const Row& row) const {
     map.insert(QStringLiteral("trunking"), row.trunking);
     map.insert(QStringLiteral("gainDb"), row.gainDb);
     map.insert(QStringLiteral("ppm"), row.ppm);
+    map.insert(QStringLiteral("hangtime"), row.hangtime);
     map.insert(QStringLiteral("bandwidthKhz"), row.bandwidthKhz);
     map.insert(QStringLiteral("biasTee"), row.biasTee);
     map.insert(QStringLiteral("extraArgs"), row.extraArgs);

--- a/src/ui/qt/saved_systems_model.h
+++ b/src/ui/qt/saved_systems_model.h
@@ -45,6 +45,7 @@ class SavedSystemsModel : public QAbstractListModel {
         DecodeFlagRole,
         TrunkingRole,
         GainDbRole,       // -1 = use the app-wide default
+        HangtimeRole,     // seconds as a string; empty = app default
         PpmRole,          // INT_MIN sentinel avoided; stored as string, empty = default
         BandwidthKhzRole, // -1 = default
         BiasTeeRole,      // tri-state: -1 = follow the app-wide pref, 0 = off, 1 = on
@@ -171,6 +172,7 @@ class SavedSystemsModel : public QAbstractListModel {
         bool trunking = false;
         int gainDb = -1;
         QString ppm;
+        QString hangtime;
         int bandwidthKhz = -1;
         /* -1 follows the app-wide pref, 0 is explicitly off, 1 explicitly on. An
          * explicit off must survive a global on: it is the operator saying this

--- a/src/ui/qt/scan_list_starter.cpp
+++ b/src/ui/qt/scan_list_starter.cpp
@@ -10,6 +10,7 @@
 #include <QRegularExpression>
 #include <QSaveFile>
 #include <QSet>
+#include <QStandardPaths>
 #include <QString>
 #include <QStringList>
 #include <QTemporaryFile>
@@ -167,8 +168,14 @@ ScanListStarter::resolveEntryProfiles(QVariantMap& prepared, QString* error) con
 
 static bool
 validateAndStoreCsv(const QByteArray& csv, const QString& path, bool materialize, int* count, QString* error) {
-    // Validate a private temporary file before touching a previous runnable CSV.
-    QTemporaryFile staged(QDir::tempPath() + QStringLiteral("/dsdneo-scan-XXXXXX.csv"));
+    // Android need not have a writable global temp directory. Stage in the
+    // app's cache, privately, before touching a previous runnable CSV.
+    const QString directory = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (directory.isEmpty() || !QDir().mkpath(directory)) {
+        *error = QStringLiteral("Cannot prepare the scan-list validation.");
+        return false;
+    }
+    QTemporaryFile staged(directory + QStringLiteral("/dsdneo-scan-XXXXXX.csv"));
     if (!staged.open() || !staged.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner)
         || staged.write(csv) != csv.size() || !staged.flush()) {
         *error = QStringLiteral("Cannot prepare the scan-list validation.");

--- a/src/ui/qt/scan_list_starter.cpp
+++ b/src/ui/qt/scan_list_starter.cpp
@@ -233,6 +233,7 @@ ScanListStarter::prepare(const QVariantMap& list, bool materialize) const {
         prefs.biasTee = m_prefs->biasTee();
         prefs.skipEncrypted = m_prefs->skipEncrypted();
         prefs.autoPpm = m_prefs->autoPpm();
+        prefs.hangtimeSec = m_prefs->hangtimeSec();
         prefs.extraArgs = m_prefs->extraArgs();
     }
     const QString path = json_store_path(QStringLiteral("scan_lists/") + uid + QStringLiteral(".csv"));

--- a/src/ui/qt/session_args.cpp
+++ b/src/ui/qt/session_args.cpp
@@ -82,6 +82,15 @@ normalized_ppm(const QVariantMap& system, const SessionArgPrefs& prefs) {
     return ppm;
 }
 
+/** Resolve the optional system override before any argv is emitted. */
+bool
+resolve_hangtime(const QVariantMap& system, const SessionArgPrefs& prefs, double& seconds) {
+    const QString overrideText = system.value(QStringLiteral("hangtime")).toString().trimmed();
+    bool ok = true;
+    seconds = overrideText.isEmpty() ? prefs.hangtimeSec : overrideText.toDouble(&ok);
+    return ok && std::isfinite(seconds) && seconds >= 0.0 && seconds <= 30.0;
+}
+
 /** @brief Append "-i <spec>" for the system's source type. */
 void
 append_input_args(QStringList& args, const QVariantMap& system, const QString& sourceType, const QString& tail,
@@ -153,7 +162,7 @@ append_csv_args(QStringList& args, const QVariantMap& system) {
 
 /** @brief Append the decode chip, trunking, policy flags, and extra CLI args. */
 void
-append_flag_args(QStringList& args, const QVariantMap& system, const SessionArgPrefs& prefs) {
+append_flag_args(QStringList& args, const QVariantMap& system, const SessionArgPrefs& prefs, double hangtime) {
     const QString decodeFlag = system.value(QStringLiteral("decodeFlag")).toString().trimmed();
     if (!decodeFlag.isEmpty()) {
         // A chip may carry several flags, so split rather than push whole.
@@ -168,6 +177,7 @@ append_flag_args(QStringList& args, const QVariantMap& system, const SessionArgP
     if (prefs.autoPpm) {
         args << QStringLiteral("--auto-ppm");
     }
+    args << QStringLiteral("-t") << QString::number(hangtime, 'f', 1);
     const QString extra =
         (system.value(QStringLiteral("extraArgs")).toString() + QLatin1Char(' ') + prefs.extraArgs).trimmed();
     if (!extra.isEmpty()) {
@@ -420,6 +430,7 @@ session_args_error_text(SessionArgsError error) {
                 "Enter an M17 AES key with 32, 48, or 64 hex digits; an all-zero key is unavailable to the decoder.");
         case SessionArgsError::Frequency: return QStringLiteral("Enter a positive frequency in MHz.");
         case SessionArgsError::Ppm: return QStringLiteral("Enter a whole number for PPM.");
+        case SessionArgsError::Hangtime: return QStringLiteral("Enter hang time in seconds from 0 to 30.");
         case SessionArgsError::KeyType: return QStringLiteral("Choose one encryption key type.");
         case SessionArgsError::KeyBasic: return QStringLiteral("Enter a basic key from 0 to 255.");
         case SessionArgsError::KeyHex: return QStringLiteral("Enter 10, 32, or 64 hexadecimal digits.");
@@ -523,6 +534,11 @@ session_args_build(const QVariantMap& system, const SessionArgPrefs& prefs, Sess
         return fail(SessionArgsError::Ppm);
     }
 
+    double hangtime = 0.0;
+    if (!resolve_hangtime(system, prefs, hangtime)) {
+        return fail(SessionArgsError::Hangtime);
+    }
+
     if (!session_args_profile_compatible(system)) {
         return fail(SessionArgsError::KeyType);
     }
@@ -554,7 +570,7 @@ session_args_build(const QVariantMap& system, const SessionArgPrefs& prefs, Sess
     if (!system.value("decryptionProfileRef").toString().isEmpty()) {
         args << "--key-profile-ref" << system.value("decryptionProfileRef").toString();
     }
-    append_flag_args(args, system, prefs);
+    append_flag_args(args, system, prefs, hangtime);
     return args;
 }
 
@@ -577,6 +593,7 @@ SessionArgsBuilder::buildArgs(const QVariantMap& system, SessionArgsError* error
         prefs.biasTee = m_prefs->biasTee();
         prefs.skipEncrypted = m_prefs->skipEncrypted();
         prefs.autoPpm = m_prefs->autoPpm();
+        prefs.hangtimeSec = m_prefs->hangtimeSec();
         prefs.extraArgs = m_prefs->extraArgs();
     }
     QVariantMap input = system;
@@ -613,6 +630,7 @@ validationResult(SessionArgsError error) {
     result.insert(QStringLiteral("ok"), error == SessionArgsError::None);
     result.insert(QStringLiteral("error"), error == SessionArgsError::Frequency      ? QStringLiteral("frequency")
                                            : error == SessionArgsError::Ppm          ? QStringLiteral("ppm")
+                                           : error == SessionArgsError::Hangtime     ? QStringLiteral("hangtime")
                                            : error == SessionArgsError::UnsafeOption ? QStringLiteral("unsafe-option")
                                            : error == SessionArgsError::None         ? QString()
                                                                                      : QStringLiteral("encryption"));

--- a/src/ui/qt/session_args.h
+++ b/src/ui/qt/session_args.h
@@ -38,6 +38,7 @@ struct SessionArgPrefs {
     bool biasTee = false;
     bool skipEncrypted = true;
     bool autoPpm = false;
+    double hangtimeSec = 2.0;
     QString extraArgs;
 };
 
@@ -53,6 +54,7 @@ enum class SessionArgsError {
     None,
     Frequency,
     Ppm,
+    Hangtime,
     KeyType,
     KeyBasic,
     KeyHex,
@@ -87,7 +89,7 @@ bool session_args_freq_valid(const QString& freqMhz);
  *
  * Per-system overrides fall back to the app-wide defaults (-1 / empty string
  * mean "no override"; biasTee is -1 follow / 0 off / 1 on). A malformed
- * frequency or PPM must fail here, not downstream as a silently mistuned or
+ * frequency, PPM or hang time must fail here, not downstream as a silently mistuned or
  * uncorrected session.
  */
 QStringList session_args_build(const QVariantMap& system, const SessionArgPrefs& prefs, SessionArgsError* error);

--- a/src/ui/qt/ui_controller.cpp
+++ b/src/ui/qt/ui_controller.cpp
@@ -99,7 +99,9 @@ UiController::flushHistory() {
     if (m_history == nullptr) {
         return;
     }
-    m_history->refresh(dsd_app_get_latest_snapshot());
+    const dsd_opts* opts_snapshot = dsd_app_get_latest_opts_snapshot();
+    const dsd_state* snapshot = dsd_app_get_latest_snapshot();
+    m_history->refresh(snapshot, opts_snapshot);
 }
 
 void
@@ -246,7 +248,7 @@ UiController::tick() {
     /* The call history is persistent by design, so unlike the metrics it is never
      * cleared on session boundaries — only fed. */
     if (m_history != nullptr) {
-        m_history->refresh(snapshot);
+        m_history->refresh(snapshot, opts_snapshot);
     }
     if (live && m_talkgroups != nullptr) {
         m_talkgroups->refresh(opts_snapshot, snapshot);

--- a/tests/test_support/qt_test_paths.h
+++ b/tests/test_support/qt_test_paths.h
@@ -18,6 +18,7 @@ dsd_test_qt_isolate_paths() {
     QStandardPaths::setTestModeEnabled(false);
     qputenv("XDG_DATA_HOME", directory.path().toUtf8());
     qputenv("XDG_CONFIG_HOME", directory.path().toUtf8());
+    qputenv("XDG_CACHE_HOME", (directory.path() + "/cache").toUtf8());
 #else
     QStandardPaths::setTestModeEnabled(true);
 #endif

--- a/tests/ui/qml/tst_context_fixture.qml
+++ b/tests/ui/qml/tst_context_fixture.qml
@@ -16,7 +16,7 @@ TestCase {
         // The screens the other cases load, plus Theme.qml: the screens pull it
         // in as a singleton and it reads prefs itself.
         var missing = testContext.missingContextKeys(
-            ["HistoryScreen.qml", "MonitorScreen.qml", "SpectrumScreen.qml", "ExploreSetupScreen.qml", "RadioSheet.qml",
+            ["HistoryScreen.qml", "HistoryDetailSheet.qml", "MonitorScreen.qml", "SpectrumScreen.qml", "ExploreSetupScreen.qml", "RadioSheet.qml",
              "ImportsScreen.qml", "WizardScreen.qml", "HomeScreen.qml", "SettingsScreen.qml", "Main.qml",
              "SiteChooserSheet.qml", "ScanListScreen.qml", "ScanListCard.qml", "ScanEntryRow.qml", "DiagnosticsScreen.qml", "RadioReferenceScreen.qml", "TalkgroupsScreen.qml", "TalkgroupCard.qml", "TalkgroupEditSheet.qml", "TalkgroupSaveFlow.qml", "Theme.qml"])
 

--- a/tests/ui/qml/tst_history_hold.qml
+++ b/tests/ui/qml/tst_history_hold.qml
@@ -21,6 +21,7 @@ Item {
             testContext.resetCommands()
             testContext.setHostRunning(true)
             testContext.setMetric("heldTg", 0)
+            testContext.setMetric("optionsKnown", true)
             testContext.setMetric("scanRotationActive", false)
             callHistory.sessionUid = "test-system"
         }
@@ -29,6 +30,7 @@ Item {
             loader.item.visible = false
             testContext.setHostRunning(false)
             testContext.setMetric("heldTg", 0)
+            testContext.setMetric("optionsKnown", false)
             testContext.setMetric("scanRotationActive", false)
             callHistory.sessionUid = "test-system"
         }
@@ -38,6 +40,8 @@ Item {
                 {tag: "same-system", running: true, uid: "test-system", held: 0, enabled: true, send: 1001},
                 {tag: "replace-hold", running: true, uid: "test-system", held: 2002, enabled: true, send: 1001},
                 {tag: "release", running: true, uid: "test-system", held: 1001, enabled: true, send: 0},
+                {tag: "release-other-system", running: true, uid: "different", held: 1001, enabled: true, send: 0},
+                {tag: "release-in-explore", running: true, uid: "test-system", sessionUid: "", held: 1001, enabled: true, send: 0},
                 {tag: "stopped", running: false, uid: "test-system", held: 0, enabled: false, reason: "Start this system to hold"},
                 {tag: "stopped-held", running: false, uid: "test-system", held: 1001, enabled: false, reason: "Start this system to hold"},
                 {tag: "another-system", running: true, uid: "different", held: 0, enabled: false, reason: "Heard on another system"},
@@ -48,6 +52,36 @@ Item {
                 {tag: "text-target", running: true, uid: "test-system", held: 0, tg: 0, enabled: false},
                 {tag: "release-in-scan", running: true, uid: "", scanning: true, held: 1001, enabled: true, send: 0}
             ]
+        }
+
+        function test_startup_waits_for_effective_options() {
+            // Android can report Running during a slow input open, before a
+            // redraw has replaced the metrics cleared by Starting.
+            testContext.setMetric("optionsKnown", false)
+            loader.item.open({name: "Dispatch", tg: 1001, systemUid: "test-system"})
+            var button = findChild(loader.item, "historyHoldButton")
+            var reason = findChild(loader.item, "historyHoldReason")
+            verify(!button.enabled)
+            compare(reason.text, "Waiting for session settings")
+            waitForRendering(button)
+            mouseClick(button, button.width / 2, button.height / 2)
+            compare(testContext.holdCalls(), 0)
+
+            testContext.setMetric("scanRotationActive", true)
+            testContext.setMetric("optionsKnown", true)
+            verify(!button.enabled)
+            compare(reason.text, "Hold needs a single saved system")
+
+            // A later single-system start must wait again, then become usable
+            // once its effective options arrive, even without a live call.
+            testContext.setMetric("optionsKnown", false)
+            testContext.setMetric("scanRotationActive", false)
+            verify(!button.enabled)
+            testContext.setMetric("optionsKnown", true)
+            verify(button.enabled)
+            mouseClick(button, button.width / 2, button.height / 2)
+            compare(testContext.holdCalls(), 1)
+            compare(testContext.lastHoldTg(), 1001)
         }
 
         function test_hold(data) {

--- a/tests/ui/qml/tst_history_hold.qml
+++ b/tests/ui/qml/tst_history_hold.qml
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import QtQuick
+import QtTest
+
+Item {
+    width: 420
+    height: 900
+
+    Loader {
+        id: loader
+        anchors.fill: parent
+        source: uiDir + "/HistoryDetailSheet.qml"
+    }
+
+    TestCase {
+        name: "HistoryHold"
+        when: windowShown
+
+        function init() {
+            verify(loader.item !== null)
+            testContext.resetCommands()
+            testContext.setHostRunning(true)
+            testContext.setMetric("heldTg", 0)
+            testContext.setMetric("scanRotationActive", false)
+            callHistory.sessionUid = "test-system"
+        }
+
+        function cleanup() {
+            loader.item.visible = false
+            testContext.setHostRunning(false)
+            testContext.setMetric("heldTg", 0)
+            testContext.setMetric("scanRotationActive", false)
+            callHistory.sessionUid = "test-system"
+        }
+
+        function test_hold_data() {
+            return [
+                {tag: "same-system", running: true, uid: "test-system", held: 0, enabled: true, send: 1001},
+                {tag: "replace-hold", running: true, uid: "test-system", held: 2002, enabled: true, send: 1001},
+                {tag: "release", running: true, uid: "test-system", held: 1001, enabled: true, send: 0},
+                {tag: "stopped", running: false, uid: "test-system", held: 0, enabled: false, reason: "Start this system to hold"},
+                {tag: "stopped-held", running: false, uid: "test-system", held: 1001, enabled: false, reason: "Start this system to hold"},
+                {tag: "another-system", running: true, uid: "different", held: 0, enabled: false, reason: "Heard on another system"},
+                {tag: "exploring", running: true, uid: "test-system", sessionUid: "", held: 0, enabled: false, reason: "Hold needs a single saved system"},
+                {tag: "scan-from-extra-args", running: true, uid: "test-system", scanning: true, held: 0, enabled: false, reason: "Hold needs a single saved system"},
+                {tag: "old-scan-row", running: true, uid: "", held: 0, enabled: false, reason: "Heard on another system"},
+                {tag: "legacy", running: true, held: 0, enabled: false, reason: "Heard on another system"},
+                {tag: "text-target", running: true, uid: "test-system", held: 0, tg: 0, enabled: false},
+                {tag: "release-in-scan", running: true, uid: "", scanning: true, held: 1001, enabled: true, send: 0}
+            ]
+        }
+
+        function test_hold(data) {
+            testContext.setHostRunning(data.running)
+            testContext.setMetric("heldTg", data.held)
+            testContext.setMetric("scanRotationActive", data.scanning === true)
+            if (data.sessionUid !== undefined)
+                callHistory.sessionUid = data.sessionUid
+            var record = {name: "Dispatch", tg: data.tg === undefined ? 1001 : data.tg}
+            if (data.uid !== undefined)
+                record.systemUid = data.uid
+            loader.item.open(record)
+            var button = findChild(loader.item, "historyHoldButton")
+            var reason = findChild(loader.item, "historyHoldReason")
+            compare(button.visible, record.tg > 0)
+            compare(button.enabled, data.enabled)
+            compare(button.text, data.held === record.tg && data.held > 0 ? "Release hold" : "Hold TG " + record.tg)
+            if (data.reason) {
+                verify(reason.visible)
+                compare(reason.text, data.reason)
+            }
+            if (button.visible) {
+                waitForRendering(button)
+                mouseClick(button, button.width / 2, button.height / 2)
+            }
+            compare(testContext.holdCalls(), data.enabled ? 1 : 0)
+            if (data.enabled) {
+                compare(testContext.lastHoldTg(), data.send)
+                verify(!loader.item.visible)
+                compare(metrics.heldTg, data.held, "The command must not guess the next snapshot")
+            }
+        }
+    }
+}

--- a/tests/ui/qml/tst_history_session_identity.qml
+++ b/tests/ui/qml/tst_history_session_identity.qml
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import QtQuick
+import QtTest
+
+Item {
+    width: 420
+    height: 900
+    Loader { id: loader }
+
+    TestCase {
+        name: "HistorySessionIdentity"
+        when: windowShown
+
+        function init() {
+            testContext.useLifecycleHost(true, true)
+            testContext.setDelayedStop(false)
+            while (savedSystems.count)
+                savedSystems.remove(0)
+            while (scanLists.count)
+                scanLists.remove(0)
+            savedSystems.add({name: "Saved site", sourceType: "rtltcp", host: "127.0.0.1", port: 1234, freqMhz: "851.5"})
+            callHistory.sessionUid = "previous-session"
+            loader.source = uiDir + "/Main.qml"
+            verify(loader.item !== null)
+        }
+
+        function cleanup() {
+            loader.source = ""
+            testContext.useLifecycleHost(false)
+            while (savedSystems.count)
+                savedSystems.remove(0)
+            while (scanLists.count)
+                scanLists.remove(0)
+            callHistory.sessionUid = "test-system"
+            callHistory.sessionLabel = "Test Site"
+        }
+
+        function test_saved_to_explore_from_here() {
+            loader.item.startSystem(0)
+            testContext.setLifecyclePhase(2)
+            compare(callHistory.sessionUid, savedSystems.get(0).uid)
+            findChild(loader.item, "monitorScreen").openSpectrum()
+            var spectrum = findChild(loader.item, "spectrumScreen")
+            verify(spectrum !== null)
+            spectrum.exploreFromHere()
+            compare(callHistory.sessionUid, "")
+            compare(callHistory.sessionLabel, "Exploring")
+        }
+
+        function test_scan_start_has_no_identity() {
+            scanLists.add({name: "Scan", sourceType: "rtltcp", host: "127.0.0.1", port: 1234,
+                entries: [{kind: "freq", name: "Simplex", protocol: "p25", freqMhz: "851.5", enabled: true}]})
+            loader.item.startWithMap(scanLists.get(0), 0, true)
+            compare(decoderHost.sessionState, 1)
+            compare(callHistory.sessionUid, "")
+        }
+
+        function test_explore_start_has_no_identity() {
+            loader.item.startWithMap(loader.item.exploreSystem("rtltcp", "127.0.0.1", 1234, "851.5"), -1, false)
+            compare(decoderHost.sessionState, 1)
+            compare(callHistory.sessionUid, "")
+        }
+
+        function test_invalid_start_preserves_identity() {
+            var sys = savedSystems.get(0)
+            sys.hangtime = "abc"
+            loader.item.startWithMap(sys, 0, false)
+            compare(decoderHost.sessionState, 0)
+            compare(callHistory.sessionUid, "previous-session")
+            compare(loader.item.startError, "Enter hang time in seconds from 0 to 30.")
+        }
+    }
+}

--- a/tests/ui/qml/tst_monitor_recent_calls.qml
+++ b/tests/ui/qml/tst_monitor_recent_calls.qml
@@ -48,6 +48,43 @@ Item {
             tryVerify(function () { return tc.atTop() })
         }
 
+        function cleanup() {
+            for (var slot = 1; slot <= 2; ++slot) {
+                for (var field of ["CallName", "TgText", "SrcText"])
+                    testContext.setMetric("slot" + slot + field, "")
+                testContext.setMetric("slot" + slot + "TgId", 0)
+                testContext.setMetric("slot" + slot + "CallState", 0)
+            }
+            testContext.setMetric("leadSlot", 0)
+        }
+
+        function test_headline_deduplication_data() {
+            return [
+                {tag: "number", name: "4001", tg: "4001", id: 4001, headline: "TG 4001", ids: "SRC 7001", other: "TG 4001"},
+                {tag: "callsign", name: "KC1ABC", tg: "KC1ABC", id: 0, headline: "KC1ABC", ids: "TG KC1ABC · SRC 7001", other: "KC1ABC · TG KC1ABC"},
+                {tag: "alias", name: "Fire", tg: "4001", id: 4001, headline: "Fire", ids: "TG 4001 · SRC 7001", other: "Fire · TG 4001"},
+                {tag: "empty-name", name: "", tg: "4001", id: 4001, headline: "4001", ids: "TG 4001 · SRC 7001", other: "TG 4001"}
+            ]
+        }
+
+        function test_headline_deduplication(data) {
+            var ids = findChild(screenLoader.item, "heroIds")
+            var other = findChild(screenLoader.item, "otherSlotIdentity")
+            for (var slot = 1; slot <= 2; ++slot) {
+                testContext.setMetric("slot" + slot + "CallState", 2)
+                testContext.setMetric("slot" + slot + "CallName", data.name)
+                testContext.setMetric("slot" + slot + "TgText", data.tg)
+                testContext.setMetric("slot" + slot + "TgId", data.id)
+                testContext.setMetric("slot" + slot + "SrcText", "7001")
+            }
+            for (var lead = 1; lead <= 2; ++lead) {
+                testContext.setMetric("leadSlot", lead)
+                compare(screenLoader.item.heroHeadline, data.headline)
+                compare(ids.text, data.ids)
+                compare(other.text, data.other)
+            }
+        }
+
         function test_source_alias_is_visible() {
             var newest = callHistory.pushWithSourceName("Radio 1201")
             tryVerify(function () {

--- a/tests/ui/qml/tst_monitor_recent_calls.qml
+++ b/tests/ui/qml/tst_monitor_recent_calls.qml
@@ -49,6 +49,7 @@ Item {
         }
 
         function cleanup() {
+            findChild(screenLoader.item, "monitorHistoryDetail").visible = false
             for (var slot = 1; slot <= 2; ++slot) {
                 for (var field of ["CallName", "TgText", "SrcText"])
                     testContext.setMetric("slot" + slot + field, "")
@@ -83,6 +84,21 @@ Item {
                 compare(ids.text, data.ids)
                 compare(other.text, data.other)
             }
+        }
+
+        function test_recent_row_opens_details() {
+            callHistory.sessionUid = "test-system"
+            var name = callHistory.push("TODAY")
+            tc.list.positionViewAtBeginning()
+            var row = null
+            tryVerify(function () { row = tc.list.itemAtIndex(0); return row !== null && row.name === name })
+            verify(row.interactive)
+            waitForRendering(row)
+            mouseClick(row, row.width / 2, row.height / 2)
+            var sheet = findChild(screenLoader.item, "monitorHistoryDetail")
+            tryCompare(sheet, "visible", true)
+            compare(sheet.record.name, name)
+            compare(sheet.record.systemUid, "test-system")
         }
 
         function test_source_alias_is_visible() {

--- a/tests/ui/qml/tst_settings_hangtime.qml
+++ b/tests/ui/qml/tst_settings_hangtime.qml
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import QtQuick
+import QtTest
+
+Item {
+    width: 420
+    height: 900
+
+    Loader {
+        id: screenLoader
+        anchors.fill: parent
+    }
+
+    TestCase {
+        name: "SettingsHangtime"
+        when: windowShown
+
+        function init() {
+            testContext.useLifecycleHost(true)
+            prefs.hangtimeSec = 2.0
+            screenLoader.source = uiDir + "/SettingsScreen.qml"
+            verify(screenLoader.item !== null)
+        }
+
+        function cleanup() {
+            screenLoader.source = ""
+            prefs.hangtimeSec = 2.0
+            testContext.useLifecycleHost(false)
+        }
+
+        function test_edit_data() {
+            return [
+                {tag: "valid", text: "3.5", value: 3.5, valid: true},
+                {tag: "text", text: "abc", value: 2.0, valid: false},
+                {tag: "range", text: "45", value: 2.0, valid: false}
+            ]
+        }
+
+        function test_edit(data) {
+            var field = findChild(screenLoader.item, "hangtimePreferenceField")
+            verify(field !== null)
+            compare(field.text, "2.0")
+            field.input.forceActiveFocus()
+            field.input.selectAll()
+            for (var i = 0; i < data.text.length; ++i)
+                keyClick(data.text.charAt(i))
+            keyClick(Qt.Key_Return)
+            compare(prefs.hangtimeSec, data.value)
+            compare(field.error, data.valid ? "" : "Enter seconds from 0 to 30, e.g. 2.0.")
+        }
+    }
+}

--- a/tests/ui/qml/tst_settings_units.qml
+++ b/tests/ui/qml/tst_settings_units.qml
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+import QtQuick
+import QtTest
+
+Item {
+    width: 420
+    height: 900
+
+    Loader {
+        id: screenLoader
+        anchors.fill: parent
+    }
+
+    TestCase {
+        name: "SettingsUnits"
+        when: windowShown
+
+        function init() {
+            testContext.useLifecycleHost(true)
+            prefs.metricUnits = false
+            screenLoader.source = uiDir + "/SettingsScreen.qml"
+            verify(screenLoader.item !== null)
+        }
+
+        function cleanup() {
+            screenLoader.source = ""
+            prefs.metricUnits = false
+            testContext.useLifecycleHost(false)
+        }
+
+        function test_toggle_units() {
+            var toggle = findChild(screenLoader.item, "metricUnitsToggle")
+            verify(toggle !== null)
+            compare(toggle.checked, false)
+            compare(toggle.subtitle, "Distances in miles (mi)")
+            waitForRendering(screenLoader.item)
+            mouseClick(toggle, toggle.width / 2, toggle.height / 2)
+            compare(prefs.metricUnits, true)
+            compare(toggle.checked, true)
+            compare(toggle.subtitle, "Distances in kilometers (km)")
+
+            // Reopening Settings must reflect the saved choice.
+            screenLoader.source = ""
+            screenLoader.source = uiDir + "/SettingsScreen.qml"
+            verify(screenLoader.item !== null)
+            toggle = findChild(screenLoader.item, "metricUnitsToggle")
+            verify(toggle !== null)
+            compare(toggle.checked, true)
+            toggle.forceActiveFocus()
+            keyClick(Qt.Key_Space)
+            compare(prefs.metricUnits, false)
+            compare(toggle.checked, false)
+            compare(toggle.subtitle, "Distances in miles (mi)")
+        }
+    }
+}

--- a/tests/ui/qml/tst_site_chooser_sheet.qml
+++ b/tests/ui/qml/tst_site_chooser_sheet.qml
@@ -2,6 +2,7 @@
 import QtQuick
 import QtTest
 import "../../../src/ui/qt/qml" as Ui
+import "../../../src/ui/qt/qml/Util.js" as Util
 Item {
     width: 420; height: 900
     Ui.SiteChooserSheet { id: sheet }
@@ -12,6 +13,8 @@ Item {
         when: windowShown
         function init() {
             testContext.useLifecycleHost(true)
+            prefs.metricUnits = false
+            prefs.setLocationFix(0, 0, 0)
             while (savedSystems.count) savedSystems.remove(0)
             savedSystems.add({name:"North", rrSid:12, rrSiteId:16863, siteName:"North", siteLat:42, siteLon:-91, hasSitePos:true})
             savedSystems.add({name:"South", rrSid:12, rrSiteId:48391, siteName:"South", siteLat:41, siteLon:-91, hasSitePos:true})
@@ -19,7 +22,55 @@ Item {
             sheet.openFor(0)
             starts.clear(); switches.clear()
         }
-        function cleanup() { sheet.visible = false; testContext.useLifecycleHost(false); while (savedSystems.count) savedSystems.remove(0) }
+        function cleanup() {
+            sheet.visible = false
+            prefs.metricUnits = false
+            prefs.setLocationFix(0, 0, 0)
+            testContext.useLifecycleHost(false)
+            while (savedSystems.count) savedSystems.remove(0)
+        }
+        function test_distance_units_update_live() {
+            var north = findChild(sheet, "siteChoice0")
+            var south = findChild(sheet, "siteChoice1")
+            verify(north !== null && south !== null)
+            compare(north.text, "North")
+            compare(south.text, "South")
+
+            prefs.setLocationFix(41, -91, Date.now(), 100)
+            compare(north.text, "North · 69.1 mi")
+            compare(south.text, "South · 0.0 mi")
+            compare(sheet.nearest, 1)
+            prefs.metricUnits = true
+            compare(north.text, "North · 111.2 km")
+            compare(south.text, "South · 0.0 km")
+            compare(sheet.nearest, 1)
+            prefs.metricUnits = false
+            compare(north.text, "North · 69.1 mi")
+
+            savedSystems.update(0, {hasSitePos: false})
+            north = findChild(sheet, "siteChoice0")
+            compare(north.text, "North")
+            prefs.setLocationFix(0, 0, 0)
+            south = findChild(sheet, "siteChoice1")
+            compare(south.text, "South")
+            compare(sheet.nearest, -1)
+        }
+        function test_distance_format_data() {
+            return [
+                {tag: "mile", km: 1.609344, imperial: "1.0 mi", metric: "1.6 km"},
+                {tag: "rounding", km: 10, imperial: "6.2 mi", metric: "10.0 km"},
+                {tag: "zero", km: 0, imperial: "0.0 mi", metric: "0.0 km"},
+                {tag: "unavailable", km: -1, imperial: "", metric: ""},
+                {tag: "nan", km: NaN, imperial: "", metric: ""},
+                {tag: "infinite", km: Infinity, imperial: "", metric: ""},
+                {tag: "missing", km: undefined, imperial: "", metric: ""},
+                {tag: "null", km: null, imperial: "", metric: ""}
+            ]
+        }
+        function test_distance_format(data) {
+            compare(Util.fmtDistanceKm(data.km, false), data.imperial)
+            compare(Util.fmtDistanceKm(data.km, true), data.metric)
+        }
         function test_reopen_same_uid_after_reindexing() {
             // Place a one-site group immediately before another group, so a stale
             // row index would select the other group after removing an earlier row.

--- a/tests/ui/qml/tst_wizard_trunking.qml
+++ b/tests/ui/qml/tst_wizard_trunking.qml
@@ -53,6 +53,52 @@ Item {
             }
         }
 
+        function test_hangtime_save_data() {
+            return [
+                {tag: "default", value: "", valid: true},
+                {tag: "zero", value: "0", valid: true},
+                {tag: "decimal", value: "2.5", valid: true},
+                {tag: "maximum", value: "30", valid: true},
+                {tag: "text", value: "abc", valid: false},
+                {tag: "too-large", value: "45", valid: false},
+                {tag: "negative", value: "-1", valid: false},
+                {tag: "precision", value: "2.55", valid: false}
+            ]
+        }
+
+        function test_hangtime_save(data) {
+            var before = savedSystems.count
+            tc.wizard.hangtimeText = data.value
+            tc.wizard.nameText = "Hang time test"
+            tc.wizard.step = 1
+            compare(tc.wizard.stepValid(), data.valid)
+            var field = findChild(tc.wizard, "systemHangtimeField")
+            verify(field !== null)
+            compare(field.error, data.valid ? "" : "Enter hang time in seconds from 0 to 30.")
+            tc.wizard.step = 2
+            compare(tc.wizard.stepValid(), data.valid)
+            tc.wizard.commit()
+            if (savedSystems.count > before)
+                tc.savedRow = before
+            compare(savedSystems.count, before + (data.valid ? 1 : 0))
+            if (data.valid) {
+                compare(savedSystems.get(before).hangtime, data.value)
+                tc.wizard.openForEdit(before)
+                compare(tc.wizard.hangtimeText, data.value)
+            }
+        }
+
+        function test_hangtime_dirty_and_reset() {
+            var draft = tc.wizard.draftFingerprint()
+            tc.wizard.hangtimeText = "4.5"
+            verify(tc.wizard.draftFingerprint() !== draft)
+            tc.wizard.openForFound(null, "851.375")
+            compare(tc.wizard.hangtimeText, "")
+            tc.wizard.hangtimeText = "4.5"
+            tc.wizard.openForAdd(false)
+            compare(tc.wizard.hangtimeText, "")
+        }
+
         // The shipped defaults have to decode. openForAdd() prefills 851.375 —
         // an 800 MHz P25 control channel, which is why it is the prefill — and
         // leaves Auto selected, so nothing else in the flow ever answers the

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -1683,6 +1683,7 @@ class Setup : public QObject {
         metrics[QStringLiteral("encLockoutCount")] = 0;
         // On-the-fly scan controls (#380): no rotation running at rest.
         metrics[QStringLiteral("scanRotationActive")] = false;
+        metrics[QStringLiteral("optionsKnown")] = false;
         metrics[QStringLiteral("scanHold")] = false;
         metrics[QStringLiteral("scanTargetId")] = QString();
         metrics[QStringLiteral("scanTargetOrdinal")] = 0;

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -1518,6 +1518,7 @@ class Setup : public QObject {
          * AppPrefs' own defaults, so a case that reads one sees what a fresh
          * install would. */
         prefs[QStringLiteral("autoPpm")] = false;
+        prefs[QStringLiteral("hangtimeSec")] = 2.0;
         prefs[QStringLiteral("gainDb")] = 30;
         prefs[QStringLiteral("ppm")] = 0;
         prefs[QStringLiteral("bandwidthKhz")] = 48;

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -1555,6 +1555,7 @@ class Setup : public QObject {
          * scheme; the token set is the only thing that reads it. */
         QVariantMap prefs;
         prefs[QStringLiteral("appearance")] = 2;
+        prefs[QStringLiteral("metricUnits")] = false;
         prefs[QStringLiteral("onboardingDone")] = true;
         prefs[QStringLiteral("backgroundListening")] = false;
         prefs[QStringLiteral("notificationExplained")] = true;

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -398,8 +398,9 @@ class CommandRecorder : public QObject {
     }
 
     Q_INVOKABLE bool
-    // cppcheck-suppress functionStatic // Qt meta-object entry point must remain an instance method.
-    holdTalkgroup(double) const {
+    holdTalkgroup(double tg) {
+        ++m_hold_calls;
+        m_last_hold_tg = tg;
         return true;
     }
 
@@ -571,6 +572,8 @@ class CommandRecorder : public QObject {
 
     void
     reset() {
+        m_hold_calls = 0;
+        m_last_hold_tg = 0;
         m_key_apply_calls = 0;
         m_key_payload_valid = false;
         m_key_accepted = true;
@@ -687,6 +690,16 @@ class CommandRecorder : public QObject {
     }
 
     int
+    holdCalls() const {
+        return m_hold_calls;
+    }
+
+    double
+    lastHoldTg() const {
+        return m_last_hold_tg;
+    }
+
+    int
     talkgroupListenCalls() const {
         return m_talkgroup_listen_calls;
     }
@@ -722,6 +735,8 @@ class CommandRecorder : public QObject {
     }
 
   private:
+    int m_hold_calls = 0;
+    double m_last_hold_tg = 0;
     int m_key_apply_calls = 0;
     bool m_key_payload_valid = false;
     bool m_key_accepted = true;
@@ -766,6 +781,7 @@ class CallLogStore : public QAbstractListModel {
     Q_OBJECT
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(QString sessionLabel READ sessionLabel WRITE setSessionLabel NOTIFY sessionLabelChanged)
+    Q_PROPERTY(QString sessionUid READ sessionUid WRITE setSessionUid NOTIFY sessionUidChanged)
     Q_PROPERTY(QStringList systemLabels READ systemLabels NOTIFY countChanged)
 
   public:
@@ -779,6 +795,7 @@ class CallLogStore : public QAbstractListModel {
         qint64 when = 0;
         int durationSecs = 4;
         QString systemName;
+        QString systemUid;
         QString dayLabel;
         QString timeText;
         int kind = CallHistoryModel::KindVoice;
@@ -811,6 +828,20 @@ class CallLogStore : public QAbstractListModel {
         Q_EMIT sessionLabelChanged();
     }
 
+    QString
+    sessionUid() const {
+        return m_sessionUid;
+    }
+
+    void
+    setSessionUid(const QString& uid) {
+        if (uid == m_sessionUid) {
+            return;
+        }
+        m_sessionUid = uid;
+        Q_EMIT sessionUidChanged();
+    }
+
     QStringList
     systemLabels() const {
         return m_rows.isEmpty() ? QStringList() : QStringList{m_systemName};
@@ -832,6 +863,7 @@ class CallLogStore : public QAbstractListModel {
             case CallHistoryModel::WhenRole: return row.when;
             case CallHistoryModel::DurationSecsRole: return row.durationSecs;
             case CallHistoryModel::SystemNameRole: return row.systemName;
+            case CallHistoryModel::SystemUidRole: return row.systemUid;
             case CallHistoryModel::DayLabelRole: return row.dayLabel;
             case CallHistoryModel::TimeTextRole: return row.timeText;
             case CallHistoryModel::KindRole: return row.kind;
@@ -852,6 +884,7 @@ class CallLogStore : public QAbstractListModel {
                 {CallHistoryModel::WhenRole, "when"},
                 {CallHistoryModel::DurationSecsRole, "durationSecs"},
                 {CallHistoryModel::SystemNameRole, "systemName"},
+                {CallHistoryModel::SystemUidRole, "systemUid"},
                 {CallHistoryModel::DayLabelRole, "dayLabel"},
                 {CallHistoryModel::TimeTextRole, "timeText"},
                 {CallHistoryModel::KindRole, "kind"},
@@ -872,6 +905,7 @@ class CallLogStore : public QAbstractListModel {
         row.src = 200000 + static_cast<qulonglong>(m_seq);
         row.when = m_clock++;
         row.systemName = m_systemName;
+        row.systemUid = m_sessionUid;
         row.dayLabel = dayLabel.isEmpty() ? QStringLiteral("TODAY") : dayLabel;
         row.timeText = QStringLiteral("12:%1").arg(m_seq % 60, 2, 10, QLatin1Char('0'));
         beginInsertRows(QModelIndex(), 0, 0);
@@ -963,10 +997,12 @@ class CallLogStore : public QAbstractListModel {
   Q_SIGNALS:
     void countChanged();
     void sessionLabelChanged();
+    void sessionUidChanged();
 
   private:
     QList<StoreRow> m_rows;
     QString m_systemName = QStringLiteral("Test Site");
+    QString m_sessionUid = QStringLiteral("test-system");
     QString m_sessionLabel = QStringLiteral("Test Site");
     int m_seq = 0;
     /* Fixed, ascending stamps: nothing here should depend on the wall clock. */
@@ -1077,6 +1113,16 @@ class Setup : public QObject {
         }
         m_talkgroups->refresh(m_talkgroup_opts.get(), m_talkgroup_state.get());
         return true;
+    }
+
+    Q_INVOKABLE int
+    holdCalls() const {
+        return m_commands->holdCalls();
+    }
+
+    Q_INVOKABLE double
+    lastHoldTg() const {
+        return m_commands->lastHoldTg();
     }
 
     Q_INVOKABLE int

--- a/tests/ui/test_ui_qt_call_history_model.cpp
+++ b/tests/ui/test_ui_qt_call_history_model.cpp
@@ -32,13 +32,17 @@
 #include <QStringList>
 #include <QTemporaryDir>
 #include <QVariant>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/state.h>
 #include <initializer_list>
+#include <memory>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 #include "../test_support/qt_test_paths.h"
+#include "json_store.h"
 
 #include "call_history_model.h"
 #include "dsd-neo/core/safe_api.h"
@@ -139,6 +143,93 @@ struct RingFixture {
         rings[slot].revision++;
     }
 };
+
+void
+test_system_identity_persistence(void) {
+    resetStorage();
+    RingFixture ring;
+    auto opts = std::make_unique<dsd_opts>();
+    const time_t when = 1754500800;
+    {
+        CallHistoryModel model;
+        model.setSessionLabel("Same name");
+        model.setSessionUid("system-a");
+        ring.commit(0, 1001, 2001, when, when + 4);
+        model.refresh(ring.state, opts.get());
+        expect("ingest exposes saved identity",
+               model.data(model.index(0), CallHistoryModel::SystemUidRole) == "system-a");
+        model.setSessionUid("system-b");
+        ring.commit(0, 1001, 2001, when + 5, when + 9);
+        model.refresh(ring.state, opts.get());
+        expect("same-named systems do not merge", model.count() == 2);
+        expect("changing session identity preserves old rows",
+               model.data(model.index(1), CallHistoryModel::SystemUidRole) == "system-a");
+        expect("new calls carry the new identity",
+               model.data(model.index(0), CallHistoryModel::SystemUidRole) == "system-b");
+    }
+    {
+        CallHistoryModel restored;
+        expect("session identity persists", restored.sessionUid() == "system-b");
+        expect("row identity persists",
+               restored.data(restored.index(0), CallHistoryModel::SystemUidRole) == "system-b"
+                   && restored.data(restored.index(1), CallHistoryModel::SystemUidRole) == "system-a");
+        restored.refresh(ring.state, opts.get());
+        expect("identity does not change ring deduplication", restored.count() == 2);
+    }
+    auto rows = dsd_qt::json_store_load_array("call_history.json");
+    auto legacy = rows.at(1).toObject();
+    legacy.remove("systemUid");
+    rows.replace(1, legacy);
+    expect("legacy history fixture saved", dsd_qt::json_store_save_array("call_history.json", rows));
+    CallHistoryModel legacyModel;
+    expect("legacy row has no hold identity",
+           legacyModel.data(legacyModel.index(1), CallHistoryModel::SystemUidRole).toString().isEmpty());
+}
+
+void
+test_scanning_rows_never_gain_hold_identity(void) {
+    for (int scanMode = 0; scanMode < 2; ++scanMode) {
+        resetStorage();
+        RingFixture ring;
+        auto opts = std::make_unique<dsd_opts>();
+        opts->scanner_mode = scanMode == 0;
+        opts->trunk_scan_enabled = scanMode == 1;
+        const time_t when = 1754500900;
+        {
+            CallHistoryModel model;
+            // A saved system can carry -Y or --trunk-scan in extra arguments.
+            model.setSessionLabel("Saved source");
+            model.setSessionUid("saved-source");
+            ring.commit(0, 1001, 2001, when, when + 4);
+            model.refresh(ring.state, opts.get());
+            expect("effective scanning excludes row identity even without a channel label",
+                   model.count() == 1
+                       && model.data(model.index(0), CallHistoryModel::SystemUidRole).toString().isEmpty());
+        }
+        CallHistoryModel restored;
+        expect("scanned row remains ineligible after reload",
+               restored.count() == 1
+                   && restored.data(restored.index(0), CallHistoryModel::SystemUidRole).toString().isEmpty());
+        opts->scanner_mode = 0;
+        opts->trunk_scan_enabled = 0;
+        ring.commit(0, 1001, 2001, when + 5, when + 9);
+        restored.refresh(ring.state, opts.get());
+        expect("later single-system call is eligible and cannot merge into a scan row",
+               restored.count() == 2
+                   && restored.data(restored.index(0), CallHistoryModel::SystemUidRole) == "saved-source"
+                   && restored.data(restored.index(1), CallHistoryModel::SystemUidRole).toString().isEmpty());
+        ring.commit(0, 3001, 4001, when + 20, when + 24, "", "", "Retained scan target");
+        restored.refresh(ring.state, opts.get());
+        expect("retained scan-labelled rows stay ineligible after rotation stops",
+               restored.count() == 3
+                   && restored.data(restored.index(0), CallHistoryModel::SystemUidRole).toString().isEmpty());
+        ring.commit(0, 5001, 6001, when + 30, when + 34);
+        restored.refresh(ring.state);
+        expect("unknown effective options cannot grant hold identity",
+               restored.count() == 4
+                   && restored.data(restored.index(0), CallHistoryModel::SystemUidRole).toString().isEmpty());
+    }
+}
 
 void
 test_two_slots_same_second_same_talkgroup(void) {
@@ -533,6 +624,8 @@ main(int argc, char** argv) {
     QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, settingsDir.path());
     QSettings::setPath(QSettings::NativeFormat, QSettings::UserScope, settingsDir.path());
 
+    test_system_identity_persistence();
+    test_scanning_rows_never_gain_hold_identity();
     test_source_labels_survive_merge_and_relaunch();
     test_source_label_is_independent_of_refresh_timing();
     test_source_label_provenance_survives_merged_span_and_relaunch();

--- a/tests/ui/test_ui_qt_controller.cpp
+++ b/tests/ui/test_ui_qt_controller.cpp
@@ -176,6 +176,51 @@ test_history_receives_effective_scan_options() {
     freeState(&state);
 }
 
+// Reproduce the options-publication/redraw gap during Android input startup.
+static void
+test_startup_options_wait_for_redraw() {
+    static dsd_opts opts;
+    static dsd_state state;
+    initOpts(&opts);
+    initState(&state);
+    Host host;
+    dsd_qt::MetricsModel metrics;
+    dsd_qt::UiController controller(&host, &metrics, nullptr, nullptr);
+    controller.setPollIntervalMs(50);
+    const auto poll = [&]() {
+        QEventLoop loop;
+        QTimer::singleShot(65, &loop, &QEventLoop::quit);
+        controller.start();
+        loop.exec();
+        controller.stop();
+    };
+    for (int mode = 0; mode < 3; ++mode) {
+        // A completed single-system session left a valid, non-scanning view.
+        opts.scanner_mode = 0;
+        opts.trunk_scan_enabled = 0;
+        metrics.refresh(&opts, &state);
+        check(metrics.optionsKnown() && !metrics.scanRotationActive());
+        host.setPhase(Host::Starting);
+        check(!metrics.optionsKnown());
+        (void)dsd_app_frontend_redraw_consume();
+        opts.scanner_mode = mode == 0;
+        opts.trunk_scan_enabled = mode == 1;
+        // Runtime admission and snapshots precede the slow input open. Android
+        // already reports Running, but no decoder redraw has arrived yet.
+        dsd_app_frontend_runtime_start(&opts, &state);
+        host.setPhase(Host::Running);
+        poll();
+        check(!metrics.optionsKnown() && !metrics.scanRotationActive());
+        dsd_app_request_redraw();
+        poll();
+        check(metrics.optionsKnown() && metrics.scanRotationActive() == (mode != 2));
+        host.setPhase(Host::Idle);
+        check(!metrics.optionsKnown());
+        dsd_app_frontend_runtime_stop();
+    }
+    freeState(&state);
+}
+
 // Run the actual sheet against the real bridge and decoder queue, including CSV media overrides.
 static void
 test_sheet_policy_edits() {
@@ -352,6 +397,7 @@ main(int argc, char** argv) {
     QCoreApplication::setApplicationName("dsd-neo-controller");
     dsd_test_qt_isolate_paths();
     test_history_receives_effective_scan_options();
+    test_startup_options_wait_for_redraw();
     test_sheet_policy_edits();
     test_zero_bounds();
     test_auto_start_requests();

--- a/tests/ui/test_ui_qt_controller.cpp
+++ b/tests/ui/test_ui_qt_controller.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include <QAbstractListModel>
 #include <QChar>
+#include <QCoreApplication>
 #include <QEventLoop>
 #include <QFile>
 #include <QGuiApplication>
@@ -39,6 +40,8 @@
 #include "../../android/local_device_state.h"
 #include "../../src/app_control/commands_internal.h"
 #include "../../src/app_control/snapshot_internal.h"
+#include "../test_support/qt_test_paths.h"
+#include "call_history_model.h"
 #include "command_bridge.h"
 #include "decoder_host.h"
 #include "diagnostics_log.h"
@@ -126,6 +129,51 @@ test_initial_usb_record() {
         check(properties == 1 && attachments == 0);
         check(usb.failureKind == (ready ? Host::NoDeviceFailure : Host::DevicePermission));
     }
+}
+
+static void
+test_history_receives_effective_scan_options() {
+    static dsd_opts opts;
+    static dsd_state state;
+    initOpts(&opts);
+    initState(&state);
+    dsd_qt::CallHistoryModel history;
+    history.setSessionLabel("Saved source");
+    history.setSessionUid("saved-source");
+    dsd_qt::UiController controller(nullptr, nullptr, &history, nullptr);
+    controller.setPollIntervalMs(50);
+    for (int mode = 0; mode < 3; ++mode) {
+        opts.scanner_mode = mode == 0;
+        opts.trunk_scan_enabled = mode == 1;
+        for (bool flush : {false, true}) {
+            auto& ring = state.event_history_s[0];
+            auto& item = ring.Event_History_Items[1];
+            item.category = DSD_EVENT_CATEGORY_VOICE;
+            item.target_id = 9001 + mode * 2 + flush;
+            item.source_id = 8001;
+            item.event_start_time = 1754500000 + mode * 20 + (flush ? 10 : 0);
+            item.event_time = item.event_start_time + 4;
+            ++ring.push_seq;
+            ++ring.commit_rev;
+            ++ring.revision;
+            dsd_app_telemetry_publish_opts_snapshot(&opts);
+            dsd_app_telemetry_publish_snapshot(&state);
+            if (flush) {
+                controller.flushHistory();
+            } else {
+                dsd_app_request_redraw();
+                QEventLoop loop;
+                QTimer::singleShot(65, &loop, &QEventLoop::quit);
+                controller.start();
+                loop.exec();
+                controller.stop();
+            }
+            check(history.count() == mode * 2 + (flush ? 2 : 1));
+            check(history.data(history.index(0), dsd_qt::CallHistoryModel::SystemUidRole).toString()
+                  == (mode == 2 ? "saved-source" : ""));
+        }
+    }
+    freeState(&state);
 }
 
 // Run the actual sheet against the real bridge and decoder queue, including CSV media overrides.
@@ -300,6 +348,10 @@ test_zero_bounds() {
 int
 main(int argc, char** argv) {
     QGuiApplication app(argc, argv);
+    QCoreApplication::setOrganizationName("dsd-neo-test");
+    QCoreApplication::setApplicationName("dsd-neo-controller");
+    dsd_test_qt_isolate_paths();
+    test_history_receives_effective_scan_options();
     test_sheet_policy_edits();
     test_zero_bounds();
     test_auto_start_requests();

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -375,9 +375,44 @@ test_decryption_metadata() {
     dsd_state_ext_free_all(&state);
 }
 
+static void
+test_options_readiness() {
+    static dsd_opts opts;
+    static dsd_state state;
+    initOpts(&opts);
+    initState(&state);
+    dsd_qt::MetricsModel model;
+    int changes = 0;
+    QObject::connect(&model, &dsd_qt::MetricsModel::controlChanged, [&]() { ++changes; });
+    expect("fresh metrics do not establish single-system options",
+           !model.optionsKnown() && !model.scanRotationActive());
+    model.refresh(nullptr, &state);
+    expect("state without options is not ready", !model.optionsKnown());
+    model.refresh(&opts, nullptr);
+    expect("options without a state snapshot are not ready", !model.optionsKnown());
+    model.refresh(&opts, &state);
+    expect("valid quiet snapshot establishes options", model.optionsKnown() && !model.scanRotationActive());
+    expect("readiness notifies controls", changes > 0);
+    const int unchanged = changes;
+    model.refresh(&opts, &state);
+    expect("unchanged options do not notify twice", changes == unchanged);
+    for (int mode = 0; mode < 2; ++mode) {
+        model.clear();
+        expect("clear forgets the previous session's options", !model.optionsKnown());
+        opts.scanner_mode = mode == 0;
+        opts.trunk_scan_enabled = mode == 1;
+        model.refresh(&opts, &state);
+        expect("both effective scan modes arrive with readiness", model.optionsKnown() && model.scanRotationActive());
+        model.refresh(nullptr, &state);
+        expect("losing a snapshot resets readiness", !model.optionsKnown());
+    }
+    freeState(&state);
+}
+
 int
 main(int argc, char** argv) {
     QCoreApplication app(argc, argv);
+    test_options_readiness();
     test_decryption_metadata();
     test_site();
     test_quality();

--- a/tests/ui/test_ui_qt_persistence.cpp
+++ b/tests/ui/test_ui_qt_persistence.cpp
@@ -405,6 +405,29 @@ test_app_prefs(void) {
 }
 
 void
+test_units_preference() {
+    {
+        AppPrefs prefs;
+        expect("units default to imperial", !prefs.metricUnits());
+        int changes = 0;
+        QObject::connect(&prefs, &AppPrefs::metricUnitsChanged, &prefs, [&changes]() { ++changes; });
+        prefs.setMetricUnits(false);
+        expect("unchanged units do not notify", changes == 0);
+        prefs.setMetricUnits(true);
+        expect("metric selection updates and notifies", prefs.metricUnits() && changes == 1);
+        prefs.setMetricUnits(true);
+        expect("repeated metric selection does not notify", changes == 1);
+    }
+    {
+        AppPrefs reloaded;
+        expect("metric units persist across instances", reloaded.metricUnits());
+        reloaded.setMetricUnits(false);
+    }
+    AppPrefs restored;
+    expect("switching back to imperial persists", !restored.metricUnits());
+}
+
+void
 test_migration_write_failure() {
     const QString store = QStringLiteral("saved_systems.json");
     expect("legacy fixture saved", json_store_save_array(store, QJsonArray{QJsonObject{{"name", "legacy"}}}));
@@ -635,6 +658,7 @@ main(int argc, char** argv) {
     test_saved_systems();
     test_saved_systems_csv_fields();
     test_app_prefs();
+    test_units_preference();
     test_migration_write_failure();
     test_foundation_persistence();
     // WP-S2: opting out preserves the last successful target, including scan lists.

--- a/tests/ui/test_ui_qt_persistence.cpp
+++ b/tests/ui/test_ui_qt_persistence.cpp
@@ -134,6 +134,7 @@ full_system_map(void) {
     map.insert(QStringLiteral("trunking"), true);
     map.insert(QStringLiteral("gainDb"), 36);
     map.insert(QStringLiteral("ppm"), QStringLiteral("-2"));
+    map.insert(QStringLiteral("hangtime"), QStringLiteral("1.5"));
     map.insert(QStringLiteral("bandwidthKhz"), 12);
     map.insert(QStringLiteral("biasTee"), true);
     map.insert(QStringLiteral("extraArgs"), QStringLiteral("-C chan.csv"));
@@ -158,6 +159,7 @@ test_saved_systems(void) {
         expect("tuning overrides round-trip",
                got.value(QStringLiteral("gainDb")).toInt() == 36
                    && got.value(QStringLiteral("ppm")).toString() == QStringLiteral("-2")
+                   && got.value(QStringLiteral("hangtime")).toString() == QStringLiteral("1.5")
                    && got.value(QStringLiteral("bandwidthKhz")).toInt() == 12
                    && got.value(QStringLiteral("biasTee")).toInt() == 1
                    && got.value(QStringLiteral("extraArgs")).toString() == QStringLiteral("-C chan.csv"));
@@ -215,10 +217,21 @@ test_saved_systems(void) {
         expect("explicit bias-tee off persists as off", model.get(3).value(QStringLiteral("biasTee")).toInt() == 0);
     }
 
+    auto legacyRows = json_store_load_array(QStringLiteral("saved_systems.json"));
+    auto legacyRow = legacyRows.at(1).toObject();
+    legacyRow.remove(QStringLiteral("hangtime"));
+    legacyRows.replace(1, legacyRow);
+    expect("legacy system stored without hang time",
+           json_store_save_array(QStringLiteral("saved_systems.json"), legacyRows));
+
     /* A second instance is the Activity-restart path: everything above must
      * come back from disk, including the legacy decode-flag migration. */
     SavedSystemsModel reloaded;
     expect("reload restores every row", reloaded.count() == 4);
+    expect("hang time persists through partial edits and reload",
+           reloaded.get(0).value("hangtime") == "1.5"
+               && reloaded.data(reloaded.index(0), SavedSystemsModel::HangtimeRole) == "1.5");
+    expect("legacy hang time follows app default", reloaded.get(1).value("hangtime").toString().isEmpty());
     expect("reload restores fields",
            reloaded.get(0).value(QStringLiteral("name")).toString() == QStringLiteral("Renamed")
                && reloaded.get(0).value(QStringLiteral("extraArgs")).toString() == QStringLiteral("-C chan.csv"));
@@ -326,6 +339,12 @@ test_app_prefs(void) {
         expect("background listening defaults on", prefs.backgroundListening());
         expect("skip-encrypted defaults on", prefs.skipEncrypted());
         expect("auto-ppm defaults off", !prefs.autoPpm());
+        expect("hang time defaults to two seconds", prefs.hangtimeSec() == 2.0);
+        prefs.setHangtimeSec(99);
+        expect("hang time is clamped", prefs.hangtimeSec() == 30.0);
+        prefs.setHangtimeSec(-1);
+        expect("hang time has a zero lower bound", prefs.hangtimeSec() == 0.0);
+        prefs.setHangtimeSec(3.5);
         expect("bias tee defaults off", !prefs.biasTee());
         expect("gain defaults to 30 dB", prefs.gainDb() == 30);
         expect("ppm defaults to 0", prefs.ppm() == 0);
@@ -369,6 +388,7 @@ test_app_prefs(void) {
 
     AppPrefs reloaded;
     expect("gain persists across instances", reloaded.gainDb() == 42);
+    expect("hang time persists across instances", reloaded.hangtimeSec() == 3.5);
     expect("extra args persist across instances", reloaded.extraArgs() == QStringLiteral("--enc-lockout"));
     expect("onboarding flag persists", reloaded.onboardingDone());
     expect("explore source persists", reloaded.exploreSourceType() == QStringLiteral("rtltcp"));

--- a/tests/ui/test_ui_qt_scan_list_roundtrip.cpp
+++ b/tests/ui/test_ui_qt_scan_list_roundtrip.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include <QByteArray>
+#include <QByteArrayView>
 #include <QCoreApplication>
 #include <QDir>
 #include <QFile>
@@ -15,6 +16,8 @@
 #include <cstdio>
 #include <dsd-neo/app_control/trunk_scan_validate.h>
 #include <initializer_list>
+#include <qsystemdetection.h>
+#include <qtenvironmentvariables.h>
 #include <utility>
 #include "../test_support/qt_test_paths.h"
 #include "json_store.h"
@@ -55,6 +58,22 @@ main(int argc, char** argv) {
     check(loaded.count() == 1 && loaded.get(0).value("uid") == uid
           && loaded.get(0).value("lastHeard").toLongLong() > 0);
     ScanListStarter starter(nullptr, nullptr);
+#if defined(Q_OS_UNIX)
+    // Android has no usable global /tmp. Validation and build must still work
+    // with only the app's cache writable, including before that cache exists.
+    const bool hadTmpDir = qEnvironmentVariableIsSet("TMPDIR");
+    const QByteArray previousTmpDir = qgetenv("TMPDIR");
+    qputenv("TMPDIR", (dir.path() + "/missing-temp").toUtf8());
+    const auto validation = starter.validate(list);
+    check(validation.value("ok").toBool() && validation.value("targetCount").toInt() == 1);
+    const auto withoutTemp = starter.build(list);
+    check(withoutTemp.value("ok").toBool() && withoutTemp.value("targetCount").toInt() == 1);
+    if (hadTmpDir) {
+        qputenv("TMPDIR", previousTmpDir);
+    } else {
+        qunsetenv("TMPDIR");
+    }
+#endif
     auto result = starter.build(list);
     check(result.value("ok").toBool() && result.value("targetCount").toInt() == 1);
     const QString path = json_store_path("scan_lists/" + uid + ".csv");

--- a/tests/ui/test_ui_qt_scan_list_targets.cpp
+++ b/tests/ui/test_ui_qt_scan_list_targets.cpp
@@ -151,6 +151,7 @@ main(int argc, char** argv) {
     QString error;
     check(session_args_scan_build(list, "851.5", "/targets.csv", prefs, &error).isEmpty() && !error.isEmpty());
     prefs.extraArgs = "-F";
+    prefs.hangtimeSec = 4.5;
     prefs.autoPpm = true;
     list["voiceOnly"] = true;
     list["defaultDwellMs"] = 250;
@@ -164,6 +165,13 @@ main(int argc, char** argv) {
     list["biasTee"] = 1;
     auto args = session_args_scan_build(list, "851.5", "/targets.csv", prefs, &error);
     check(args.last() == "-F");
+    check(args.count("-t") == 1 && args.value(args.indexOf("-t") + 1) == "4.5");
+    prefs.extraArgs = "-t 9 -F";
+    const auto extraArgs = session_args_scan_build(list, "851.5", "/targets.csv", prefs, &error);
+    check(error.isEmpty() && extraArgs.count("-t") == 2 && extraArgs.last() == "-F"
+          && extraArgs.value(extraArgs.indexOf("-t") + 1) == "4.5"
+          && extraArgs.value(extraArgs.lastIndexOf("-t") + 1) == "9");
+    prefs.extraArgs = "-F";
     check(error.isEmpty() && args.contains("rtltcp:localhost:1234:851.5M:38:4:24:0:2:bias")
           && args.contains("--trunk-scan") && args.contains("--scan-voice-only") && args.contains("--src-csv")
           && args.contains("--trunk-scan-dwell-ms") && args.contains("--trunk-scan-activity-hold-ms")

--- a/tests/ui/test_ui_qt_session_args.cpp
+++ b/tests/ui/test_ui_qt_session_args.cpp
@@ -23,6 +23,7 @@
 #include <QVariantMap>
 #include <QtGlobal>
 #include <initializer_list>
+#include <limits>
 #include <qtenvironmentvariables.h>
 #include <stdio.h>
 #include "decoder_host.h"
@@ -61,6 +62,43 @@ QString
 input_spec(const QStringList& args) {
     const qsizetype i = args.indexOf(QStringLiteral("-i"));
     return (i >= 0 && i + 1 < args.size()) ? args.at(i + 1) : QString();
+}
+
+void
+test_hangtime(void) {
+    auto sys = usb_system();
+    SessionArgPrefs prefs;
+    SessionArgsError error = SessionArgsError::None;
+    auto args = session_args_build(sys, prefs, &error);
+    expect("default hang time", args.count("-t") == 1 && args.value(args.indexOf("-t") + 1) == "2.0");
+    prefs.hangtimeSec = 3.5;
+    args = session_args_build(sys, prefs, &error);
+    expect("preference hang time", args.value(args.indexOf("-t") + 1) == "3.5");
+    sys["hangtime"] = "1.5";
+    sys["extraArgs"] = "-t 9 -F";
+    prefs.extraArgs = "-t 8";
+    args = session_args_build(sys, prefs, &error);
+    expect("system override precedes extras",
+           error == SessionArgsError::None && args.count("-t") == 3
+               && args.mid(args.indexOf("-t")) == QStringList({"-t", "1.5", "-t", "9", "-F", "-t", "8"}));
+    dsd_qt::SessionArgsBuilder builder(nullptr);
+    for (const auto& value : QStringList{"abc", "-1", "45", "nan", "inf"}) {
+        sys["hangtime"] = value;
+        expect("invalid hang time refuses argv",
+               session_args_build(sys, prefs, &error).isEmpty() && error == SessionArgsError::Hangtime);
+        const auto result = builder.build(sys);
+        expect("hang time has its own validation category",
+               !result.value("ok").toBool() && result.value("error") == "hangtime"
+                   && result.value("errorText") == "Enter hang time in seconds from 0 to 30.");
+    }
+    for (const auto& value : QStringList{"0", "30", " 2.5 "}) {
+        sys["hangtime"] = value;
+        expect("boundary hang times accepted", !session_args_build(sys, prefs, &error).isEmpty());
+    }
+    sys["hangtime"] = "";
+    prefs.hangtimeSec = std::numeric_limits<double>::quiet_NaN();
+    expect("nonfinite preference refuses argv",
+           session_args_build(sys, prefs, &error).isEmpty() && error == SessionArgsError::Hangtime);
 }
 
 void
@@ -431,6 +469,7 @@ main(int argc, char** argv) {
         expect("global key display is refused", session_args_build(sys, prefs, nullptr).isEmpty());
     }
     test_freq_validation();
+    test_hangtime();
     test_defaults_and_overrides();
     test_csv_args();
     test_ppm_shapes();


### PR DESCRIPTION
## Summary

- Add Voice hang time to Decoding settings (default 2.0 seconds, range 0.0–30.0) and an optional saved-system override. Changes apply at the next start; explicit extra `-t` arguments take precedence. Scan lists use the app default.
- Show an unaliased numeric talkgroup once in the Monitor headline and concurrent-slot strip, preserving callsigns and aliases.
- Let History and Monitor recent-call details hold a talkgroup from the currently running saved system. Persist system UIDs, exclude Explore and effective scan sessions—including scans enabled through Extra decoder arguments—and keep older or scanned rows ineligible on later runs. Release follows the decoder snapshot.

## Review

- [x] Changes reviewed against the surrounding module design, persistence and snapshot ownership contracts.
- [ ] Implementation behavior, ownership boundaries and failure modes reviewed by a human.
- [x] High-risk areas assessed: frontend settings, argument validation and history attribution; no engine/protocol changes.
- [x] Added code read and adapted to repository conventions.
- [x] Commits carry GPG signatures and DCO sign-offs.

## Tests And Guardrails

- [x] Configure and build `dev-debug` with `DSD_ENABLE_QT_UI=ON`.
- [x] All 40 tests selected by `ctest --preset dev-debug -R '^(UI_QT_|APP_CONTROL_|CORE_TALKGROUP_POLICY)' --output-on-failure` pass, including the registered QML suite.
- [x] Regression coverage includes both Monitor slots; Settings and wizard validation; preference/model persistence; argv precedence; same-system Hold/Release; Explore/scan transitions; and effective scan options during both polling and final history flush.
- [x] `tools/check_arch_rules.sh`.
- [x] `DSD_HOOK_JOBS=8 tools/preflight_ci.sh --base origin/main`.
- [ ] Android live RF check: no device was connected. Verify effective P25 hang time and release timing with `--p25-sm-log`, then exercise Hold/Release from History and Monitor on hardware. The Android start path does not dump argv; host tests assert argument construction.

## Risk

- Security/dependency impact: history retains only non-secret system identity; existing command and snapshot boundaries are preserved.
- CLI/UI behavior impact: hang-time settings apply on the next start. History holds require matching saved identity and an effective single-system session; an existing hold can be released while running.
- Compatibility or packaging impact: legacy saved systems follow the app default. Legacy history remains readable with hold disabled. No new test executables or QML resources are required.
