### PR TITLE
feat(ui): show scan state and live timing for trunk scan and -Y

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -558,10 +558,10 @@ Notes
 - Hang time after voice/sync loss (seconds): `-t <secs>`
   - This is not the idle dwell between `--trunk-scan` targets. DMR control/rest-channel acquisition has its own
     two-second window; use target `dwell_ms` to budget each visit. See [trunk-scan timing](trunk-scan.md).
-  - Under `-Y` without `--scan-voice-only`, the terminal's `Scan Timing` row counts this value down from the last
-    sync as `Hangtime`. The rotation rule itself compares whole seconds, so the hop can land up to a second after the
-    countdown reaches `0.0s`; the countdown is a readout of the same anchor, and the policy is unchanged. NXDN holds
-    the scan two extra seconds after each confirmed frame, so on an NXDN row the countdown starts above `-t`.
+  - Under `-Y` without `--scan-voice-only`, the terminal's `Scan Timing` row counts down to the first whole-second
+    tick when the time since the last sync exceeds `-t`. Its total is therefore `floor(-t) + 1` seconds, including
+    one second for `-t 0`; the rotation policy is unchanged. NXDN holds the scan two extra seconds after each confirmed
+    frame, so on an NXDN row the countdown can initially exceed the displayed total.
   - P25 Talk Complete, TDU, TDULC, MAC_END_PTT, MAC_IDLE, and MAC_HANGTIME mark a transmission boundary. They close
     that slot's media and start or refresh the traffic-carrier inactivity timer without returning to the control
     channel. A follow-up PTT/ACTIVE on the retained carrier opens a clean call epoch without retuning.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -558,6 +558,9 @@ Notes
 - Hang time after voice/sync loss (seconds): `-t <secs>`
   - This is not the idle dwell between `--trunk-scan` targets. DMR control/rest-channel acquisition has its own
     two-second window; use target `dwell_ms` to budget each visit. See [trunk-scan timing](trunk-scan.md).
+  - Under `-Y` without `--scan-voice-only`, the terminal's `Scan Timing` row counts this value down from the last
+    sync as `Hangtime`. The rotation rule itself compares whole seconds, so the hop can land up to a second after the
+    countdown reaches `0.0s`; the countdown is a readout of the same anchor, and the policy is unchanged.
   - P25 Talk Complete, TDU, TDULC, MAC_END_PTT, MAC_IDLE, and MAC_HANGTIME mark a transmission boundary. They close
     that slot's media and start or refresh the traffic-carrier inactivity timer without returning to the control
     channel. A follow-up PTT/ACTIVE on the retained carrier opens a clean call epoch without retuning.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -560,7 +560,8 @@ Notes
     two-second window; use target `dwell_ms` to budget each visit. See [trunk-scan timing](trunk-scan.md).
   - Under `-Y` without `--scan-voice-only`, the terminal's `Scan Timing` row counts this value down from the last
     sync as `Hangtime`. The rotation rule itself compares whole seconds, so the hop can land up to a second after the
