### PR TITLE
fix(ci): analyse every includer of a changed header with IWYU

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -283,14 +283,27 @@ if [[ ${#missing_worktree_paths[@]} -gt 0 ]]; then
 fi
 
 analysis_tus=("${changed_sources[@]}")
+# IWYU analyses every includer of a changed header (see tools/ci_changed_files.sh);
+# the capped sample is for the slower analyzers only.
+iwyu_tus=("${changed_sources[@]}")
 
 escape_rg() {
   printf '%s' "$1" | sed -e 's/[][(){}.^$*+?|\\]/\\&/g'
 }
 
 MAX_TUS_PER_HEADER_PER_LANGUAGE=5
+limit_includers() {
+  if [[ "$1" -gt 0 ]]; then
+    head -n "$1"
+  else
+    cat
+  fi
+}
+# collect_header_includers PATTERN [CAP] -> includers per language, at most CAP
+# of each (0: every includer).
 collect_header_includers() {
   local pattern="$1"
+  local cap="${2:-$MAX_TUS_PER_HEADER_PER_LANGUAGE}"
   local c_file=""
   local cxx_file=""
   local c_matches=()
@@ -301,14 +314,14 @@ collect_header_includers() {
       -g'*.c' \
       "$pattern" src apps tests examples 2> /dev/null |
       sort |
-      head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
+      limit_includers "$cap" || true
   )
   mapfile -t cxx_matches < <(
     rg -l --glob '!src/third_party/**' \
       -g'*.cc' -g'*.cpp' -g'*.cxx' \
       "$pattern" src apps tests examples 2> /dev/null |
       sort |
-      head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
+      limit_includers "$cap" || true
   )
 
   for c_file in "${c_matches[@]}"; do
@@ -335,6 +348,8 @@ if [[ ${#changed_headers[@]} -gt 0 ]]; then
 
       mapfile -t matches < <(collect_header_includers "$pattern")
       analysis_tus+=("${matches[@]}")
+      mapfile -t matches < <(collect_header_includers "$pattern" 0)
+      iwyu_tus+=("${matches[@]}")
     done
   else
     echo "pre-push: rg not found; header include expansion skipped." >&2
@@ -344,9 +359,12 @@ fi
 if [[ ${#analysis_tus[@]} -gt 0 ]]; then
   mapfile -t analysis_tus < <(printf '%s\n' "${analysis_tus[@]}" | sort -u)
 fi
+if [[ ${#iwyu_tus[@]} -gt 0 ]]; then
+  mapfile -t iwyu_tus < <(printf '%s\n' "${iwyu_tus[@]}" | sort -u)
+fi
 
 echo "pre-push: changed paths=${#changed_paths[@]} sources=${#changed_sources[@]}" \
-  "headers=${#changed_headers[@]} tus=${#analysis_tus[@]}"
+  "headers=${#changed_headers[@]} tus=${#analysis_tus[@]} iwyu=${#iwyu_tus[@]}"
 
 cppcheck_sources=()
 for p in "${analysis_tus[@]}"; do
@@ -405,6 +423,7 @@ mark_missing_tool() {
 # 64. Serial mode lets every tool use the whole machine, since nothing else
 # runs beside it.
 tu_count=${#analysis_tus[@]}
+iwyu_count=${#iwyu_tus[@]}
 cppcheck_count=${#cppcheck_sources[@]}
 
 # analyzer_share BUDGET PERMILLE CAP -> workers, at least 1, at most CAP (0: uncapped)
@@ -430,7 +449,7 @@ if [[ "$RUNNER_SERIAL" == "1" ]]; then
   jobs_format=$JOBS
   jobs_tidy=$(analyzer_share "$JOBS" 1000 "$tu_count")
   jobs_fanalyzer=$(analyzer_share "$JOBS" 1000 "$tu_count")
-  jobs_iwyu=$(analyzer_share "$JOBS" 1000 "$tu_count")
+  jobs_iwyu=$(analyzer_share "$JOBS" 1000 "$iwyu_count")
   if [[ $cppcheck_count -gt 0 ]]; then
     jobs_cppcheck=$(analyzer_share "$JOBS" 1000 "$cppcheck_count")
   fi
@@ -448,7 +467,7 @@ else
     jobs_cppcheck=$(analyzer_share "$analyzer_budget" 410 "$cppcheck_count")
   fi
   jobs_fanalyzer=$(analyzer_share "$analyzer_budget" 130 "$tu_count")
-  jobs_iwyu=$(analyzer_share "$analyzer_budget" 30 "$tu_count")
+  jobs_iwyu=$(analyzer_share "$analyzer_budget" 30 "$iwyu_count")
   jobs_tidy=$((analyzer_budget - jobs_cppcheck - jobs_fanalyzer - jobs_iwyu))
   if [[ $jobs_tidy -lt 1 ]]; then
     jobs_tidy=1
@@ -589,7 +608,7 @@ lane_cppcheck() {
 # shellcheck disable=SC2329 # Started through runner_spawn.
 lane_iwyu() {
   if command -v include-what-you-use > /dev/null 2>&1; then
-    run_check "IWYU strict (${tu_count} TU(s), ${jobs_iwyu} worker(s))" tools/iwyu.sh --strict --jobs "$jobs_iwyu" -- "${analysis_tus[@]}"
+    run_check "IWYU strict (${iwyu_count} TU(s), ${jobs_iwyu} worker(s))" tools/iwyu.sh --strict --jobs "$jobs_iwyu" -- "${iwyu_tus[@]}"
   else
     mark_missing_tool "include-what-you-use" "IWYU analysis"
   fi

--- a/.github/workflows/linux-ci.yaml
+++ b/.github/workflows/linux-ci.yaml
@@ -1377,14 +1377,19 @@ jobs:
         include:
           - name: clang-tidy
             run_cmd: tools/clang_tidy.sh
+            tus_file: analysis_tus.txt
             artifact_name: clang-tidy-report
             artifact_path: .clang-tidy.local.out
+          # IWYU takes every includer of a changed header (iwyu_tus.txt); the
+          # capped analysis_tus.txt sample is for the slower analyzers.
           - name: iwyu
             run_cmd: tools/iwyu.sh --strict
+            tus_file: iwyu_tus.txt
             artifact_name: iwyu-report
             artifact_path: .iwyu.local.out
           - name: gcc-fanalyzer
             run_cmd: tools/gcc_fanalyzer.sh --strict
+            tus_file: analysis_tus.txt
             artifact_name: gcc-fanalyzer-report
             artifact_path: .gcc-fanalyzer.local.out
     steps:
@@ -1512,7 +1517,7 @@ jobs:
             cmake --preset dev-debug
 
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              mapfile -t files < .ci/changed-files/analysis_tus.txt
+              mapfile -t files < ".ci/changed-files/${{ matrix.tus_file }}"
               ${{ matrix.run_cmd }} -- "${files[@]}"
             else
               ${{ matrix.run_cmd }}

--- a/tests/dsp/test_rtl_symbol_pipeline.cpp
+++ b/tests/dsp/test_rtl_symbol_pipeline.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>

--- a/tests/tools/test_ci_changed_files_header_expansion.sh
+++ b/tests/tools/test_ci_changed_files_header_expansion.sh
@@ -8,8 +8,11 @@
 # never reached a tests/ TU on a pull request; an IWYU verdict that only renders
 # from a tests/ includer then failed the full-tree push run on main after #471
 # merged. The cap now applies per top-level tree, so every tree that includes the
-# header is represented. This builds a throwaway repository in which src/ alone
-# overflows the cap and checks the tests/ includer still lands in analysis_tus.
+# header is represented. IWYU additionally gets every includer (iwyu_tus.txt):
+# after #505 a tests/ TU past the cap within its own tree needed <atomic> for a
+# member that became std::atomic, and only the full-tree push run saw it. This
+# builds a throwaway repository in which src/ alone overflows the cap and checks
+# the tests/ includer still lands in analysis_tus and every includer in iwyu_tus.
 set -euo pipefail
 
 if ! command -v rg > /dev/null 2>&1; then
@@ -47,6 +50,7 @@ head=$(git rev-parse HEAD)
 
 bash "$SCRIPT" --base "$base" --head "$head" --out-dir out > /dev/null 2>&1
 mapfile -t tus < out/analysis_tus.txt
+mapfile -t iwyu_tus < out/iwyu_tus.txt
 
 has() {
   local want="$1"
@@ -86,8 +90,35 @@ has src/core/unrelated.c && {
   fail=1
 }
 
+# IWYU is uncapped: all seven src/ C includers, the C++ one, and the other trees.
+iwyu_src_c=0
+for t in "${iwyu_tus[@]}"; do
+  [[ "$t" == src/*.c && "$t" != src/core/unrelated.c ]] && iwyu_src_c=$((iwyu_src_c + 1))
+done
+if [[ $iwyu_src_c -ne 7 ]]; then
+  echo "FAIL: expected all 7 src/ C includers in iwyu_tus, got $iwyu_src_c" >&2
+  fail=1
+fi
+for want in src/core/z.cpp tests/core/test_widget.c apps/cli/main.c; do
+  found=0
+  for t in "${iwyu_tus[@]}"; do
+    [[ "$t" == "$want" ]] && found=1
+  done
+  if [[ $found -ne 1 ]]; then
+    echo "FAIL: $want missing from iwyu_tus" >&2
+    fail=1
+  fi
+done
+for t in "${iwyu_tus[@]}"; do
+  if [[ "$t" == src/core/unrelated.c ]]; then
+    echo "FAIL: non-includer listed in iwyu_tus" >&2
+    fail=1
+  fi
+done
+
 if [[ $fail -ne 0 ]]; then
   printf 'analysis_tus:\n%s\n' "${tus[@]}" >&2
+  printf 'iwyu_tus:\n%s\n' "${iwyu_tus[@]}" >&2
   exit 1
 fi
-echo "PASS: header expansion samples every tree under the per-language cap"
+echo "PASS: header expansion samples every tree under the per-language cap and IWYU sees every includer"

--- a/tools/ci_changed_files.sh
+++ b/tools/ci_changed_files.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 # Compute the changed-file target sets used by pull-request CI.
 # This mirrors the local pre-push targeting rules: changed source files are
-# analyzed directly, and changed headers expand to representative C and C++ TUs.
+# analyzed directly, and changed headers expand to representative C and C++ TUs
+# (capped per tree and language) for the slower analyzers, and to every includer
+# for IWYU, whose verdict depends on the header's types and is cheap to run.
 
 ROOT_DIR=$(git rev-parse --show-toplevel 2> /dev/null || pwd)
 cd "$ROOT_DIR"
@@ -125,8 +127,11 @@ escape_rg() {
 # merge (#471, the IWYU failure on main after the merge).
 HEADER_INCLUDER_ROOTS=(src apps tests examples)
 
+# collect_header_includers PATTERN [CAP] -> includers per tree and language,
+# at most CAP of each (0: every includer).
 collect_header_includers() {
   local pattern="$1"
+  local cap="${2:-$MAX_TUS_PER_HEADER_PER_LANGUAGE}"
   local root=""
   local f=""
   local matches=()
@@ -140,7 +145,7 @@ collect_header_includers() {
         -g'*.c' \
         "$pattern" "$root" 2> /dev/null |
         sort |
-        head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
+        limit_includers "$cap" || true
     )
     for f in "${matches[@]}"; do
       printf '%s\n' "$f"
@@ -150,12 +155,20 @@ collect_header_includers() {
         -g'*.cc' -g'*.cpp' -g'*.cxx' \
         "$pattern" "$root" 2> /dev/null |
         sort |
-        head -n "$MAX_TUS_PER_HEADER_PER_LANGUAGE" || true
+        limit_includers "$cap" || true
     )
     for f in "${matches[@]}"; do
       printf '%s\n' "$f"
     done
   done
+}
+
+limit_includers() {
+  if [[ "$1" -gt 0 ]]; then
+    head -n "$1"
+  else
+    cat
+  fi
 }
 
 mkdir -p "$OUT_DIR"
@@ -246,6 +259,11 @@ for p in "${changed_paths[@]}"; do
 done
 
 analysis_tus=("${changed_sources[@]}")
+# IWYU gets every includer of a changed header: a type change in a header (an
+# atomic member, say) alters which includes its consumers need, and the capped
+# sample missed tests/ TUs past the cut twice (#471, #505), leaving the failure
+# for the full-tree push run on main. Full-tree IWYU costs about two minutes.
+iwyu_tus=("${changed_sources[@]}")
 if [[ $EXPAND_HEADERS -eq 1 && ${#changed_headers[@]} -gt 0 ]]; then
   if command -v rg > /dev/null 2>&1; then
     for hdr in "${changed_headers[@]}"; do
@@ -263,6 +281,8 @@ if [[ $EXPAND_HEADERS -eq 1 && ${#changed_headers[@]} -gt 0 ]]; then
 
       mapfile -t matches < <(collect_header_includers "$pattern")
       analysis_tus+=("${matches[@]}")
+      mapfile -t matches < <(collect_header_includers "$pattern" 0)
+      iwyu_tus+=("${matches[@]}")
     done
   else
     echo "ci-changed-files: rg not found; header include expansion skipped." >&2
@@ -289,6 +309,9 @@ fi
 if [[ ${#analysis_tus[@]} -gt 0 ]]; then
   mapfile -t analysis_tus < <(sort_unique_array "${analysis_tus[@]}")
 fi
+if [[ ${#iwyu_tus[@]} -gt 0 ]]; then
+  mapfile -t iwyu_tus < <(sort_unique_array "${iwyu_tus[@]}")
+fi
 if [[ ${#cppcheck_sources[@]} -gt 0 ]]; then
   mapfile -t cppcheck_sources < <(sort_unique_array "${cppcheck_sources[@]}")
 fi
@@ -305,6 +328,7 @@ fi
 write_list "$OUT_DIR/changed_paths.txt" "${changed_paths[@]}"
 write_list "$OUT_DIR/format_files.txt" "${format_files[@]}"
 write_list "$OUT_DIR/analysis_tus.txt" "${analysis_tus[@]}"
+write_list "$OUT_DIR/iwyu_tus.txt" "${iwyu_tus[@]}"
 write_list "$OUT_DIR/cppcheck_sources.txt" "${cppcheck_sources[@]}"
 write_list "$OUT_DIR/semgrep_targets.txt" "${semgrep_targets[@]}"
 write_list "$OUT_DIR/cmake_format_files.txt" "${cmake_format_files[@]}"
@@ -313,7 +337,7 @@ write_list "$OUT_DIR/dependency_scan_targets.txt" "${dependency_scan_targets[@]}
 
 echo "ci-changed-files: base=${BASE_REF} head=${HEAD_REF}"
 echo "ci-changed-files: changed=${#changed_paths[@]} format=${#format_files[@]}" \
-  "tus=${#analysis_tus[@]} cppcheck=${#cppcheck_sources[@]} semgrep=${#semgrep_targets[@]}" \
+  "tus=${#analysis_tus[@]} iwyu=${#iwyu_tus[@]} cppcheck=${#cppcheck_sources[@]} semgrep=${#semgrep_targets[@]}" \
   "cmake=${#cmake_format_files[@]} workflows=${#workflow_security_targets[@]}" \
   "deps=${#dependency_scan_targets[@]} semgrep_full=${semgrep_full_scan}"
 
@@ -323,6 +347,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     echo "changed_paths=${#changed_paths[@]}"
     echo "format_files=${#format_files[@]}"
     echo "analysis_tus=${#analysis_tus[@]}"
+    echo "iwyu_tus=${#iwyu_tus[@]}"
     echo "cppcheck_sources=${#cppcheck_sources[@]}"
     echo "semgrep_targets=${#semgrep_targets[@]}"
     echo "semgrep_full_scan=${semgrep_full_scan}"


### PR DESCRIPTION
## Summary

The push-to-main IWYU job failed after #505: `tests/dsp/test_rtl_symbol_pipeline.cpp` assigns `channel_squelch_level`, which #505 turned into a `std::atomic<float>`, so the file now needs `<atomic>`. The PR-scoped IWYU job never analysed it because `tools/ci_changed_files.sh` caps the consumers of a changed header at five per tree and language, and this test fell past the cap (the demod state header has 23 test consumers).

- Add the missing include.
- Give IWYU an uncapped consumer list (`iwyu_tus.txt`) in the changed-files script, the pre-push hook and the workflow matrix. clang-tidy, cppcheck and gcc-fanalyzer keep the capped sample, since a full-tree IWYU run is about two minutes on CI while the others are far slower.

## Verification

- `tools/iwyu.sh --strict -- tests/dsp/test_rtl_symbol_pipeline.cpp`: analyzed=1 suggested=0; full-tree `tools/iwyu.sh --strict`: analyzed=869 suggested=0.
- `tests/tools/test_ci_changed_files_header_expansion.sh` extended to assert the uncapped IWYU list; passes.
- Replaying the #505 diff through the script: capped list 137 units without the test, IWYU list 511 units with it.
- shell lint and workflow lint clean; the modified pre-push hook ran on this push.