-    countdown reaches `0.0s`; the countdown is a readout of the same anchor, and the policy is unchanged.
+    countdown reaches `0.0s`; the countdown is a readout of the same anchor, and the policy is unchanged. NXDN holds
+    the scan two extra seconds after each confirmed frame, so on an NXDN row the countdown starts above `-t`.
   - P25 Talk Complete, TDU, TDULC, MAC_END_PTT, MAC_IDLE, and MAC_HANGTIME mark a transmission boundary. They close
     that slot's media and start or refresh the traffic-carrier inactivity timer without returning to the control
     channel. A follow-up PTT/ACTIVE on the retained carrier opens a clean call epoch without retuning.

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -48,7 +48,11 @@ Generated (do not edit/commit):
   - Voice-gated scan for -Y and trunk scan (issue #381): `src/engine/scan_voice_gate.c` behind
     `include/dsd-neo/engine/scan_voice_gate.h`; its probe returns separate active and retained last-media clocks so
     a protocol terminator cannot erase the scanner's tail anchor (tests: `ENGINE_SCAN_VOICE_GATE`,
-    `ENGINE_NO_CARRIER_RESET`, `ENGINE_TRUNK_SCAN`)
+    `ENGINE_NO_CARRIER_RESET`, `ENGINE_TRUNK_SCAN`). The same file owns the scan-timing publication
+    (`dsd_scan_timing_clear()` / `dsd_scan_timing_publish()`) and the -Y timing tick
+    `dsd_engine_scan_y_timing_tick()`, which stamps `dsd_state::scan_timing` with the stay reason and the absolute
+    monotonic deadline of the window that is running (issue #508); the deadline it publishes is the same instant
+    `dsd_scan_voice_gate_should_step()` flips, so the readout cannot drift from the rotation it describes
   - Installs runtime hook tables used by DSP/frame-sync code
     (`src/engine/frame_sync_hooks_install.c`, `include/dsd-neo/runtime/frame_sync_hooks.h`)
 - Build files: `src/engine/CMakeLists.txt`
@@ -82,6 +86,12 @@ behavior, the CSV columns, and the CLI/config options live in `docs/trunk-scan.m
 - Conventional activity reports: `dsd_engine_trunk_scan_dmr_conventional_activity()`,
   `dsd_engine_trunk_scan_nxdn_conventional_activity()`, and `dsd_engine_trunk_scan_p25_conventional_activity()`,
   reached from protocol code through the runtime hooks.
+
+Beside the active-target publication the coordinator also publishes the stay reason and live timing for the parked
+target into `dsd_state::scan_timing` once per tick (issue #508), from the same effective dwell/hold resolvers the
+rotation itself uses. It is a readout, not a decision: the reason function is pure and the old held/not-held verdict
+is a one-line wrapper over it, so no rotation, hold or step moves because of it. `app_control/scan_timing_view`
+turns it into a row (see below).
 
 Every parked target keeps its own snapshot of decoder state — channel map, trunking/LCN state, call and P25 identity
 metadata (the IDEN tables and the user band plan behind them), the encrypted-target lockout ledger, and the NXDN
@@ -316,6 +326,14 @@ installs from `src/engine/trunk_tuning.c` in `src/engine/trunk_tuning_hooks_inst
   Such sessions therefore report the defaults — no carrier lock, no CFO, no output/symbol rate, and the
   invalid-SNR sentinel — and a frontend should omit those rows rather than render them as zeros. Applies to
   every frontend, not just the Android app
+- Shared display decisions, so no frontend has to restate one: `include/dsd-neo/app_control/call_view.h` and
+  `src/app_control/call_view.c` fold the canonical call state into a per-slot line, and
+  `include/dsd-neo/app_control/scan_timing_view.h` and `src/app_control/scan_timing_view.c` fold
+  `dsd_state::scan_timing` into the Scan Timing row — the stay phrase, the remaining/total of the window that is
+  running, and which of dwell/hold/hang is worth printing (issue #508). The decoder owns every deadline; these
+  views only difference it against the caller's monotonic clock, which is what keeps the terminal row, the Qt panel
+  and the Android app from drifting on what "suspended" or "hold" means. Tests: `APP_CONTROL_CALL_VIEW`,
+  `APP_CONTROL_SCAN_TIMING_VIEW`, and the terminal goldens in `UI_NCURSES_PRINTER_HELPERS`.
 - Decode quality: `include/dsd-neo/app_control/p25_metrics.h` and `src/app_control/p25_metrics.c`
   copy FEC ok percentages, populated P25 voice-error averages, and non-P25 last-frame
   errors from the caller's held snapshot. The core vocoder maintains ring counts;

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -543,6 +543,9 @@ Build files: `src/protocol/CMakeLists.txt` and per‑protocol `src/protocol/<nam
 
 Qt Quick frontend (`src/ui/qt`):
 
+- After the session's first decoder redraw, `UiController` refreshes live metrics on every timer tick so scan
+  countdowns and the sync-loss hold continue aging if input stalls. History, network and policy models still
+  refresh on decoder redraws; session lifecycle clears live metrics and prevents stale snapshots from restoring them.
 - QML plus C++ view-models (metrics, call history + per-view filters, saved systems, imported CSV files, app
   preferences, command bridge) that poll app-control on a timer; used by the Android app today and intended as the
   shared basis for a desktop GUI. `imported_files_model.{h,cpp}` is the library behind the CSV pickers: it copies

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -142,6 +142,10 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
 - `--trunk-scan-activity-hold-ms <ms>` sets the default hold time after allowed conventional DMR/P25/NXDN activity
   (NXDN96 and NXDN48 alike). Default: `1200`.
 - Per-target CSV values override these defaults.
+- The terminal's `Scan Timing` row reports the *effective* dwell and hold for the target on air — the values left
+  after the CSV column and the CLI/config default have been resolved — and labels `-t` as `hang`, never as a dwell.
+  `(suspended)` beside the dwell means it is disarmed while something holds the target, not that it expired. See
+  [the terminal UI guide](ui-terminal.md).
 - `-t <seconds>` is voice/sync-loss hangtime, not the interval between trunk-scan targets. Zero does not
   bypass target dwell or control-channel acquisition. After a followed trunked call releases, a fresh idle
   dwell starts; repeated calls can keep a busy system parked.
@@ -274,6 +278,11 @@ During scanning:
   and a `| Target: county-p25` line at the top of Call Info, which is the one that survives compact view.
   While idle, Call Info follows the parked target's protocol panel; an unknown NXDN RAN or IDAS area
   is shown as `--`.
+- A `| Scan Timing:` row directly under the Trunk Scan row says why the receiver is staying on that target —
+  `Acquiring control`, `Following call`, `Retune pending`, `Retune retry`, `Manual hold`, `Idle dwell`, and the
+  conventional `Voice` / `Voice tail` / `Activity hold` / `Qualify` — with a countdown on whichever window is
+  running and the target's effective dwell and hold beside it. The phrase table is in
+  [the terminal UI guide](ui-terminal.md); the Qt and Android panels show the same thing.
 - Idle targets rotate after their dwell time.
 - The rotation can be driven from the terminal (Trunking menu, or the hotkeys): `Y` holds the scan on the parked
   target, `b` avoids the parked target for the rest of the session and moves on, `L` moves to the next eligible target

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -143,7 +143,8 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
   (NXDN96 and NXDN48 alike). Default: `1200`.
 - Per-target CSV values override these defaults.
 - The terminal's `Scan Timing` row reports the *effective* dwell and hold for the target on air — the values left
-  after the CSV column and the CLI/config default have been resolved — and labels `-t` as `hang`, never as a dwell.
+  after the CSV column and the CLI/config default have been resolved — and labels the active protocol's effective
+  hangtime as `hang`, including protocol overrides, never as a dwell.
   `(suspended)` beside the dwell means it is disarmed while something holds the target, not that it expired. See
   [the terminal UI guide](ui-terminal.md).
 - `-t <seconds>` is voice/sync-loss hangtime, not the interval between trunk-scan targets. Zero does not

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -558,7 +558,7 @@ running out.
 | `Manual hold` | `Y` holds the scan here | none |
 | `Qualify` | synced under `--scan-voice-only`, no allowed voice yet | the qualify window |
 | `Idle dwell` | nothing holds the row | the idle dwell |
-| `Hangtime` | `-Y` without `--scan-voice-only`: waiting out `-t` since the last sync | `-t` |
+| `Hangtime` | `-Y` without `--scan-voice-only`: waiting out `-t` since the last sync | next whole second after `-t` |
 
 Which phrases you can see depends on the protocol: an NXDN trunked target has no state machine to report control
 acquisition, so it never reads `Acquiring control`.
@@ -568,13 +568,16 @@ The values that follow are the *effective* ones for the row on air, after CSV an
 - `dwell` is the idle dwell, printed only when it is not itself the running timer. `(suspended)` means something on
   the air has disarmed it — a call, a retune, a control-channel hunt — and `(paused)` means the operator hold has.
 - `hold` is the activity hold. It appears on conventional and `-Y` rows only; a trunked target has none.
-- `hang` is `-t`, and appears only while a trunked call is being followed.
+- `hang` is the active protocol's effective hangtime, and appears only while a trunked call is being followed.
+  It includes `DSD_NEO_DMR_HANGTIME` / `DSD_NEO_P25_HANGTIME` overrides and the optional P25 Phase 1 error-hold
+  extension. NXDN uses `-t`.
 
 The row is not shown in compact view. The countdown is a published deadline differenced against the terminal's own
 clock, so it keeps running while the input is stalled and stops at `0.0s`; the phrase beside it is only as fresh as the
 last snapshot, which is published while samples flow. A narrow terminal cuts the row at the edge rather than wrapping
 it. On an NXDN row under `-Y`, the decoder keeps the scan two seconds past each confirmed frame, so the `Hangtime`
-countdown starts above `-t`.
+countdown can initially exceed its displayed total. That total is `floor(-t) + 1` seconds, matching the scanner's
+strict whole-second comparison; even `-t 0` waits for the next whole second.
 
 Call Info repeats the answer on its own first line, because compact view hides the Input Output section:
 

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -529,6 +529,51 @@ With `--trunk-scan` the same section names the target on air and its place in th
 shows no frequency: the protocol panels below it already carry the one being decoded. While a target is on air the
 Scan Mode row above it shows no name, so the screen never names two channels at once.
 
+### Scan Timing
+
+Directly under whichever scanner row is active — Scan Mode under `-Y`, Trunk Scan under `--trunk-scan`, and only the
+Trunk Scan one when both are running — a `Scan Timing` row says why the receiver is staying where it is and how much
+of that is left:
+
+```
+| Scan Timing: Idle dwell 1.8s/3.0s  hold 2.0s
+| Scan Timing: Following call  dwell 3.0s (suspended)  hang 2.0s
+| Scan Timing: Voice tail 1.5s/2.0s  dwell 3.0s (suspended)
+| Scan Timing: Manual hold  dwell 3.0s (paused)
+| Scan Timing: Hangtime 1.4s/2.0s
+```
+
+The phrase names the reason; the `remaining/total` pair after it, when there is one, is whichever window is actually
+running out.
+
+| Phrase | Staying because | Running timer |
+| --- | --- | --- |
+| `Retune pending` | a backend retune request has not resolved | none |
+| `Retune retry` | the retune failed; cooling down before retrying in place | the retry cooldown |
+| `Acquiring control` | the trunking state machine is hunting a control channel | none |
+| `Following call` | the trunking state machine is following a call | none; `hang` is the budget |
+| `Voice` | conventional voice media is active | the activity hold |
+| `Voice tail` | holding past the last voice frame (`--scan-voice-only`) | the activity hold |
+| `Activity hold` | allowed conventional activity was decoded | the activity hold |
+| `Manual hold` | `Y` holds the scan here | none |
+| `Qualify` | synced under `--scan-voice-only`, no allowed voice yet | the qualify window |
+| `Idle dwell` | nothing holds the row | the idle dwell |
+| `Hangtime` | `-Y` without `--scan-voice-only`: waiting out `-t` since the last sync | `-t` |
+
+Which phrases you can see depends on the protocol: an NXDN trunked target has no state machine to report control
+acquisition, so it only ever reads `Following call` or `Idle dwell`.
+
+The values that follow are the *effective* ones for the row on air, after CSV and option overrides:
+
+- `dwell` is the idle dwell, printed only when it is not itself the running timer. `(suspended)` means something on
+  the air has disarmed it — a call, a retune, a control-channel hunt — and `(paused)` means the operator hold has.
+- `hold` is the activity hold. It appears on conventional and `-Y` rows only; a trunked target has none.
+- `hang` is `-t`, and appears only while a trunked call is being followed.
+
+The row is not shown in compact view. The countdown is a published deadline differenced against the monotonic clock,
+and snapshots are published only while samples flow, so it freezes if the input stalls instead of running past zero on
+its own. A narrow terminal cuts the row at the edge rather than wrapping it.
+
 Call Info repeats the answer on its own first line, because compact view hides the Input Output section:
 
 ```

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -561,7 +561,7 @@ running out.
 | `Hangtime` | `-Y` without `--scan-voice-only`: waiting out `-t` since the last sync | `-t` |
 
 Which phrases you can see depends on the protocol: an NXDN trunked target has no state machine to report control
-acquisition, so it only ever reads `Following call` or `Idle dwell`.
+acquisition, so it never reads `Acquiring control`.
 
 The values that follow are the *effective* ones for the row on air, after CSV and option overrides:
 
@@ -570,9 +570,11 @@ The values that follow are the *effective* ones for the row on air, after CSV an
 - `hold` is the activity hold. It appears on conventional and `-Y` rows only; a trunked target has none.
 - `hang` is `-t`, and appears only while a trunked call is being followed.
 
-The row is not shown in compact view. The countdown is a published deadline differenced against the monotonic clock,
-and snapshots are published only while samples flow, so it freezes if the input stalls instead of running past zero on
-its own. A narrow terminal cuts the row at the edge rather than wrapping it.
+The row is not shown in compact view. The countdown is a published deadline differenced against the terminal's own
+clock, so it keeps running while the input is stalled and stops at `0.0s`; the phrase beside it is only as fresh as the
+last snapshot, which is published while samples flow. A narrow terminal cuts the row at the edge rather than wrapping
+it. On an NXDN row under `-Y`, the decoder keeps the scan two seconds past each confirmed frame, so the `Hangtime`
+countdown starts above `-t`.
 
 Call Info repeats the answer on its own first line, because compact view hides the Input Output section:
 

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -501,12 +501,12 @@ While scanning, the screen says which channel you are listening to.
 The Input Output section names the `-Y` scan list row the receiver is parked on, at the end of its row:
 
 ```
-| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Channel: Marion
+| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec Channel: Marion
 ```
 
 The name comes from the optional `name` column of the channel map (see `docs/csv-formats.md`); a row without one
 renders exactly as it always did. The name goes last because it is the one field whose length you choose: the
-frequency and speed keep their columns, and on a narrow terminal it is the name that reaches the edge.
+frequency and hangtime keep their columns, and on a narrow terminal it is the name that reaches the edge.
 
 While `Y` holds the scan, `HOLD` appears ahead of the name with the other facts about the channel on air. While
 `b` has taken rows out of the rotation for the session, `Avoids: N` closes the row: it counts the rows that are
@@ -516,7 +516,7 @@ while synced without voice, VOICE while voice media is active, TAIL while holdin
 trunked `--trunk-scan` target shows no marker, since the gate leaves trunked targets alone.
 
 ```
-| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec HOLD Channel: Marion Avoids: 2
+| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec HOLD Channel: Marion Avoids: 2
 ```
 
 With `--trunk-scan` the same section names the target on air and its place in the rotation:
@@ -540,7 +540,7 @@ of that is left:
 | Scan Timing: Following call  dwell 3.0s (suspended)  hang 2.0s
 | Scan Timing: Voice tail 1.5s/2.0s  dwell 3.0s (suspended)
 | Scan Timing: Manual hold  dwell 3.0s (paused)
-| Scan Timing: Hangtime 1.4s/2.0s
+| Scan Timing: Hangtime 1.4s/3.0s
 ```
 
 The phrase names the reason; the `remaining/total` pair after it, when there is one, is whichever window is actually
@@ -552,7 +552,7 @@ running out.
 | `Retune retry` | the retune failed; cooling down before retrying in place | the retry cooldown |
 | `Acquiring control` | the trunking state machine is hunting a control channel | none |
 | `Following call` | the trunking state machine is following a call | none; `hang` is the budget |
-| `Voice` | conventional voice media is active | the activity hold |
+| `Voice` | conventional voice media is active (`--scan-voice-only`) | the activity hold |
 | `Voice tail` | holding past the last voice frame (`--scan-voice-only`) | the activity hold |
 | `Activity hold` | allowed conventional activity was decoded | the activity hold |
 | `Manual hold` | `Y` holds the scan here | none |
@@ -565,9 +565,11 @@ acquisition, so it never reads `Acquiring control`.
 
 The values that follow are the *effective* ones for the row on air, after CSV and option overrides:
 
-- `dwell` is the idle dwell, printed only when it is not itself the running timer. `(suspended)` means something on
-  the air has disarmed it — a call, a retune, a control-channel hunt — and `(paused)` means the operator hold has.
-- `hold` is the activity hold. It appears on conventional and `-Y` rows only; a trunked target has none.
+- `dwell` is the idle dwell, shown as a separate budget when it is not the running timer, including the interval
+  after hold release before the next decoder tick arms it. `(suspended)` means something on the air has disarmed
+  it — a call, a retune, a control-channel hunt — and `(paused)` means the operator hold has.
+- `hold` is the activity hold, printed only when it is not itself the running timer. It appears on conventional
+  and `-Y` rows only; a trunked target has none.
 - `hang` is the active protocol's effective hangtime, and appears only while a trunked call is being followed.
   It includes `DSD_NEO_DMR_HANGTIME` / `DSD_NEO_P25_HANGTIME` overrides and the optional P25 Phase 1 error-hold
   extension. NXDN uses `-t`.

--- a/include/dsd-neo/app_control/scan_timing_view.h
+++ b/include/dsd-neo/app_control/scan_timing_view.h
@@ -27,10 +27,9 @@ extern "C" {
 
 /** @brief What the idle dwell budget is doing while the row is on air. */
 enum {
-    DSD_APP_SCAN_DWELL_NONE = 0,  /**< No dwell budget applies (or it is the live window). */
-    DSD_APP_SCAN_DWELL_RUNNING,   /**< The dwell is the live window counting down. */
-    DSD_APP_SCAN_DWELL_SUSPENDED, /**< Disarmed while something else holds the row. */
-    DSD_APP_SCAN_DWELL_PAUSED,    /**< Disarmed by the operator hold. */
+    DSD_APP_SCAN_DWELL_NONE = 0,      /**< No dwell budget applies (or it is the live window). */
+    DSD_APP_SCAN_DWELL_SUSPENDED = 2, /**< Disarmed while something else holds the row. */
+    DSD_APP_SCAN_DWELL_PAUSED = 3,    /**< Disarmed by the operator hold. */
 };
 
 /**
@@ -52,7 +51,7 @@ typedef struct {
     uint8_t show_hold;     /**< 1 = @c hold_ms applies (conventional rows only). */
     uint32_t hold_ms;      /**< Effective activity hold. */
     uint8_t show_hang;     /**< 1 = @c hang_ms governs the current stay (-t). */
-    uint32_t hang_ms;      /**< Voice/sync-loss hangtime, from -t. */
+    uint32_t hang_ms;      /**< Active protocol's effective voice/sync-loss hangtime. */
 } dsd_app_scan_timing;
 
 /**

--- a/include/dsd-neo/app_control/scan_timing_view.h
+++ b/include/dsd-neo/app_control/scan_timing_view.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Frontend-neutral decisions about what the scan timing line should say (issue #508).
+ *
+ * The decoder publishes why the scanner is staying on the row on air and the monotonic
+ * deadline of whichever window is running (dsd_state::scan_timing). A status surface has
+ * to turn that into a phrase, a remaining time and a set of "show this budget" verdicts.
+ * That translation lives here, shared, so the terminal row, the Qt panel and the Android
+ * app cannot drift apart on what "suspended" or "hold" means.
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_SCAN_TIMING_VIEW_H_
+#define DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_SCAN_TIMING_VIEW_H_
+
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief What the idle dwell budget is doing while the row is on air. */
+enum {
+    DSD_APP_SCAN_DWELL_NONE = 0,  /**< No dwell budget applies (or it is the live window). */
+    DSD_APP_SCAN_DWELL_RUNNING,   /**< The dwell is the live window counting down. */
+    DSD_APP_SCAN_DWELL_SUSPENDED, /**< Disarmed while something else holds the row. */
+    DSD_APP_SCAN_DWELL_PAUSED,    /**< Disarmed by the operator hold. */
+};
+
+/**
+ * @brief Display-ready scan timing for the row on air.
+ *
+ * @c phrase is a static English label; frontends that translate wrap it themselves.
+ * Every millisecond field is already clamped and derived, so a surface only formats.
+ */
+typedef struct {
+    uint8_t active;        /**< 0 = no scanner on, or nothing published: render nothing. */
+    uint8_t reason;        /**< dsd_scan_stay_reason. */
+    const char* phrase;    /**< Static label for @c reason (and the voice-gate phase). */
+    uint8_t timer_live;    /**< 1 = @c remaining_ms / @c span_ms describe a running window. */
+    uint32_t remaining_ms; /**< max(0, deadline - now). */
+    uint32_t span_ms;      /**< Full width of the running window. */
+    uint8_t show_dwell;    /**< 1 = @c dwell_ms is worth printing beside the phrase. */
+    uint32_t dwell_ms;     /**< Effective idle dwell (or -Y qualify window). */
+    uint8_t dwell_state;   /**< One of the DSD_APP_SCAN_DWELL_* values. */
+    uint8_t show_hold;     /**< 1 = @c hold_ms applies (conventional rows only). */
+    uint32_t hold_ms;      /**< Effective activity hold. */
+    uint8_t show_hang;     /**< 1 = @c hang_ms governs the current stay (-t). */
+    uint32_t hang_ms;      /**< Voice/sync-loss hangtime, from -t. */
+} dsd_app_scan_timing;
+
+/**
+ * @brief Fill @p out from the published scan timing.
+ *
+ * Zeroes @p out first. @p now_m is monotonic seconds, the clock the decoder stamps the
+ * deadlines from. Returns 1 when there is something to show (@c active), 0 when the row
+ * should be left blank, and -1 for invalid arguments.
+ */
+int dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double now_m, dsd_app_scan_timing* out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_SCAN_TIMING_VIEW_H_ */

--- a/include/dsd-neo/app_control/scan_timing_view.h
+++ b/include/dsd-neo/app_control/scan_timing_view.h
@@ -27,6 +27,7 @@ extern "C" {
 
 /** @brief What the idle dwell budget is doing while the row is on air. */
 enum {
+    /* Value 1 is reserved; keep these values stable for existing QML consumers. */
     DSD_APP_SCAN_DWELL_NONE = 0,      /**< No dwell budget applies (or it is the live window). */
     DSD_APP_SCAN_DWELL_SUSPENDED = 2, /**< Disarmed while something else holds the row. */
     DSD_APP_SCAN_DWELL_PAUSED = 3,    /**< Disarmed by the operator hold. */

--- a/include/dsd-neo/core/dsd_time.h
+++ b/include/dsd-neo/core/dsd_time.h
@@ -29,6 +29,15 @@ dsd_time_now_monotonic_s(void) {
     return (double)dsd_time_monotonic_ns() / 1e9;
 }
 
+/**
+ * @brief Return wall-clock time in seconds, on the same epoch as time(NULL) but with
+ * sub-second precision, for converting a time_t anchor into a monotonic deadline.
+ */
+static inline double
+dsd_time_now_realtime_s(void) {
+    return (double)dsd_time_realtime_ns() / 1e9;
+}
+
 /** @brief Stamp current time as control-channel sync (monotonic + wall clock). */
 void dsd_mark_cc_sync(dsd_state* state);
 

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -424,6 +424,7 @@ struct dsd_scan_timing_publication {
     uint32_t span_ms;     /**< full width of the live window; 0 when there is no timer */
     uint32_t dwell_ms;    /**< effective idle dwell (or -Y qualify) for the row on air; 0 = n/a */
     uint32_t hold_ms;     /**< effective activity hold; 0 on trunked rows and when n/a */
+    uint32_t hang_ms;     /**< active protocol's effective hangtime budget; 0 when n/a */
     uint8_t reason;       /**< dsd_scan_stay_reason */
     uint8_t conventional; /**< 1 = conventional / -Y row, so hold_ms means something */
 };

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -399,6 +399,35 @@ typedef enum {
     DSD_SCAN_VOICE_GATE_TAIL = 3,
 } dsd_scan_voice_gate_phase;
 
+/** Why the receiver is staying on the scanner's current row (issue #508). Frontend-neutral:
+ * the decoder owns every deadline and the UI only renders what is published. NONE means
+ * nothing holds the row -- for --trunk-scan that is exactly the old "not held" verdict. */
+typedef enum {
+    DSD_SCAN_STAY_NONE = 0,
+    DSD_SCAN_STAY_RETUNE_PENDING = 1, /**< a backend retune request has not resolved */
+    DSD_SCAN_STAY_RETUNE_RETRY = 2,   /**< retune failed; cooling down before retrying in place */
+    DSD_SCAN_STAY_CC_ACQUIRE = 3,     /**< trunking SM is acquiring a control channel */
+    DSD_SCAN_STAY_CALL_FOLLOW = 4,    /**< trunking SM is following a call, hangtime included */
+    DSD_SCAN_STAY_VOICE = 5,          /**< conventional row: voice media is active */
+    DSD_SCAN_STAY_ACTIVITY_HOLD = 6,  /**< conventional row: activity hold / voice tail running */
+    DSD_SCAN_STAY_MANUAL_HOLD = 7,    /**< operator hold (Y): the dwell is paused, not expired */
+    DSD_SCAN_STAY_IDLE_DWELL = 8,     /**< nothing holds it; the idle dwell / qualify window runs */
+    DSD_SCAN_STAY_HANGTIME = 9,       /**< -Y legacy rule: waiting out -t since the last sync */
+} dsd_scan_stay_reason;
+
+/** Live scan timing for the frontends' Scan Timing row (issue #508). Plain inline
+ * scalars: it rides the vertex_ks_count..ui_msg snapshot copy range (ui_snapshot.c static
+ * assert) and must never grow a pointer, or the byte-range copy would alias decoder memory. */
+struct dsd_scan_timing_publication {
+    double started_m;     /**< monotonic start of the live window; < 0 when there is none */
+    double deadline_m;    /**< monotonic expiry; < 0 = no live timer (suspended/paused/unanchored) */
+    uint32_t span_ms;     /**< full width of the live window; 0 when there is no timer */
+    uint32_t dwell_ms;    /**< effective idle dwell (or -Y qualify) for the row on air; 0 = n/a */
+    uint32_t hold_ms;     /**< effective activity hold; 0 on trunked rows and when n/a */
+    uint8_t reason;       /**< dsd_scan_stay_reason */
+    uint8_t conventional; /**< 1 = conventional / -Y row, so hold_ms means something */
+};
+
 // dsd_state is a C aggregate, not a C++ class: it is allocated once and zeroed by
 // initState() before anything reads it, and C code — which is most of its users —
 // has no constructors to write. A C++ TU that includes this header would otherwise
@@ -1696,6 +1725,10 @@ struct dsd_state {
     int scan_voice_gate_roll_seen;
     uint8_t scan_voice_gate_hold_seen;
     uint8_t scan_voice_gate_phase;
+    /* Scan state + live timing for the Scan Timing row (issue #508). Written by the
+     * --trunk-scan coordinator for its parked target, or by the -Y timing tick when trunk
+     * scan is off; the two never both write it. Rides the vertex_ks_count..ui_msg range. */
+    dsd_scan_timing_publication scan_timing;
 
     // Transient UI message (shown briefly in ncurses printer)
     char ui_msg[128];

--- a/include/dsd-neo/core/state_fwd.h
+++ b/include/dsd-neo/core/state_fwd.h
@@ -20,6 +20,7 @@ extern "C" {
 
 typedef struct dsd_state dsd_state;
 typedef struct Event_History_I Event_History_I;
+typedef struct dsd_scan_timing_publication dsd_scan_timing_publication;
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/engine/scan_voice_gate.h
+++ b/include/dsd-neo/engine/scan_voice_gate.h
@@ -62,10 +62,13 @@ void dsd_scan_timing_publish(dsd_state* state, const dsd_scan_timing_publication
 /**
  * Publish the -Y scanner's stay reason and step deadline. A no-op unless
  * scanner_mode == 1 && trunk_scan_enabled != 1: under --trunk-scan the coordinator owns
- * the publication, exactly as it owns scan_voice_gate_phase. Every published anchor is
- * absolute, so the caller passes no clock; the renderer differences them against its own.
+ * the publication, exactly as it owns scan_voice_gate_phase.
+ *
+ * The legacy hangtime rule anchors on the wall-clock last_cc_sync_time (which NXDN can
+ * stamp two seconds into the future), so the publisher takes both clocks, sampled
+ * together, to express that anchor as a monotonic deadline the renderer can difference.
  */
-void dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state);
+void dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state, double now_m, double now_wall_s);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/engine/scan_voice_gate.h
+++ b/include/dsd-neo/engine/scan_voice_gate.h
@@ -53,6 +53,20 @@ int dsd_scan_voice_gate_owns_step(const dsd_opts* opts, const dsd_state* state);
 /** Non-zero when the gate says the -Y visit is over and the scan should step. */
 int dsd_scan_voice_gate_should_step(const dsd_opts* opts, const dsd_state* state, double now_m);
 
+/** Take the scan timing publication back down (scan off, shutdown, between targets). */
+void dsd_scan_timing_clear(dsd_state* state);
+
+/** Publish one scan timing report for the row on air (issue #508). */
+void dsd_scan_timing_publish(dsd_state* state, const dsd_scan_timing_publication* report);
+
+/**
+ * Publish the -Y scanner's stay reason and step deadline. A no-op unless
+ * scanner_mode == 1 && trunk_scan_enabled != 1: under --trunk-scan the coordinator owns
+ * the publication, exactly as it owns scan_voice_gate_phase. Every published anchor is
+ * absolute, so the caller passes no clock; the renderer differences them against its own.
+ */
+void dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -472,6 +472,9 @@ p25_sm_ctx_t* p25_sm_get_ctx(void);
  */
 double p25_sm_hangtime_started_m(const p25_sm_ctx_t* ctx);
 
+/** Resolve the configured hangtime with the current Phase 1 error-hold extension. */
+double p25_sm_effective_hangtime(const dsd_state* state, double hangtime);
+
 /**
  * @brief Trigger explicit release and return to CC.
  *

--- a/src/app_control/CMakeLists.txt
+++ b/src/app_control/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
         notification_status.c
         p25_metrics.c
         rr_import_apply.c
+        scan_timing_view.c
         symbol_profile.c
         tcp_audio_connect.c
         telemetry_hooks_install.c

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -36,6 +36,7 @@
 #include <dsd-neo/dsp/frame_sync.h>
 #include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/frame_processing.h>
+#include <dsd-neo/engine/scan_voice_gate.h>
 #include <dsd-neo/io/control.h>
 #include <dsd-neo/io/rigctl_client.h>
 #include <dsd-neo/io/rtl_stream_c.h>
@@ -4601,6 +4602,8 @@ apply_manual_scan_avoid_clear(dsd_state* state) {
 
 static void
 apply_trunk_scan_control(dsd_opts* opts, dsd_state* state, int op) {
+    char target_id[sizeof(state->trunk_scan_active_id)];
+    DSD_SNPRINTF(target_id, sizeof(target_id), "%s", state->trunk_scan_active_id);
     const int rc = dsd_trunk_scan_hook_control(opts, state, op);
     if (rc == DSD_TRUNK_SCAN_CONTROL_BUSY) {
         ui_set_toast(state, 3, "Trunk scan busy; try again");
@@ -4620,7 +4623,7 @@ apply_trunk_scan_control(dsd_opts* opts, dsd_state* state, int op) {
             if (rc == DSD_TRUNK_SCAN_CONTROL_REFUSED) {
                 ui_set_toast(state, 3, "Cannot avoid the last usable trunk scan target");
             } else {
-                ui_set_toast(state, 3, "Avoiding target %s (%u avoided)", state->trunk_scan_active_id,
+                ui_set_toast(state, 3, "Avoiding target %s (%u avoided)", target_id,
                              (unsigned)state->trunk_scan_avoided_count);
             }
             break;
@@ -5108,6 +5111,13 @@ dsd_app_drain_cmds(dsd_opts* opts, dsd_state* state) {
         DSD_SECURE_ZERO(&cmd, sizeof cmd);
         // After applying a command, publish updated snapshots so the UI can
         // render consistent opts/state without racing live structures.
+        if (opts && state && opts->scanner_mode == 1 && opts->trunk_scan_enabled != 1) {
+            const double now_m = dsd_time_now_monotonic_s();
+            // Controls can change visits or hold state inside a long input wait.
+            // Refresh the gate and its publication before exposing that command.
+            dsd_scan_voice_gate_tick(opts, state, 0, now_m);
+            dsd_engine_scan_y_timing_tick(opts, state, now_m, dsd_time_now_realtime_s());
+        }
         dsd_telemetry_publish_opts_snapshot(opts);
         if (state) {
             dsd_telemetry_publish_snapshot(state);

--- a/src/app_control/scan_timing_view.c
+++ b/src/app_control/scan_timing_view.c
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/app_control/scan_timing_view.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <stdint.h>
+
+/* Step 0 contract stub: the reason/phrase table lands with the terminal renderer. */
+int
+dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double now_m, dsd_app_scan_timing* out) {
+    if (!out) {
+        return -1;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    if (!opts || !state) {
+        return -1;
+    }
+    (void)now_m;
+    return 0;
+}

--- a/src/app_control/scan_timing_view.c
+++ b/src/app_control/scan_timing_view.c
@@ -5,8 +5,10 @@
 
 #include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
 #include <stdint.h>
 
 /**

--- a/src/app_control/scan_timing_view.c
+++ b/src/app_control/scan_timing_view.c
@@ -24,7 +24,7 @@ typedef struct {
     uint8_t dwell_state; /**< DSD_APP_SCAN_DWELL_* to report while the dwell is shown. */
     uint8_t show_dwell;  /**< 0 where the dwell is the live window, so the span already says it. */
     uint8_t show_hold;   /**< 0 where the hold is the live window, or the row is trunked. */
-    uint8_t show_hang;   /**< 1 only where -t is what ends the stay. */
+    uint8_t show_hang;   /**< 1 only where protocol hangtime is what ends the stay. */
 } dsd_scan_timing_row;
 
 /* Indexed by dsd_scan_stay_reason. NONE is present so the array covers the enum and an
@@ -107,19 +107,6 @@ scan_timing_remaining_ms(double deadline_m, double now_m) {
     return (uint32_t)((remaining_s * 1000.0) + 0.5);
 }
 
-/** @brief -t in milliseconds, rounded, or 0 when it is not configured. */
-static uint32_t
-scan_timing_hang_ms(const dsd_opts* opts) {
-    double hang_s = (double)opts->trunk_hangtime;
-    if (!(hang_s > 0.0)) {
-        return 0U;
-    }
-    if (hang_s > DSD_APP_SCAN_REMAINING_MAX_S) {
-        hang_s = DSD_APP_SCAN_REMAINING_MAX_S;
-    }
-    return (uint32_t)((hang_s * 1000.0) + 0.5);
-}
-
 /**
  * @brief Fill in the budgets beside the phrase.
  *
@@ -129,7 +116,7 @@ scan_timing_hang_ms(const dsd_opts* opts) {
  */
 static void
 scan_timing_fill_budgets(dsd_app_scan_timing* out, const dsd_scan_timing_row* row,
-                         const dsd_scan_timing_publication* pub, const dsd_opts* opts) {
+                         const dsd_scan_timing_publication* pub) {
     out->dwell_ms = pub->dwell_ms;
     if (row->show_dwell != 0U && pub->dwell_ms != 0U) {
         out->show_dwell = 1U;
@@ -140,7 +127,7 @@ scan_timing_fill_budgets(dsd_app_scan_timing* out, const dsd_scan_timing_row* ro
         out->show_hold = 1U;
     }
     if (row->show_hang != 0U) {
-        out->hang_ms = scan_timing_hang_ms(opts);
+        out->hang_ms = pub->hang_ms;
         out->show_hang = (out->hang_ms != 0U) ? 1U : 0U;
     }
 }
@@ -166,6 +153,6 @@ dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double no
         out->remaining_ms = scan_timing_remaining_ms(pub->deadline_m, now_m);
         out->span_ms = pub->span_ms;
     }
-    scan_timing_fill_budgets(out, row, pub, opts);
+    scan_timing_fill_budgets(out, row, pub);
     return 1;
 }

--- a/src/app_control/scan_timing_view.c
+++ b/src/app_control/scan_timing_view.c
@@ -48,7 +48,7 @@ _Static_assert((int)(sizeof(k_scan_timing_rows) / sizeof(k_scan_timing_rows[0]))
                "every dsd_scan_stay_reason needs a display row");
 
 /** @brief Longest countdown the view will report, guarding the cast below. */
-#define DSD_APP_SCAN_REMAINING_MAX_S 86400.0
+#define DSD_APP_SCAN_REMAINING_MAX_S ((double)UINT32_MAX / 1000.0)
 
 /**
  * @brief Whether there is a stay worth rendering at all.
@@ -101,8 +101,8 @@ scan_timing_remaining_ms(double deadline_m, double now_m) {
     if (!(remaining_s > 0.0)) {
         return 0U;
     }
-    if (remaining_s > DSD_APP_SCAN_REMAINING_MAX_S) {
-        remaining_s = DSD_APP_SCAN_REMAINING_MAX_S;
+    if (remaining_s >= DSD_APP_SCAN_REMAINING_MAX_S) {
+        return UINT32_MAX;
     }
     return (uint32_t)((remaining_s * 1000.0) + 0.5);
 }
@@ -118,7 +118,10 @@ static void
 scan_timing_fill_budgets(dsd_app_scan_timing* out, const dsd_scan_timing_row* row,
                          const dsd_scan_timing_publication* pub) {
     out->dwell_ms = pub->dwell_ms;
-    if (row->show_dwell != 0U && pub->dwell_ms != 0U) {
+    // After hold release the next decoder tick arms the dwell. Until then its
+    // effective budget is still useful even though no remaining/total pair runs.
+    const int dwell_unarmed = pub->reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL && !out->timer_live;
+    if ((row->show_dwell != 0U || dwell_unarmed) && pub->dwell_ms != 0U) {
         out->show_dwell = 1U;
         out->dwell_state = row->dwell_state;
     }

--- a/src/app_control/scan_timing_view.c
+++ b/src/app_control/scan_timing_view.c
@@ -9,16 +9,161 @@
 #include <dsd-neo/core/state.h>
 #include <stdint.h>
 
-/* Step 0 contract stub: the reason/phrase table lands with the terminal renderer. */
+/**
+ * @brief What one stay reason renders as, before the row's own numbers are applied.
+ *
+ * A table rather than a switch so the display rule is one readable list: the terminal
+ * row, the Qt panel and the Android app all render from this, and a rule spelled out in
+ * three places is a rule that drifts. Each flag is a verdict about whether the budget is
+ * worth a column at all; whether it has a value to print is the publication's business.
+ */
+typedef struct {
+    const char* phrase;  /**< Static English label; a phase variant may override it. */
+    uint8_t dwell_state; /**< DSD_APP_SCAN_DWELL_* to report while the dwell is shown. */
+    uint8_t show_dwell;  /**< 0 where the dwell is the live window, so the span already says it. */
+    uint8_t show_hold;   /**< 0 where the hold is the live window, or the row is trunked. */
+    uint8_t show_hang;   /**< 1 only where -t is what ends the stay. */
+} dsd_scan_timing_row;
+
+/* Indexed by dsd_scan_stay_reason. NONE is present so the array covers the enum and an
+   out-of-range reason from a newer decoder is rejected by a bound rather than by luck. */
+static const dsd_scan_timing_row k_scan_timing_rows[] = {
+    [DSD_SCAN_STAY_NONE] = {"", DSD_APP_SCAN_DWELL_NONE, 0U, 0U, 0U},
+    [DSD_SCAN_STAY_RETUNE_PENDING] = {"Retune pending", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 1U, 0U},
+    [DSD_SCAN_STAY_RETUNE_RETRY] = {"Retune retry", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 1U, 0U},
+    [DSD_SCAN_STAY_CC_ACQUIRE] = {"Acquiring control", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 0U, 0U},
+    [DSD_SCAN_STAY_CALL_FOLLOW] = {"Following call", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 0U, 1U},
+    [DSD_SCAN_STAY_VOICE] = {"Voice", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 0U, 0U},
+    [DSD_SCAN_STAY_ACTIVITY_HOLD] = {"Activity hold", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 0U, 0U},
+    [DSD_SCAN_STAY_MANUAL_HOLD] = {"Manual hold", DSD_APP_SCAN_DWELL_PAUSED, 1U, 1U, 0U},
+    [DSD_SCAN_STAY_IDLE_DWELL] = {"Idle dwell", DSD_APP_SCAN_DWELL_NONE, 0U, 1U, 0U},
+    [DSD_SCAN_STAY_HANGTIME] = {"Hangtime", DSD_APP_SCAN_DWELL_NONE, 0U, 0U, 0U},
+};
+
+/* A reason the decoder can publish but this table cannot render would reach the surfaces
+   as a blank phrase. Sized against the last enumerator so adding one fails the build. */
+_Static_assert((int)(sizeof(k_scan_timing_rows) / sizeof(k_scan_timing_rows[0])) == (int)DSD_SCAN_STAY_HANGTIME + 1,
+               "every dsd_scan_stay_reason needs a display row");
+
+/** @brief Longest countdown the view will report, guarding the cast below. */
+#define DSD_APP_SCAN_REMAINING_MAX_S 86400.0
+
+/**
+ * @brief Whether there is a stay worth rendering at all.
+ *
+ * Both halves matter. A stale publication survives the scanner being switched off --
+ * nothing clears it on the way out -- so the scanner flags are what make it current; and
+ * a reason this build does not know is from a newer decoder writing the same snapshot
+ * bytes, which must render nothing rather than an empty phrase.
+ */
+static int
+scan_timing_is_active(const dsd_opts* opts, const dsd_scan_timing_publication* pub) {
+    if (opts->trunk_scan_enabled != 1 && opts->scanner_mode != 1) {
+        return 0;
+    }
+    if (pub->reason == (uint8_t)DSD_SCAN_STAY_NONE) {
+        return 0;
+    }
+    return pub->reason < (uint8_t)(sizeof(k_scan_timing_rows) / sizeof(k_scan_timing_rows[0]));
+}
+
+/**
+ * @brief The two rows whose label depends on what the voice gate is doing.
+ *
+ * The gate's phase is the only thing that separates a hold that is still following voice
+ * from one counting out its tail, and an idle dwell from the qualify window that shares
+ * its clock. Both are cosmetic refinements of the same stay, which is why they are a
+ * phrase choice here rather than reasons of their own.
+ */
+static const char*
+scan_timing_phrase(const dsd_scan_timing_row* row, uint8_t reason, uint8_t phase) {
+    if (reason == (uint8_t)DSD_SCAN_STAY_ACTIVITY_HOLD && phase == (uint8_t)DSD_SCAN_VOICE_GATE_TAIL) {
+        return "Voice tail";
+    }
+    if (reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL && phase == (uint8_t)DSD_SCAN_VOICE_GATE_QUALIFY) {
+        return "Qualify";
+    }
+    return row->phrase;
+}
+
+/**
+ * @brief Milliseconds left on the published deadline, clamped at zero.
+ *
+ * The decoder decides when the receiver moves; a poll that lands after the deadline is a
+ * frame late, not a scanner that overstayed. Clamping through the comparison's negation
+ * also settles a NaN clock, which would otherwise cast to an arbitrary count.
+ */
+static uint32_t
+scan_timing_remaining_ms(double deadline_m, double now_m) {
+    double remaining_s = deadline_m - now_m;
+    if (!(remaining_s > 0.0)) {
+        return 0U;
+    }
+    if (remaining_s > DSD_APP_SCAN_REMAINING_MAX_S) {
+        remaining_s = DSD_APP_SCAN_REMAINING_MAX_S;
+    }
+    return (uint32_t)((remaining_s * 1000.0) + 0.5);
+}
+
+/** @brief -t in milliseconds, rounded, or 0 when it is not configured. */
+static uint32_t
+scan_timing_hang_ms(const dsd_opts* opts) {
+    double hang_s = (double)opts->trunk_hangtime;
+    if (!(hang_s > 0.0)) {
+        return 0U;
+    }
+    if (hang_s > DSD_APP_SCAN_REMAINING_MAX_S) {
+        hang_s = DSD_APP_SCAN_REMAINING_MAX_S;
+    }
+    return (uint32_t)((hang_s * 1000.0) + 0.5);
+}
+
+/**
+ * @brief Fill in the budgets beside the phrase.
+ *
+ * Every effective value is copied through whether or not it is shown -- a surface with
+ * room for more than one line can still report the dwell that is counting down -- while
+ * the show_ flags carry the display rule.
+ */
+static void
+scan_timing_fill_budgets(dsd_app_scan_timing* out, const dsd_scan_timing_row* row,
+                         const dsd_scan_timing_publication* pub, const dsd_opts* opts) {
+    out->dwell_ms = pub->dwell_ms;
+    if (row->show_dwell != 0U && pub->dwell_ms != 0U) {
+        out->show_dwell = 1U;
+        out->dwell_state = row->dwell_state;
+    }
+    out->hold_ms = pub->hold_ms;
+    if (row->show_hold != 0U && pub->conventional == 1U && pub->hold_ms != 0U) {
+        out->show_hold = 1U;
+    }
+    if (row->show_hang != 0U) {
+        out->hang_ms = scan_timing_hang_ms(opts);
+        out->show_hang = (out->hang_ms != 0U) ? 1U : 0U;
+    }
+}
+
 int
 dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double now_m, dsd_app_scan_timing* out) {
-    if (!out) {
+    if (out) {
+        DSD_MEMSET(out, 0, sizeof(*out));
+    }
+    if (!opts || !state || !out) {
         return -1;
     }
-    DSD_MEMSET(out, 0, sizeof(*out));
-    if (!opts || !state) {
-        return -1;
+    const dsd_scan_timing_publication* pub = &state->scan_timing;
+    if (!scan_timing_is_active(opts, pub)) {
+        return 0;
     }
-    (void)now_m;
-    return 0;
+    const dsd_scan_timing_row* row = &k_scan_timing_rows[pub->reason];
+    out->active = 1U;
+    out->reason = pub->reason;
+    out->phrase = scan_timing_phrase(row, pub->reason, state->scan_voice_gate_phase);
+    if (pub->deadline_m >= 0.0) {
+        out->timer_live = 1U;
+        out->remaining_ms = scan_timing_remaining_ms(pub->deadline_m, now_m);
+        out->span_ms = pub->span_ms;
+    }
+    scan_timing_fill_budgets(out, row, pub, opts);
+    return 1;
 }

--- a/src/app_control/ui_snapshot.c
+++ b/src/app_control/ui_snapshot.c
@@ -152,6 +152,12 @@ _Static_assert(offsetof(dsd_state, trunk_scan_active_id) >= offsetof(dsd_state, 
 _Static_assert(offsetof(dsd_state, scan_voice_gate_arrive_m) >= offsetof(dsd_state, vertex_ks_count)
                    && UI_SNAPSHOT_FIELD_END(scan_voice_gate_phase) <= UI_SNAPSHOT_FIELD_END(ui_msg),
                "scan_voice_gate_* must ride the vertex_ks_count..ui_msg range");
+/* The scan timing publication is plain inline bytes beside the voice-gate memory, so like
+ * them it has to be inside a copy range -- left out of one it would silently never reach
+ * the UI. */
+_Static_assert(offsetof(dsd_state, scan_timing) >= offsetof(dsd_state, vertex_ks_count)
+                   && UI_SNAPSHOT_FIELD_END(scan_timing) <= UI_SNAPSHOT_FIELD_END(ui_msg),
+               "scan_timing must ride the vertex_ks_count..ui_msg range");
 
 /* The embedded trunk_lcn_freq[] is a plain array copied by the byte ranges
  * above; the scan-list heap tail past it needs an explicit deep copy.

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -940,6 +940,9 @@ init_state_trunk_scan_publication(dsd_state* state) {
     state->scan_voice_gate_roll_seen = 0;
     state->scan_voice_gate_hold_seen = 0;
     state->scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_OFF;
+    DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
+    state->scan_timing.started_m = -1.0;
+    state->scan_timing.deadline_m = -1.0;
 }
 
 static void

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2615,15 +2615,13 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
                 break;
             }
         }
-        /* Outside the voice-gate block on purpose: this loop can spin here for seconds
-         * while frames keep syncing, and the legacy hangtime anchor moves the whole
-         * time, so the Scan Timing row would freeze mid-countdown if it only refreshed
-         * under -Y --scan-voice-only. */
-        dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
         dsd_runtime_pump_controls(opts, state);
         if (!dsd_engine_channel_scan_service_sync(opts, state)) {
             break;
         }
+        /* Refresh after controls, even with the voice gate off: continuous sync
+         * keeps moving the legacy hangtime anchor throughout this inner loop. */
+        dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
         if (frame_tune_generation) {
             *frame_tune_generation = dsd_trunk_tuning_generation();
         }
@@ -2649,18 +2647,22 @@ live_scanner_main_loop(dsd_opts* opts, dsd_state* state) {
         }
         dsd_trunk_scan_hook_tick(opts, state);
         dsd_scan_voice_gate_tick(opts, state, 0, dsd_time_now_monotonic_s());
-        dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
         dsd_runtime_pump_controls(opts, state);
 
         if (dsd_engine_channel_scan_pending(opts, state)) {
+            dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
             dsd_sleep_ms(1);
             continue;
         }
         noCarrier(opts, state);
         if (dsd_engine_channel_scan_pending(opts, state)) {
+            dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
             dsd_sleep_ms(1);
             continue;
         }
+        /* noCarrier and pending-row commits can replace the visit anchors. Publish
+         * the incoming visit before getFrameSync starts emitting its snapshots. */
+        dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
         frame_tune_generation = dsd_trunk_tuning_generation();
         state->synctype = getFrameSync(opts, state);
         live_scanner_update_thresholds(state, &last_max, &last_min);

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2615,6 +2615,11 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
                 break;
             }
         }
+        /* Outside the voice-gate block on purpose: this loop can spin here for seconds
+         * while frames keep syncing, and the legacy hangtime anchor moves the whole
+         * time, so the Scan Timing row would freeze mid-countdown if it only refreshed
+         * under -Y --scan-voice-only. */
+        dsd_engine_scan_y_timing_tick(opts, state);
         dsd_runtime_pump_controls(opts, state);
         if (!dsd_engine_channel_scan_service_sync(opts, state)) {
             break;
@@ -2644,6 +2649,7 @@ live_scanner_main_loop(dsd_opts* opts, dsd_state* state) {
         }
         dsd_trunk_scan_hook_tick(opts, state);
         dsd_scan_voice_gate_tick(opts, state, 0, dsd_time_now_monotonic_s());
+        dsd_engine_scan_y_timing_tick(opts, state);
         dsd_runtime_pump_controls(opts, state);
 
         if (dsd_engine_channel_scan_pending(opts, state)) {

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2619,7 +2619,7 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
          * while frames keep syncing, and the legacy hangtime anchor moves the whole
          * time, so the Scan Timing row would freeze mid-countdown if it only refreshed
          * under -Y --scan-voice-only. */
-        dsd_engine_scan_y_timing_tick(opts, state);
+        dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
         dsd_runtime_pump_controls(opts, state);
         if (!dsd_engine_channel_scan_service_sync(opts, state)) {
             break;
@@ -2649,7 +2649,7 @@ live_scanner_main_loop(dsd_opts* opts, dsd_state* state) {
         }
         dsd_trunk_scan_hook_tick(opts, state);
         dsd_scan_voice_gate_tick(opts, state, 0, dsd_time_now_monotonic_s());
-        dsd_engine_scan_y_timing_tick(opts, state);
+        dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
         dsd_runtime_pump_controls(opts, state);
 
         if (dsd_engine_channel_scan_pending(opts, state)) {

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
 
+#include <math.h>
 #include <stdint.h>
 
 #include "dsd-neo/core/opts_fwd.h"
@@ -230,4 +231,98 @@ dsd_scan_timing_publish(dsd_state* state, const dsd_scan_timing_publication* rep
         return;
     }
     state->scan_timing = *report;
+}
+
+/* Seed the -Y report. The effective windows are the row's, not the live timer's: they
+ * stay visible while a hold pauses the countdown, and are 0 when the voice gate is off
+ * because the legacy hangtime rule has neither a qualify nor a hold window. */
+static void
+scan_y_timing_seed(const dsd_opts* opts, dsd_scan_timing_publication* out) {
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->started_m = -1.0;
+    out->deadline_m = -1.0;
+    out->conventional = 1U;
+    if (!scan_voice_gate_enabled(opts)) {
+        return;
+    }
+    out->dwell_ms = (uint32_t)scan_voice_resolve_ms(opts->scan_voice_qualify_ms, DSD_SCAN_VOICE_DEFAULT_QUALIFY_MS);
+    out->hold_ms = (uint32_t)scan_voice_resolve_ms(opts->scan_voice_hold_ms, DSD_SCAN_VOICE_DEFAULT_HOLD_MS);
+}
+
+/* Anti-drift: dsd_scan_voice_gate_should_step() flips at anchor + span_ms / 1000.0, so
+ * the published deadline is that same expression rather than a second approximation. */
+static void
+scan_y_timing_arm(dsd_scan_timing_publication* out, double started_m, uint32_t span_ms) {
+    out->started_m = started_m;
+    out->deadline_m = started_m + ((double)span_ms / 1000.0);
+    out->span_ms = span_ms;
+}
+
+/* The gate owns the step: voice (or its tail) counts down the hold window from the last
+ * media frame, and a synced-but-silent visit counts down the qualify window. */
+static void
+scan_y_timing_fill_gate(const dsd_state* state, dsd_scan_timing_publication* out) {
+    if (state->scan_voice_gate_voice_m >= 0.0) {
+        out->reason = state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_VOICE
+                          ? (uint8_t)DSD_SCAN_STAY_VOICE
+                          : (uint8_t)DSD_SCAN_STAY_ACTIVITY_HOLD;
+        scan_y_timing_arm(out, state->scan_voice_gate_voice_m, out->hold_ms);
+        return;
+    }
+    /* dsd_scan_voice_gate_owns_step() is true and no voice anchor exists, so the sync
+     * anchor is the one that is set. */
+    out->reason = (uint8_t)DSD_SCAN_STAY_IDLE_DWELL;
+    scan_y_timing_arm(out, state->scan_voice_gate_sync_m, out->dwell_ms);
+}
+
+/* -t parses any non-negative double, so the second-to-millisecond conversion has to
+ * saturate rather than wrap on its way into the publication's uint32_t. */
+static uint32_t
+scan_y_timing_span_ms(double seconds) {
+    const double span_ms = seconds * 1000.0;
+    if (span_ms >= (double)UINT32_MAX) {
+        return UINT32_MAX;
+    }
+    return (uint32_t)lround(span_ms);
+}
+
+/* The legacy rule waits out -t since the last sync and knows nothing else, so it reports
+ * no dwell and no hold. Without an anchor or with -t 0 there is nothing to count down. */
+static void
+scan_y_timing_fill_hangtime(const dsd_opts* opts, const dsd_state* state, dsd_scan_timing_publication* out) {
+    out->reason = (uint8_t)DSD_SCAN_STAY_HANGTIME;
+    out->dwell_ms = 0U;
+    out->hold_ms = 0U;
+    if (state->last_cc_sync_time_m <= 0.0 || opts->trunk_hangtime <= 0.0f) {
+        return;
+    }
+    out->started_m = state->last_cc_sync_time_m;
+    out->deadline_m = out->started_m + (double)opts->trunk_hangtime;
+    out->span_ms = scan_y_timing_span_ms((double)opts->trunk_hangtime);
+}
+
+void
+dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return;
+    }
+    /* Under --trunk-scan the coordinator publishes for its parked target; the two must
+     * never both write the field. With no scanner running there is nothing to report. */
+    if (opts->scanner_mode != 1 || opts->trunk_scan_enabled == 1) {
+        return;
+    }
+    dsd_scan_timing_publication report;
+    scan_y_timing_seed(opts, &report);
+    if (state->lcn_scan_hold) {
+        /* The rotation is parked by the operator: the window is paused, not expired.
+         * dsd_scan_voice_gate_should_step() returns 0 here and the no-carrier step
+         * returns early, so publishing a deadline would count down to a hop that the
+         * release, not the clock, actually causes. */
+        report.reason = (uint8_t)DSD_SCAN_STAY_MANUAL_HOLD;
+    } else if (dsd_scan_voice_gate_owns_step(opts, state)) {
+        scan_y_timing_fill_gate(state, &report);
+    } else {
+        scan_y_timing_fill_hangtime(opts, state, &report);
+    }
+    dsd_scan_timing_publish(state, &report);
 }

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
 
 #include <math.h>
@@ -287,7 +288,7 @@ scan_y_timing_span_ms(double seconds) {
 }
 
 /* The legacy rule waits out -t since the last sync and knows nothing else, so it reports
- * no dwell and no hold. Without an anchor or with -t 0 there is nothing to count down.
+ * no dwell and no hold. Without an anchor there is nothing to count down.
  *
  * The anchor is the wall-clock last_cc_sync_time the step rule itself compares
  * (engine.c no_carrier_scanner_step_is_due), not its monotonic twin: NXDN stamps the
@@ -301,12 +302,15 @@ scan_y_timing_fill_hangtime(const dsd_opts* opts, const dsd_state* state, double
     out->reason = (uint8_t)DSD_SCAN_STAY_HANGTIME;
     out->dwell_ms = 0U;
     out->hold_ms = 0U;
-    if (state->last_cc_sync_time == 0 || opts->trunk_hangtime <= 0.0f) {
+    if (state->last_cc_sync_time == 0 || !(opts->trunk_hangtime >= 0.0f)) {
         return;
     }
     out->started_m = now_m + ((double)state->last_cc_sync_time - now_wall_s);
-    out->deadline_m = out->started_m + (double)opts->trunk_hangtime;
-    out->span_ms = scan_y_timing_span_ms((double)opts->trunk_hangtime);
+    /* noCarrier compares whole seconds with strict >. The next integer after
+     * -t is the first wall-clock tick that permits a hop, including for -t 0. */
+    const double span_s = floor((double)opts->trunk_hangtime) + 1.0;
+    out->deadline_m = out->started_m + span_s;
+    out->span_ms = scan_y_timing_span_ms(span_s);
 }
 
 void
@@ -321,7 +325,9 @@ dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state, double now
     }
     dsd_scan_timing_publication report;
     scan_y_timing_seed(opts, &report);
-    if (state->lcn_scan_hold) {
+    if (dsd_engine_channel_scan_waiting(state)) {
+        report.reason = (uint8_t)DSD_SCAN_STAY_RETUNE_PENDING;
+    } else if (state->lcn_scan_hold) {
         /* The rotation is parked by the operator: the window is paused, not expired.
          * dsd_scan_voice_gate_should_step() returns 0 here and the no-carrier step
          * returns early, so publishing a deadline would count down to a hop that the

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -283,26 +283,34 @@ scan_y_timing_span_ms(double seconds) {
     if (span_ms >= (double)UINT32_MAX) {
         return UINT32_MAX;
     }
-    return (uint32_t)lround(span_ms);
+    return (uint32_t)llround(span_ms);
 }
 
 /* The legacy rule waits out -t since the last sync and knows nothing else, so it reports
- * no dwell and no hold. Without an anchor or with -t 0 there is nothing to count down. */
+ * no dwell and no hold. Without an anchor or with -t 0 there is nothing to count down.
+ *
+ * The anchor is the wall-clock last_cc_sync_time the step rule itself compares
+ * (engine.c no_carrier_scanner_step_is_due), not its monotonic twin: NXDN stamps the
+ * wall clock two seconds ahead after a confirmed frame without touching the monotonic
+ * field, and a countdown read from the twin would reach zero two seconds early. The
+ * window is re-expressed on the monotonic clock through the two clocks sampled together,
+ * so it can start in the future and stays put from tick to tick. */
 static void
-scan_y_timing_fill_hangtime(const dsd_opts* opts, const dsd_state* state, dsd_scan_timing_publication* out) {
+scan_y_timing_fill_hangtime(const dsd_opts* opts, const dsd_state* state, double now_m, double now_wall_s,
+                            dsd_scan_timing_publication* out) {
     out->reason = (uint8_t)DSD_SCAN_STAY_HANGTIME;
     out->dwell_ms = 0U;
     out->hold_ms = 0U;
-    if (state->last_cc_sync_time_m <= 0.0 || opts->trunk_hangtime <= 0.0f) {
+    if (state->last_cc_sync_time == 0 || opts->trunk_hangtime <= 0.0f) {
         return;
     }
-    out->started_m = state->last_cc_sync_time_m;
+    out->started_m = now_m + ((double)state->last_cc_sync_time - now_wall_s);
     out->deadline_m = out->started_m + (double)opts->trunk_hangtime;
     out->span_ms = scan_y_timing_span_ms((double)opts->trunk_hangtime);
 }
 
 void
-dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state) {
+dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state, double now_m, double now_wall_s) {
     if (!opts || !state) {
         return;
     }
@@ -322,7 +330,7 @@ dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state) {
     } else if (dsd_scan_voice_gate_owns_step(opts, state)) {
         scan_y_timing_fill_gate(state, &report);
     } else {
-        scan_y_timing_fill_hangtime(opts, state, &report);
+        scan_y_timing_fill_hangtime(opts, state, now_m, now_wall_s, &report);
     }
     dsd_scan_timing_publish(state, &report);
 }

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -5,6 +5,7 @@
 
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
@@ -211,4 +212,22 @@ dsd_scan_voice_gate_should_step(const dsd_opts* opts, const dsd_state* state, do
     }
     /* Never synced this visit: the caller falls back to the legacy hangtime rule. */
     return 0;
+}
+
+void
+dsd_scan_timing_clear(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
+    state->scan_timing.started_m = -1.0;
+    state->scan_timing.deadline_m = -1.0;
+}
+
+void
+dsd_scan_timing_publish(dsd_state* state, const dsd_scan_timing_publication* report) {
+    if (!state || !report) {
+        return;
+    }
+    state->scan_timing = *report;
 }

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -2946,10 +2946,9 @@ trunk_scan_publish_timing(const dsd_opts* opts, dsd_state* state, const dsd_trun
             hang_s = rt->dmr_ctx.hangtime_s;
         }
         /* Bound the conversion, including invalid/nonfinite configured values. */
-        if (hang_s > 86400.0) {
-            hang_s = 86400.0;
-        }
-        if (hang_s > 0.0) {
+        if (hang_s >= (double)UINT32_MAX / 1000.0) {
+            report.hang_ms = UINT32_MAX;
+        } else if (hang_s > 0.0) {
             report.hang_ms = (uint32_t)((hang_s * 1000.0) + 0.5);
         }
     }
@@ -3041,6 +3040,9 @@ trunk_scan_control_advance_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_sc
 static int
 trunk_scan_control_hold_toggle(dsd_state* state, dsd_trunk_scan_coord* coord) {
     coord->hold_active = coord->hold_active ? 0 : 1;
+    // Disarm at the command boundary: both toggles can arrive before another
+    // tick observes the hold. Release must still grant a fresh idle dwell.
+    coord->targets[coord->active].idle_since_m = -1.0;
     trunk_scan_publish_active_target(state, coord);
     return coord->hold_active;
 }
@@ -3089,13 +3091,20 @@ dsd_engine_trunk_scan_control(dsd_opts* opts, dsd_state* state, int op) {
     if (!opts || !state || !coord || coord->count == 0 || coord->active >= coord->count) {
         return DSD_TRUNK_SCAN_CONTROL_UNAVAILABLE;
     }
+    int rc;
     switch (op) {
-        case DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE: return trunk_scan_control_hold_toggle(state, coord);
-        case DSD_TRUNK_SCAN_CONTROL_AVOID_CLEAR: return trunk_scan_control_avoid_clear(state, coord);
-        case DSD_TRUNK_SCAN_CONTROL_AVOID_ACTIVE: return trunk_scan_control_avoid_active(opts, state, coord);
-        case DSD_TRUNK_SCAN_CONTROL_ADVANCE: return trunk_scan_control_advance(opts, state, coord);
+        case DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE: rc = trunk_scan_control_hold_toggle(state, coord); break;
+        case DSD_TRUNK_SCAN_CONTROL_AVOID_CLEAR: rc = trunk_scan_control_avoid_clear(state, coord); break;
+        case DSD_TRUNK_SCAN_CONTROL_AVOID_ACTIVE: rc = trunk_scan_control_avoid_active(opts, state, coord); break;
+        case DSD_TRUNK_SCAN_CONTROL_ADVANCE: rc = trunk_scan_control_advance(opts, state, coord); break;
         default: return DSD_TRUNK_SCAN_CONTROL_REFUSED;
     }
+    // The command queue publishes immediately, possibly while input is stalled.
+    // Its target label and timing must already describe the same visit.
+    if (rc >= 0) {
+        trunk_scan_publish_timing(opts, state, coord, trunk_scan_now_m());
+    }
+    return rc;
 }
 
 static int

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -2938,6 +2938,21 @@ trunk_scan_publish_timing(const dsd_opts* opts, dsd_state* state, const dsd_trun
     report.dwell_ms = dwell_ms > 0 ? (uint32_t)dwell_ms : 0U;
     report.hold_ms = hold_ms > 0 ? (uint32_t)hold_ms : 0U;
     trunk_scan_timing_select_reason(opts, state, coord, now_m, &report);
+    if (report.reason == (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW) {
+        double hang_s = opts->trunk_hangtime;
+        if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
+            hang_s = p25_sm_effective_hangtime(state, rt->p25_ctx.config.hangtime_s);
+        } else if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
+            hang_s = rt->dmr_ctx.hangtime_s;
+        }
+        /* Bound the conversion, including invalid/nonfinite configured values. */
+        if (hang_s > 86400.0) {
+            hang_s = 86400.0;
+        }
+        if (hang_s > 0.0) {
+            report.hang_ms = (uint32_t)((hang_s * 1000.0) + 0.5);
+        }
+    }
     dsd_scan_timing_publish(state, &report);
 }
 

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -62,6 +62,11 @@
 #define DSD_TRUNK_SCAN_MAX_FREQUENCY_HZ UINT32_MAX
 #endif
 
+/* How long a failed retune cools down before the coordinator tries the same target again.
+ * Published as the RETUNE_RETRY window, so the policy and the countdown a frontend draws
+ * can never disagree about the length of the wait. */
+#define TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S 2.0
+
 typedef struct {
     unsigned long long p2_wacn;
     unsigned long long p2_sysid;
@@ -394,6 +399,11 @@ trunk_scan_type_is_conventional(dsd_trunk_scan_target_type type) {
         case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return 1;
     }
     return 0;
+}
+
+static int
+trunk_scan_target_is_trunked(dsd_trunk_scan_target_type type) {
+    return !trunk_scan_type_is_conventional(type);
 }
 
 static int
@@ -1859,6 +1869,7 @@ trunk_scan_clear_published_target(dsd_state* state) {
     state->trunk_scan_hold = 0U;
     state->trunk_scan_active_avoided = 0U;
     state->trunk_scan_avoided_count = 0U;
+    dsd_scan_timing_clear(state);
 }
 
 static size_t
@@ -2475,7 +2486,7 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     uint64_t tune_request_id = 0U;
     dsd_trunk_tune_result tune_result = trunk_scan_retune_active(opts, state, rt, &tune_request_id);
     if (!dsd_trunk_tune_result_is_ok(tune_result)) {
-        rt->retry_until_m = now_m + 2.0;
+        rt->retry_until_m = now_m + TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S;
         LOG_WARN("WARNING: Trunk scan target '%s' retune failed; cooling down briefly\n", rt->target.id);
         return -1;
     }
@@ -2605,7 +2616,7 @@ trunk_scan_retry_active_if_due(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_
         return;
     }
     if (trunk_scan_switch_to(opts, state, coord, coord->active, 0) == TRUNK_SCAN_PREPARE_FAILED) {
-        rt->retry_until_m = now_m + 2.0;
+        rt->retry_until_m = now_m + TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S;
     }
 }
 
@@ -2631,25 +2642,79 @@ trunk_scan_target_dwell_ms(const dsd_opts* opts, const dsd_trunk_scan_target_run
     return rt->target.dwell_ms;
 }
 
-static int
-trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coord, double now_m) {
-    const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
-    if (rt->tune_pending) {
-        return 1;
-    }
+/* A trunked row stays for whatever its protocol state machine is doing. The SM owns those
+ * deadlines, not the coordinator, so none of these reasons carries a window. */
+static dsd_scan_stay_reason
+trunk_scan_trunked_stay_reason(const dsd_opts* opts, const dsd_trunk_scan_target_runtime* rt) {
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
-        return (rt->p25_ctx.cc_tune_pending || opts->trunk_is_tuned == 1
-                || p25_sm_get_state(&rt->p25_ctx) == P25_SM_TUNED);
+        if (rt->p25_ctx.cc_tune_pending) {
+            return DSD_SCAN_STAY_CC_ACQUIRE;
+        }
+        return (opts->trunk_is_tuned == 1 || p25_sm_get_state(&rt->p25_ctx) == P25_SM_TUNED) ? DSD_SCAN_STAY_CALL_FOLLOW
+                                                                                             : DSD_SCAN_STAY_NONE;
     }
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
-        return (rt->dmr_ctx.cc_tune_request_id != 0U || opts->trunk_is_tuned == 1
-                || dmr_sm_get_state(&rt->dmr_ctx) == DMR_SM_TUNED);
+        if (rt->dmr_ctx.cc_tune_request_id != 0U) {
+            return DSD_SCAN_STAY_CC_ACQUIRE;
+        }
+        return (opts->trunk_is_tuned == 1 || dmr_sm_get_state(&rt->dmr_ctx) == DMR_SM_TUNED) ? DSD_SCAN_STAY_CALL_FOLLOW
+                                                                                             : DSD_SCAN_STAY_NONE;
     }
-    if (trunk_scan_type_is_nxdn_trunk(rt->target.type)) {
-        return opts->trunk_is_tuned == 1;
+    /* NXDN trunking keeps no coordinator-visible state machine: tuned is all it can say. */
+    return opts->trunk_is_tuned == 1 ? DSD_SCAN_STAY_CALL_FOLLOW : DSD_SCAN_STAY_NONE;
+}
+
+/* The one window the coordinator owns outright: a conventional row holds for its effective
+ * activity hold, measured from the last activity the policy allowed. */
+static dsd_scan_stay_reason
+trunk_scan_conventional_stay_reason(const dsd_opts* opts, const dsd_state* state,
+                                    const dsd_trunk_scan_target_runtime* rt, double now_m, double* started_m,
+                                    double* deadline_m, uint32_t* span_ms) {
+    const int hold_ms = trunk_scan_target_hold_ms(opts, rt);
+    const double hold_s = (double)hold_ms / 1000.0;
+    if (!(rt->last_allowed_activity_m > 0.0 && (now_m - rt->last_allowed_activity_m) < hold_s)) {
+        return DSD_SCAN_STAY_NONE;
     }
-    double hold_s = (double)trunk_scan_target_hold_ms(opts, rt) / 1000.0;
-    return rt->last_allowed_activity_m > 0.0 && (now_m - rt->last_allowed_activity_m) < hold_s;
+    if (started_m) {
+        *started_m = rt->last_allowed_activity_m;
+    }
+    if (deadline_m) {
+        *deadline_m = rt->last_allowed_activity_m + hold_s;
+    }
+    if (span_ms) {
+        *span_ms = hold_ms > 0 ? (uint32_t)hold_ms : 0U;
+    }
+    return (state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_VOICE) ? DSD_SCAN_STAY_VOICE
+                                                                                : DSD_SCAN_STAY_ACTIVITY_HOLD;
+}
+
+/*
+ * Why the receiver is staying on the active target, in the branch order the old boolean
+ * verdict used: every reason but DSD_SCAN_STAY_NONE is exactly what the tick used to treat
+ * as "held", so no rotation decision moves.
+ *
+ * Evaluated twice per tick -- once for the rotation policy, once for the publication -- and
+ * must therefore stay side-effect free: it only reads opts, state and the target runtime.
+ * started_m/deadline_m/span_ms describe the live window, may each be NULL, and are left
+ * untouched by the reasons that have no coordinator-owned deadline.
+ */
+static dsd_scan_stay_reason
+trunk_scan_active_stay_reason(const dsd_opts* opts, const dsd_state* state, const dsd_trunk_scan_coord* coord,
+                              double now_m, double* started_m, double* deadline_m, uint32_t* span_ms) {
+    const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    if (rt->tune_pending) {
+        return DSD_SCAN_STAY_RETUNE_PENDING;
+    }
+    if (trunk_scan_target_is_trunked(rt->target.type)) {
+        return trunk_scan_trunked_stay_reason(opts, rt);
+    }
+    return trunk_scan_conventional_stay_reason(opts, state, rt, now_m, started_m, deadline_m, span_ms);
+}
+
+static int
+trunk_scan_active_is_held(const dsd_opts* opts, const dsd_state* state, const dsd_trunk_scan_coord* coord,
+                          double now_m) {
+    return trunk_scan_active_stay_reason(opts, state, coord, now_m, NULL, NULL, NULL) != DSD_SCAN_STAY_NONE;
 }
 
 static void
@@ -2764,15 +2829,10 @@ trunk_scan_resolve_pending_retune(dsd_state* state, dsd_trunk_scan_target_runtim
 
     rt->tune_request_id = 0U;
     rt->tune_pending = 0;
-    rt->retry_until_m = now_m + 2.0;
+    rt->retry_until_m = now_m + TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S;
     LOG_WARN("WARNING: Trunk scan target '%s' asynchronous retune failed; cooling down briefly\n", rt->target.id);
     (void)state;
     return -1;
-}
-
-static int
-trunk_scan_target_is_trunked(dsd_trunk_scan_target_type type) {
-    return !trunk_scan_type_is_conventional(type);
 }
 
 /* Voice-only scan (issue #381): conventional targets hold only from decoded voice
@@ -2806,9 +2866,83 @@ trunk_scan_refresh_voice_media_hold(const dsd_opts* opts, dsd_state* state, dsd_
     }
 }
 
+/* Pick the reason the row on air is staying, and the window it runs for when the coordinator
+ * owns one. Split out of trunk_scan_publish_timing() so both stay small; the report arrives
+ * with no timer armed and its effective dwell/hold already resolved. */
 static void
-trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord) {
-    double now_m = trunk_scan_now_m();
+trunk_scan_timing_select_reason(const dsd_opts* opts, const dsd_state* state, const dsd_trunk_scan_coord* coord,
+                                double now_m, dsd_scan_timing_publication* report) {
+    const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    if (rt->tune_pending) {
+        /* The backend owns an unresolved request; there is no deadline to name. */
+        report->reason = (uint8_t)DSD_SCAN_STAY_RETUNE_PENDING;
+        return;
+    }
+    if (rt->retry_until_m > now_m) {
+        report->reason = (uint8_t)DSD_SCAN_STAY_RETUNE_RETRY;
+        report->started_m = rt->retry_until_m - TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S;
+        report->deadline_m = rt->retry_until_m;
+        report->span_ms = (uint32_t)(TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S * 1000.0);
+        return;
+    }
+    double started_m = -1.0;
+    double deadline_m = -1.0;
+    uint32_t span_ms = 0U;
+    const dsd_scan_stay_reason stay =
+        trunk_scan_active_stay_reason(opts, state, coord, now_m, &started_m, &deadline_m, &span_ms);
+    if (stay != DSD_SCAN_STAY_NONE) {
+        report->reason = (uint8_t)stay;
+        report->started_m = started_m;
+        report->deadline_m = deadline_m;
+        report->span_ms = span_ms;
+        return;
+    }
+    if (coord->hold_active) {
+        /* The operator hold disarms the dwell rather than expiring it: nothing counts down. */
+        report->reason = (uint8_t)DSD_SCAN_STAY_MANUAL_HOLD;
+        return;
+    }
+    report->reason = (uint8_t)DSD_SCAN_STAY_IDLE_DWELL;
+    if (rt->idle_since_m >= 0.0) {
+        report->started_m = rt->idle_since_m;
+        report->deadline_m = rt->idle_since_m + (double)trunk_scan_target_dwell_ms(opts, rt) / 1000.0;
+        report->span_ms = report->dwell_ms;
+    }
+}
+
+/*
+ * One scan-timing report for the target on air (issue #508). Absolute monotonic anchors only:
+ * the frontends difference them against their own clock, so a stalled UI cannot invent a
+ * countdown the decoder is not running. Additive -- it decides nothing.
+ */
+static void
+trunk_scan_publish_timing(const dsd_opts* opts, dsd_state* state, const dsd_trunk_scan_coord* coord, double now_m) {
+    if (!opts || !state) {
+        return;
+    }
+    if (!coord || coord->active >= coord->count) {
+        dsd_scan_timing_clear(state);
+        return;
+    }
+    const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    const int conventional = !trunk_scan_target_is_trunked(rt->target.type);
+    const int dwell_ms = trunk_scan_target_dwell_ms(opts, rt);
+    /* A trunked row has no activity hold to speak of, and publishing one would only invite
+     * the frontends to draw a timer the coordinator never runs. */
+    const int hold_ms = conventional ? trunk_scan_target_hold_ms(opts, rt) : 0;
+    dsd_scan_timing_publication report;
+    DSD_MEMSET(&report, 0, sizeof report);
+    report.started_m = -1.0;
+    report.deadline_m = -1.0;
+    report.conventional = conventional ? 1U : 0U;
+    report.dwell_ms = dwell_ms > 0 ? (uint32_t)dwell_ms : 0U;
+    report.hold_ms = hold_ms > 0 ? (uint32_t)hold_ms : 0U;
+    trunk_scan_timing_select_reason(opts, state, coord, now_m, &report);
+    dsd_scan_timing_publish(state, &report);
+}
+
+static void
+trunk_scan_tick_targets_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord, double now_m) {
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
     if (rt->tune_pending && rt->dmr_ctx.cc_tune_request_id != 0U) {
         /* Resolve the DMR backend deadline even while the initial park keeps
@@ -2832,7 +2966,7 @@ trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* c
         trunk_scan_share_peer_idens(coord, state, rt);
     }
     trunk_scan_refresh_voice_media_hold(opts, state, rt, now_m);
-    if (trunk_scan_active_is_held(opts, coord, now_m)) {
+    if (trunk_scan_active_is_held(opts, state, coord, now_m)) {
         rt->idle_since_m = -1.0;
         return;
     }
@@ -2851,6 +2985,15 @@ trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* c
     if ((now_m - rt->idle_since_m) >= dwell_s) {
         trunk_scan_advance(opts, state, coord);
     }
+}
+
+/* The body above has a dozen early returns and can rotate; publishing here, once, means the
+ * report always describes whichever target the tick actually left on air. */
+static void
+trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord) {
+    const double now_m = trunk_scan_now_m();
+    trunk_scan_tick_targets_locked(opts, state, coord, now_m);
+    trunk_scan_publish_timing(opts, state, coord, now_m);
 }
 
 void

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -61,7 +61,6 @@ static void p25_voice_release_or_preserve_companion(p25_sm_ctx_t* ctx, dsd_opts*
                                                     const char* slot_log);
 static void handle_enc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev);
 static void handle_crypto_pending(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const p25_sm_event_t* ev);
-static double p25_sm_effective_hangtime(const dsd_state* state, double hangtime);
 static int p25_sm_crypto_classification_in_flight(const p25_sm_ctx_t* ctx, const dsd_state* state, double now_m,
                                                   double grant_timeout);
 
@@ -5506,7 +5505,7 @@ p25_sm_tick_on_cc(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, double no
     try_next_cc(ctx, opts, state, now_m);
 }
 
-static double
+double
 p25_sm_effective_hangtime(const dsd_state* state, double hangtime) {
     if (!state || hangtime <= 0.0) {
         return hangtime;

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -424,11 +424,11 @@ MetricsModel::fillScanTimingView(View& next, const dsd_opts* opts_snapshot, cons
     next.scan_timer_live = view.timer_live != 0U;
     /* Tenths, truncated: see scanTimerRemainingDs(). */
     next.scan_timer_remaining_ds = static_cast<int>(view.remaining_ms / 100U);
-    next.scan_timer_span_ms = static_cast<int>(view.span_ms);
+    next.scan_timer_span_ms = view.span_ms;
     next.scan_dwell_ms = view.show_dwell != 0U ? static_cast<int>(view.dwell_ms) : 0;
     next.scan_dwell_state = view.dwell_state;
     next.scan_hold_ms = view.show_hold != 0U ? static_cast<int>(view.hold_ms) : 0;
-    next.scan_hang_ms = view.show_hang != 0U ? static_cast<int>(view.hang_ms) : 0;
+    next.scan_hang_ms = view.show_hang != 0U ? view.hang_ms : 0U;
 }
 
 namespace {

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -311,7 +311,8 @@ MetricsModel::~MetricsModel() = default;
 bool
 MetricsModel::View::operator==(const View& other) const {
     return site == other.site && qualityEquals(other) && tunerEquals(other) && slot_call[0] == other.slot_call[0]
-           && slot_call[1] == other.slot_call[1] && controlEquals(other) && ui_message == other.ui_message;
+           && slot_call[1] == other.slot_call[1] && controlEquals(other) && scanTimingEquals(other)
+           && ui_message == other.ui_message;
 }
 
 void
@@ -325,6 +326,7 @@ MetricsModel::publish(const View& next) {
     const bool slot1Moved = !(next.slot_call[0] == m_view.slot_call[0]);
     const bool slot2Moved = !(next.slot_call[1] == m_view.slot_call[1]);
     const bool controlMoved = !next.controlEquals(m_view);
+    const bool scanTimingMoved = !next.scanTimingEquals(m_view);
     const bool messageMoved = next.ui_message != m_view.ui_message;
     m_view = next;
     if (siteMoved) {
@@ -347,6 +349,9 @@ MetricsModel::publish(const View& next) {
     }
     if (controlMoved) {
         Q_EMIT controlChanged();
+    }
+    if (scanTimingMoved) {
+        Q_EMIT scanTimingChanged();
     }
     if (messageMoved) {
         Q_EMIT uiMessageChanged();

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -25,6 +25,7 @@
 #include <QtGlobal>
 #include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/app_control/frontend.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/enc_lockout.h>
@@ -387,6 +388,42 @@ MetricsModel::fillScanControlView(View& next, const dsd_opts* opts_snapshot, con
     next.scan_hold = trunk_scan ? (snapshot->trunk_scan_hold != 0) : (snapshot->lcn_scan_hold != 0);
     next.scan_avoid_count = trunk_scan ? snapshot->trunk_scan_avoided_count : snapshot->lcn_avoid_count;
     next.scan_target_avoided = trunk_scan && snapshot->trunk_scan_active_avoided != 0;
+}
+
+/**
+ * @brief Why the rotation is staying on the row on air, and how long is left (#508).
+ *
+ * Every decision behind the row -- the phrase, whether a window is counting down,
+ * which of the dwell/hold/hang budgets is worth printing -- is made once in
+ * app-control, from a publication whose deadlines the decoder owns. A frontend only
+ * copies and formats, so this panel, the terminal row and Android cannot drift apart
+ * on what "suspended" means or on when a trunked row may show a conventional hold.
+ *
+ * The withheld budgets are zeroed rather than carried: QML gates each group on its
+ * own reading being positive, so a value the view declined to show must not arrive
+ * as a number the row could print.
+ */
+void
+MetricsModel::fillScanTimingView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot,
+                                 double now_m) const {
+    dsd_app_scan_timing view;
+    if (dsd_app_scan_timing_view(opts_snapshot, snapshot, now_m, &view) != 1) {
+        return;
+    }
+    next.scan_timing_visible = view.active != 0U;
+    next.scan_stay_reason = view.reason;
+    /* A static English label out of a fixed set, translated at run time. lupdate
+     * cannot extract through the pointer; the set is small enough that a catalogue
+     * lists it beside the terminal's own wording rather than duplicating it here. */
+    next.scan_stay_phrase = view.phrase != nullptr ? tr(view.phrase) : QString();
+    next.scan_timer_live = view.timer_live != 0U;
+    /* Tenths, truncated: see scanTimerRemainingDs(). */
+    next.scan_timer_remaining_ds = static_cast<int>(view.remaining_ms / 100U);
+    next.scan_timer_span_ms = static_cast<int>(view.span_ms);
+    next.scan_dwell_ms = view.show_dwell != 0U ? static_cast<int>(view.dwell_ms) : 0;
+    next.scan_dwell_state = view.dwell_state;
+    next.scan_hold_ms = view.show_hold != 0U ? static_cast<int>(view.hold_ms) : 0;
+    next.scan_hang_ms = view.show_hang != 0U ? static_cast<int>(view.hang_ms) : 0;
 }
 
 namespace {
@@ -773,6 +810,10 @@ MetricsModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) 
     next.held_tg = static_cast<qulonglong>(snapshot->tg_hold);
     next.enc_lockout_count = dsd_enc_lockout_active_count(snapshot);
     fillScanControlView(next, opts_snapshot, snapshot);
+    /* The same monotonic reading the call lines were aged against, not a second
+     * clock read: one frame has to describe one instant, or the countdown and the
+     * call durations beside it would come from moments either side of the poll. */
+    fillScanTimingView(next, opts_snapshot, snapshot, now_m);
 
     /* The engine's command acknowledgement, shown until its own expiry stamp. The
      * timer takes an expired message down without waiting for another publish —

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -153,11 +153,11 @@ class MetricsModel : public QObject {
     Q_PROPERTY(QString scanStayPhrase READ scanStayPhrase NOTIFY scanTimingChanged)
     Q_PROPERTY(bool scanTimerLive READ scanTimerLive NOTIFY scanTimingChanged)
     Q_PROPERTY(int scanTimerRemainingDs READ scanTimerRemainingDs NOTIFY scanTimingChanged)
-    Q_PROPERTY(int scanTimerSpanMs READ scanTimerSpanMs NOTIFY scanTimingChanged)
+    Q_PROPERTY(quint32 scanTimerSpanMs READ scanTimerSpanMs NOTIFY scanTimingChanged)
     Q_PROPERTY(int scanDwellMs READ scanDwellMs NOTIFY scanTimingChanged)
     Q_PROPERTY(int scanDwellState READ scanDwellState NOTIFY scanTimingChanged)
     Q_PROPERTY(int scanHoldMs READ scanHoldMs NOTIFY scanTimingChanged)
-    Q_PROPERTY(int scanHangMs READ scanHangMs NOTIFY scanTimingChanged)
+    Q_PROPERTY(quint32 scanHangMs READ scanHangMs NOTIFY scanTimingChanged)
     Q_PROPERTY(bool syncedHere READ syncedHere NOTIFY tunerChanged)
     Q_PROPERTY(QString syncLabel READ syncLabel NOTIFY tunerChanged)
     Q_PROPERTY(bool trunkableSync READ trunkableSync NOTIFY tunerChanged)
@@ -783,7 +783,7 @@ class MetricsModel : public QObject {
     }
 
     /** @brief Full width of the running window, so the countdown reads as a fraction. */
-    int
+    quint32
     scanTimerSpanMs() const {
         return m_view.scan_timer_span_ms;
     }
@@ -807,7 +807,7 @@ class MetricsModel : public QObject {
     }
 
     /** @brief The active protocol's effective hangtime budget for the current stay. */
-    int
+    quint32
     scanHangMs() const {
         return m_view.scan_hang_ms;
     }
@@ -1123,11 +1123,11 @@ class MetricsModel : public QObject {
         QString scan_stay_phrase;
         int scan_stay_reason = 0;
         int scan_timer_remaining_ds = 0;
-        int scan_timer_span_ms = 0;
+        quint32 scan_timer_span_ms = 0;
         int scan_dwell_ms = 0;
         int scan_dwell_state = 0;
         int scan_hold_ms = 0;
-        int scan_hang_ms = 0;
+        quint32 scan_hang_ms = 0;
         bool scan_timing_visible = false;
         bool scan_timer_live = false;
 

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -148,16 +148,16 @@ class MetricsModel : public QObject {
     Q_PROPERTY(bool scanTargetAvoided READ scanTargetAvoided NOTIFY controlChanged)
     /* #508: why the rotation is staying on the row on air, and how long is left.
        One group, one signal: they are read together by one row. */
-    Q_PROPERTY(bool scanTimingVisible READ scanTimingVisible NOTIFY controlChanged)
-    Q_PROPERTY(int scanStayReason READ scanStayReason NOTIFY controlChanged)
-    Q_PROPERTY(QString scanStayPhrase READ scanStayPhrase NOTIFY controlChanged)
-    Q_PROPERTY(bool scanTimerLive READ scanTimerLive NOTIFY controlChanged)
-    Q_PROPERTY(int scanTimerRemainingDs READ scanTimerRemainingDs NOTIFY controlChanged)
-    Q_PROPERTY(int scanTimerSpanMs READ scanTimerSpanMs NOTIFY controlChanged)
-    Q_PROPERTY(int scanDwellMs READ scanDwellMs NOTIFY controlChanged)
-    Q_PROPERTY(int scanDwellState READ scanDwellState NOTIFY controlChanged)
-    Q_PROPERTY(int scanHoldMs READ scanHoldMs NOTIFY controlChanged)
-    Q_PROPERTY(int scanHangMs READ scanHangMs NOTIFY controlChanged)
+    Q_PROPERTY(bool scanTimingVisible READ scanTimingVisible NOTIFY scanTimingChanged)
+    Q_PROPERTY(int scanStayReason READ scanStayReason NOTIFY scanTimingChanged)
+    Q_PROPERTY(QString scanStayPhrase READ scanStayPhrase NOTIFY scanTimingChanged)
+    Q_PROPERTY(bool scanTimerLive READ scanTimerLive NOTIFY scanTimingChanged)
+    Q_PROPERTY(int scanTimerRemainingDs READ scanTimerRemainingDs NOTIFY scanTimingChanged)
+    Q_PROPERTY(int scanTimerSpanMs READ scanTimerSpanMs NOTIFY scanTimingChanged)
+    Q_PROPERTY(int scanDwellMs READ scanDwellMs NOTIFY scanTimingChanged)
+    Q_PROPERTY(int scanDwellState READ scanDwellState NOTIFY scanTimingChanged)
+    Q_PROPERTY(int scanHoldMs READ scanHoldMs NOTIFY scanTimingChanged)
+    Q_PROPERTY(int scanHangMs READ scanHangMs NOTIFY scanTimingChanged)
     Q_PROPERTY(bool syncedHere READ syncedHere NOTIFY tunerChanged)
     Q_PROPERTY(QString syncLabel READ syncLabel NOTIFY tunerChanged)
     Q_PROPERTY(bool trunkableSync READ trunkableSync NOTIFY tunerChanged)
@@ -773,10 +773,9 @@ class MetricsModel : public QObject {
     /**
      * @brief Time left in the running window, in tenths of a second.
      *
-     * Tenths rather than milliseconds because this reading decides whether
-     * controlChanged fires: at millisecond resolution every 250 ms poll would move
-     * it and re-evaluate every binding on the control group, for a row that renders
-     * one decimal place. Truncated, so it never claims more time than is left.
+     * scanTimingChanged fires only when the rendered tenth changes. Countdown
+     * updates have their own signal so they do not refresh unrelated controls.
+     * Truncated, so it never claims more time than is left.
      */
     int
     scanTimerRemainingDs() const {
@@ -795,7 +794,7 @@ class MetricsModel : public QObject {
         return m_view.scan_dwell_ms;
     }
 
-    /** @brief DSD_APP_SCAN_DWELL_*: running, suspended under a hold, or paused by the operator. */
+    /** @brief DSD_APP_SCAN_DWELL_*: hidden, suspended under a hold, or paused by the operator. */
     int
     scanDwellState() const {
         return m_view.scan_dwell_state;
@@ -807,7 +806,7 @@ class MetricsModel : public QObject {
         return m_view.scan_hold_ms;
     }
 
-    /** @brief The -t hangtime, when it is what governs the current stay. */
+    /** @brief The active protocol's effective hangtime budget for the current stay. */
     int
     scanHangMs() const {
         return m_view.scan_hang_ms;
@@ -998,6 +997,7 @@ class MetricsModel : public QObject {
     void slot2Changed();
     void leadSlotChanged();
     void controlChanged();
+    void scanTimingChanged();
     void uiMessageChanged();
 
   private:
@@ -1155,9 +1155,7 @@ class MetricsModel : public QObject {
                    && scan_avoid_count == other.scan_avoid_count && scan_target_avoided == other.scan_target_avoided;
         }
 
-        /* Split out for the same reason as scanControlEquals: it rides controlChanged
-           with the rest, and folding ten more readings into one comparison would put
-           it over the complexity ceiling. */
+        /* Countdown updates notify only the scan timing row. */
         bool
         scanTimingEquals(const View& other) const {
             return scan_timing_visible == other.scan_timing_visible && scan_stay_reason == other.scan_stay_reason
@@ -1187,8 +1185,8 @@ class MetricsModel : public QObject {
             return audio_muted == other.audio_muted && held_tg == other.held_tg
                    && enc_lockout_count == other.enc_lockout_count && tuner_controlled == other.tuner_controlled
                    && trunking_enabled == other.trunking_enabled && scanner_mode == other.scanner_mode
-                   && scanControlEquals(other) && scanTimingEquals(other) && scan_mode == other.scan_mode
-                   && decode_mode == other.decode_mode && decryptionEquals(other) && radioControlsEqual(other);
+                   && scanControlEquals(other) && scan_mode == other.scan_mode && decode_mode == other.decode_mode
+                   && decryptionEquals(other) && radioControlsEqual(other);
         }
     };
 

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -146,6 +146,18 @@ class MetricsModel : public QObject {
     Q_PROPERTY(bool scanHold READ scanHold NOTIFY controlChanged)
     Q_PROPERTY(int scanAvoidCount READ scanAvoidCount NOTIFY controlChanged)
     Q_PROPERTY(bool scanTargetAvoided READ scanTargetAvoided NOTIFY controlChanged)
+    /* #508: why the rotation is staying on the row on air, and how long is left.
+       One group, one signal: they are read together by one row. */
+    Q_PROPERTY(bool scanTimingVisible READ scanTimingVisible NOTIFY controlChanged)
+    Q_PROPERTY(int scanStayReason READ scanStayReason NOTIFY controlChanged)
+    Q_PROPERTY(QString scanStayPhrase READ scanStayPhrase NOTIFY controlChanged)
+    Q_PROPERTY(bool scanTimerLive READ scanTimerLive NOTIFY controlChanged)
+    Q_PROPERTY(int scanTimerRemainingDs READ scanTimerRemainingDs NOTIFY controlChanged)
+    Q_PROPERTY(int scanTimerSpanMs READ scanTimerSpanMs NOTIFY controlChanged)
+    Q_PROPERTY(int scanDwellMs READ scanDwellMs NOTIFY controlChanged)
+    Q_PROPERTY(int scanDwellState READ scanDwellState NOTIFY controlChanged)
+    Q_PROPERTY(int scanHoldMs READ scanHoldMs NOTIFY controlChanged)
+    Q_PROPERTY(int scanHangMs READ scanHangMs NOTIFY controlChanged)
     Q_PROPERTY(bool syncedHere READ syncedHere NOTIFY tunerChanged)
     Q_PROPERTY(QString syncLabel READ syncLabel NOTIFY tunerChanged)
     Q_PROPERTY(bool trunkableSync READ trunkableSync NOTIFY tunerChanged)
@@ -729,6 +741,79 @@ class MetricsModel : public QObject {
     }
 
     /**
+     * @brief Whether there is a scan stay reason to show at all (#508).
+     *
+     * False whenever no rotation is running, and false for a rotation that has
+     * published nothing yet. Decided in app-control, not here, so this panel, the
+     * terminal row and Android cannot disagree about when the row appears.
+     */
+    bool
+    scanTimingVisible() const {
+        return m_view.scan_timing_visible;
+    }
+
+    /** @brief dsd_scan_stay_reason for the row on air; the phrase is its label. */
+    int
+    scanStayReason() const {
+        return m_view.scan_stay_reason;
+    }
+
+    /** @brief "Following call", "Idle dwell", "Manual hold" -- why it is staying. */
+    const QString&
+    scanStayPhrase() const {
+        return m_view.scan_stay_phrase;
+    }
+
+    /** @brief A window is counting down; without it the stay has no deadline to show. */
+    bool
+    scanTimerLive() const {
+        return m_view.scan_timer_live;
+    }
+
+    /**
+     * @brief Time left in the running window, in tenths of a second.
+     *
+     * Tenths rather than milliseconds because this reading decides whether
+     * controlChanged fires: at millisecond resolution every 250 ms poll would move
+     * it and re-evaluate every binding on the control group, for a row that renders
+     * one decimal place. Truncated, so it never claims more time than is left.
+     */
+    int
+    scanTimerRemainingDs() const {
+        return m_view.scan_timer_remaining_ds;
+    }
+
+    /** @brief Full width of the running window, so the countdown reads as a fraction. */
+    int
+    scanTimerSpanMs() const {
+        return m_view.scan_timer_span_ms;
+    }
+
+    /** @brief Effective idle dwell for this row, 0 when it is not worth showing. */
+    int
+    scanDwellMs() const {
+        return m_view.scan_dwell_ms;
+    }
+
+    /** @brief DSD_APP_SCAN_DWELL_*: running, suspended under a hold, or paused by the operator. */
+    int
+    scanDwellState() const {
+        return m_view.scan_dwell_state;
+    }
+
+    /** @brief Effective activity hold; 0 on trunked rows, which have none. */
+    int
+    scanHoldMs() const {
+        return m_view.scan_hold_ms;
+    }
+
+    /** @brief The -t hangtime, when it is what governs the current stay. */
+    int
+    scanHangMs() const {
+        return m_view.scan_hang_ms;
+    }
+
+    /**
      * @brief The engine's transient command acknowledgement, empty when none.
      *
      * Commands only enqueue a request; this is the engine saying what actually
@@ -1034,6 +1119,17 @@ class MetricsModel : public QObject {
         int scan_target_count = 0;
         bool scan_hold = false;
         bool scan_target_avoided = false;
+        /* #508: the stay reason and the live window, copied from the app-control view. */
+        QString scan_stay_phrase;
+        int scan_stay_reason = 0;
+        int scan_timer_remaining_ds = 0;
+        int scan_timer_span_ms = 0;
+        int scan_dwell_ms = 0;
+        int scan_dwell_state = 0;
+        int scan_hold_ms = 0;
+        int scan_hang_ms = 0;
+        bool scan_timing_visible = false;
+        bool scan_timer_live = false;
 
         /* Exact comparison is right for the two doubles: they are carried through
          * unmodified from the metrics boundary, so "unchanged" means the identical
@@ -1059,6 +1155,19 @@ class MetricsModel : public QObject {
                    && scan_avoid_count == other.scan_avoid_count && scan_target_avoided == other.scan_target_avoided;
         }
 
+        /* Split out for the same reason as scanControlEquals: it rides controlChanged
+           with the rest, and folding ten more readings into one comparison would put
+           it over the complexity ceiling. */
+        bool
+        scanTimingEquals(const View& other) const {
+            return scan_timing_visible == other.scan_timing_visible && scan_stay_reason == other.scan_stay_reason
+                   && scan_stay_phrase == other.scan_stay_phrase && scan_timer_live == other.scan_timer_live
+                   && scan_timer_remaining_ds == other.scan_timer_remaining_ds
+                   && scan_timer_span_ms == other.scan_timer_span_ms && scan_dwell_ms == other.scan_dwell_ms
+                   && scan_dwell_state == other.scan_dwell_state && scan_hold_ms == other.scan_hold_ms
+                   && scan_hang_ms == other.scan_hang_ms;
+        }
+
         bool
         decryptionEquals(const View& other) const {
             return configured_force == other.configured_force && effective_force == other.effective_force
@@ -1078,8 +1187,8 @@ class MetricsModel : public QObject {
             return audio_muted == other.audio_muted && held_tg == other.held_tg
                    && enc_lockout_count == other.enc_lockout_count && tuner_controlled == other.tuner_controlled
                    && trunking_enabled == other.trunking_enabled && scanner_mode == other.scanner_mode
-                   && scanControlEquals(other) && scan_mode == other.scan_mode && decode_mode == other.decode_mode
-                   && decryptionEquals(other) && radioControlsEqual(other);
+                   && scanControlEquals(other) && scanTimingEquals(other) && scan_mode == other.scan_mode
+                   && decode_mode == other.decode_mode && decryptionEquals(other) && radioControlsEqual(other);
         }
     };
 
@@ -1100,6 +1209,8 @@ class MetricsModel : public QObject {
     void fillDecoderView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot, double now_m);
     /** @brief Scan hold and avoids (#380), read from whichever rotation is running. */
     static void fillScanControlView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot);
+    /** @brief Why the rotation is staying on this row and how long is left (#508). */
+    void fillScanTimingView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot, double now_m) const;
 
   public:
 #ifdef DSD_NEO_TEST_HOOKS

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -180,8 +180,7 @@ Item {
                 font.pixelSize: Theme.fontSize(11)
                 font.letterSpacing: 0.8
                 color: Theme.textSubdued
-                // A phone is 411 dp wide and the budgets cap at 600 s: the row has to
-                // give way rather than push the header controls off screen.
+                // On a narrow phone screen, elide long budgets to leave room for controls.
                 elide: Text.ElideRight
             }
 

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -142,6 +142,49 @@ Item {
                 elide: Text.ElideRight
             }
 
+            // Why the rotation is staying on the row above and how long is left
+            // (#508). The same grammar as the terminal's `| Scan Timing:` row --
+            // one space before the countdown, two between groups, seconds to one
+            // decimal place -- so a reader moving between the two surfaces reads
+            // the same line. Which budgets appear at all was decided in
+            // app-control; a zero here means "the view withheld it".
+            Text {
+                width: parent.width
+                objectName: "scanTimingRow"
+                visible: metrics.scanTimingVisible
+                text: {
+                    var out = metrics.scanStayPhrase;
+                    if (metrics.scanTimerLive) {
+                        out += " " + qsTr("%1s/%2s").arg((metrics.scanTimerRemainingDs / 10).toFixed(1)).arg((metrics.scanTimerSpanMs / 1000).toFixed(1));
+                    }
+                    if (metrics.scanDwellMs > 0) {
+                        out += "  " + qsTr("dwell %1s").arg((metrics.scanDwellMs / 1000).toFixed(1));
+                        // DSD_APP_SCAN_DWELL_SUSPENDED / _PAUSED: disarmed while
+                        // something else holds the row, versus stopped by the
+                        // operator. Neither is a dwell that expired.
+                        if (metrics.scanDwellState === 2) {
+                            out += " " + qsTr("(suspended)");
+                        } else if (metrics.scanDwellState === 3) {
+                            out += " " + qsTr("(paused)");
+                        }
+                    }
+                    if (metrics.scanHoldMs > 0) {
+                        out += "  " + qsTr("hold %1s").arg((metrics.scanHoldMs / 1000).toFixed(1));
+                    }
+                    if (metrics.scanHangMs > 0) {
+                        out += "  " + qsTr("hang %1s").arg((metrics.scanHangMs / 1000).toFixed(1));
+                    }
+                    return out;
+                }
+                font.family: Theme.mono
+                font.pixelSize: Theme.fontSize(11)
+                font.letterSpacing: 0.8
+                color: Theme.textSubdued
+                // A phone is 411 dp wide and the budgets cap at 600 s: the row has to
+                // give way rather than push the header controls off screen.
+                elide: Text.ElideRight
+            }
+
             TapHandler {
                 onLongPressed: screen.editSystem()
             }

--- a/src/ui/qt/ui_controller.cpp
+++ b/src/ui/qt/ui_controller.cpp
@@ -208,6 +208,11 @@ UiController::invalidateForTarget(const dsd_state* snapshot) {
     }
 }
 
+bool
+UiController::sessionIsLive() const {
+    return !m_host || m_session == DecoderHost::Running || m_session == DecoderHost::Stopping;
+}
+
 void
 UiController::tick() {
     pollTalkgroupExport();
@@ -226,7 +231,12 @@ UiController::tick() {
         pollDecryptionResult();
     }
 
-    if (dsd_app_frontend_redraw_consume() == 0) {
+    const bool redraw = dsd_app_frontend_redraw_consume() != 0;
+    const bool live = sessionIsLive();
+    // Once this session has supplied its first redraw, age its held deadlines on
+    // every UI tick. Input can stall without another redraw; scan countdowns and
+    // the short sync hold must still expire. Keep the startup admission gate.
+    if (!redraw && !(live && m_metrics && m_metrics->optionsKnown())) {
         return;
     }
 
@@ -237,13 +247,15 @@ UiController::tick() {
     const dsd_opts* opts_snapshot = dsd_app_get_latest_opts_snapshot();
     const dsd_state* snapshot = dsd_app_get_latest_snapshot();
 
-    const bool live = !m_host || m_session == DecoderHost::Running || m_session == DecoderHost::Stopping;
     invalidateForTarget(snapshot);
-    if (live && m_network != nullptr) {
-        m_network->refresh(snapshot);
-    }
     if (live && m_metrics != nullptr) {
         m_metrics->refresh(opts_snapshot, snapshot);
+    }
+    if (!redraw) {
+        return;
+    }
+    if (live && m_network != nullptr) {
+        m_network->refresh(snapshot);
     }
     /* The call history is persistent by design, so unlike the metrics it is never
      * cleared on session boundaries — only fed. */

--- a/src/ui/qt/ui_controller.h
+++ b/src/ui/qt/ui_controller.h
@@ -104,6 +104,7 @@ class UiController : public QObject {
     void decryptionResultChanged();
 
   private:
+    bool sessionIsLive() const;
     void tick();
     void pollTalkgroupExport();
     void pollDecryptionResult();

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -1098,7 +1098,7 @@ ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* stat
             printw(" Frequency: %.06lf MHz",
                    (double)*dsd_state_trunk_lcn_slot_const(state, state->lcn_freq_roll - 1) / 1000000);
         }
-        printw(" Speed: %.02lf sec",
+        printw(" Hangtime: %.02lf sec",
                opts->trunk_hangtime); // default aligned to OP25 (2.0s) unless overridden
         ui_render_scan_voice_gate(opts, state);
         // Why the scan stopped moving, ahead of the name so the fixed fields keep their columns.

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -21,6 +21,7 @@
 #include <curses.h>
 #include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/app_control/history.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/channel_label.h>
 #include <dsd-neo/core/dsd_time.h>
@@ -992,6 +993,96 @@ ui_render_trunk_scan_status(const dsd_opts* opts, const dsd_state* state) {
     printw("\n");
 }
 
+/* Declared here because the Scan Timing row has to truncate to the panel width, and the
+   width helper lives with the panel renderers much further down the file. */
+static int ui_get_panel_cols(void);
+
+static void ui_scan_timing_appendf(char* buf, size_t buf_sz, size_t* used, const char* fmt, ...)
+    DSD_ATTR_FORMAT(printf, 4, 5);
+
+/* Append one group of the Scan Timing row. Overflow is clamped rather than reported: the
+   row is a status line that a narrow terminal truncates anyway, and a caller that had to
+   check every group would be the thing most likely to get the grammar wrong. */
+static void
+ui_scan_timing_appendf(char* buf, size_t buf_sz, size_t* used, const char* fmt, ...) {
+    if (*used + 1U >= buf_sz) {
+        return;
+    }
+    va_list ap;
+    va_start(ap, fmt);
+    int wrote = DSD_VSNPRINTF(buf + *used, buf_sz - *used, fmt, ap);
+    va_end(ap);
+    if (wrote < 0) {
+        return;
+    }
+    *used += (size_t)wrote;
+    if (*used >= buf_sz) {
+        *used = buf_sz - 1U;
+    }
+}
+
+/* Why the idle dwell is not the thing counting down: suspended means something on the air
+   holds the row, paused means the operator does. */
+static const char*
+ui_scan_timing_dwell_suffix(uint8_t dwell_state) {
+    switch (dwell_state) {
+        case DSD_APP_SCAN_DWELL_SUSPENDED: return " (suspended)";
+        case DSD_APP_SCAN_DWELL_PAUSED: return " (paused)";
+        default: return "";
+    }
+}
+
+/* The Scan Timing row without its newline (issue #508): why the scanner is staying on the
+   row above and how long is left of it, from the shared app-control view so the terminal
+   and the Qt panel cannot drift on what "suspended" or "hold" means. Pure, and taking the
+   clock as an argument, so the goldens can pin the exact bytes. Returns the length
+   written, or 0 when there is no scan timing to show. */
+static int
+ui_format_scan_timing_row(const dsd_opts* opts, const dsd_state* state, double now_m, char* buf, size_t buf_sz) {
+    if (!buf || buf_sz == 0U) {
+        return 0;
+    }
+    buf[0] = '\0';
+    dsd_app_scan_timing view;
+    if (dsd_app_scan_timing_view(opts, state, now_m, &view) != 1) {
+        return 0;
+    }
+    size_t used = 0U;
+    ui_scan_timing_appendf(buf, buf_sz, &used, "| Scan Timing: %s", view.phrase);
+    if (view.timer_live) {
+        ui_scan_timing_appendf(buf, buf_sz, &used, " %.1fs/%.1fs", (double)view.remaining_ms / 1000.0,
+                               (double)view.span_ms / 1000.0);
+    }
+    if (view.show_dwell) {
+        ui_scan_timing_appendf(buf, buf_sz, &used, "  dwell %.1fs%s", (double)view.dwell_ms / 1000.0,
+                               ui_scan_timing_dwell_suffix(view.dwell_state));
+    }
+    if (view.show_hold) {
+        ui_scan_timing_appendf(buf, buf_sz, &used, "  hold %.1fs", (double)view.hold_ms / 1000.0);
+    }
+    if (view.show_hang) {
+        ui_scan_timing_appendf(buf, buf_sz, &used, "  hang %.1fs", (double)view.hang_ms / 1000.0);
+    }
+    return (int)used;
+}
+
+/* Cut to the panel width rather than wrapped: this row redraws several times a second as
+   the countdown moves, and a wrapped one would push every row below it down by one line
+   for as long as the phrase stayed long. */
+static void
+ui_render_scan_timing_row(const dsd_opts* opts, const dsd_state* state) {
+    char line[192];
+    int len = ui_format_scan_timing_row(opts, state, dsd_time_now_monotonic_s(), line, sizeof(line));
+    if (len <= 0) {
+        return;
+    }
+    int cols = ui_get_panel_cols();
+    if (len > cols) {
+        len = cols;
+    }
+    printw("%.*s\n", len, line);
+}
+
 static void
 ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* state) {
     if (opts->scanner_mode == 1) {
@@ -1033,9 +1124,18 @@ ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* stat
             printw(" Avoids: %u", (unsigned int)state->lcn_avoid_count);
         }
         printw(" \n");
+        // The timing row belongs directly under the scanner row that owns the stay. With
+        // --trunk-scan running that is the Trunk Scan row below, which publishes the target's
+        // own effective dwell and hold, so the -Y row only claims it when trunk scan is off.
+        if (opts->trunk_scan_enabled != 1) {
+            ui_render_scan_timing_row(opts, state);
+        }
     }
 
     ui_render_trunk_scan_status(opts, state);
+    if (opts->trunk_scan_enabled == 1) {
+        ui_render_scan_timing_row(opts, state);
+    }
 
     if (opts->reverse_mute == 1) {
         printw("| Reverse Mute - Muting Unencrypted Voice\n");

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -1050,7 +1050,8 @@ ui_format_scan_timing_row(const dsd_opts* opts, const dsd_state* state, double n
     size_t used = 0U;
     ui_scan_timing_appendf(buf, buf_sz, &used, "| Scan Timing: %s", view.phrase);
     if (view.timer_live) {
-        ui_scan_timing_appendf(buf, buf_sz, &used, " %.1fs/%.1fs", (double)view.remaining_ms / 1000.0,
+        const uint32_t remaining_ds = view.remaining_ms / 100U;
+        ui_scan_timing_appendf(buf, buf_sz, &used, " %.1fs/%.1fs", (double)remaining_ds / 10.0,
                                (double)view.span_ms / 1000.0);
     }
     if (view.show_dwell) {
@@ -1077,8 +1078,9 @@ ui_render_scan_timing_row(const dsd_opts* opts, const dsd_state* state) {
         return;
     }
     int cols = ui_get_panel_cols();
-    if (len > cols) {
-        len = cols;
+    if (len >= cols) {
+        /* Writing the final column wraps before the explicit newline. */
+        len = cols - 1;
     }
     printw("%.*s\n", len, line);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -600,6 +600,13 @@ dsd_neo_add_public_header_smoke_test(
   dsd-neo/app_control/call_view.h
   C
 )
+
+dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_app_control_scan_timing_view
+  HEADERS_PUBLIC_APP_CONTROL_SCAN_TIMING_VIEW
+  dsd-neo/app_control/scan_timing_view.h
+  C
+)
 dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_app_control_commands
   HEADERS_PUBLIC_APP_CONTROL_COMMANDS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -600,12 +600,25 @@ dsd_neo_add_public_header_smoke_test(
   dsd-neo/app_control/call_view.h
   C
 )
+# Keep the Qt-facing view headers usable in C++ even when Qt is disabled.
+dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_app_control_call_view_cxx
+  HEADERS_PUBLIC_APP_CONTROL_CALL_VIEW_CXX
+  dsd-neo/app_control/call_view.h
+  CXX
+)
 
 dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_app_control_scan_timing_view
   HEADERS_PUBLIC_APP_CONTROL_SCAN_TIMING_VIEW
   dsd-neo/app_control/scan_timing_view.h
   C
+)
+dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_app_control_scan_timing_view_cxx
+  HEADERS_PUBLIC_APP_CONTROL_SCAN_TIMING_VIEW_CXX
+  dsd-neo/app_control/scan_timing_view.h
+  CXX
 )
 dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_app_control_commands

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2003,6 +2003,24 @@ target_link_libraries(
 add_test(NAME APP_CONTROL_CALL_VIEW COMMAND dsd-neo_test_app_control_call_view)
 
 add_executable(
+    dsd-neo_test_app_control_scan_timing_view
+    ui/test_app_control_scan_timing_view.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/scan_timing_view.c
+)
+target_include_directories(
+    dsd-neo_test_app_control_scan_timing_view
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/app_control
+)
+target_link_libraries(
+    dsd-neo_test_app_control_scan_timing_view
+    PRIVATE dsd-neo_test_call_state_support
+)
+add_test(
+    NAME APP_CONTROL_SCAN_TIMING_VIEW
+    COMMAND dsd-neo_test_app_control_scan_timing_view
+)
+
+add_executable(
     dsd-neo_test_app_control_notification_status
     ui/test_app_control_notification_status.c
     ${PROJECT_SOURCE_DIR}/src/app_control/notification_status.c
@@ -2069,9 +2087,12 @@ if(DSD_ENABLE_TERMINAL_UI)
         COMMAND dsd-neo_test_ui_ncurses_p25_display_helpers
     )
 
+    # The shared scan-timing view comes in as a source rather than a stub: the Scan Timing
+    # goldens are only worth anything if they run through the real display table.
     add_executable(
         dsd-neo_test_ui_ncurses_printer_helpers
         ui/test_ui_ncurses_printer_helpers.c
+        ${PROJECT_SOURCE_DIR}/src/app_control/scan_timing_view.c
     )
     target_compile_definitions(
         dsd-neo_test_ui_ncurses_printer_helpers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4824,6 +4824,35 @@ if(NOT APPLE AND (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"))
         NAME ENGINE_SYNCED_TRUNK_SCAN_TICK
         COMMAND dsd-neo_test_engine_synced_trunk_scan_tick
     )
+    # The time() wrapper below requires a Unix time symbol.
+    if(NOT WIN32)
+        add_executable(
+            dsd-neo_test_engine_scan_timing
+            engine/test_engine_scan_timing.c
+            ${PROJECT_SOURCE_DIR}/src/app_control/scan_timing_view.c
+        )
+        target_include_directories(
+            dsd-neo_test_engine_scan_timing
+            PRIVATE ${PROJECT_SOURCE_DIR}/include
+        )
+        target_link_libraries(
+            dsd-neo_test_engine_scan_timing
+            PRIVATE
+                "-Wl,--wrap=getFrameSync"
+                "-Wl,--wrap=dsd_engine_scan_tune_to_freq"
+                "-Wl,--wrap=SetFreq"
+                "-Wl,--wrap=time"
+                "-Wl,--start-group"
+                dsd-neo_engine
+                "-Wl,--end-group"
+                ${LIBS}
+                dsd-neo_test_support
+        )
+        add_test(
+            NAME ENGINE_SCAN_TIMING
+            COMMAND dsd-neo_test_engine_scan_timing
+        )
+    endif()
 endif()
 
 add_executable(

--- a/tests/engine/test_engine_scan_timing.c
+++ b/tests/engine/test_engine_scan_timing.c
@@ -291,6 +291,20 @@ test_protocol_hangtime_publication(const char* protocol, float configured_hangti
         dsd_engine_trunk_scan_tick(opts, state);
         assert(state->scan_timing.hang_ms == 8500U);
     }
+    state->p25_p1_voice_err_hist_count = 0;
+    state->p25_p1_voice_err_hist_sum = 0;
+    const double large_hangtimes[] = {172800.0, 1.0e9};
+    for (size_t i = 0; i < sizeof(large_hangtimes) / sizeof(large_hangtimes[0]); ++i) {
+        if (strcmp(protocol, "p25-trunk") == 0) {
+            p25_sm_ctx_t* ctx = dsd_engine_trunk_scan_active_p25_ctx();
+            ctx->config.hangtime_s = large_hangtimes[i];
+        } else {
+            dmr_sm_ctx_t* ctx = dsd_engine_trunk_scan_active_dmr_ctx();
+            ctx->hangtime_s = large_hangtimes[i];
+        }
+        dsd_engine_trunk_scan_tick(opts, state);
+        assert(state->scan_timing.hang_ms == (i == 0 ? 172800000U : UINT32_MAX));
+    }
     dsd_engine_trunk_scan_shutdown(opts, state);
     assert(state->scan_timing.hang_ms == 0U);
     freeState(state);

--- a/tests/engine/test_engine_scan_timing.c
+++ b/tests/engine/test_engine_scan_timing.c
@@ -297,9 +297,11 @@ test_protocol_hangtime_publication(const char* protocol, float configured_hangti
     for (size_t i = 0; i < sizeof(large_hangtimes) / sizeof(large_hangtimes[0]); ++i) {
         if (strcmp(protocol, "p25-trunk") == 0) {
             p25_sm_ctx_t* ctx = dsd_engine_trunk_scan_active_p25_ctx();
+            assert(ctx);
             ctx->config.hangtime_s = large_hangtimes[i];
         } else {
             dmr_sm_ctx_t* ctx = dsd_engine_trunk_scan_active_dmr_ctx();
+            assert(ctx);
             ctx->hangtime_s = large_hangtimes[i];
         }
         dsd_engine_trunk_scan_tick(opts, state);

--- a/tests/engine/test_engine_scan_timing.c
+++ b/tests/engine/test_engine_scan_timing.c
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/* Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com> */
+
+#include <assert.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
+#include <dsd-neo/core/channel_mode.h>
+#include <dsd-neo/core/dsd_time.h>
+#include <dsd-neo/core/init.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <dsd-neo/core/synctype_ids.h>
+#include <dsd-neo/engine/channel_scan.h>
+#include <dsd-neo/engine/engine.h>
+#include <dsd-neo/engine/frame_processing.h>
+#include <dsd-neo/engine/scan_voice_gate.h>
+#include <dsd-neo/engine/trunk_scan.h>
+#include <dsd-neo/platform/sockets.h>
+#include <dsd-neo/protocol/dmr/dmr_trunk_sm.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
+#include <dsd-neo/runtime/config.h>
+#include <dsd-neo/runtime/control_pump.h>
+#include <dsd-neo/runtime/exitflag.h>
+#include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/trunk_tuning_hooks.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "test_support.h"
+
+static int g_typed;
+static int g_pending;
+static int g_stage_before_loop;
+static int g_sync_calls;
+static int g_tune_calls;
+static uint64_t g_tune_request;
+static int g_wait_polls;
+static int g_pending_seen;
+static time_t g_test_wall;
+
+// NOLINTBEGIN(misc-use-internal-linkage)
+void printFrameInfo(dsd_opts* opts, dsd_state* state);
+void LFSRN(const char* input, char* output, dsd_state* state);
+
+void
+printFrameInfo(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+}
+
+void
+LFSRN(const char* input, char* output, dsd_state* state) {
+    (void)input;
+    (void)output;
+    (void)state;
+}
+
+void
+processFrame(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    (void)state;
+    assert(0 && "the timing regression never supplies a synced frame");
+}
+
+// NOLINTEND(misc-use-internal-linkage)
+
+// NOLINTBEGIN(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+dsd_trunk_tune_result __wrap_dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long freq, int sps,
+                                                          uint64_t* request);
+int __wrap_getFrameSync(dsd_opts* opts, dsd_state* state);
+bool __wrap_SetFreq(dsd_socket_t sockfd, long freq);
+time_t __real_time(time_t* result);
+time_t __wrap_time(time_t* result);
+
+time_t
+__wrap_time(time_t* result) {
+    if (!g_test_wall) {
+        return __real_time(result);
+    }
+    if (result) {
+        *result = g_test_wall;
+    }
+    return g_test_wall;
+}
+
+bool
+__wrap_SetFreq(dsd_socket_t sockfd, long freq) {
+    (void)sockfd;
+    assert(freq > 0);
+    return true;
+}
+
+dsd_trunk_tune_result
+__wrap_dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long freq, int sps, uint64_t* request) {
+    (void)opts;
+    (void)state;
+    (void)sps;
+    assert(freq > 0);
+    ++g_tune_calls;
+    *request = dsd_trunk_tuning_request_begin();
+    g_tune_request = *request;
+    if (g_pending) {
+        dsd_trunk_tuning_request_mark_ready(*request);
+    } else {
+        dsd_trunk_tuning_request_complete(*request, DSD_TRUNK_TUNE_RESULT_OK);
+    }
+    return g_pending ? DSD_TRUNK_TUNE_RESULT_PENDING : DSD_TRUNK_TUNE_RESULT_OK;
+}
+
+int
+__wrap_getFrameSync(dsd_opts* opts, dsd_state* state) {
+    ++g_sync_calls;
+    assert(state->lcn_freq_roll == 1);
+    assert(state->last_cc_sync_time >= time(NULL) - 1);
+    assert(state->scan_timing.reason == DSD_SCAN_STAY_HANGTIME);
+    assert(state->scan_timing.span_ms == 3000U);
+    /* The outgoing anchor was a minute old. The first snapshot on this frequency
+     * must already contain the new visit's positive countdown. */
+    assert(state->scan_timing.deadline_m > dsd_time_now_monotonic_s());
+    assert(fabs(state->scan_timing.started_m - state->last_cc_sync_time_m) < 1.1);
+    if (g_typed) {
+        assert(opts->frame_dmr == 1);
+        assert(!dsd_engine_channel_scan_waiting(state));
+        assert(g_tune_calls == 1);
+    }
+    dsd_exitflag_store(1);
+    return DSD_SYNC_NONE;
+}
+
+// NOLINTEND(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
+
+static void
+complete_pending_tune(dsd_opts* opts, dsd_state* state) {
+    (void)opts;
+    if (!g_pending || !g_tune_request
+        || dsd_trunk_tuning_request_status(g_tune_request, NULL) != DSD_TRUNK_TUNE_RESULT_PENDING) {
+        return;
+    }
+    /* Wait until the pending phase was published. Bound the wait so a missing
+     * publication fails instead of hanging the test. */
+    ++g_wait_polls;
+    assert(g_wait_polls < 10);
+    if (state->scan_timing.reason == DSD_SCAN_STAY_RETUNE_PENDING) {
+        assert(state->scan_timing.deadline_m < 0.0);
+        g_pending_seen = 1;
+        dsd_trunk_tuning_request_complete(g_tune_request, DSD_TRUNK_TUNE_RESULT_OK);
+    }
+}
+
+static int
+start_scan(dsd_opts* opts, dsd_state* state, void* context) {
+    (void)context;
+    opts->scanner_mode = 1;
+    opts->use_rigctl = 1;
+    opts->setmod_bw = 0;
+    opts->trunk_hangtime = 2.0f;
+    state->last_cc_sync_time = time(NULL) - 60;
+    state->last_cc_sync_time_m = dsd_time_now_monotonic_s() - 60.0;
+    state->lcn_freq_count = 2;
+    state->lcn_freq_roll = 0;
+    *dsd_state_trunk_lcn_slot(state, 0) = 150000000;
+    *dsd_state_trunk_lcn_slot(state, 1) = 151000000;
+    if (g_typed) {
+        assert(dsd_channel_mode_set(state, 0, DSD_SCAN_MODE_DMR) == 0);
+    }
+    if (g_stage_before_loop) {
+        assert(dsd_engine_channel_scan_step(opts, state) == 0);
+        assert(dsd_engine_channel_scan_waiting(state));
+    }
+    return 0;
+}
+
+static void
+test_scan_retune_publication(int typed, int pending, int staged) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts && state);
+    initOpts(opts);
+    initState(state);
+    DSD_SNPRINTF(opts->audio_in_dev, sizeof(opts->audio_in_dev), "%s", "m17udp");
+    DSD_SNPRINTF(opts->audio_out_dev, sizeof(opts->audio_out_dev), "%s", "null");
+    opts->audio_in_type = AUDIO_IN_NULL;
+    opts->audio_out_type = 9;
+    g_typed = typed;
+    g_pending = pending;
+    g_stage_before_loop = staged;
+    g_sync_calls = g_tune_calls = 0;
+    g_tune_request = 0U;
+    g_wait_polls = g_pending_seen = 0;
+    dsd_runtime_set_control_pump(complete_pending_tune);
+    const dsd_engine_lifecycle_hooks hooks = {.start = start_scan};
+    assert(dsd_engine_run_with_lifecycle(opts, state, &hooks) == 0);
+    assert(g_sync_calls == 1);
+    assert(g_pending_seen == pending);
+    dsd_runtime_set_control_pump(NULL);
+    freeState(state);
+    free(state);
+    free(opts);
+}
+
+static void
+test_legacy_deadline_matches_rotation(void) {
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts && state);
+    initOpts(opts);
+    initState(state);
+    opts->scanner_mode = 1;
+    state->lcn_freq_count = 2;
+    /* Zero-frequency rows advance the visit without needing a physical tuner. */
+    *dsd_state_trunk_lcn_slot(state, 0) = 0;
+    const float budgets[] = {0.0f, 0.25f, 2.0f, 2.5f};
+    for (size_t i = 0; i < sizeof(budgets) / sizeof(budgets[0]); ++i) {
+        opts->trunk_hangtime = budgets[i];
+        state->lcn_freq_roll = 0;
+        state->last_cc_sync_time = 100;
+        dsd_engine_scan_y_timing_tick(opts, state, 1000.0, 100.0);
+        const double deadline = state->scan_timing.deadline_m;
+        assert(deadline > 1000.0);
+        g_test_wall = 100 + (time_t)(deadline - 1000.0) - 1;
+        noCarrier(opts, state);
+        assert(state->lcn_freq_roll == 0);
+        ++g_test_wall;
+        noCarrier(opts, state);
+        assert(state->lcn_freq_roll == 1);
+    }
+    g_test_wall = 0;
+    freeState(state);
+    free(state);
+    free(opts);
+}
+
+static void
+test_protocol_hangtime_publication(const char* protocol, float configured_hangtime) {
+    char path[DSD_TEST_PATH_MAX];
+    int fd = dsd_test_mkstemp(path, sizeof(path), "scan-timing");
+    assert(fd >= 0);
+    FILE* file = fdopen(fd, "w");
+    assert(file);
+    DSD_FPRINTF(file,
+                "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes\n"
+                "test,%s,851000000,,3000,,\n",
+                protocol);
+    assert(fclose(file) == 0);
+    dsd_opts* opts = calloc(1, sizeof(*opts));
+    dsd_state* state = calloc(1, sizeof(*state));
+    assert(opts && state);
+    initOpts(opts);
+    initState(state);
+    opts->trunk_scan_enabled = 1;
+    opts->use_rigctl = 1;
+    opts->trunk_hangtime = configured_hangtime;
+    DSD_SNPRINTF(opts->trunk_scan_targets_csv, sizeof(opts->trunk_scan_targets_csv), "%s", path);
+    char err[256] = {0};
+    g_pending = 0;
+    assert(dsd_engine_trunk_scan_init(opts, state, err, sizeof(err)) == 0);
+    const double now = dsd_time_now_monotonic_s();
+    if (strcmp(protocol, "p25-trunk") == 0) {
+        p25_sm_ctx_t* ctx = dsd_engine_trunk_scan_active_p25_ctx();
+        assert(ctx && ctx->config.hangtime_s == 7.0);
+        ctx->state = P25_SM_TUNED;
+        ctx->cc_tune_pending = 0;
+        ctx->vc_freq_hz = 852000000;
+        ctx->t_tune_m = now;
+        ctx->config.grant_timeout_s = 30.0;
+    } else {
+        dmr_sm_ctx_t* ctx = dsd_engine_trunk_scan_active_dmr_ctx();
+        assert(ctx && ctx->hangtime_s == 7.0);
+        ctx->state = DMR_SM_TUNED;
+        ctx->cc_tune_request_id = 0U;
+        ctx->t_tune_m = now;
+        ctx->t_voice_m = now;
+    }
+    opts->trunk_is_tuned = 1;
+    dsd_engine_trunk_scan_tick(opts, state);
+    assert(state->scan_timing.reason == DSD_SCAN_STAY_CALL_FOLLOW);
+    assert(state->scan_timing.hang_ms == 7000U);
+    dsd_app_scan_timing view;
+    assert(dsd_app_scan_timing_view(opts, state, now, &view) == 1);
+    assert(view.show_hang && view.hang_ms == 7000U);
+    if (strcmp(protocol, "p25-trunk") == 0) {
+        /* The optional error hold extends the same protocol budget. */
+        state->p25_p1_voice_err_hist_count = 1;
+        state->p25_p1_voice_err_hist_sum = 20;
+        dsd_engine_trunk_scan_tick(opts, state);
+        assert(state->scan_timing.hang_ms == 8500U);
+    }
+    dsd_engine_trunk_scan_shutdown(opts, state);
+    assert(state->scan_timing.hang_ms == 0U);
+    freeState(state);
+    free(state);
+    free(opts);
+    assert(remove(path) == 0);
+}
+
+int
+main(void) {
+    test_legacy_deadline_matches_rotation();
+    test_scan_retune_publication(0, 0, 0);
+    test_scan_retune_publication(1, 0, 0);
+    test_scan_retune_publication(1, 1, 0);
+    test_scan_retune_publication(1, 1, 1);
+    assert(dsd_test_setenv("DSD_NEO_DMR_HANGTIME", "7", 1) == 0);
+    assert(dsd_test_setenv("DSD_NEO_P25_HANGTIME", "7", 1) == 0);
+    assert(dsd_test_setenv("DSD_NEO_P25P1_ERR_HOLD_PCT", "10", 1) == 0);
+    assert(dsd_test_setenv("DSD_NEO_P25P1_ERR_HOLD_S", "1.5", 1) == 0);
+    dsd_neo_config_init();
+    test_protocol_hangtime_publication("p25-trunk", 2.0f);
+    test_protocol_hangtime_publication("dmr-trunk", 2.0f);
+    test_protocol_hangtime_publication("p25-trunk", 0.0f);
+    test_protocol_hangtime_publication("dmr-trunk", 0.0f);
+    assert(dsd_test_unsetenv("DSD_NEO_DMR_HANGTIME") == 0);
+    assert(dsd_test_unsetenv("DSD_NEO_P25_HANGTIME") == 0);
+    assert(dsd_test_unsetenv("DSD_NEO_P25P1_ERR_HOLD_PCT") == 0);
+    assert(dsd_test_unsetenv("DSD_NEO_P25P1_ERR_HOLD_S") == 0);
+    dsd_neo_config_init();
+    return 0;
+}

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -11,7 +11,9 @@
  * holds through the tail from the last media time even when a terminator ends
  * the call before the first gate tick, 0.10 s span debounce, policy gating
  * (blocked encrypted, private evaluator, unknown identity), DATA ignored,
- * operator hold, and visit resets.
+ * operator hold, and visit resets. Also pins the scan timing publication the
+ * Scan Timing row renders (issue #508): reason, effective windows, and a deadline
+ * that agrees with dsd_scan_voice_gate_should_step() to the millisecond.
  */
 
 #include <dsd-neo/core/call_state.h>
@@ -541,6 +543,219 @@ test_tick_leaves_phase_alone_without_scanner_mode(void) {
     fixture_free(&fix);
 }
 
+/* ---- Scan timing publication for the -Y row (issue #508) ------------------- */
+
+static void
+check_timing_window(const char* started_tag, const char* deadline_tag, const char* span_tag,
+                    const dsd_scan_timing_publication* timing, double started_m, double deadline_m, uint32_t span_ms) {
+    CHECK(started_tag, fabs(timing->started_m - started_m) < 1e-6);
+    CHECK(deadline_tag, fabs(timing->deadline_m - deadline_m) < 1e-6);
+    CHECK(span_tag, timing->span_ms == span_ms);
+}
+
+/* Anti-drift: the published deadline is only useful if it is the instant
+ * dsd_scan_voice_gate_should_step() first says yes. A countdown that reaches 0.0 a
+ * frame before or after the hop is a bug report waiting to happen. */
+static void
+check_deadline_matches_should_step(const gate_fixture* fix, const char* early_tag, const char* late_tag) {
+    const double deadline_m = fix->state->scan_timing.deadline_m;
+    CHECK(early_tag, dsd_scan_voice_gate_should_step(fix->opts, fix->state, deadline_m - 1e-3) == 0);
+    CHECK(late_tag, dsd_scan_voice_gate_should_step(fix->opts, fix->state, deadline_m + 1e-3) == 1);
+}
+
+static void
+test_y_timing_silent_under_trunk_scan(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    /* Under --trunk-scan the coordinator owns the publication for its parked target,
+     * exactly as it owns scan_voice_gate_phase. */
+    fix.opts->trunk_scan_enabled = 1;
+    dsd_scan_timing_clear(fix.state);
+    fix.state->scan_timing.reason = (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW;
+    fix.state->scan_timing.deadline_m = 142.0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("trunk scan keeps reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW);
+    CHECK("trunk scan keeps deadline", fabs(fix.state->scan_timing.deadline_m - 142.0) < 1e-6);
+    /* No scanner running at all publishes nothing either. */
+    fix.opts->trunk_scan_enabled = 0;
+    fix.opts->scanner_mode = 0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("no scanner keeps reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW);
+    CHECK("no scanner keeps deadline", fabs(fix.state->scan_timing.deadline_m - 142.0) < 1e-6);
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_legacy_hangtime_window(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_voice_only = 0;
+    fix.opts->trunk_hangtime = 2.0f;
+    fix.state->last_cc_sync_time_m = 100.0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("hangtime reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    CHECK("hangtime is conventional", fix.state->scan_timing.conventional == 1U);
+    check_timing_window("hangtime start", "hangtime deadline", "hangtime span", &fix.state->scan_timing, 100.0, 102.0,
+                        2000U);
+    CHECK("hangtime has no dwell", fix.state->scan_timing.dwell_ms == 0U);
+    CHECK("hangtime has no hold", fix.state->scan_timing.hold_ms == 0U);
+    /* A gate that is enabled but has never synced this visit abstains, so the legacy
+     * rule still owns the step -- and it has neither window to report. */
+    fix.opts->scan_voice_only = 1;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 0, 100.5);
+    CHECK("unsynced gate abstains", dsd_scan_voice_gate_owns_step(fix.opts, fix.state) == 0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("unsynced gate reports hangtime", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    CHECK("unsynced gate hides dwell", fix.state->scan_timing.dwell_ms == 0U);
+    CHECK("unsynced gate hides hold", fix.state->scan_timing.hold_ms == 0U);
+    /* -t takes any non-negative double, so the millisecond span saturates instead of
+     * wrapping into the publication's uint32_t. */
+    fix.opts->scan_voice_only = 0;
+    fix.opts->trunk_hangtime = 1.0e9f;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("absurd hangtime saturates the span", fix.state->scan_timing.span_ms == UINT32_MAX);
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_hangtime_without_anchor(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_voice_only = 0;
+    fix.opts->trunk_hangtime = 2.0f;
+    fix.state->last_cc_sync_time_m = 0.0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("unanchored reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    CHECK("unanchored has no start", fix.state->scan_timing.started_m < 0.0);
+    CHECK("unanchored has no deadline", fix.state->scan_timing.deadline_m < 0.0);
+    CHECK("unanchored has no span", fix.state->scan_timing.span_ms == 0U);
+    /* -t 0 has an anchor but no window to count down. */
+    fix.state->last_cc_sync_time_m = 100.0;
+    fix.opts->trunk_hangtime = 0.0f;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("zero hangtime reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    CHECK("zero hangtime has no deadline", fix.state->scan_timing.deadline_m < 0.0);
+    CHECK("zero hangtime has no span", fix.state->scan_timing.span_ms == 0U);
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_manual_hold_pauses_the_timer(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    fix.state->lcn_scan_hold = 1;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("manual hold reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_MANUAL_HOLD);
+    CHECK("manual hold has no start", fix.state->scan_timing.started_m < 0.0);
+    CHECK("manual hold has no deadline", fix.state->scan_timing.deadline_m < 0.0);
+    CHECK("manual hold has no span", fix.state->scan_timing.span_ms == 0U);
+    /* The row's effective windows stay visible: they are paused, not gone. */
+    CHECK("manual hold keeps dwell", fix.state->scan_timing.dwell_ms == 1000U);
+    CHECK("manual hold keeps hold", fix.state->scan_timing.hold_ms == 2000U);
+    CHECK("manual hold never steps", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 400.0) == 0);
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_qualify_window(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_voice_qualify_ms = 3000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("qualify reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
+    CHECK("qualify is conventional", fix.state->scan_timing.conventional == 1U);
+    CHECK("qualify publishes the effective dwell", fix.state->scan_timing.dwell_ms == 3000U);
+    CHECK("qualify publishes the effective hold", fix.state->scan_timing.hold_ms == 2000U);
+    check_timing_window("qualify start", "qualify deadline", "qualify span", &fix.state->scan_timing, 100.0, 103.0,
+                        3000U);
+    check_deadline_matches_should_step(&fix, "qualify holds before the deadline", "qualify steps after the deadline");
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_voice_and_tail_share_the_hold_window(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    open_voice_epoch(&fix, 100.2, 0.15, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.4);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("voice reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_VOICE);
+    check_timing_window("voice start", "voice deadline", "voice span", &fix.state->scan_timing, 100.35, 102.35, 2000U);
+    check_deadline_matches_should_step(&fix, "voice holds before the deadline", "voice steps after the deadline");
+    /* The tail is the same window from the same last-media anchor; only the reason moves. */
+    (void)dsd_call_state_end_ex(fix.state, 0, 100.5, DSD_CALL_END_SYNC_LOSS);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 0, 100.6);
+    CHECK("tail phase", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_TAIL);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("tail reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_ACTIVITY_HOLD);
+    check_timing_window("tail start", "tail deadline", "tail span", &fix.state->scan_timing, 100.35, 102.35, 2000U);
+    check_deadline_matches_should_step(&fix, "tail holds before the deadline", "tail steps after the deadline");
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_hop_restarts_the_window(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->trunk_hangtime = 2.0f;
+    fix.state->last_cc_sync_time_m = 100.0;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    check_timing_window("first visit start", "first visit deadline", "first visit span", &fix.state->scan_timing, 100.0,
+                        101.0, 1000U);
+    /* A hop stamps a fresh legacy anchor and re-opens the gate's visit, so the
+     * countdown restarts on the new row instead of carrying the old one over. */
+    fix.state->last_cc_sync_time_m = 200.0;
+    dsd_scan_voice_gate_note_retune(fix.state, 200.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("hop falls back to hangtime", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    check_timing_window("hop start", "hop deadline", "hop span", &fix.state->scan_timing, 200.0, 202.0, 2000U);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 200.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("new visit qualifies", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
+    check_timing_window("new visit start", "new visit deadline", "new visit span", &fix.state->scan_timing, 200.0,
+                        201.0, 1000U);
+    check_deadline_matches_should_step(&fix, "new visit holds", "new visit steps");
+    fixture_free(&fix);
+}
+
 int
 main(void) {
     test_tick_leaves_phase_alone_without_scanner_mode();
@@ -557,6 +772,13 @@ main(void) {
     test_operator_hold_and_visit_reset();
     test_stale_epoch_cannot_rearm();
     test_zero_ms_falls_back_to_defaults();
+    test_y_timing_silent_under_trunk_scan();
+    test_y_timing_legacy_hangtime_window();
+    test_y_timing_hangtime_without_anchor();
+    test_y_timing_manual_hold_pauses_the_timer();
+    test_y_timing_qualify_window();
+    test_y_timing_voice_and_tail_share_the_hold_window();
+    test_y_timing_hop_restarts_the_window();
     if (g_failures != 0) {
         DSD_FPRINTF(stderr, "%d voice-gate check(s) failed\n", g_failures);
         return 1;

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -21,6 +21,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
 
 #include <math.h>
@@ -33,6 +34,12 @@
 #include "dsd-neo/core/state_fwd.h"
 
 static int g_failures = 0;
+
+int
+dsd_engine_channel_scan_waiting(const dsd_state* state) {
+    (void)state;
+    return 0;
+}
 
 #define CHECK(tag, cond)                                                                                               \
     do {                                                                                                               \
@@ -609,21 +616,21 @@ test_y_timing_legacy_hangtime_window(void) {
     dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.25, 1000.25);
     CHECK("hangtime reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     CHECK("hangtime is conventional", fix.state->scan_timing.conventional == 1U);
-    check_timing_window("hangtime start", "hangtime deadline", "hangtime span", &fix.state->scan_timing, 100.0, 102.0,
-                        2000U);
+    check_timing_window("hangtime start", "hangtime deadline", "hangtime span", &fix.state->scan_timing, 100.0, 103.0,
+                        3000U);
     CHECK("hangtime has no dwell", fix.state->scan_timing.dwell_ms == 0U);
     CHECK("hangtime has no hold", fix.state->scan_timing.hold_ms == 0U);
     /* A later tick re-expresses the same wall anchor and lands on the same deadline. */
     dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 101.5, 1001.5);
     check_timing_window("hangtime start again", "hangtime deadline again", "hangtime span again",
-                        &fix.state->scan_timing, 100.0, 102.0, 2000U);
+                        &fix.state->scan_timing, 100.0, 103.0, 3000U);
     /* NXDN stamps the wall anchor two seconds ahead after a confirmed frame (and leaves
      * the monotonic twin alone), so the window starts in the future and the countdown
      * begins above -t rather than reaching zero two seconds before the hop. */
     fix.state->last_cc_sync_time = (time_t)1002;
     dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.25, 1000.25);
     check_timing_window("nxdn future start", "nxdn future deadline", "nxdn future span", &fix.state->scan_timing, 102.0,
-                        104.0, 2000U);
+                        105.0, 3000U);
     fix.state->last_cc_sync_time = (time_t)1000;
     /* A gate that is enabled but has never synced this visit abstains, so the legacy
      * rule still owns the step -- and it has neither window to report. */
@@ -661,13 +668,13 @@ test_y_timing_hangtime_without_anchor(void) {
     CHECK("unanchored has no start", fix.state->scan_timing.started_m < 0.0);
     CHECK("unanchored has no deadline", fix.state->scan_timing.deadline_m < 0.0);
     CHECK("unanchored has no span", fix.state->scan_timing.span_ms == 0U);
-    /* -t 0 has an anchor but no window to count down. */
+    /* Strict whole-second > still waits for the next wall tick with -t 0. */
     fix.state->last_cc_sync_time = (time_t)100;
     fix.opts->trunk_hangtime = 0.0f;
     dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("zero hangtime reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
-    CHECK("zero hangtime has no deadline", fix.state->scan_timing.deadline_m < 0.0);
-    CHECK("zero hangtime has no span", fix.state->scan_timing.span_ms == 0U);
+    CHECK("zero hangtime waits for the next second", fix.state->scan_timing.deadline_m == 101.0);
+    CHECK("zero hangtime span", fix.state->scan_timing.span_ms == 1000U);
     fixture_free(&fix);
 }
 
@@ -763,7 +770,7 @@ test_y_timing_hop_restarts_the_window(void) {
     dsd_scan_voice_gate_note_retune(fix.state, 200.0);
     dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 200.0, 200.0);
     CHECK("hop falls back to hangtime", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
-    check_timing_window("hop start", "hop deadline", "hop span", &fix.state->scan_timing, 200.0, 202.0, 2000U);
+    check_timing_window("hop start", "hop deadline", "hop span", &fix.state->scan_timing, 200.0, 203.0, 3000U);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 200.0);
     dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 200.0, 200.0);
     CHECK("new visit qualifies", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -26,6 +26,7 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <time.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -579,13 +580,13 @@ test_y_timing_silent_under_trunk_scan(void) {
     dsd_scan_timing_clear(fix.state);
     fix.state->scan_timing.reason = (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW;
     fix.state->scan_timing.deadline_m = 142.0;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("trunk scan keeps reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW);
     CHECK("trunk scan keeps deadline", fabs(fix.state->scan_timing.deadline_m - 142.0) < 1e-6);
     /* No scanner running at all publishes nothing either. */
     fix.opts->trunk_scan_enabled = 0;
     fix.opts->scanner_mode = 0;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("no scanner keeps reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW);
     CHECK("no scanner keeps deadline", fabs(fix.state->scan_timing.deadline_m - 142.0) < 1e-6);
     fixture_free(&fix);
@@ -601,21 +602,36 @@ test_y_timing_legacy_hangtime_window(void) {
     }
     fix.opts->scan_voice_only = 0;
     fix.opts->trunk_hangtime = 2.0f;
-    fix.state->last_cc_sync_time_m = 100.0;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    /* The step rule compares the wall-clock anchor, so that is what the countdown is
+     * built from: wall 1000 with the clocks read at wall 1000.25 / monotonic 100.25. */
+    fix.state->last_cc_sync_time = (time_t)1000;
+    fix.state->last_cc_sync_time_m = 0.0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.25, 1000.25);
     CHECK("hangtime reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     CHECK("hangtime is conventional", fix.state->scan_timing.conventional == 1U);
     check_timing_window("hangtime start", "hangtime deadline", "hangtime span", &fix.state->scan_timing, 100.0, 102.0,
                         2000U);
     CHECK("hangtime has no dwell", fix.state->scan_timing.dwell_ms == 0U);
     CHECK("hangtime has no hold", fix.state->scan_timing.hold_ms == 0U);
+    /* A later tick re-expresses the same wall anchor and lands on the same deadline. */
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 101.5, 1001.5);
+    check_timing_window("hangtime start again", "hangtime deadline again", "hangtime span again",
+                        &fix.state->scan_timing, 100.0, 102.0, 2000U);
+    /* NXDN stamps the wall anchor two seconds ahead after a confirmed frame (and leaves
+     * the monotonic twin alone), so the window starts in the future and the countdown
+     * begins above -t rather than reaching zero two seconds before the hop. */
+    fix.state->last_cc_sync_time = (time_t)1002;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.25, 1000.25);
+    check_timing_window("nxdn future start", "nxdn future deadline", "nxdn future span", &fix.state->scan_timing, 102.0,
+                        104.0, 2000U);
+    fix.state->last_cc_sync_time = (time_t)1000;
     /* A gate that is enabled but has never synced this visit abstains, so the legacy
      * rule still owns the step -- and it has neither window to report. */
     fix.opts->scan_voice_only = 1;
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 0, 100.5);
     CHECK("unsynced gate abstains", dsd_scan_voice_gate_owns_step(fix.opts, fix.state) == 0);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("unsynced gate reports hangtime", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     CHECK("unsynced gate hides dwell", fix.state->scan_timing.dwell_ms == 0U);
     CHECK("unsynced gate hides hold", fix.state->scan_timing.hold_ms == 0U);
@@ -623,7 +639,7 @@ test_y_timing_legacy_hangtime_window(void) {
      * wrapping into the publication's uint32_t. */
     fix.opts->scan_voice_only = 0;
     fix.opts->trunk_hangtime = 1.0e9f;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("absurd hangtime saturates the span", fix.state->scan_timing.span_ms == UINT32_MAX);
     fixture_free(&fix);
 }
@@ -638,16 +654,17 @@ test_y_timing_hangtime_without_anchor(void) {
     }
     fix.opts->scan_voice_only = 0;
     fix.opts->trunk_hangtime = 2.0f;
-    fix.state->last_cc_sync_time_m = 0.0;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    fix.state->last_cc_sync_time = (time_t)0;
+    fix.state->last_cc_sync_time_m = 100.0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("unanchored reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     CHECK("unanchored has no start", fix.state->scan_timing.started_m < 0.0);
     CHECK("unanchored has no deadline", fix.state->scan_timing.deadline_m < 0.0);
     CHECK("unanchored has no span", fix.state->scan_timing.span_ms == 0U);
     /* -t 0 has an anchor but no window to count down. */
-    fix.state->last_cc_sync_time_m = 100.0;
+    fix.state->last_cc_sync_time = (time_t)100;
     fix.opts->trunk_hangtime = 0.0f;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("zero hangtime reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     CHECK("zero hangtime has no deadline", fix.state->scan_timing.deadline_m < 0.0);
     CHECK("zero hangtime has no span", fix.state->scan_timing.span_ms == 0U);
@@ -665,7 +682,7 @@ test_y_timing_manual_hold_pauses_the_timer(void) {
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
     fix.state->lcn_scan_hold = 1;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("manual hold reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_MANUAL_HOLD);
     CHECK("manual hold has no start", fix.state->scan_timing.started_m < 0.0);
     CHECK("manual hold has no deadline", fix.state->scan_timing.deadline_m < 0.0);
@@ -688,7 +705,7 @@ test_y_timing_qualify_window(void) {
     fix.opts->scan_voice_qualify_ms = 3000;
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("qualify reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
     CHECK("qualify is conventional", fix.state->scan_timing.conventional == 1U);
     CHECK("qualify publishes the effective dwell", fix.state->scan_timing.dwell_ms == 3000U);
@@ -710,7 +727,7 @@ test_y_timing_voice_and_tail_share_the_hold_window(void) {
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     open_voice_epoch(&fix, 100.2, 0.15, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.4);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("voice reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_VOICE);
     check_timing_window("voice start", "voice deadline", "voice span", &fix.state->scan_timing, 100.35, 102.35, 2000U);
     check_deadline_matches_should_step(&fix, "voice holds before the deadline", "voice steps after the deadline");
@@ -718,7 +735,7 @@ test_y_timing_voice_and_tail_share_the_hold_window(void) {
     (void)dsd_call_state_end_ex(fix.state, 0, 100.5, DSD_CALL_END_SYNC_LOSS);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 0, 100.6);
     CHECK("tail phase", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_TAIL);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("tail reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_ACTIVITY_HOLD);
     check_timing_window("tail start", "tail deadline", "tail span", &fix.state->scan_timing, 100.35, 102.35, 2000U);
     check_deadline_matches_should_step(&fix, "tail holds before the deadline", "tail steps after the deadline");
@@ -734,21 +751,21 @@ test_y_timing_hop_restarts_the_window(void) {
         return;
     }
     fix.opts->trunk_hangtime = 2.0f;
-    fix.state->last_cc_sync_time_m = 100.0;
+    fix.state->last_cc_sync_time = (time_t)100;
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     check_timing_window("first visit start", "first visit deadline", "first visit span", &fix.state->scan_timing, 100.0,
                         101.0, 1000U);
     /* A hop stamps a fresh legacy anchor and re-opens the gate's visit, so the
      * countdown restarts on the new row instead of carrying the old one over. */
-    fix.state->last_cc_sync_time_m = 200.0;
+    fix.state->last_cc_sync_time = (time_t)200;
     dsd_scan_voice_gate_note_retune(fix.state, 200.0);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 200.0, 200.0);
     CHECK("hop falls back to hangtime", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     check_timing_window("hop start", "hop deadline", "hop span", &fix.state->scan_timing, 200.0, 202.0, 2000U);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 200.0);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 200.0, 200.0);
     CHECK("new visit qualifies", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
     check_timing_window("new visit start", "new visit deadline", "new visit span", &fix.state->scan_timing, 200.0,
                         201.0, 1000U);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -8009,6 +8009,7 @@ test_scan_timing_manual_hold_pauses_and_release_rearms(void) {
     test_rc |= expect_control_rc("hold on",
                                  dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 1);
 
+    test_rc |= expect_scan_timing(&state, "hold command before tick", DSD_SCAN_STAY_MANUAL_HOLD, -1.0, 250U, 0U);
     trunk_scan_test_set_now(0.26);
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "manual hold", 0U);
@@ -8024,6 +8025,21 @@ test_scan_timing_manual_hold_pauses_and_release_rearms(void) {
     test_rc |= expect_active_target(&state, "hold release", 0U);
     test_rc |= expect_scan_timing(&state, "hold release", DSD_SCAN_STAY_IDLE_DWELL, 3.35, 250U, 0U);
     test_rc |= expect_scan_timing_window(&state, "hold release", 3.10, 250U);
+
+    // Controls may both be drained before another coordinator tick, for example
+    // while input is stalled. Release still owes this target a fresh dwell.
+    trunk_scan_test_set_now(3.20);
+    test_rc |= expect_control_rc("hold between ticks",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 1);
+    trunk_scan_test_set_now(4.0);
+    test_rc |= expect_control_rc("release between ticks",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 0);
+    test_rc |= expect_scan_timing(&state, "release command before tick", DSD_SCAN_STAY_IDLE_DWELL, -1.0, 250U, 0U);
+    trunk_scan_test_set_now(4.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "release between ticks", 0U);
+    test_rc |=
+        expect_scan_timing(&state, "fresh dwell after batched controls", DSD_SCAN_STAY_IDLE_DWELL, 4.35, 250U, 0U);
 
     dsd_engine_trunk_scan_shutdown(&opts, &state);
     trunk_scan_test_clear_now();
@@ -8056,6 +8072,18 @@ test_scan_timing_rotation_publishes_incoming_row(void) {
     test_rc |= expect_scan_timing(&state, "rotation", DSD_SCAN_STAY_IDLE_DWELL, 0.66, 400U, 600U);
     test_rc |= expect_scan_timing_window(&state, "rotation", 0.26, 400U);
     test_rc |= expect_scan_timing_conventional(&state, "rotation", 1U);
+
+    // Manual advances and avoids publish before the command queue snapshots the
+    // new target, without waiting for more samples to drive the next tick.
+    trunk_scan_test_set_now(0.30);
+    test_rc |= expect_control_rc("manual advance",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_ADVANCE), 0);
+    test_rc |= expect_active_target(&state, "manual advance", 0U);
+    test_rc |= expect_scan_timing(&state, "manual advance before tick", DSD_SCAN_STAY_IDLE_DWELL, 0.55, 250U, 250U);
+    test_rc |= expect_control_rc("manual avoid",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_AVOID_ACTIVE), 0);
+    test_rc |= expect_active_target(&state, "manual avoid", 1U);
+    test_rc |= expect_scan_timing(&state, "manual avoid before tick", DSD_SCAN_STAY_IDLE_DWELL, 0.70, 400U, 600U);
 
     dsd_engine_trunk_scan_shutdown(&opts, &state);
     trunk_scan_test_clear_now();

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -81,6 +81,12 @@ test_tg_policy_tune_allowed(const dsd_opts* opts, int call_type_enabled, int enc
     return 1;
 }
 
+double
+p25_sm_effective_hangtime(const dsd_state* state, double hangtime) {
+    (void)state;
+    return hangtime;
+}
+
 void
 p25_sm_init_ctx(p25_sm_ctx_t* ctx, const dsd_opts* opts, dsd_state* state) {
     if (!ctx) {

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -7827,6 +7827,419 @@ test_parser_optional_headers_are_case_insensitive(void) {
     return test_rc;
 }
 
+/*
+ * Scan timing publication (#508). The coordinator owns every deadline, so these read the
+ * absolute monotonic anchors straight out of dsd_state; nothing here asks for a remaining
+ * time, which is the renderer's job. Doubles are compared with a tolerance.
+ */
+static int
+expect_scan_timing(const dsd_state* state, const char* stage, unsigned reason, double deadline_m, unsigned dwell_ms,
+                   unsigned hold_ms) {
+    const dsd_scan_timing_publication* timing = &state->scan_timing;
+    int rc = 0;
+    if ((unsigned)timing->reason != reason || (unsigned)timing->dwell_ms != dwell_ms
+        || (unsigned)timing->hold_ms != hold_ms) {
+        DSD_FPRINTF(stderr, "scan timing after %s: reason=%u dwell=%u hold=%u, want %u/%u/%u\n", stage,
+                    (unsigned)timing->reason, (unsigned)timing->dwell_ms, (unsigned)timing->hold_ms, reason, dwell_ms,
+                    hold_ms);
+        rc = 1;
+    }
+    if (deadline_m < 0.0) {
+        if (timing->deadline_m >= 0.0) {
+            DSD_FPRINTF(stderr, "scan timing after %s: deadline %.6f, want no live timer\n", stage, timing->deadline_m);
+            rc = 1;
+        }
+        return rc;
+    }
+    if (timing->deadline_m < 0.0 || fabs(timing->deadline_m - deadline_m) > 1e-6) {
+        DSD_FPRINTF(stderr, "scan timing after %s: deadline %.6f, want %.6f\n", stage, timing->deadline_m, deadline_m);
+        rc = 1;
+    }
+    return rc;
+}
+
+static int
+expect_scan_timing_window(const dsd_state* state, const char* stage, double started_m, unsigned span_ms) {
+    const dsd_scan_timing_publication* timing = &state->scan_timing;
+    if (fabs(timing->started_m - started_m) > 1e-6 || (unsigned)timing->span_ms != span_ms) {
+        DSD_FPRINTF(stderr, "scan timing window after %s: started=%.6f span=%u, want %.6f/%u\n", stage,
+                    timing->started_m, (unsigned)timing->span_ms, started_m, span_ms);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_scan_timing_conventional(const dsd_state* state, const char* stage, unsigned conventional) {
+    if ((unsigned)state->scan_timing.conventional != conventional) {
+        DSD_FPRINTF(stderr, "scan timing conventional flag after %s: %u, want %u\n", stage,
+                    (unsigned)state->scan_timing.conventional, conventional);
+        return 1;
+    }
+    return 0;
+}
+
+/*
+ * A trunked row walks acquisition -> call following -> idle dwell. Neither trunking reason
+ * carries a coordinator-owned deadline (the protocol SM owns those), and a trunked row never
+ * publishes an activity hold. Shutdown takes the publication down with the label.
+ */
+static int
+test_scan_timing_trunked_acquire_follow_and_dwell(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_control_init("a,p25-trunk,851000000,,250,,\n"
+                          "b,p25-trunk,852000000,,250,,\n",
+                          &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    p25_sm_ctx_t* ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
+    if (!ctx) {
+        DSD_FPRINTF(stderr, "scan timing: no active P25 context\n");
+        dsd_engine_trunk_scan_shutdown(&opts, &state);
+        trunk_scan_test_clear_now();
+        cleanup_paths(dir, target_path, NULL);
+        return 1;
+    }
+
+    ctx->cc_tune_pending = 1;
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "cc acquisition", 0U);
+    test_rc |= expect_scan_timing(&state, "cc acquisition", DSD_SCAN_STAY_CC_ACQUIRE, -1.0, 250U, 0U);
+    test_rc |= expect_scan_timing_conventional(&state, "cc acquisition", 0U);
+
+    ctx->cc_tune_pending = 0;
+    opts.trunk_is_tuned = 1;
+    trunk_scan_test_set_now(0.50);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "call follow", 0U);
+    test_rc |= expect_scan_timing(&state, "call follow", DSD_SCAN_STAY_CALL_FOLLOW, -1.0, 250U, 0U);
+
+    /* The release re-arms the dwell on this very tick, so the deadline is a full dwell out. */
+    opts.trunk_is_tuned = 0;
+    trunk_scan_test_set_now(0.60);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "idle dwell", 0U);
+    test_rc |= expect_scan_timing(&state, "idle dwell", DSD_SCAN_STAY_IDLE_DWELL, 0.85, 250U, 0U);
+    test_rc |= expect_scan_timing_window(&state, "idle dwell", 0.60, 250U);
+    test_rc |= expect_scan_timing_conventional(&state, "idle dwell", 0U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "shutdown", DSD_SCAN_STAY_NONE, -1.0, 0U, 0U);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * A conventional row's activity hold is the one window the coordinator owns outright: later
+ * activity pushes the same deadline out rather than opening a second one, and the expiry tick
+ * re-arms the idle dwell.
+ */
+static int
+test_scan_timing_conventional_activity_hold_restarts(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_control_init("a,dmr-conventional,461000000,,250,250,\n"
+                          "b,dmr-conventional,462000000,,250,250,\n",
+                          &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_dmr_conventional_activity(&opts, &state, 1001, 2002, 0, 0, 0);
+    trunk_scan_test_set_now(0.20);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "activity hold", 0U);
+    test_rc |= expect_scan_timing(&state, "activity hold", DSD_SCAN_STAY_ACTIVITY_HOLD, 0.35, 250U, 250U);
+    test_rc |= expect_scan_timing_window(&state, "activity hold", 0.10, 250U);
+    test_rc |= expect_scan_timing_conventional(&state, "activity hold", 1U);
+
+    trunk_scan_test_set_now(0.30);
+    dsd_engine_trunk_scan_dmr_conventional_activity(&opts, &state, 1001, 2002, 0, 0, 0);
+    trunk_scan_test_set_now(0.31);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "refreshed hold", 0U);
+    test_rc |= expect_scan_timing(&state, "refreshed hold", DSD_SCAN_STAY_ACTIVITY_HOLD, 0.55, 250U, 250U);
+    test_rc |= expect_scan_timing_window(&state, "refreshed hold", 0.30, 250U);
+
+    /* The hold lapses at 0.55; the first tick past it re-arms the dwell in place. */
+    trunk_scan_test_set_now(0.56);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "hold expiry", 0U);
+    test_rc |= expect_scan_timing(&state, "hold expiry", DSD_SCAN_STAY_IDLE_DWELL, 0.81, 250U, 250U);
+    test_rc |= expect_scan_timing_conventional(&state, "hold expiry", 1U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "conventional shutdown", DSD_SCAN_STAY_NONE, -1.0, 0U, 0U);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* An operator hold pauses the dwell: no deadline at all, and the release re-arms a full one. */
+static int
+test_scan_timing_manual_hold_pauses_and_release_rearms(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_control_init("a,p25-trunk,851000000,,250,,\n"
+                          "b,p25-trunk,852000000,,250,,\n",
+                          &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    test_rc |= expect_control_rc("hold on",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 1);
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "manual hold", 0U);
+    test_rc |= expect_scan_timing(&state, "manual hold", DSD_SCAN_STAY_MANUAL_HOLD, -1.0, 250U, 0U);
+    trunk_scan_test_set_now(3.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "manual hold past the dwell", DSD_SCAN_STAY_MANUAL_HOLD, -1.0, 250U, 0U);
+
+    test_rc |= expect_control_rc("hold off",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 0);
+    trunk_scan_test_set_now(3.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "hold release", 0U);
+    test_rc |= expect_scan_timing(&state, "hold release", DSD_SCAN_STAY_IDLE_DWELL, 3.35, 250U, 0U);
+    test_rc |= expect_scan_timing_window(&state, "hold release", 3.10, 250U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* The publication follows the receiver: an advancing tick publishes the incoming row's own
+ * effective dwell and hold, not the outgoing row's. */
+static int
+test_scan_timing_rotation_publishes_incoming_row(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_control_init("a,dmr-conventional,461000000,,250,250,\n"
+                          "b,dmr-conventional,462000000,,400,600,\n",
+                          &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "row a dwell", DSD_SCAN_STAY_IDLE_DWELL, 0.25, 250U, 250U);
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "rotation", 1U);
+    test_rc |= expect_scan_timing(&state, "rotation", DSD_SCAN_STAY_IDLE_DWELL, 0.66, 400U, 600U);
+    test_rc |= expect_scan_timing_window(&state, "rotation", 0.26, 400U);
+    test_rc |= expect_scan_timing_conventional(&state, "rotation", 1U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* When every alternate retune fails the advance falls back on the original row: the tick still
+ * publishes exactly once, for the row the receiver never left, and says it is cooling down. */
+static int
+test_scan_timing_fallback_to_original_publishes_retry(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_control_init("a,p25-trunk,851000000,,250,,\n"
+                          "b,p25-trunk,852000000,,250,,\n",
+                          &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    g_counting_tune_to_cc_failures_remaining = 2;
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    g_counting_tune_to_cc_failures_remaining = 0;
+    test_rc |= expect_active_target(&state, "failed alternates", 0U);
+    test_rc |= expect_published_target(&state, "failed alternates", "a", 1U, 2U);
+    test_rc |= expect_scan_timing(&state, "failed alternates", DSD_SCAN_STAY_RETUNE_RETRY, 2.26, 250U, 0U);
+    test_rc |= expect_scan_timing_window(&state, "failed alternates", 0.26, 2000U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* The voice gate decides which conventional phrase the row publishes: VOICE while media is
+ * live, the tail as an activity hold on the same window, and the qualify window as the dwell. */
+static int
+test_scan_timing_voice_gate_phases(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,dmr-conventional,461000000,,250,250,\n"
+                             "b,dmr-conventional,462000000,,250,250,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.scan_voice_only = 1;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "scan timing voice-gate init failed: %s\n", err);
+        test_rc = 1;
+    }
+    if (seed_voice_gate_media_epoch(&state, 0.10, 0.25, DSD_CALL_CRYPTO_CLEAR) != 0) {
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.30);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "voice", DSD_SCAN_STAY_VOICE, 0.50, 250U, 250U);
+    test_rc |= expect_scan_timing_window(&state, "voice", 0.25, 250U);
+
+    if (dsd_call_state_update_media(&state, 0U, 1, 0.49) != 1) {
+        DSD_FPRINTF(stderr, "scan timing voice-gate media refresh failed\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.49);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_call_state_end_ex(&state, 0U, 0.50, DSD_CALL_END_SYNC_LOSS) != 1) {
+        DSD_FPRINTF(stderr, "scan timing voice-gate epoch end failed\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.70);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "voice tail", DSD_SCAN_STAY_ACTIVITY_HOLD, 0.74, 250U, 250U);
+    test_rc |= expect_scan_timing_window(&state, "voice tail", 0.49, 250U);
+
+    trunk_scan_test_set_now(0.75);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "qualify", 0U);
+    test_rc |= expect_scan_timing(&state, "qualify", DSD_SCAN_STAY_IDLE_DWELL, 1.00, 250U, 250U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_state_ext_free_all(&state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* A row's own --scan-voice-qualify-ms/--scan-voice-hold-ms replace the CSV columns while the
+ * gate is on, so the published dwell and hold have to be the effective ones. */
+static int
+test_scan_timing_row_voice_options_override_effective_values(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,options\n";
+    static const char body[] =
+        "a,dmr-conventional,461000000,,250,250,,--scan-voice-qualify-ms 1000 --scan-voice-hold-ms 900\n"
+        "b,dmr-conventional,462000000,,250,250,,\n";
+    if (write_targets_file_with_header(dir, header, body, target_path, sizeof target_path) != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.scan_voice_only = 1;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "scan timing row-options init failed: %s\n", err);
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "row voice options", 0U);
+    test_rc |= expect_scan_timing(&state, "row voice options", DSD_SCAN_STAY_IDLE_DWELL, 1.00, 1000U, 900U);
+    test_rc |= expect_scan_timing_window(&state, "row voice options", 0.0, 1000U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_state_ext_free_all(&state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* An unresolved backend retune has no deadline the coordinator can name; the failure that
+ * follows starts the retry cooldown, and that one it does own. */
+static int
+test_scan_timing_pending_retune_then_retry_cooldown(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,nxdn-trunk,461000000,,250,,\n", target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(1.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "scan timing pending-retune init failed: %s\n", err);
+        test_rc = 1;
+    }
+    const uint64_t request_id = dsd_trunk_tuning_pending_request();
+    if (request_id == 0U) {
+        DSD_FPRINTF(stderr, "scan timing pending-retune left no request\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(2.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "pending retune", DSD_SCAN_STAY_RETUNE_PENDING, -1.0, 250U, 0U);
+
+    dsd_trunk_tuning_request_publish(request_id, DSD_TRUNK_TUNE_RESULT_FAILED);
+    trunk_scan_test_set_now(3.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "retry cooldown", 0U);
+    test_rc |= expect_scan_timing(&state, "retry cooldown", DSD_SCAN_STAY_RETUNE_RETRY, 5.0, 250U, 0U);
+    test_rc |= expect_scan_timing_window(&state, "retry cooldown", 3.0, 2000U);
+
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "pending shutdown", DSD_SCAN_STAY_NONE, -1.0, 0U, 0U);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -7937,6 +8350,14 @@ main(void) {
     rc |= run_with_default_tune_hook(test_trunk_scan_rejects_global_p25_bandplan);
     rc |= run_with_default_tune_hook(test_target_p25_bandplan_loads_and_survives_rotation);
     rc |= run_with_default_tune_hook(test_p25_bandplan_export_collects_every_target);
+    rc |= run_with_default_tune_hook(test_scan_timing_trunked_acquire_follow_and_dwell);
+    rc |= run_with_default_tune_hook(test_scan_timing_conventional_activity_hold_restarts);
+    rc |= run_with_default_tune_hook(test_scan_timing_manual_hold_pauses_and_release_rearms);
+    rc |= run_with_default_tune_hook(test_scan_timing_rotation_publishes_incoming_row);
+    rc |= run_with_default_tune_hook(test_scan_timing_fallback_to_original_publishes_retry);
+    rc |= run_with_default_tune_hook(test_scan_timing_voice_gate_phases);
+    rc |= run_with_default_tune_hook(test_scan_timing_row_voice_options_override_effective_values);
+    rc |= run_with_default_tune_hook(test_scan_timing_pending_retune_then_retry_cooldown);
     return rc;
 }
 

--- a/tests/ui/qml/tst_monitor_scan_target.qml
+++ b/tests/ui/qml/tst_monitor_scan_target.qml
@@ -64,6 +64,9 @@ Item {
             testContext.setMetric("scanTimingVisible", true);
             tryCompare(row, "visible", true);
             tryCompare(row, "text", "Idle dwell 1.8s/3.0s  hold 2.0s");
+            // Large accepted -t values retain the publisher's unsigned total.
+            testContext.setMetric("scanTimerSpanMs", 4294967295);
+            tryCompare(row, "text", "Idle dwell 1.8s/4294967.3s  hold 2.0s");
             // A followed call: no countdown, the dwell disarmed under it, and the -t
             // hangtime. A trunked row never carries a conventional hold.
             testContext.setMetric("scanStayPhrase", "Following call");

--- a/tests/ui/qml/tst_monitor_scan_target.qml
+++ b/tests/ui/qml/tst_monitor_scan_target.qml
@@ -25,6 +25,16 @@ Item {
             testContext.setMetric("scanTargetOrdinal", 0);
             testContext.setMetric("scanTargetCount", 0);
             testContext.setMetric("scanHold", false);
+            testContext.setMetric("scanTimingVisible", false);
+            testContext.setMetric("scanStayReason", 0);
+            testContext.setMetric("scanStayPhrase", "");
+            testContext.setMetric("scanTimerLive", false);
+            testContext.setMetric("scanTimerRemainingDs", 0);
+            testContext.setMetric("scanTimerSpanMs", 0);
+            testContext.setMetric("scanDwellMs", 0);
+            testContext.setMetric("scanDwellState", 0);
+            testContext.setMetric("scanHoldMs", 0);
+            testContext.setMetric("scanHangMs", 0);
         }
 
         function test_target_rotation_and_hold() {
@@ -40,6 +50,40 @@ Item {
             tryCompare(header, "text", "");
         }
 
+        // Mirrors the terminal's Scan Timing grammar (issue #508): one space before
+        // the countdown, two between groups, seconds to one decimal place.
+        function test_scan_timing_row() {
+            var row = findChild(screen, "scanTimingRow");
+            verify(row !== null, "the monitor carries a scan timing row");
+            verify(!row.visible, "nothing published: the row stays down");
+            testContext.setMetric("scanStayPhrase", "Idle dwell");
+            testContext.setMetric("scanTimerLive", true);
+            testContext.setMetric("scanTimerRemainingDs", 18);
+            testContext.setMetric("scanTimerSpanMs", 3000);
+            testContext.setMetric("scanHoldMs", 2000);
+            testContext.setMetric("scanTimingVisible", true);
+            tryCompare(row, "visible", true);
+            tryCompare(row, "text", "Idle dwell 1.8s/3.0s  hold 2.0s");
+            // A followed call: no countdown, the dwell disarmed under it, and the -t
+            // hangtime. A trunked row never carries a conventional hold.
+            testContext.setMetric("scanStayPhrase", "Following call");
+            testContext.setMetric("scanTimerLive", false);
+            testContext.setMetric("scanTimerRemainingDs", 0);
+            testContext.setMetric("scanTimerSpanMs", 0);
+            testContext.setMetric("scanHoldMs", 0);
+            testContext.setMetric("scanDwellMs", 3000);
+            testContext.setMetric("scanDwellState", 2);
+            testContext.setMetric("scanHangMs", 2000);
+            tryCompare(row, "text", "Following call  dwell 3.0s (suspended)  hang 2.0s");
+            // The operator hold pauses the dwell rather than expiring it.
+            testContext.setMetric("scanStayPhrase", "Manual hold");
+            testContext.setMetric("scanDwellState", 3);
+            testContext.setMetric("scanHangMs", 0);
+            tryCompare(row, "text", "Manual hold  dwell 3.0s (paused)");
+            cleanup();
+            tryCompare(row, "visible", false);
+        }
+
         function test_header_controls_do_not_overlap_data() {
             return [{tag: "phone", w: 411, h: 900, scale: 1},
                     {tag: "large text", w: 411, h: 900, scale: 1.6},
@@ -50,8 +94,19 @@ Item {
             Ui.Theme.fontScale = data.scale;
             screen.sitesAvailable = true;
             testContext.setMetric("radioInput", true);
+            // The widest thing the timing row can say, shown: a row that only fits
+            // because it is hidden is not a layout that works.
+            testContext.setMetric("scanStayPhrase", "Acquiring control");
+            testContext.setMetric("scanTimerLive", true);
+            testContext.setMetric("scanTimerRemainingDs", 5999);
+            testContext.setMetric("scanTimerSpanMs", 600000);
+            testContext.setMetric("scanDwellMs", 600000);
+            testContext.setMetric("scanDwellState", 2);
+            testContext.setMetric("scanHoldMs", 600000);
+            testContext.setMetric("scanHangMs", 600000);
+            testContext.setMetric("scanTimingVisible", true);
             waitForRendering(screen);
-            var names = ["runningSiteChooserButton", "openSpectrumButton", "monitorLiveStatus", "monitorHeaderTitle"];
+            var names = ["runningSiteChooserButton", "openSpectrumButton", "monitorLiveStatus", "monitorHeaderTitle", "scanTimingRow"];
             for (var i = 0; i < names.length; ++i) {
                 var a = findChild(screen, names[i]);
                 var ap = a.mapToItem(screen, 0, 0);

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -1719,6 +1719,18 @@ class Setup : public QObject {
         metrics[QStringLiteral("scanTargetCount")] = 0;
         metrics[QStringLiteral("scanAvoidCount")] = 0;
         metrics[QStringLiteral("scanTargetAvoided")] = false;
+        // Why the rotation is staying and how long is left (#508). Nothing is
+        // published at rest, so the row is down and every budget reads 0.
+        metrics[QStringLiteral("scanTimingVisible")] = false;
+        metrics[QStringLiteral("scanStayReason")] = 0;
+        metrics[QStringLiteral("scanStayPhrase")] = QString();
+        metrics[QStringLiteral("scanTimerLive")] = false;
+        metrics[QStringLiteral("scanTimerRemainingDs")] = 0;
+        metrics[QStringLiteral("scanTimerSpanMs")] = 0;
+        metrics[QStringLiteral("scanDwellMs")] = 0;
+        metrics[QStringLiteral("scanDwellState")] = 0;
+        metrics[QStringLiteral("scanHoldMs")] = 0;
+        metrics[QStringLiteral("scanHangMs")] = 0;
         // Whether an automatic controller owns the tuner, which one, and where it
         // points. The two named owners word a message; tunerControlled is the gate.
         metrics[QStringLiteral("tunerControlled")] = false;

--- a/tests/ui/test_app_control_frontend_public_boundary.c
+++ b/tests/ui/test_app_control_frontend_public_boundary.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/app_control/history.h>
 #include <dsd-neo/app_control/p25_metrics.h>
 #include <dsd-neo/app_control/p25_network.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/app_control/trunk_scan_validate.h>
 #include <dsd-neo/core/frontend_types.h>

--- a/tests/ui/test_app_control_frontend_public_boundary.c
+++ b/tests/ui/test_app_control_frontend_public_boundary.c
@@ -60,5 +60,6 @@ main(void) {
     (void)&dsd_app_get_latest_opts_snapshot;
     (void)&dsd_app_frontend_get_metrics_for_snapshot;
     (void)&dsd_app_trunk_scan_validate_targets_csv;
+    (void)&dsd_app_scan_timing_view;
     return 0;
 }

--- a/tests/ui/test_app_control_scan_timing_view.c
+++ b/tests/ui/test_app_control_scan_timing_view.c
@@ -10,9 +10,10 @@
 #include <assert.h>
 #include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
-#include <stddef.h>
+#include <dsd-neo/core/state_fwd.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -59,7 +60,7 @@ assert_phrase(const dsd_app_scan_timing* view, const char* phrase) {
    disarmed until it does, and a conventional row still states its activity hold. */
 static void
 test_retune_pending_row(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -86,7 +87,7 @@ test_retune_pending_row(void) {
 /* A failed retune cooling down in place: the cooldown is the live window. */
 static void
 test_retune_retry_row(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -108,7 +109,7 @@ test_retune_retry_row(void) {
    no deadline to count down and no conventional hold to state. */
 static void
 test_cc_acquire_row(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -129,7 +130,7 @@ test_cc_acquire_row(void) {
    naming beside the suspended dwell. */
 static void
 test_call_follow_row_shows_hangtime(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -167,7 +168,7 @@ test_hangtime_is_only_shown_while_following_a_call(void) {
         DSD_SCAN_STAY_RETUNE_PENDING, DSD_SCAN_STAY_RETUNE_RETRY, DSD_SCAN_STAY_CC_ACQUIRE, DSD_SCAN_STAY_VOICE,
         DSD_SCAN_STAY_ACTIVITY_HOLD,  DSD_SCAN_STAY_MANUAL_HOLD,  DSD_SCAN_STAY_IDLE_DWELL, DSD_SCAN_STAY_HANGTIME,
     };
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -187,7 +188,7 @@ test_hangtime_is_only_shown_while_following_a_call(void) {
    budget would print the same number twice. */
 static void
 test_voice_row(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -211,7 +212,7 @@ test_voice_row(void) {
    voice frame has already gone by. */
 static void
 test_activity_hold_row_names_the_tail(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -241,7 +242,7 @@ test_activity_hold_row_names_the_tail(void) {
    air is holding the row and nothing will release it but the operator. */
 static void
 test_manual_hold_row_pauses_the_dwell(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -262,7 +263,7 @@ test_manual_hold_row_pauses_the_dwell(void) {
    as a budget; the -Y qualify window is the same window under another name. */
 static void
 test_idle_dwell_row_and_qualify_variant(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -295,7 +296,7 @@ test_idle_dwell_row_and_qualify_variant(void) {
    or hold to state beside it. */
 static void
 test_hangtime_row(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -326,7 +327,7 @@ test_hangtime_row(void) {
    the decoder decides when to move, and the UI must not imply it already has not. */
 static void
 test_remaining_clamps_at_zero(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -350,7 +351,7 @@ test_remaining_clamps_at_zero(void) {
    publishes none; neither half of that rule may be the only one holding the line. */
 static void
 test_hold_is_conventional_only(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -370,7 +371,7 @@ test_hold_is_conventional_only(void) {
 /* A dwell nobody configured is not a budget worth a column. */
 static void
 test_dwell_needs_a_value(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -387,7 +388,7 @@ test_dwell_needs_a_value(void) {
 /* Every reason answers with a phrase; a row with none would render a bare label. */
 static void
 test_every_reason_has_a_phrase(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -412,7 +413,7 @@ test_every_reason_has_a_phrase(void) {
    session must not put a countdown on a receiver that is not scanning. */
 static void
 test_inactive_without_a_scanner(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -439,7 +440,7 @@ test_inactive_without_a_scanner(void) {
    rather than a phrase for reason zero. */
 static void
 test_inactive_when_reason_is_none(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -454,7 +455,7 @@ test_inactive_when_reason_is_none(void) {
 
 static void
 test_null_arguments_are_safe(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 

--- a/tests/ui/test_app_control_scan_timing_view.c
+++ b/tests/ui/test_app_control_scan_timing_view.c
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Shared scan-timing display decision, independent of any frontend (issue #508).
+ */
+
+#include <assert.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* dsd_state is far too large for the stack; the view only reads scan_timing and the
+   voice-gate phase, both of which a zeroed block already answers for. */
+static dsd_state*
+make_state(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    assert(state != NULL);
+    return state;
+}
+
+/* A scanner is running and a target is on air: the precondition every row shares. */
+static void
+make_opts(dsd_opts* opts) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    opts->trunk_scan_enabled = 1;
+}
+
+/* One published stay, stamped the way the decoder stamps it: an absolute deadline, or
+   a negative one when nothing is counting down. */
+static void
+publish(dsd_state* state, uint8_t reason, uint8_t conventional, double deadline_m, uint32_t span_ms, uint32_t dwell_ms,
+        uint32_t hold_ms) {
+    DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
+    state->scan_timing.reason = reason;
+    state->scan_timing.conventional = conventional;
+    state->scan_timing.started_m = (deadline_m >= 0.0) ? deadline_m - ((double)span_ms / 1000.0) : -1.0;
+    state->scan_timing.deadline_m = deadline_m;
+    state->scan_timing.span_ms = span_ms;
+    state->scan_timing.dwell_ms = dwell_ms;
+    state->scan_timing.hold_ms = hold_ms;
+}
+
+static void
+assert_phrase(const dsd_app_scan_timing* view, const char* phrase) {
+    assert(view->phrase != NULL);
+    assert(strcmp(view->phrase, phrase) == 0);
+}
+
+/* A backend retune that has not resolved: nothing counts down, the idle dwell is
+   disarmed until it does, and a conventional row still states its activity hold. */
+static void
+test_retune_pending_row(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_RETUNE_PENDING, 1U, -1.0, 0U, 3000U, 1200U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.active == 1U);
+    assert(view.reason == (uint8_t)DSD_SCAN_STAY_RETUNE_PENDING);
+    assert_phrase(&view, "Retune pending");
+    assert(view.timer_live == 0U);
+    assert(view.remaining_ms == 0U);
+    assert(view.span_ms == 0U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_ms == 3000U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 1U);
+    assert(view.hold_ms == 1200U);
+    assert(view.show_hang == 0U);
+    assert(view.hang_ms == 0U);
+
+    free(state);
+}
+
+/* A failed retune cooling down in place: the cooldown is the live window. */
+static void
+test_retune_retry_row(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_RETUNE_RETRY, 0U, 102.0, 2000U, 3000U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Retune retry");
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 2000U);
+    assert(view.span_ms == 2000U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 0U);
+
+    free(state);
+}
+
+/* Hunting a control channel: the trunking state machine owns the clock, so there is
+   no deadline to count down and no conventional hold to state. */
+static void
+test_cc_acquire_row(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_CC_ACQUIRE, 0U, -1.0, 0U, 3000U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Acquiring control");
+    assert(view.timer_live == 0U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 0U);
+    assert(view.show_hang == 0U);
+
+    free(state);
+}
+
+/* Following a trunked call: -t is what ends the stay, so it is the one budget worth
+   naming beside the suspended dwell. */
+static void
+test_call_follow_row_shows_hangtime(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    opts.trunk_hangtime = 2.0f;
+    publish(state, DSD_SCAN_STAY_CALL_FOLLOW, 0U, -1.0, 0U, 3000U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Following call");
+    assert(view.timer_live == 0U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 0U);
+    assert(view.show_hang == 1U);
+    assert(view.hang_ms == 2000U);
+
+    /* A fractional -t rounds to the nearest millisecond rather than truncating. */
+    opts.trunk_hangtime = 1.25f;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.hang_ms == 1250U);
+
+    /* -t 0 leaves nothing to state. */
+    opts.trunk_hangtime = 0.0f;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_hang == 0U);
+    assert(view.hang_ms == 0U);
+
+    free(state);
+}
+
+/* Hangtime belongs to a followed trunked call and to nothing else: no other row may
+   claim -t, whatever it is set to. */
+static void
+test_hangtime_is_only_shown_while_following_a_call(void) {
+    static const uint8_t others[] = {
+        DSD_SCAN_STAY_RETUNE_PENDING, DSD_SCAN_STAY_RETUNE_RETRY, DSD_SCAN_STAY_CC_ACQUIRE, DSD_SCAN_STAY_VOICE,
+        DSD_SCAN_STAY_ACTIVITY_HOLD,  DSD_SCAN_STAY_MANUAL_HOLD,  DSD_SCAN_STAY_IDLE_DWELL, DSD_SCAN_STAY_HANGTIME,
+    };
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    opts.trunk_hangtime = 2.0f;
+    for (size_t i = 0; i < sizeof(others) / sizeof(others[0]); i++) {
+        publish(state, others[i], 1U, -1.0, 0U, 3000U, 1200U);
+        assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+        assert(view.show_hang == 0U);
+        assert(view.hang_ms == 0U);
+    }
+
+    free(state);
+}
+
+/* Conventional voice on air: the hold window is the live timer, so restating it as a
+   budget would print the same number twice. */
+static void
+test_voice_row(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_VOICE, 1U, 101.2, 2000U, 3000U, 2000U);
+    state->scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_VOICE;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Voice");
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 1200U);
+    assert(view.span_ms == 2000U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 0U);
+    assert(view.hold_ms == 2000U);
+
+    free(state);
+}
+
+/* The activity hold reads as a voice tail only while the voice gate says the last
+   voice frame has already gone by. */
+static void
+test_activity_hold_row_names_the_tail(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_ACTIVITY_HOLD, 1U, 100.8, 2000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Activity hold");
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 800U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 0U);
+
+    state->scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_TAIL;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Voice tail");
+
+    /* QUALIFY and VOICE are not a tail: only TAIL renames this row. */
+    state->scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_QUALIFY;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Activity hold");
+
+    free(state);
+}
+
+/* An operator hold: the dwell is paused rather than suspended, because nothing on the
+   air is holding the row and nothing will release it but the operator. */
+static void
+test_manual_hold_row_pauses_the_dwell(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_MANUAL_HOLD, 1U, -1.0, 0U, 3000U, 1200U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Manual hold");
+    assert(view.timer_live == 0U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_PAUSED);
+    assert(view.show_hold == 1U);
+    assert(view.hold_ms == 1200U);
+
+    free(state);
+}
+
+/* The idle dwell is the live window, so the row shows it as a countdown and not also
+   as a budget; the -Y qualify window is the same window under another name. */
+static void
+test_idle_dwell_row_and_qualify_variant(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Idle dwell");
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 1800U);
+    assert(view.span_ms == 3000U);
+    assert(view.show_dwell == 0U);
+    assert(view.dwell_ms == 3000U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_NONE);
+    assert(view.show_hold == 1U);
+    assert(view.hold_ms == 2000U);
+
+    state->scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_QUALIFY;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Qualify");
+
+    /* Any other phase is the plain idle dwell again. */
+    state->scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_TAIL;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Idle dwell");
+
+    free(state);
+}
+
+/* The -Y legacy rule: the whole stay is -t since the last sync, so there is no dwell
+   or hold to state beside it. */
+static void
+test_hangtime_row(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.scanner_mode = 1;
+    opts.trunk_hangtime = 2.0f;
+    publish(state, DSD_SCAN_STAY_HANGTIME, 1U, 101.4, 2000U, 0U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Hangtime");
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 1400U);
+    assert(view.span_ms == 2000U);
+    assert(view.show_dwell == 0U);
+    assert(view.show_hold == 0U);
+    assert(view.show_hang == 0U);
+
+    /* No anchor yet (never synced): the reason still holds, the countdown does not. */
+    publish(state, DSD_SCAN_STAY_HANGTIME, 1U, -1.0, 0U, 0U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.timer_live == 0U);
+    assert(view.remaining_ms == 0U);
+    assert(view.span_ms == 0U);
+
+    free(state);
+}
+
+/* A deadline the poll arrived after reads as zero, never as a wrapped unsigned age:
+   the decoder decides when to move, and the UI must not imply it already has not. */
+static void
+test_remaining_clamps_at_zero(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 97.5, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 0U);
+    assert(view.span_ms == 3000U);
+
+    /* Exactly on the deadline is zero too, not a rounded-up millisecond. */
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 100.0, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 0U);
+
+    free(state);
+}
+
+/* A trunked row has no conventional activity hold to state, and the coordinator
+   publishes none; neither half of that rule may be the only one holding the line. */
+static void
+test_hold_is_conventional_only(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 0U, 101.8, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_hold == 0U);
+
+    /* Conventional with nothing configured stays quiet as well. */
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_hold == 0U);
+
+    free(state);
+}
+
+/* A dwell nobody configured is not a budget worth a column. */
+static void
+test_dwell_needs_a_value(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_MANUAL_HOLD, 1U, -1.0, 0U, 0U, 1200U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_dwell == 0U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_NONE);
+    assert(view.show_hold == 1U);
+
+    free(state);
+}
+
+/* Every reason answers with a phrase; a row with none would render a bare label. */
+static void
+test_every_reason_has_a_phrase(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    for (uint8_t reason = (uint8_t)DSD_SCAN_STAY_RETUNE_PENDING; reason <= (uint8_t)DSD_SCAN_STAY_HANGTIME; reason++) {
+        publish(state, reason, 1U, -1.0, 0U, 3000U, 1200U);
+        assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+        assert(view.reason == reason);
+        assert(view.phrase != NULL);
+        assert(view.phrase[0] != '\0');
+    }
+
+    /* A reason from a newer decoder than this build knows is not rendered at all. */
+    publish(state, (uint8_t)(DSD_SCAN_STAY_HANGTIME + 1), 1U, -1.0, 0U, 3000U, 1200U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 0);
+    assert(view.active == 0U);
+
+    free(state);
+}
+
+/* No scanner is running: a publication left over from an earlier -Y or --trunk-scan
+   session must not put a countdown on a receiver that is not scanning. */
+static void
+test_inactive_without_a_scanner(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 0);
+    assert(view.active == 0U);
+    assert(view.phrase == NULL);
+    assert(view.remaining_ms == 0U);
+    assert(view.show_dwell == 0U);
+    assert(view.show_hold == 0U);
+
+    /* Either scanner is enough. */
+    opts.scanner_mode = 1;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    opts.scanner_mode = 0;
+    opts.trunk_scan_enabled = 1;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+
+    free(state);
+}
+
+/* Nothing holds the row and nothing is published: the surface renders no row at all
+   rather than a phrase for reason zero. */
+static void
+test_inactive_when_reason_is_none(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_NONE, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 0);
+    assert(view.active == 0U);
+    assert(view.phrase == NULL);
+
+    free(state);
+}
+
+static void
+test_null_arguments_are_safe(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+
+    /* A rejected call still leaves the caller's view zeroed, so a frontend that
+       ignores the status cannot render a stale row. */
+    DSD_MEMSET(&view, 0xFF, sizeof(view));
+    assert(dsd_app_scan_timing_view(NULL, state, 100.0, &view) == -1);
+    assert(view.active == 0U);
+    assert(view.phrase == NULL);
+
+    DSD_MEMSET(&view, 0xFF, sizeof(view));
+    assert(dsd_app_scan_timing_view(&opts, NULL, 100.0, &view) == -1);
+    assert(view.active == 0U);
+
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, NULL) == -1);
+
+    free(state);
+}
+
+int
+main(void) {
+    test_retune_pending_row();
+    test_retune_retry_row();
+    test_cc_acquire_row();
+    test_call_follow_row_shows_hangtime();
+    test_hangtime_is_only_shown_while_following_a_call();
+    test_voice_row();
+    test_activity_hold_row_names_the_tail();
+    test_manual_hold_row_pauses_the_dwell();
+    test_idle_dwell_row_and_qualify_variant();
+    test_hangtime_row();
+    test_remaining_clamps_at_zero();
+    test_hold_is_conventional_only();
+    test_dwell_needs_a_value();
+    test_every_reason_has_a_phrase();
+    test_inactive_without_a_scanner();
+    test_inactive_when_reason_is_none();
+    test_null_arguments_are_safe();
+    printf("APP_CONTROL_SCAN_TIMING_VIEW ok\n");
+    return 0;
+}

--- a/tests/ui/test_app_control_scan_timing_view.c
+++ b/tests/ui/test_app_control_scan_timing_view.c
@@ -296,6 +296,12 @@ test_idle_dwell_row_and_qualify_variant(void) {
     assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
     assert_phrase(&view, "Idle dwell");
 
+    // Hold release is visible immediately, before the next tick arms a dwell.
+    state->scan_timing.deadline_m = -1.0;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.timer_live == 0U);
+    assert(view.show_dwell == 1U && view.dwell_ms == 3000U);
+
     free(state);
 }
 
@@ -310,12 +316,12 @@ test_hangtime_row(void) {
     DSD_MEMSET(&opts, 0, sizeof(opts));
     opts.scanner_mode = 1;
     opts.trunk_hangtime = 2.0f;
-    publish(state, DSD_SCAN_STAY_HANGTIME, 1U, 101.4, 2000U, 0U, 0U);
+    publish(state, DSD_SCAN_STAY_HANGTIME, 1U, 101.4, 3000U, 0U, 0U);
     assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
     assert_phrase(&view, "Hangtime");
     assert(view.timer_live == 1U);
     assert(view.remaining_ms == 1400U);
-    assert(view.span_ms == 2000U);
+    assert(view.span_ms == 3000U);
     assert(view.show_dwell == 0U);
     assert(view.show_hold == 0U);
     assert(view.show_hang == 0U);
@@ -326,6 +332,15 @@ test_hangtime_row(void) {
     assert(view.timer_live == 0U);
     assert(view.remaining_ms == 0U);
     assert(view.span_ms == 0U);
+
+    // Valid multi-day hangtimes keep their full remaining and total values.
+    publish(state, DSD_SCAN_STAY_HANGTIME, 1U, 172901.0, 172801000U, 0U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.remaining_ms == 172801000U && view.span_ms == 172801000U);
+    // Beyond the millisecond contract's range, both sides saturate at the same bound.
+    publish(state, DSD_SCAN_STAY_HANGTIME, 1U, 1.0e9, UINT32_MAX, 0U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.remaining_ms == UINT32_MAX && view.span_ms == UINT32_MAX);
 
     free(state);
 }

--- a/tests/ui/test_app_control_scan_timing_view.c
+++ b/tests/ui/test_app_control_scan_timing_view.c
@@ -126,7 +126,7 @@ test_cc_acquire_row(void) {
     free(state);
 }
 
-/* Following a trunked call: -t is what ends the stay, so it is the one budget worth
+/* Following a trunked call: protocol hangtime ends the stay, so it is the budget worth
    naming beside the suspended dwell. */
 static void
 test_call_follow_row_shows_hangtime(void) {
@@ -137,6 +137,7 @@ test_call_follow_row_shows_hangtime(void) {
     make_opts(&opts);
     opts.trunk_hangtime = 2.0f;
     publish(state, DSD_SCAN_STAY_CALL_FOLLOW, 0U, -1.0, 0U, 3000U, 0U);
+    state->scan_timing.hang_ms = 7000U;
     assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
     assert_phrase(&view, "Following call");
     assert(view.timer_live == 0U);
@@ -144,15 +145,21 @@ test_call_follow_row_shows_hangtime(void) {
     assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
     assert(view.show_hold == 0U);
     assert(view.show_hang == 1U);
-    assert(view.hang_ms == 2000U);
+    assert(view.hang_ms == 7000U);
 
-    /* A fractional -t rounds to the nearest millisecond rather than truncating. */
-    opts.trunk_hangtime = 1.25f;
+    /* A protocol override remains visible even when the configured -t is zero. */
+    opts.trunk_hangtime = 0.0f;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_hang == 1U);
+    assert(view.hang_ms == 7000U);
+
+    state->scan_timing.hang_ms = 1250U;
     assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
     assert(view.hang_ms == 1250U);
 
-    /* -t 0 leaves nothing to state. */
-    opts.trunk_hangtime = 0.0f;
+    /* An effective zero leaves nothing to state even with a positive -t. */
+    opts.trunk_hangtime = 2.0f;
+    state->scan_timing.hang_ms = 0U;
     assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
     assert(view.show_hang == 0U);
     assert(view.hang_ms == 0U);

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1913,9 +1913,11 @@ static int g_scan_control_result = 0;
 static int
 fake_scan_control(dsd_opts* opts, dsd_state* state, int op) {
     (void)opts;
-    (void)state;
     g_scan_control_calls++;
     g_scan_control_last_op = op;
+    if (op == DSD_TRUNK_SCAN_CONTROL_AVOID_ACTIVE && g_scan_control_result >= 0) {
+        DSD_SNPRINTF(state->trunk_scan_active_id, sizeof(state->trunk_scan_active_id), "incoming");
+    }
     return g_scan_control_result;
 }
 
@@ -1948,6 +1950,7 @@ test_scan_hold_avoid_commands(void) {
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("scan hold drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_int("scan hold sets flag", state.lcn_scan_hold, 1);
+    rc |= expect_int("scan hold publishes timing before snapshot", state.scan_timing.reason, DSD_SCAN_STAY_MANUAL_HOLD);
     rc |= expect_true("scan hold keeps dwell", state.last_cc_sync_time_m == 42.0);
     rc |= expect_contains("scan hold toast", state.ui_msg, "hold on");
     rc |= expect_int("scan hold release queued", dsd_app_command_action(DSD_APP_CMD_SCAN_HOLD_TOGGLE),
@@ -1956,6 +1959,24 @@ test_scan_hold_avoid_commands(void) {
     rc |= expect_int("scan hold release clears flag", state.lcn_scan_hold, 0);
     rc |= expect_true("scan hold release restarts dwell", state.last_cc_sync_time_m > 42.0);
     rc |= expect_contains("scan hold release toast", state.ui_msg, "hold off");
+    rc |= expect_int("scan release publishes hangtime", state.scan_timing.reason, DSD_SCAN_STAY_HANGTIME);
+    rc |= expect_true("scan release publishes a fresh deadline",
+                      state.scan_timing.deadline_m > state.last_cc_sync_time_m);
+
+    // A hold and release drained without a gate tick must also reset the voice
+    // qualify window, rather than retaining an expired sync from the old visit.
+    opts.scan_voice_only = 1;
+    state.scan_voice_gate_sync_m = 42.0;
+    state.scan_voice_gate_hold_seen = 0U;
+    rc |= expect_int("voice-gate hold queued", dsd_app_command_action(DSD_APP_CMD_SCAN_HOLD_TOGGLE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("voice-gate release queued", dsd_app_command_action(DSD_APP_CMD_SCAN_HOLD_TOGGLE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("voice-gate toggles drained", dsd_app_drain_cmds(&opts, &state), 2);
+    rc |= expect_true("voice-gate release resets old sync", state.scan_voice_gate_sync_m < 0.0);
+    rc |= expect_true("voice-gate release restarts the visit", state.scan_voice_gate_arrive_m > 42.0);
+    rc |= expect_int("unsynced release uses the fresh hangtime", state.scan_timing.reason, DSD_SCAN_STAY_HANGTIME);
+    opts.scan_voice_only = 0;
 
     /* Manual next while held still moves, and the hold stays on. */
     state.lcn_scan_hold = 1;
@@ -2036,11 +2057,13 @@ test_scan_hold_avoid_commands(void) {
     rc |= expect_int("trunk-scan hold leaves -Y flag", state.lcn_scan_hold, 0);
     rc |= expect_contains("trunk-scan hold toast", state.ui_msg, "hold on");
     g_scan_control_result = 0;
+    DSD_SNPRINTF(state.trunk_scan_active_id, sizeof(state.trunk_scan_active_id), "avoided");
     rc |= expect_int("trunk-scan avoid queued", dsd_app_command_action(DSD_APP_CMD_SCAN_AVOID),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);
     rc |= expect_int("trunk-scan avoid drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_int("trunk-scan avoid op", g_scan_control_last_op, DSD_TRUNK_SCAN_CONTROL_AVOID_ACTIVE);
     rc |= expect_int("trunk-scan avoid leaves -Y count", (int)state.lcn_avoid_count, 0);
+    rc |= expect_contains("trunk-scan avoid names the outgoing target", state.ui_msg, "Avoiding target avoided");
     g_scan_control_result = 2;
     rc |= expect_int("trunk-scan clear queued", dsd_app_command_action(DSD_APP_CMD_SCAN_AVOID_CLEAR),
                      DSD_APP_COMMAND_SUBMIT_QUEUED);

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -191,10 +191,15 @@ whline(WINDOW* win, chtype ch, int n) { // NOLINT(misc-use-internal-linkage)
     return 0;
 }
 
+/* Terminal width the printer sees. Settable so a test can narrow it and check that a row
+   which does not fit is cut rather than wrapped; 80 is the default every other test
+   renders against, and a test that changes it restores it. */
+static int g_stub_max_x = 80;
+
 int
 getmaxx(const WINDOW* win) { // NOLINT(misc-use-internal-linkage)
     (void)win;
-    return 80;
+    return g_stub_max_x;
 }
 
 int
@@ -2138,6 +2143,197 @@ test_voice_average_units(void) {
     g_voice_average_valid = 0;
 }
 
+/* One published stay, stamped the way the decoder stamps it: an absolute monotonic
+   deadline, or a negative one when nothing is counting down. */
+static void
+seed_scan_timing(dsd_state* state, uint8_t reason, uint8_t conventional, double deadline_m, uint32_t span_ms,
+                 uint32_t dwell_ms, uint32_t hold_ms) {
+    DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
+    state->scan_timing.reason = reason;
+    state->scan_timing.conventional = conventional;
+    state->scan_timing.started_m = (deadline_m >= 0.0) ? deadline_m - ((double)span_ms / 1000.0) : -1.0;
+    state->scan_timing.deadline_m = deadline_m;
+    state->scan_timing.span_ms = span_ms;
+    state->scan_timing.dwell_ms = dwell_ms;
+    state->scan_timing.hold_ms = hold_ms;
+}
+
+/* The formatter is pure and takes the clock, so a golden can be the exact bytes rather
+   than a substring: the Qt panel renders the same grammar from the same view. */
+static void
+assert_scan_timing_row(const dsd_opts* opts, const dsd_state* state, const char* expected) {
+    char line[192];
+    int len = ui_format_scan_timing_row(opts, state, 100.0, line, sizeof(line));
+    assert(len == (int)strlen(expected));
+    assert(strcmp(line, expected) == 0);
+}
+
+static void
+test_scan_timing_row_phrases(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.trunk_scan_enabled = 1;
+    opts.trunk_hangtime = 2.0f;
+
+    /* Trunked rows carry no conventional activity hold, so none is printed beside them. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_RETUNE_RETRY, 0U, 102.0, 2000U, 3000U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Retune retry 2.0s/2.0s  dwell 3.0s (suspended)");
+
+    seed_scan_timing(&state, DSD_SCAN_STAY_CC_ACQUIRE, 0U, -1.0, 0U, 3000U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Acquiring control  dwell 3.0s (suspended)");
+
+    /* -t is what ends a followed call, so it is the budget named beside the dwell. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_CALL_FOLLOW, 0U, -1.0, 0U, 3000U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Following call  dwell 3.0s (suspended)  hang 2.0s");
+
+    seed_scan_timing(&state, DSD_SCAN_STAY_MANUAL_HOLD, 0U, -1.0, 0U, 3000U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Manual hold  dwell 3.0s (paused)");
+
+    /* Conventional rows add the effective activity hold, except where that hold is
+       already the window counting down. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_RETUNE_PENDING, 1U, -1.0, 0U, 3000U, 1200U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Retune pending  dwell 3.0s (suspended)  hold 1.2s");
+
+    seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 1.8s/3.0s  hold 2.0s");
+
+    seed_scan_timing(&state, DSD_SCAN_STAY_VOICE, 1U, 101.2, 2000U, 3000U, 2000U);
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_VOICE;
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Voice 1.2s/2.0s  dwell 3.0s (suspended)");
+
+    /* Both voice-gate variants: the same reason reads differently once the gate says
+       where in a transmission the hold is. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_ACTIVITY_HOLD, 1U, 101.5, 2000U, 3000U, 2000U);
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_OFF;
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Activity hold 1.5s/2.0s  dwell 3.0s (suspended)");
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_TAIL;
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Voice tail 1.5s/2.0s  dwell 3.0s (suspended)");
+
+    seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 100.6, 1000U, 1000U, 2000U);
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_OFF;
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 0.6s/1.0s  hold 2.0s");
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_QUALIFY;
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Qualify 0.6s/1.0s  hold 2.0s");
+
+    /* The -Y legacy rule: -t since the last sync is the whole stay, with no dwell or hold
+       of its own to state. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.scanner_mode = 1;
+    opts.trunk_hangtime = 2.0f;
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_OFF;
+    seed_scan_timing(&state, DSD_SCAN_STAY_HANGTIME, 1U, 101.4, 2000U, 0U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Hangtime 1.4s/2.0s");
+
+    /* Nothing has synced on this row yet: the reason holds, the countdown has no anchor
+       to run from, and an unanchored timer is left off rather than shown as zero. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_HANGTIME, 1U, -1.0, 0U, 0U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Hangtime");
+}
+
+/* The decoder decides when the receiver moves. A poll that lands after the deadline is a
+   frame late, not a scanner that overstayed, so the row floors at zero instead of
+   reporting a negative age that wrapped through an unsigned. */
+static void
+test_scan_timing_row_clamps_expired_timers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.trunk_scan_enabled = 1;
+    seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 95.0, 3000U, 3000U, 2000U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 0.0s/3.0s  hold 2.0s");
+}
+
+static void
+test_scan_timing_row_is_silent_without_a_scan(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    char line[192];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    /* No scanner is running: a publication left over from an earlier session says nothing
+       about a receiver now parked by hand. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert(ui_format_scan_timing_row(&opts, &state, 100.0, line, sizeof(line)) == 0);
+    assert(line[0] == '\0');
+
+    /* Scanning, but nothing holds the row and nothing is published for it. */
+    opts.trunk_scan_enabled = 1;
+    seed_scan_timing(&state, DSD_SCAN_STAY_NONE, 1U, -1.0, 0U, 0U, 0U);
+    assert(ui_format_scan_timing_row(&opts, &state, 100.0, line, sizeof(line)) == 0);
+    assert(line[0] == '\0');
+}
+
+/* The row sits directly under whichever scanner row is on screen, and there is only ever
+   one of it: with both scanners running the stay belongs to the trunk-scan target. */
+static void
+test_scan_timing_row_placement(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_lcn_name_stub();
+
+    /* A stay with no live timer, so the rendered bytes do not depend on the wall clock
+       the renderer reads for itself. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_MANUAL_HOLD, 1U, -1.0, 0U, 3000U, 0U);
+
+    opts.scanner_mode = 1;
+    opts.trunk_hangtime = 2.0f;
+    state.lcn_freq_count = 1;
+    state.lcn_freq_roll = 1;
+    state.trunk_lcn_freq[0] = 462012500;
+    reset_printw_capture();
+    ui_render_scanner_and_reverse_status(&opts, &state);
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec \n"
+                          "| Scan Timing: Manual hold  dwell 3.0s (paused)\n");
+
+    opts.scanner_mode = 0;
+    opts.trunk_scan_enabled = 1;
+    DSD_SNPRINTF(state.trunk_scan_active_id, sizeof(state.trunk_scan_active_id), "county-p25");
+    state.trunk_scan_active_ordinal = 3;
+    state.trunk_scan_target_count = 6;
+    reset_printw_capture();
+    ui_render_scanner_and_reverse_status(&opts, &state);
+    assert_capture_equals("| Trunk Scan:  Target: county-p25 (3/6)\n"
+                          "| Scan Timing: Manual hold  dwell 3.0s (paused)\n");
+
+    opts.scanner_mode = 1;
+    reset_printw_capture();
+    ui_render_scanner_and_reverse_status(&opts, &state);
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec \n"
+                          "| Trunk Scan:  Target: county-p25 (3/6)\n"
+                          "| Scan Timing: Manual hold  dwell 3.0s (paused)\n");
+}
+
+/* A narrow terminal cuts the row instead of wrapping it: this line redraws several times
+   a second as the countdown moves, and a wrapped one would push every row below it down
+   by one for as long as the phrase stayed long. */
+static void
+test_scan_timing_row_truncates_to_panel_width(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.trunk_scan_enabled = 1;
+    seed_scan_timing(&state, DSD_SCAN_STAY_RETUNE_PENDING, 1U, -1.0, 0U, 3000U, 1200U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Retune pending  dwell 3.0s (suspended)  hold 1.2s");
+
+    g_stub_max_x = 40;
+    reset_printw_capture();
+    ui_render_scan_timing_row(&opts, &state);
+    g_stub_max_x = 80;
+    assert_capture_equals("| Scan Timing: Retune pending  dwell 3.0\n");
+    assert(strlen(g_printw_capture) == 41U);
+    assert(strchr(g_printw_capture, '\n') == g_printw_capture + 40);
+}
+
 int
 main(void) {
     test_voice_average_units();
@@ -2153,6 +2349,11 @@ main(void) {
     test_scanner_status_row_rendering();
     test_scan_voice_gate_status_rendering();
     test_trunk_scan_status_row_rendering();
+    test_scan_timing_row_phrases();
+    test_scan_timing_row_clamps_expired_timers();
+    test_scan_timing_row_is_silent_without_a_scan();
+    test_scan_timing_row_placement();
+    test_scan_timing_row_truncates_to_panel_width();
     test_call_info_channel_line_rendering();
     test_history_and_sort_helpers();
     test_history_color_pair_policy();

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -33,6 +33,7 @@
 #include <dsd-neo/ui/ui_prims.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -40,12 +41,35 @@
 #include "dsd-neo/core/dsd_time.h"
 #include "dsd-neo/platform/platform.h"
 
+#if defined(NCURSES_VERSION)
+/* Read the real cursor before replacing ncurses accessors with helper-test stubs. */
+static void
+assert_window_cursor(WINDOW* win, int expected_y, int expected_x) {
+    int y, x;
+    getyx(win, y, x);
+    assert(y == expected_y);
+    assert(x == expected_x);
+}
+
+static WINDOW* g_cursor_window;
+#endif
+
 /* ncurses builds with NCURSES_OPAQUE=0 (Debian/Ubuntu) expose these accessors as
    function-like macros, which would expand over the stub definitions below. */
 #undef getcurx
 #undef getcury
 #undef getmaxx
 #undef getmaxy
+
+/* Keep the real library accessors available to the cursor regression above. */
+#define getcurx  test_getcurx
+#define getcury  test_getcury
+#define getmaxx  test_getmaxx
+#define getmaxy  test_getmaxy
+#define waddch   test_waddch
+#define waddnstr test_waddnstr
+#define wmove    test_wmove
+#define werase   test_werase
 
 int ncurses_last_synctype;
 WINDOW* stdscr;
@@ -101,6 +125,14 @@ int
 printw(const char* fmt, ...) { // NOLINT(misc-use-internal-linkage)
     va_list ap;
     va_start(ap, fmt);
+#if defined(NCURSES_VERSION)
+    if (g_cursor_window) {
+        va_list cursor_ap;
+        va_copy(cursor_ap, ap);
+        assert(vw_printw(g_cursor_window, fmt, cursor_ap) != ERR);
+        va_end(cursor_ap);
+    }
+#endif
     append_printw_capture(fmt, ap);
     va_end(ap);
     return 0;
@@ -113,14 +145,14 @@ wprintw(WINDOW* win, const char* fmt, ...) { // NOLINT(misc-use-internal-linkage
     return 0;
 }
 
-int
+static int
 waddch(WINDOW* win, const chtype ch) { // NOLINT(misc-use-internal-linkage)
     (void)win;
     (void)ch;
     return 0;
 }
 
-int
+static int
 waddnstr(WINDOW* win, const char* str, int n) { // NOLINT(misc-use-internal-linkage)
     (void)win;
     (void)str;
@@ -169,13 +201,13 @@ wattr_off(WINDOW* win, attr_t attrs, void* opts) { // NOLINT(misc-use-internal-l
     return 0;
 }
 
-int
+static int
 werase(WINDOW* win) { // NOLINT(misc-use-internal-linkage)
     (void)win;
     return 0;
 }
 
-int
+static int
 wmove(WINDOW* win, int y, int x) { // NOLINT(misc-use-internal-linkage)
     (void)win;
     (void)y;
@@ -196,25 +228,25 @@ whline(WINDOW* win, chtype ch, int n) { // NOLINT(misc-use-internal-linkage)
    renders against, and a test that changes it restores it. */
 static int g_stub_max_x = 80;
 
-int
+static int
 getmaxx(const WINDOW* win) { // NOLINT(misc-use-internal-linkage)
     (void)win;
     return g_stub_max_x;
 }
 
-int
+static int
 getmaxy(const WINDOW* win) { // NOLINT(misc-use-internal-linkage)
     (void)win;
     return 24;
 }
 
-int
+static int
 getcurx(const WINDOW* win) { // NOLINT(misc-use-internal-linkage)
     (void)win;
     return 0;
 }
 
-int
+static int
 getcury(const WINDOW* win) { // NOLINT(misc-use-internal-linkage)
     (void)win;
     return 0;
@@ -2187,6 +2219,7 @@ test_scan_timing_row_phrases(void) {
 
     /* -t is what ends a followed call, so it is the budget named beside the dwell. */
     seed_scan_timing(&state, DSD_SCAN_STAY_CALL_FOLLOW, 0U, -1.0, 0U, 3000U, 0U);
+    state.scan_timing.hang_ms = 2000U;
     assert_scan_timing_row(&opts, &state, "| Scan Timing: Following call  dwell 3.0s (suspended)  hang 2.0s");
 
     seed_scan_timing(&state, DSD_SCAN_STAY_MANUAL_HOLD, 0U, -1.0, 0U, 3000U, 0U);
@@ -2198,6 +2231,9 @@ test_scan_timing_row_phrases(void) {
     assert_scan_timing_row(&opts, &state, "| Scan Timing: Retune pending  dwell 3.0s (suspended)  hold 1.2s");
 
     seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 1.8s/3.0s  hold 2.0s");
+    /* The same 1855 ms fixture as Qt: both surfaces truncate to tenths. */
+    state.scan_timing.deadline_m = 101.855;
     assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 1.8s/3.0s  hold 2.0s");
 
     seed_scan_timing(&state, DSD_SCAN_STAY_VOICE, 1U, 101.2, 2000U, 3000U, 2000U);
@@ -2329,10 +2365,46 @@ test_scan_timing_row_truncates_to_panel_width(void) {
     reset_printw_capture();
     ui_render_scan_timing_row(&opts, &state);
     g_stub_max_x = 80;
-    assert_capture_equals("| Scan Timing: Retune pending  dwell 3.0\n");
-    assert(strlen(g_printw_capture) == 41U);
-    assert(strchr(g_printw_capture, '\n') == g_printw_capture + 40);
+    assert_capture_equals("| Scan Timing: Retune pending  dwell 3.\n");
+    assert(strlen(g_printw_capture) == 40U);
+    assert(strchr(g_printw_capture, '\n') == g_printw_capture + 39);
 }
+
+#if defined(NCURSES_VERSION)
+static void
+test_scan_timing_row_real_cursor(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    opts.trunk_scan_enabled = 1;
+    seed_scan_timing(&state, DSD_SCAN_STAY_RETUNE_PENDING, 1U, -1.0, 0U, 3000U, 1200U);
+    char line[192];
+    const int len = ui_format_scan_timing_row(&opts, &state, 100.0, line, sizeof(line));
+    const int widths[] = {1, 40, len, 80};
+    FILE* input = tmpfile();
+    FILE* output = tmpfile();
+    assert(input && output);
+    SCREEN* screen = newterm("xterm", output, input);
+    assert(screen);
+    for (size_t i = 0; i < sizeof(widths) / sizeof(widths[0]); ++i) {
+        g_stub_max_x = widths[i];
+        g_cursor_window = newwin(4, widths[i], 0, 0);
+        assert(g_cursor_window);
+        reset_printw_capture();
+        ui_render_scan_timing_row(&opts, &state);
+        assert_window_cursor(g_cursor_window, 1, 0);
+        assert(delwin(g_cursor_window) != ERR);
+        g_cursor_window = NULL;
+    }
+    g_stub_max_x = 80;
+    endwin();
+    delscreen(screen);
+    stdscr = NULL;
+    assert(fclose(output) == 0);
+    assert(fclose(input) == 0);
+}
+#endif
 
 int
 main(void) {
@@ -2354,6 +2426,9 @@ main(void) {
     test_scan_timing_row_is_silent_without_a_scan();
     test_scan_timing_row_placement();
     test_scan_timing_row_truncates_to_panel_width();
+#if defined(NCURSES_VERSION)
+    test_scan_timing_row_real_cursor();
+#endif
     test_call_info_channel_line_rendering();
     test_history_and_sort_helpers();
     test_history_color_pair_policy();

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -963,14 +963,14 @@ test_scanner_status_row_rendering(void) {
     /* An unnamed row keeps the row byte-identical to what it has always been. */
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec \n");
 
-    /* A named row spells the name out after the fixed fields, so the frequency and speed keep
+    /* A named row spells the name out after the fixed fields, so the frequency and hangtime keep
        their columns and only the operator-length name reaches a narrow terminal's edge. */
     DSD_SNPRINTF(g_lcn_name_stub[0], sizeof(g_lcn_name_stub[0]), "Marion");
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Channel: Marion \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec Channel: Marion \n");
 
     /* HOLD is a state of the channel on air, so it sits with the channel's fixed fields. The
        avoid count is a property of the list, not of this channel, so it trails the name: a
@@ -979,21 +979,22 @@ test_scanner_status_row_rendering(void) {
     state.lcn_scan_hold = 1;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec HOLD Channel: Marion \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec HOLD Channel: Marion \n");
     state.lcn_avoid_count = 2;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec HOLD Channel: Marion Avoids: 2 \n");
+    assert_capture_equals(
+        "| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec HOLD Channel: Marion Avoids: 2 \n");
     state.lcn_scan_hold = 0;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Channel: Marion Avoids: 2 \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec Channel: Marion Avoids: 2 \n");
 
     /* An unnamed row on air: the count still closes the row, after the fixed fields. */
     reset_lcn_name_stub();
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Avoids: 2 \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec Avoids: 2 \n");
     DSD_SNPRINTF(g_lcn_name_stub[0], sizeof(g_lcn_name_stub[0]), "Marion");
     state.lcn_avoid_count = 0;
 
@@ -1003,7 +1004,7 @@ test_scanner_status_row_rendering(void) {
     state.lcn_freq_roll = 2;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.037500 MHz Speed: 2.00 sec Channel: Delaware \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.037500 MHz Hangtime: 2.00 sec Channel: Delaware \n");
 
     /* A row the importer kept for its numbering but could not use: the scanner parks on the
        frequency it is already on rather than tuning this one, so its name would credit the wrong
@@ -1011,21 +1012,21 @@ test_scanner_status_row_rendering(void) {
     state.trunk_lcn_freq[1] = 0;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 0.000000 MHz Speed: 2.00 sec \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 0.000000 MHz Hangtime: 2.00 sec \n");
     state.trunk_lcn_freq[1] = 462037500;
 
     /* Before the first tune there is no row on air, so neither field prints. */
     state.lcn_freq_roll = 0;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Speed: 2.00 sec \n");
+    assert_capture_equals("| Scan Mode:  Hangtime: 2.00 sec \n");
 
     /* A roll left past a shrunken count must not reach into the stale tail. */
     DSD_SNPRINTF(g_lcn_name_stub[2], sizeof(g_lcn_name_stub[2]), "Ghost");
     state.lcn_freq_roll = 3;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Speed: 2.00 sec \n");
+    assert_capture_equals("| Scan Mode:  Hangtime: 2.00 sec \n");
 
     /* No -Y list, no row at all. */
     opts.scanner_mode = 0;
@@ -1116,14 +1117,14 @@ test_trunk_scan_status_row_rendering(void) {
     DSD_SNPRINTF(g_lcn_name_stub[0], sizeof(g_lcn_name_stub[0]), "Marion");
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec \n"
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec \n"
                           "| Trunk Scan:  Target: county-p25 (3/6)\n");
 
     /* Between targets the -Y row's name is the answer again. */
     DSD_MEMSET(state.trunk_scan_active_id, 0, sizeof(state.trunk_scan_active_id));
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Channel: Marion \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec Channel: Marion \n");
 
     reset_lcn_name_stub();
 }
@@ -2048,27 +2049,27 @@ test_scan_voice_gate_status_rendering(void) {
     state.scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_VOICE;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec \n");
 
     /* Gate on: each phase names itself after the fixed fields. */
     opts.scan_voice_only = 1;
     state.scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_QUALIFY;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Voice: QUALIFY \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec Voice: QUALIFY \n");
     state.scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_VOICE;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Voice: VOICE \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec Voice: VOICE \n");
     state.scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_TAIL;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec Voice: TAIL \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec Voice: TAIL \n");
     /* Gate on but the phase not yet published (OFF): nothing is printed. */
     state.scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_OFF;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec \n");
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec \n");
 
     /* The trunk-scan row carries the same suffix, ahead of HOLD. */
     opts.scanner_mode = 0;
@@ -2260,8 +2261,12 @@ test_scan_timing_row_phrases(void) {
     opts.scanner_mode = 1;
     opts.trunk_hangtime = 2.0f;
     state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_OFF;
-    seed_scan_timing(&state, DSD_SCAN_STAY_HANGTIME, 1U, 101.4, 2000U, 0U, 0U);
-    assert_scan_timing_row(&opts, &state, "| Scan Timing: Hangtime 1.4s/2.0s");
+    seed_scan_timing(&state, DSD_SCAN_STAY_HANGTIME, 1U, 101.4, 3000U, 0U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Hangtime 1.4s/3.0s");
+    seed_scan_timing(&state, DSD_SCAN_STAY_HANGTIME, 1U, 172901.0, 172801000U, 0U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Hangtime 172801.0s/172801.0s");
+    seed_scan_timing(&state, DSD_SCAN_STAY_HANGTIME, 1U, 1.0e9, UINT32_MAX, 0U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Hangtime 4294967.2s/4294967.3s");
 
     /* Nothing has synced on this row yet: the reason holds, the countdown has no anchor
        to run from, and an unanchored timer is left off rather than shown as zero. */
@@ -2326,7 +2331,7 @@ test_scan_timing_row_placement(void) {
     state.trunk_lcn_freq[0] = 462012500;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec \n"
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec \n"
                           "| Scan Timing: Manual hold  dwell 3.0s (paused)\n");
 
     opts.scanner_mode = 0;
@@ -2342,7 +2347,7 @@ test_scan_timing_row_placement(void) {
     opts.scanner_mode = 1;
     reset_printw_capture();
     ui_render_scanner_and_reverse_status(&opts, &state);
-    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec \n"
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec \n"
                           "| Trunk Scan:  Target: county-p25 (3/6)\n"
                           "| Scan Timing: Manual hold  dwell 3.0s (paused)\n");
 }

--- a/tests/ui/test_ui_qt_controller.cpp
+++ b/tests/ui/test_ui_qt_controller.cpp
@@ -22,8 +22,10 @@
 #include <Qt>
 #include <cstdio>
 #include <cstdlib>
+#include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/app_control/frontend_runtime.h>
 #include <dsd-neo/app_control/snapshot.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/init.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/opts_fwd.h>
@@ -221,6 +223,56 @@ test_startup_options_wait_for_redraw() {
     freeState(&state);
 }
 
+// A held snapshot still has deadlines to age when input stops producing redraws.
+static void
+test_metrics_age_without_decoder_redraw() {
+    static dsd_opts opts;
+    static dsd_state state;
+    initOpts(&opts);
+    initState(&state);
+    opts.scanner_mode = 1;
+    Host host;
+    dsd_qt::MetricsModel metrics;
+    dsd_qt::UiController controller(&host, &metrics, nullptr, nullptr);
+    controller.setPollIntervalMs(50);
+    const auto poll = [&](int duration_ms) {
+        QEventLoop loop;
+        QTimer::singleShot(duration_ms, &loop, &QEventLoop::quit);
+        controller.start();
+        loop.exec();
+        controller.stop();
+    };
+
+    // Seed the existing short sync hold, then publish loss and a scan deadline.
+    state.synctype = DSD_SYNC_P25P1_POS;
+    metrics.refresh(&opts, &state);
+    state.synctype = DSD_SYNC_NONE;
+    state.scan_timing.reason = DSD_SCAN_STAY_HANGTIME;
+    state.scan_timing.conventional = 1U;
+    state.scan_timing.started_m = dsd_time_now_monotonic_s();
+    state.scan_timing.deadline_m = state.scan_timing.started_m + 1.0;
+    state.scan_timing.span_ms = 1000U;
+    dsd_app_telemetry_publish_opts_snapshot(&opts);
+    dsd_app_telemetry_publish_snapshot(&state);
+    dsd_app_request_redraw();
+    poll(65);
+    check(metrics.scanTimerLive() && metrics.scanTimerRemainingDs() > 0);
+    check(metrics.syncedHere());
+    const int remaining = metrics.scanTimerRemainingDs();
+    check(dsd_app_frontend_redraw_consume() == 0);
+    poll(250);
+    check(metrics.scanTimerRemainingDs() < remaining);
+    poll(static_cast<int>(DSD_APP_SYNC_HOLD_S * 1000.0) + 100);
+    check(metrics.scanTimerRemainingDs() == 0);
+    check(!metrics.syncedHere());
+
+    // Lifecycle still gates stale snapshots after the engine stops.
+    host.setPhase(Host::Idle);
+    poll(65);
+    check(!metrics.scanTimingVisible() && !metrics.optionsKnown());
+    freeState(&state);
+}
+
 // Run the actual sheet against the real bridge and decoder queue, including CSV media overrides.
 static void
 test_sheet_policy_edits() {
@@ -398,6 +450,7 @@ main(int argc, char** argv) {
     dsd_test_qt_isolate_paths();
     test_history_receives_effective_scan_options();
     test_startup_options_wait_for_redraw();
+    test_metrics_age_without_decoder_redraw();
     test_sheet_policy_edits();
     test_zero_bounds();
     test_auto_start_requests();

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -17,6 +17,7 @@
 #include <QObject>
 #include <QString>
 #include <QVariant>
+#include <QtGlobal>
 #include <cmath>
 #include <initializer_list>
 #include <stdint.h>
@@ -520,6 +521,17 @@ test_scan_timing() {
     model.refresh(&opts, &state);
     expect("the countdown moves on the tenth", model.scanTimerRemainingDs() == 17 && changes > quiet);
     expect("countdowns do not notify unrelated controls", control_changes == controls_settled);
+
+    // The -Y publisher saturates large accepted -t values at UINT32_MAX milliseconds.
+    // This must remain positive at the Qt property boundary, including through QVariant.
+    g_stub_scan_timing.span_ms = UINT32_MAX;
+    g_stub_scan_timing.show_hang = 1U;
+    g_stub_scan_timing.hang_ms = UINT32_MAX;
+    model.refresh(&opts, &state);
+    expect("a large timer total does not become negative",
+           model.property("scanTimerSpanMs").toULongLong() == static_cast<qulonglong>(UINT32_MAX));
+    expect("a large effective hangtime does not become negative",
+           model.property("scanHangMs").toULongLong() == static_cast<qulonglong>(UINT32_MAX));
 
     model.clear();
     expect("a stopped session leaves no scan timing behind",

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -448,9 +448,8 @@ test_options_readiness() {
  * Why the rotation is staying on the row on air, and how long is left (#508).
  *
  * The countdown is published in tenths of a second rather than milliseconds on
- * purpose: the reading decides whether controlChanged fires, so at millisecond
- * resolution every 250 ms poll would move it and re-evaluate every binding on the
- * control group for a row that renders one decimal place.
+ * purpose: only changes to the rendered tenth notify the timing row, and they
+ * never notify the unrelated control group.
  */
 static void
 test_scan_timing() {
@@ -460,7 +459,9 @@ test_scan_timing() {
     initState(&state);
     dsd_qt::MetricsModel model;
     int changes = 0;
-    QObject::connect(&model, &dsd_qt::MetricsModel::controlChanged, [&]() { ++changes; });
+    int control_changes = 0;
+    QObject::connect(&model, &dsd_qt::MetricsModel::scanTimingChanged, [&]() { ++changes; });
+    QObject::connect(&model, &dsd_qt::MetricsModel::controlChanged, [&]() { ++control_changes; });
 
     /* A trunked target following a call: no countdown, the dwell disarmed while the
      * call holds the row, and the -t hangtime that will release it. */
@@ -486,7 +487,7 @@ test_scan_timing() {
            model.scanDwellMs() == 3000 && model.scanDwellState() == DSD_APP_SCAN_DWELL_SUSPENDED);
     expect("a trunked row never shows a conventional hold", model.scanHoldMs() == 0);
     expect("a followed call shows the hangtime that will release it", model.scanHangMs() == 2000);
-    expect("scan timing rides the control group", changes > 0);
+    expect("scan timing has its own notification", changes > 0);
     const int settled = changes;
     model.refresh(&opts, &state);
     expect("an unchanged scan timing does not notify twice", changes == settled);
@@ -499,7 +500,7 @@ test_scan_timing() {
     g_stub_scan_timing.reason = DSD_SCAN_STAY_IDLE_DWELL;
     g_stub_scan_timing.phrase = "Idle dwell";
     g_stub_scan_timing.timer_live = 1U;
-    g_stub_scan_timing.remaining_ms = 1849U;
+    g_stub_scan_timing.remaining_ms = 1855U;
     g_stub_scan_timing.span_ms = 3000U;
     g_stub_scan_timing.show_hold = 1U;
     g_stub_scan_timing.hold_ms = 2000U;
@@ -510,6 +511,7 @@ test_scan_timing() {
     expect("the dwell the countdown already shows is not printed twice", model.scanDwellMs() == 0);
 
     const int quiet = changes;
+    const int controls_settled = control_changes;
     g_stub_scan_timing.remaining_ms = 1801U;
     model.refresh(&opts, &state);
     expect("a countdown moving inside one tenth notifies nothing",
@@ -517,6 +519,7 @@ test_scan_timing() {
     g_stub_scan_timing.remaining_ms = 1799U;
     model.refresh(&opts, &state);
     expect("the countdown moves on the tenth", model.scanTimerRemainingDs() == 17 && changes > quiet);
+    expect("countdowns do not notify unrelated controls", control_changes == controls_settled);
 
     model.clear();
     expect("a stopped session leaves no scan timing behind",

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -23,6 +23,7 @@
 #include <stdio.h>
 
 #include <dsd-neo/app_control/frontend.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/init.h>
@@ -45,6 +46,10 @@ int g_failures = 0;
 /* What the stubbed frontend reports for the channel width. Per-case, because
  * every other case wants the at-rest 0. */
 static int g_stub_channel_bandwidth_hz = 0;
+
+/* The scan-timing view a case feeds the model. Zeroed between cases: reason NONE
+ * is the contract's "nothing to show", which is what every other case wants. */
+static dsd_app_scan_timing g_stub_scan_timing;
 
 void
 expect(const char* what, bool ok) {
@@ -72,6 +77,36 @@ dsd_app_frontend_get_metrics_for_snapshot(const dsd_opts* opts, const dsd_state*
     *out = dsd_frontend_metrics{};
     out->channel_bandwidth_hz = g_stub_channel_bandwidth_hz;
     return 0;
+}
+
+/*
+ * The scan-timing view, stubbed through the same link seam as the frontend metrics
+ * above, so a case can hand the model a view it built by hand.
+ *
+ * Deliberately not the real one: the reason -> phrase / show-this-budget table is
+ * app-control's and is pinned by APP_CONTROL_SCAN_TIMING_VIEW. What this suite owns
+ * is the copy out of the view into the published frame, and running the real table
+ * here would only pin it twice. The one rule reproduced is the contract's `active`
+ * gate, because the model deliberately has no gate of its own -- "is anything
+ * scanning" is decided once, in the view.
+ */
+extern "C" int
+dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double now_m, dsd_app_scan_timing* out) {
+    if (out == nullptr) {
+        return -1;
+    }
+    *out = dsd_app_scan_timing{};
+    if (opts == nullptr || state == nullptr) {
+        return -1;
+    }
+    (void)now_m;
+    const bool scanning = opts->trunk_scan_enabled == 1 || opts->scanner_mode == 1;
+    if (!scanning || g_stub_scan_timing.reason == DSD_SCAN_STAY_NONE) {
+        return 0;
+    }
+    *out = g_stub_scan_timing;
+    out->active = 1U;
+    return 1;
 }
 
 extern "C" dsd_frontend_snr_readout
@@ -409,10 +444,107 @@ test_options_readiness() {
     freeState(&state);
 }
 
+/*
+ * Why the rotation is staying on the row on air, and how long is left (#508).
+ *
+ * The countdown is published in tenths of a second rather than milliseconds on
+ * purpose: the reading decides whether controlChanged fires, so at millisecond
+ * resolution every 250 ms poll would move it and re-evaluate every binding on the
+ * control group for a row that renders one decimal place.
+ */
+static void
+test_scan_timing() {
+    static dsd_opts opts;
+    static dsd_state state;
+    initOpts(&opts);
+    initState(&state);
+    dsd_qt::MetricsModel model;
+    int changes = 0;
+    QObject::connect(&model, &dsd_qt::MetricsModel::controlChanged, [&]() { ++changes; });
+
+    /* A trunked target following a call: no countdown, the dwell disarmed while the
+     * call holds the row, and the -t hangtime that will release it. */
+    opts.trunk_scan_enabled = 1;
+    g_stub_scan_timing = dsd_app_scan_timing{};
+    g_stub_scan_timing.reason = DSD_SCAN_STAY_CALL_FOLLOW;
+    g_stub_scan_timing.phrase = "Following call";
+    g_stub_scan_timing.show_dwell = 1U;
+    g_stub_scan_timing.dwell_ms = 3000U;
+    g_stub_scan_timing.dwell_state = DSD_APP_SCAN_DWELL_SUSPENDED;
+    /* Carried by the publication but withheld by the view: a trunked row has no
+     * conventional activity hold, and printing one would invent a budget. */
+    g_stub_scan_timing.hold_ms = 2000U;
+    g_stub_scan_timing.show_hang = 1U;
+    g_stub_scan_timing.hang_ms = 2000U;
+    model.refresh(&opts, &state);
+    expect("a followed call names why the scanner stays",
+           model.scanTimingVisible() && model.scanStayReason() == DSD_SCAN_STAY_CALL_FOLLOW
+               && model.scanStayPhrase() == QStringLiteral("Following call"));
+    expect("a followed call runs no countdown",
+           !model.scanTimerLive() && model.scanTimerRemainingDs() == 0 && model.scanTimerSpanMs() == 0);
+    expect("the suspended dwell still reads out",
+           model.scanDwellMs() == 3000 && model.scanDwellState() == DSD_APP_SCAN_DWELL_SUSPENDED);
+    expect("a trunked row never shows a conventional hold", model.scanHoldMs() == 0);
+    expect("a followed call shows the hangtime that will release it", model.scanHangMs() == 2000);
+    expect("scan timing rides the control group", changes > 0);
+    const int settled = changes;
+    model.refresh(&opts, &state);
+    expect("an unchanged scan timing does not notify twice", changes == settled);
+
+    /* A conventional row counting its idle dwell down, with the activity hold that
+     * would extend the stay if something showed up. */
+    opts.trunk_scan_enabled = 0;
+    opts.scanner_mode = 1;
+    g_stub_scan_timing = dsd_app_scan_timing{};
+    g_stub_scan_timing.reason = DSD_SCAN_STAY_IDLE_DWELL;
+    g_stub_scan_timing.phrase = "Idle dwell";
+    g_stub_scan_timing.timer_live = 1U;
+    g_stub_scan_timing.remaining_ms = 1849U;
+    g_stub_scan_timing.span_ms = 3000U;
+    g_stub_scan_timing.show_hold = 1U;
+    g_stub_scan_timing.hold_ms = 2000U;
+    model.refresh(&opts, &state);
+    expect("an idle dwell counts down", model.scanTimerLive() && model.scanTimerSpanMs() == 3000);
+    expect("the countdown reaches the row in tenths", model.scanTimerRemainingDs() == 18);
+    expect("a conventional row shows its activity hold", model.scanHoldMs() == 2000);
+    expect("the dwell the countdown already shows is not printed twice", model.scanDwellMs() == 0);
+
+    const int quiet = changes;
+    g_stub_scan_timing.remaining_ms = 1801U;
+    model.refresh(&opts, &state);
+    expect("a countdown moving inside one tenth notifies nothing",
+           changes == quiet && model.scanTimerRemainingDs() == 18);
+    g_stub_scan_timing.remaining_ms = 1799U;
+    model.refresh(&opts, &state);
+    expect("the countdown moves on the tenth", model.scanTimerRemainingDs() == 17 && changes > quiet);
+
+    model.clear();
+    expect("a stopped session leaves no scan timing behind",
+           !model.scanTimingVisible() && model.scanStayReason() == DSD_SCAN_STAY_NONE
+               && model.scanStayPhrase().isEmpty() && !model.scanTimerLive() && model.scanTimerRemainingDs() == 0
+               && model.scanTimerSpanMs() == 0 && model.scanDwellMs() == 0
+               && model.scanDwellState() == DSD_APP_SCAN_DWELL_NONE && model.scanHoldMs() == 0
+               && model.scanHangMs() == 0);
+
+    /* Plain trunking and a plain single system are not rotations: there is no row to
+     * stay on, so the view says nothing and the panel shows nothing. */
+    opts.scanner_mode = 0;
+    g_stub_scan_timing.reason = DSD_SCAN_STAY_IDLE_DWELL;
+    opts.trunk_enable = 1;
+    model.refresh(&opts, &state);
+    expect("nothing is rotating: the row stays down",
+           !model.scanTimingVisible() && model.scanStayPhrase().isEmpty() && model.scanDwellMs() == 0);
+    opts.trunk_enable = 0;
+
+    g_stub_scan_timing = dsd_app_scan_timing{};
+    freeState(&state);
+}
+
 int
 main(int argc, char** argv) {
     QCoreApplication app(argc, argv);
     test_options_readiness();
+    test_scan_timing();
     test_decryption_metadata();
     test_site();
     test_quality();

--- a/tests/ui/test_ui_snapshot_event_history.c
+++ b/tests/ui/test_ui_snapshot_event_history.c
@@ -137,6 +137,7 @@ assert_render_fields(const dsd_state* snap) {
     assert(snap->scan_timing.span_ms == 3000U);
     assert(snap->scan_timing.dwell_ms == 3000U);
     assert(snap->scan_timing.hold_ms == 2000U);
+    assert(snap->scan_timing.hang_ms == 7000U);
 }
 
 static void
@@ -233,6 +234,7 @@ main(void) {
     state->scan_timing.span_ms = 3000U;
     state->scan_timing.dwell_ms = 3000U;
     state->scan_timing.hold_ms = 2000U;
+    state->scan_timing.hang_ms = 7000U;
 
     assert(dsd_trunk_cc_candidates_add(state, 851006250L, 1, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) == 1);
     assert(dsd_trunk_cc_candidates_add(state, 852006250L, 1, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) == 1);

--- a/tests/ui/test_ui_snapshot_event_history.c
+++ b/tests/ui/test_ui_snapshot_event_history.c
@@ -20,6 +20,7 @@
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -127,6 +128,15 @@ assert_render_fields(const dsd_state* snap) {
     assert(snap->trunk_scan_hold == 1U);
     assert(snap->trunk_scan_active_avoided == 1U);
     assert(snap->trunk_scan_avoided_count == 3U);
+    /* The scan timing publication rides the same inline range. The renderer differences
+       its absolute anchors against its own clock, so every field has to survive the copy. */
+    assert(snap->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
+    assert(snap->scan_timing.conventional == 1U);
+    assert(fabs(snap->scan_timing.started_m - 120.5) < 1e-6);
+    assert(fabs(snap->scan_timing.deadline_m - 123.5) < 1e-6);
+    assert(snap->scan_timing.span_ms == 3000U);
+    assert(snap->scan_timing.dwell_ms == 3000U);
+    assert(snap->scan_timing.hold_ms == 2000U);
 }
 
 static void
@@ -216,6 +226,13 @@ main(void) {
     state->trunk_scan_hold = 1U;
     state->trunk_scan_active_avoided = 1U;
     state->trunk_scan_avoided_count = 3U;
+    state->scan_timing.reason = (uint8_t)DSD_SCAN_STAY_IDLE_DWELL;
+    state->scan_timing.conventional = 1U;
+    state->scan_timing.started_m = 120.5;
+    state->scan_timing.deadline_m = 123.5;
+    state->scan_timing.span_ms = 3000U;
+    state->scan_timing.dwell_ms = 3000U;
+    state->scan_timing.hold_ms = 2000U;
 
     assert(dsd_trunk_cc_candidates_add(state, 851006250L, 1, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) == 1);
     assert(dsd_trunk_cc_candidates_add(state, 852006250L, 1, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) == 1);


### PR DESCRIPTION
## Summary

Closes #508. Adds a `Scan Timing` row in the terminal and Qt/Android monitor so operators can see why a scanner stays on its current target, which window is running, and the effective per-row dwell, conventional hold, or protocol hangtime. The existing `-Y` status labels `-t` as `Hangtime`.

The decoder publishes pointer-free state with monotonic deadlines through the existing snapshots. A shared app-control view selects phrases and applicable settings for both frontends. Conventional activity and voice qualification/tail show their live countdowns; trunked call following shows suspended dwell and the protocol's effective hangtime without claiming a fixed next-hop time. Narrow displays truncate or elide the timing row.

Scan controls publish the incoming target's timing before command snapshots. Hold releases reliably grant a fresh window even when hold and release arrive between decoder ticks. This also fixes preexisting hold-release handling in both scanners, the Qt sync-loss indicator freezing without redraws, and avoid notifications naming the incoming target instead of the avoided one. Qt countdowns continue aging while input stalls, with startup and stopped-session guards preserved. Timing values saturate only at the publication's unsigned millisecond limit.

```text
| Scan Mode:  Frequency: 462.012500 MHz Hangtime: 2.00 sec
| Scan Timing: Hangtime 1.4s/3.0s
| Scan Timing: Idle dwell 1.8s/3.0s  hold 2.0s
| Scan Timing: Following call  dwell 3.0s (suspended)  hang 2.0s
| Scan Timing: Voice tail 1.5s/2.0s  dwell 3.0s (suspended)
| Scan Timing: Manual hold  dwell 3.0s (paused)
```

`-Y` legacy totals follow the existing strict whole-second comparison (`floor(-t) + 1`). NXDN's additional two-second grace is reflected in the countdown. No maximum time per target is added; #507 remains separate.

## Review

- [x] Changes reviewed against the surrounding module design and issue #508.
- [ ] Behavior, ownership boundaries, and failure modes reviewed by a human.
- [x] Independent Opus review at `xhigh`; actionable findings triaged and addressed, including labeling, large values, Qt refresh, documentation, and C++ header coverage.
- [x] High-risk areas: none of parser, crypto, dependency, network-input, workflow, or release code changed.
- [x] Added code read and adapted to repository conventions; review-fix commit includes a DCO sign-off.

## Quality Review

- [x] Regression coverage for scan-control boundaries, fresh hold-release windows, target switching, and frontend publication/expiry behavior.
- [x] Decoder-owned deadlines and frontend snapshot boundaries preserved; scan rotation rules retain their existing dwell, activity, and call-follow semantics.
- [x] No new static-analysis suppressions, raw formatting APIs, dependencies, subprocess spawning, or workflow permissions.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j 8` with Qt enabled.
- [x] `ctest --preset dev-debug --output-on-failure -j 8`: **670 passed**, including Qt/QML and offline IQ decoding.
- [x] `tools/preflight_ci.sh --base origin/main`: architecture, redaction, formatting, CMake formatting, Lizard, Semgrep, cppcheck, clang-tidy, IWYU, GCC fanalyzer, and repository pin/install checks.
- [x] Focused regressions reproduced failures before fixes for stalled Qt countdowns, unsigned timer conversion, command timing, batched hold/release, and avoid notifications.
- [x] C++ header smoke coverage for `scan_timing_view.h` and `call_view.h`.

Live-radio hardware validation was not performed in this review. The full quality/fuzz preflight and optional scan-build were not run; no parser, dependency, or fuzz-target changes were introduced. Workflow/dependency scans were not applicable.

## Risk

- Security/dependency impact: no new dependencies or secret-bearing snapshot fields.
- CLI/UI impact: a new timing row, the `Hangtime` label, accurate command notifications, and timers that age during input stalls. Terminal compact view remains unchanged.
- Compatibility/packaging impact: an inline state publication and shared view API; no new flags, CSV columns, configuration keys, or persisted formats. Qt/Android share the same QML implementation.
