### PR TITLE
fix(p25): hand the trunk SM to the CC after a user lockout (#506)

### DIFF
--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -387,6 +387,35 @@ int p25_sm_await_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* s
                                  const char* source);
 
 /**
+ * @brief Park the SM after an external tune to the control channel (#506).
+ *
+ * Frontend commands (user talkgroup lockout, manual return-to-CC) retune the
+ * radio to the control channel through the tuning hooks themselves, bypassing
+ * p25_sm_release(). Without this handoff the SM stays TUNED with the old
+ * assignment's slot activity and judges every later grant as a preemption of
+ * that phantom call. For a TUNED SM this ends the followed calls and clears
+ * the assignment context; a parked or hunting SM keeps its context. Either
+ * way it starts the same decoded-CC acquisition gate every return goes
+ * through, so grants stay blocked until the CC decodes after the tune.
+ *
+ * The caller holds the watchdog guard across its tune, its decoder resets and
+ * this handoff (p25_sm_tick_guard_enter()), like p25_sm_select_control_channel()
+ * does internally: a watchdog tick in between would see a TUNED context with
+ * no tuned decoder and issue a second CC return of its own.
+ *
+ * @param ctx State machine context.
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param tune_result Result of the CC tune the caller already issued.
+ * @param request_id Runtime tune request for PENDING results, 0 when unknown.
+ * @param source Short diagnostic source label.
+ * @return 1 when the SM was handed off, 0 when the tune was refused or the SM
+ *         was idle and had nothing to hand off.
+ */
+int p25_sm_on_external_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, dsd_trunk_tune_result tune_result,
+                               uint64_t request_id, const char* source);
+
+/**
  * @brief Periodic tick for timeout-based transitions.
  *
  * Call at ~1-10 Hz. Handles:

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -48,6 +48,7 @@
 #include <dsd-neo/platform/threading.h>
 #include <dsd-neo/protocol/dmr/dmr.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
+#include <dsd-neo/protocol/p25/p25_sm_watchdog.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/airspy_config.h>
 #include <dsd-neo/runtime/call_alert.h>
@@ -2121,18 +2122,32 @@ set_cc_symbol_timing(const dsd_opts* opts, dsd_state* state, int sym_rate) {
 }
 
 static int
-request_manual_tune(dsd_opts* opts, dsd_state* state, long int freq, int p25_cc_symbol_rate, const char* action) {
+request_manual_tune(dsd_opts* opts, dsd_state* state, long int freq, int p25_cc_symbol_rate, const char* action,
+                    dsd_trunk_tune_result* out_result, uint64_t* out_request_id) {
     int result = 0;
     int accepted = 0;
+    dsd_trunk_tune_result tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    uint64_t request_id = 0U;
     if (p25_cc_symbol_rate != 0) {
         const int ted_sps = dsd_opts_compute_sps_rate(opts, p25_cc_symbol_rate, current_demod_rate(opts, state));
-        const dsd_trunk_tune_result cc_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, ted_sps, NULL);
-        result = (int)cc_result;
-        accepted = dsd_trunk_tune_result_is_ok(cc_result);
+        tune_result = dsd_trunk_tuning_hook_tune_to_cc(opts, state, freq, ted_sps, &request_id);
+        result = (int)tune_result;
+        accepted = dsd_trunk_tune_result_is_ok(tune_result);
     } else {
         /* Generic LCN actions and unknown CC types must not stage a P25 RTL profile. */
         result = io_control_set_freq(opts, state, freq);
         accepted = result == RTL_STREAM_TUNE_OK || result == RTL_STREAM_TUNE_TIMEOUT;
+        if (accepted) {
+            /* This leg has no correlated tune request to await, so an accepted
+             * timeout (issued, not yet confirmed) is reported as complete. */
+            tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+        }
+    }
+    if (out_result) {
+        *out_result = tune_result;
+    }
+    if (out_request_id) {
+        *out_request_id = request_id;
     }
     if (accepted) {
         return 1;
@@ -2150,6 +2165,44 @@ mark_cc_sync(dsd_state* state, int include_monotonic) {
     }
 }
 
+/* #506: the manual CC tunes below go straight to the tuner, bypassing p25_sm_release().
+ * Hand the P25 SM its parked state, or it keeps judging every later grant as a
+ * preemption of the assignment it was following. */
+static void
+hand_p25_sm_to_cc(dsd_opts* opts, dsd_state* state, dsd_trunk_tune_result tune_result, uint64_t request_id,
+                  const char* source) {
+    (void)p25_sm_on_external_cc_tune(p25_sm_get_ctx(), opts, state, tune_result, request_id, source);
+}
+
+/* Whether the P25 SM owns this trunk. When it does, the tune, the decoder resets and
+ * the SM handoff run under the watchdog guard as one step, like every other CC
+ * retune (p25_sm_select_control_channel(), the no-carrier return): a watchdog tick
+ * in between would see a TUNED context with no tuned decoder and issue a second CC
+ * return of its own. DMR and NXDN trunks keep their unguarded path. */
+static int
+p25_sm_owns_trunk(const dsd_opts* opts, const dsd_state* state) {
+    return dsd_trunk_p25_recovery_allowed(opts, state);
+}
+
+static int
+apply_manual_return_to_cc_locked(dsd_opts* opts, dsd_state* state, int p25_live) {
+    const long freq = current_cc_freq(state);
+    const int sym_rate = cc_symbol_rate(opts, state, 0);
+    dsd_trunk_tune_result tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    uint64_t request_id = 0U;
+    if (!request_manual_tune(opts, state, freq, sym_rate, "Return-to-CC", &tune_result, &request_id)) {
+        return UI_CMD_APPLY_FAILED;
+    }
+    reset_call_tracking(opts, state, 1);
+    mark_cc_sync(state, 1);
+    set_cc_symbol_timing(opts, state, sym_rate);
+    if (p25_live) {
+        hand_p25_sm_to_cc(opts, state, tune_result, request_id, "return-to-cc");
+    }
+    LOG_INFO("User Activated Return to CC\n");
+    return UI_CMD_APPLY_COMPLETED;
+}
+
 static int
 apply_manual_return_to_cc(dsd_opts* opts, dsd_state* state) {
     if (!state) {
@@ -2158,26 +2211,28 @@ apply_manual_return_to_cc(dsd_opts* opts, dsd_state* state) {
     if (opts->trunk_enable != 1 || (state->trunk_cc_freq == 0 && state->p25_cc_freq == 0)) {
         return UI_CMD_APPLY_COMPLETED;
     }
-
-    const long freq = current_cc_freq(state);
-    const int sym_rate = cc_symbol_rate(opts, state, 0);
-    if (!request_manual_tune(opts, state, freq, sym_rate, "Return-to-CC")) {
-        return UI_CMD_APPLY_FAILED;
+    const int p25_live = p25_sm_owns_trunk(opts, state);
+    if (p25_live) {
+        p25_sm_tick_guard_enter();
     }
-    reset_call_tracking(opts, state, 1);
-    mark_cc_sync(state, 1);
-    set_cc_symbol_timing(opts, state, sym_rate);
-    LOG_INFO("User Activated Return to CC\n");
-    return UI_CMD_APPLY_COMPLETED;
+    const int status = apply_manual_return_to_cc_locked(opts, state, p25_live);
+    if (p25_live) {
+        p25_sm_tick_guard_leave();
+    }
+    return status;
 }
 
 static int
-apply_lockout_decoder_transition(dsd_opts* opts, dsd_state* state) {
+apply_lockout_decoder_transition_locked(dsd_opts* opts, dsd_state* state, int p25_live) {
     long cc_freq = 0;
+    dsd_trunk_tune_result tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    uint64_t request_id = 0U;
     const int sym_rate = cc_symbol_rate(opts, state, 1);
     if (opts->trunk_enable == 1) {
         cc_freq = current_cc_freq(state);
-        if (cc_freq != 0 && !request_manual_tune(opts, state, cc_freq, sym_rate, "Lockout return-to-CC")) {
+        if (cc_freq != 0
+            && !request_manual_tune(opts, state, cc_freq, sym_rate, "Lockout return-to-CC", &tune_result,
+                                    &request_id)) {
             return UI_CMD_APPLY_FAILED;
         }
     }
@@ -2187,9 +2242,29 @@ apply_lockout_decoder_transition(dsd_opts* opts, dsd_state* state) {
         noCarrier(opts, state);
         state->trunk_cc_freq = cc_freq;
     }
+    /* Wall clock only: the P25 handoff below stamps the monotonic CC sync from the
+     * tune boundary itself, which is what its acquisition window is measured from. */
     mark_cc_sync(state, 0);
     set_cc_symbol_timing(opts, state, sym_rate);
+    if (p25_live) {
+        /* With no CC known nothing was tuned; tune_result is still FAILED and the
+         * handoff declines, leaving the SM to its own stale-context recovery. */
+        hand_p25_sm_to_cc(opts, state, tune_result, request_id, "user-lockout");
+    }
     return UI_CMD_APPLY_COMPLETED;
+}
+
+static int
+apply_lockout_decoder_transition(dsd_opts* opts, dsd_state* state) {
+    const int p25_live = p25_sm_owns_trunk(opts, state);
+    if (p25_live) {
+        p25_sm_tick_guard_enter();
+    }
+    const int status = apply_lockout_decoder_transition_locked(opts, state, p25_live);
+    if (p25_live) {
+        p25_sm_tick_guard_leave();
+    }
+    return status;
 }
 
 static int
@@ -2199,7 +2274,7 @@ try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
         return UI_CMD_APPLY_UNHANDLED;
     }
     const int sym_rate = cc_symbol_rate(opts, state, 0);
-    if (!request_manual_tune(opts, state, cand, sym_rate, "Candidate cycle")) {
+    if (!request_manual_tune(opts, state, cand, sym_rate, "Candidate cycle", NULL, NULL)) {
         return UI_CMD_APPLY_FAILED;
     }
 
@@ -2243,7 +2318,7 @@ apply_manual_lcn_cycle_untyped(dsd_opts* opts, dsd_state* state) {
         }
         return UI_CMD_APPLY_COMPLETED;
     }
-    if (!request_manual_tune(opts, state, freq, 0, "Channel cycle")) {
+    if (!request_manual_tune(opts, state, freq, 0, "Channel cycle", NULL, NULL)) {
         return UI_CMD_APPLY_FAILED;
     }
 

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -2171,7 +2171,13 @@ mark_cc_sync(dsd_state* state, int include_monotonic) {
 static void
 hand_p25_sm_to_cc(dsd_opts* opts, dsd_state* state, dsd_trunk_tune_result tune_result, uint64_t request_id,
                   const char* source) {
-    (void)p25_sm_on_external_cc_tune(p25_sm_get_ctx(), opts, state, tune_result, request_id, source);
+    if (p25_sm_on_external_cc_tune(p25_sm_get_ctx(), opts, state, tune_result, request_id, source)) {
+        return;
+    }
+    /* A decline hands the SM back to its own recovery: the tune was refused, or the
+     * context is idle or uninitialized. It mutates nothing, so without a line here
+     * "handed off" and "left alone" are indistinguishable in a field log. */
+    LOG_DEBUG("P25 SM CC handoff declined (source=%s result=%d)\n", source ? source : "unknown", (int)tune_result);
 }
 
 /* Whether the P25 SM owns this trunk. When it does, the tune, the decoder resets and
@@ -2182,6 +2188,23 @@ hand_p25_sm_to_cc(dsd_opts* opts, dsd_state* state, dsd_trunk_tune_result tune_r
 static int
 p25_sm_owns_trunk(const dsd_opts* opts, const dsd_state* state) {
     return dsd_trunk_p25_recovery_allowed(opts, state);
+}
+
+/* Each manual retune runs its tune, its decoder resets and its SM handoff as one
+ * guarded step, so a watchdog tick never observes the half-moved state in between. */
+typedef int (*manual_retune_step_fn)(dsd_opts* opts, dsd_state* state, int p25_live);
+
+static int
+run_manual_retune_guarded(dsd_opts* opts, dsd_state* state, manual_retune_step_fn step) {
+    const int p25_live = p25_sm_owns_trunk(opts, state);
+    if (p25_live) {
+        p25_sm_tick_guard_enter();
+    }
+    const int status = step(opts, state, p25_live);
+    if (p25_live) {
+        p25_sm_tick_guard_leave();
+    }
+    return status;
 }
 
 static int
@@ -2211,15 +2234,7 @@ apply_manual_return_to_cc(dsd_opts* opts, dsd_state* state) {
     if (opts->trunk_enable != 1 || (state->trunk_cc_freq == 0 && state->p25_cc_freq == 0)) {
         return UI_CMD_APPLY_COMPLETED;
     }
-    const int p25_live = p25_sm_owns_trunk(opts, state);
-    if (p25_live) {
-        p25_sm_tick_guard_enter();
-    }
-    const int status = apply_manual_return_to_cc_locked(opts, state, p25_live);
-    if (p25_live) {
-        p25_sm_tick_guard_leave();
-    }
-    return status;
+    return run_manual_retune_guarded(opts, state, apply_manual_return_to_cc_locked);
 }
 
 static int
@@ -2256,25 +2271,19 @@ apply_lockout_decoder_transition_locked(dsd_opts* opts, dsd_state* state, int p2
 
 static int
 apply_lockout_decoder_transition(dsd_opts* opts, dsd_state* state) {
-    const int p25_live = p25_sm_owns_trunk(opts, state);
-    if (p25_live) {
-        p25_sm_tick_guard_enter();
-    }
-    const int status = apply_lockout_decoder_transition_locked(opts, state, p25_live);
-    if (p25_live) {
-        p25_sm_tick_guard_leave();
-    }
-    return status;
+    return run_manual_retune_guarded(opts, state, apply_lockout_decoder_transition_locked);
 }
 
 static int
-try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
+try_manual_candidate_cycle_locked(dsd_opts* opts, dsd_state* state, int p25_live) {
     long cand = 0;
     if (opts->p25_prefer_candidates != 1 || !p25_cc_next_candidate(state, &cand)) {
         return UI_CMD_APPLY_UNHANDLED;
     }
     const int sym_rate = cc_symbol_rate(opts, state, 0);
-    if (!request_manual_tune(opts, state, cand, sym_rate, "Candidate cycle", NULL, NULL)) {
+    dsd_trunk_tune_result tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    uint64_t request_id = 0U;
+    if (!request_manual_tune(opts, state, cand, sym_rate, "Candidate cycle", &tune_result, &request_id)) {
         return UI_CMD_APPLY_FAILED;
     }
 
@@ -2282,11 +2291,14 @@ try_manual_candidate_cycle(dsd_opts* opts, dsd_state* state) {
     LOG_INFO("Candidate Cycle: tuning to %.06lf MHz\n", (double)cand / 1000000);
     mark_cc_sync(state, 1);
     set_cc_symbol_timing(opts, state, sym_rate);
+    if (p25_live) {
+        hand_p25_sm_to_cc(opts, state, tune_result, request_id, "candidate-cycle");
+    }
     return UI_CMD_APPLY_COMPLETED;
 }
 
 static int
-apply_manual_lcn_cycle_untyped(dsd_opts* opts, dsd_state* state) {
+apply_manual_lcn_cycle_untyped_locked(dsd_opts* opts, dsd_state* state, int p25_live) {
     int count = state->lcn_freq_count;
     if (count <= 0) {
         return UI_CMD_APPLY_COMPLETED;
@@ -2318,7 +2330,9 @@ apply_manual_lcn_cycle_untyped(dsd_opts* opts, dsd_state* state) {
         }
         return UI_CMD_APPLY_COMPLETED;
     }
-    if (!request_manual_tune(opts, state, freq, 0, "Channel cycle", NULL, NULL)) {
+    dsd_trunk_tune_result tune_result = DSD_TRUNK_TUNE_RESULT_FAILED;
+    uint64_t request_id = 0U;
+    if (!request_manual_tune(opts, state, freq, 0, "Channel cycle", &tune_result, &request_id)) {
         return UI_CMD_APPLY_FAILED;
     }
 
@@ -2327,27 +2341,43 @@ apply_manual_lcn_cycle_untyped(dsd_opts* opts, dsd_state* state) {
     state->lcn_freq_roll = next + 1;
     dsd_scan_row_keys_apply(state, next);
     mark_cc_sync(state, 1);
+    if (p25_live) {
+        hand_p25_sm_to_cc(opts, state, tune_result, request_id, "channel-cycle");
+    }
     return UI_CMD_APPLY_COMPLETED;
 }
 
 static int
-apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
+apply_manual_lcn_cycle_locked(dsd_opts* opts, dsd_state* state, int p25_live) {
     if (opts->scanner_mode == 1 && dsd_channel_modes_present(state)) {
         return dsd_engine_channel_scan_step_manual(opts, state) < 0 ? UI_CMD_APPLY_FAILED : UI_CMD_APPLY_COMPLETED;
     }
-    return apply_manual_lcn_cycle_untyped(opts, state);
+    return apply_manual_lcn_cycle_untyped_locked(opts, state, p25_live);
+}
+
+static int
+apply_manual_lcn_cycle(dsd_opts* opts, dsd_state* state) {
+    return run_manual_retune_guarded(opts, state, apply_manual_lcn_cycle_locked);
+}
+
+/* #506: both legs retune through the tuning hooks, past p25_sm_release(), exactly
+ * like the lockout and the return-to-CC do. Without the handoff the SM stays TUNED on
+ * the assignment it was following and refuses every later grant as a preemption of it. */
+static int
+apply_manual_channel_cycle_locked(dsd_opts* opts, dsd_state* state, int p25_live) {
+    if (opts->scanner_mode == 1 && dsd_channel_modes_present(state)) {
+        return apply_manual_lcn_cycle_locked(opts, state, p25_live);
+    }
+    const int candidate_status = try_manual_candidate_cycle_locked(opts, state, p25_live);
+    if (candidate_status != UI_CMD_APPLY_UNHANDLED) {
+        return candidate_status;
+    }
+    return apply_manual_lcn_cycle_locked(opts, state, p25_live);
 }
 
 static int
 apply_manual_channel_cycle(dsd_opts* opts, dsd_state* state) {
-    if (opts->scanner_mode == 1 && dsd_channel_modes_present(state)) {
-        return apply_manual_lcn_cycle(opts, state);
-    }
-    const int candidate_status = try_manual_candidate_cycle(opts, state);
-    if (candidate_status != UI_CMD_APPLY_UNHANDLED) {
-        return candidate_status;
-    }
-    return apply_manual_lcn_cycle(opts, state);
+    return run_manual_retune_guarded(opts, state, apply_manual_channel_cycle_locked);
 }
 
 #ifdef USE_RADIO

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -786,6 +786,37 @@ p25_sm_await_pending_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state
     return 1;
 }
 
+int
+p25_sm_on_external_cc_tune(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, dsd_trunk_tune_result tune_result,
+                           uint64_t request_id, const char* source) {
+    if (!ctx || !opts || !state || !ctx->initialized || !dsd_trunk_tune_result_is_ok(tune_result)) {
+        return 0;
+    }
+    if (ctx->state == P25_SM_IDLE) {
+        return 0;
+    }
+    const char* reason = source ? source : "external-cc-tune";
+    p25_sm_diagf(opts, state, ctx, "external_cc_tune",
+                 "source=%s state=%s freq=%ld ch=0x%04X tg=%d result=%s request=%llu", reason,
+                 p25_sm_state_name(ctx->state), ctx->vc_freq_hz, ctx->vc_channel & 0xFFFF, ctx->vc_tg,
+                 p25_tune_result_name(tune_result), (unsigned long long)request_id);
+    // Only a followed assignment has slot activity and a voice channel to drop.
+    // A parked or hunting SM keeps its stale-regrant guard and followed history;
+    // the radio still moved, so the acquisition gate is re-armed either way.
+    if (ctx->state == P25_SM_TUNED) {
+        p25_sm_clear_manual_selection_calls(ctx, opts, state);
+    }
+    // The same handoff the no-carrier and scan retunes use: grants stay gated
+    // until the pending tune completes and a CC block decodes after that
+    // boundary. In trunk-scan mode `ctx` is the coordinator's context on
+    // purpose -- its TUNED hold is what kept the scan parked on this target.
+    p25_sm_start_cc_acquisition_for_result(ctx, opts, state, tune_result, request_id, dsd_time_now_monotonic_s(),
+                                           reason, P25_SM_CC_ACQUISITION_RETURN);
+    ctx->t_hunt_try_m = 0.0;
+    set_state(ctx, opts, state, P25_SM_ON_CC, reason);
+    return 1;
+}
+
 /* ============================================================================
  * Grant Filtering
  * ============================================================================ */

--- a/tests/protocol/p25/test_p25_sm_unified_core.c
+++ b/tests/protocol/p25/test_p25_sm_unified_core.c
@@ -2135,6 +2135,147 @@ test_unassigned_companion_start_is_rejected(void) {
 }
 
 // Test: State name function for 4-state model
+/* #506: a frontend command that retunes to the control channel itself (user
+ * lockout, manual return-to-CC) bypasses p25_sm_release(). The SM must be handed
+ * its parked state, or every later grant is judged as a preemption of the
+ * assignment it was following. */
+static int
+test_external_cc_tune_hands_off_assignment(void) {
+    reset_test_state();
+    g_state.trunk_chan_map[0x1234] = 851500000;
+    g_state.trunk_chan_map[0x1235] = 852500000;
+
+    p25_sm_ctx_t ctx;
+    p25_sm_init_ctx(&ctx, &g_opts, &g_state);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 851500000, 1000, 123, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    ev = p25_sm_ev_active_call(0, 1000, 0, 123, 1, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_TUNED || !ctx.slots[0].voice_active) {
+        DSD_FPRINTF(stderr, "FAIL: External CC tune fixture did not follow the first assignment\n");
+        return 1;
+    }
+
+    // The command path resets the decoder without informing the SM: a grant for
+    // another talkgroup is then refused as a preemption of the phantom call.
+    g_opts.trunk_is_tuned = 0;
+    g_state.p25_vc_freq[0] = g_state.p25_vc_freq[1] = 0;
+    g_state.trunk_vc_freq[0] = g_state.trunk_vc_freq[1] = 0;
+    ev = p25_sm_ev_group_grant(0x1235, 852500000, 2000, 456, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_TUNED || ctx.vc_freq_hz != 851500000 || ctx.slots[0].ota_tg != 1000) {
+        DSD_FPRINTF(stderr, "FAIL: Uninformed SM no longer reproduces the #506 phantom-call refusal\n");
+        return 1;
+    }
+
+    if (!p25_sm_on_external_cc_tune(&ctx, &g_opts, &g_state, DSD_TRUNK_TUNE_RESULT_OK, 0U, "user-lockout")) {
+        DSD_FPRINTF(stderr, "FAIL: External CC tune was not handed off\n");
+        return 1;
+    }
+    if (ctx.state != P25_SM_ON_CC || ctx.slots[0].voice_active || ctx.slots[0].last_active_m > 0.0
+        || ctx.vc_freq_hz != 0 || !ctx.cc_sync_pending || g_return_requests != 0 || canonical_slot_is_active(0U)) {
+        DSD_FPRINTF(stderr, "FAIL: External CC tune left assignment state behind (state=%s)\n",
+                    p25_sm_state_name(ctx.state));
+        return 1;
+    }
+
+    // Grants stay gated until the CC decodes after the tune, as for every return.
+    ev = p25_sm_ev_group_grant(0x1235, 852500000, 2000, 456, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_ON_CC || ctx.vc_freq_hz != 0) {
+        DSD_FPRINTF(stderr, "FAIL: Grant accepted before the CC decoded after the external tune\n");
+        return 1;
+    }
+
+    // A parked SM is only re-gated: a manual return keeps its stale-regrant guard.
+    ctx.recent_call_ends[0].valid = 1;
+    if (!p25_sm_on_external_cc_tune(&ctx, &g_opts, &g_state, DSD_TRUNK_TUNE_RESULT_OK, 0U, "return-to-cc")
+        || ctx.state != P25_SM_ON_CC || !ctx.cc_sync_pending || !ctx.recent_call_ends[0].valid) {
+        DSD_FPRINTF(stderr, "FAIL: External CC tune on a parked SM did not preserve its context\n");
+        return 1;
+    }
+    ctx.recent_call_ends[0].valid = 0;
+    g_state.p25_last_cc_msg_time_m = dsd_time_now_monotonic_s() + 0.01;
+    ev = p25_sm_ev_group_grant(0x1235, 852500000, 2000, 456, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_TUNED || ctx.vc_freq_hz != 852500000 || ctx.slots[0].ota_tg != 2000) {
+        DSD_FPRINTF(stderr, "FAIL: Next grant was not followed after the external CC tune (state=%s freq=%ld)\n",
+                    p25_sm_state_name(ctx.state), ctx.vc_freq_hz);
+        return 1;
+    }
+
+    // A refused tune and an idle SM have nothing to hand off.
+    if (p25_sm_on_external_cc_tune(&ctx, &g_opts, &g_state, DSD_TRUNK_TUNE_RESULT_FAILED, 0U, "user-lockout")
+        || ctx.state != P25_SM_TUNED) {
+        DSD_FPRINTF(stderr, "FAIL: Refused external CC tune changed SM state\n");
+        return 1;
+    }
+    p25_sm_ctx_t idle;
+    g_state.p25_cc_freq = 0;
+    p25_sm_init_ctx(&idle, &g_opts, &g_state);
+    if (p25_sm_on_external_cc_tune(&idle, &g_opts, &g_state, DSD_TRUNK_TUNE_RESULT_OK, 0U, "user-lockout")
+        || idle.state != P25_SM_IDLE) {
+        DSD_FPRINTF(stderr, "FAIL: Idle SM was handed an external CC tune\n");
+        return 1;
+    }
+    return 0;
+}
+
+/* The asynchronous leg: a PENDING CC tune keeps grants gated until the tuner
+ * reports completion, and then until the CC decodes after that boundary. */
+static int
+test_external_cc_tune_pending_waits_for_completion(void) {
+    reset_test_state();
+    g_state.trunk_chan_map[0x1234] = 851500000;
+    g_state.trunk_chan_map[0x1235] = 852500000;
+
+    p25_sm_ctx_t ctx;
+    p25_sm_init_ctx(&ctx, &g_opts, &g_state);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 851500000, 1000, 123, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    const uint64_t request_id = dsd_trunk_tuning_request_begin();
+    if (ctx.state != P25_SM_TUNED || request_id == 0U) {
+        DSD_FPRINTF(stderr, "FAIL: Pending external CC tune fixture did not start\n");
+        return 1;
+    }
+
+    if (!p25_sm_on_external_cc_tune(&ctx, &g_opts, &g_state, DSD_TRUNK_TUNE_RESULT_PENDING, request_id, "user-lockout")
+        || ctx.state != P25_SM_ON_CC || !ctx.cc_tune_pending || ctx.cc_tune_request_id != request_id
+        || ctx.vc_freq_hz != 0 || ctx.slots[0].voice_active) {
+        DSD_FPRINTF(stderr, "FAIL: Pending external CC tune was not awaited (state=%s)\n",
+                    p25_sm_state_name(ctx.state));
+        return 1;
+    }
+
+    // Still moving: the grant waits for the tuner.
+    ev = p25_sm_ev_group_grant(0x1235, 852500000, 2000, 456, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_ON_CC || !ctx.cc_tune_pending) {
+        DSD_FPRINTF(stderr, "FAIL: Grant accepted while the external CC tune was still pending\n");
+        return 1;
+    }
+
+    // Tuner done, CC not yet decoded after it: the grant still waits.
+    dsd_trunk_tuning_request_complete(request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    ev = p25_sm_ev_group_grant(0x1235, 852500000, 2000, 456, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    if (ctx.state != P25_SM_ON_CC || ctx.cc_tune_pending || !ctx.cc_sync_pending) {
+        DSD_FPRINTF(stderr, "FAIL: Completed external CC tune did not move to the decoded-CC gate\n");
+        return 1;
+    }
+
+    g_state.p25_last_cc_msg_time_m = dsd_time_now_monotonic_s() + 0.01;
+    ev = p25_sm_ev_group_grant(0x1235, 852500000, 2000, 456, 0);
+    p25_sm_event(&ctx, &g_opts, &g_state, &ev);
+    dsd_trunk_tuning_requests_reset();
+    if (ctx.state != P25_SM_TUNED || ctx.vc_freq_hz != 852500000) {
+        DSD_FPRINTF(stderr, "FAIL: Next grant was not followed after the pending external CC tune (state=%s)\n",
+                    p25_sm_state_name(ctx.state));
+        return 1;
+    }
+    return 0;
+}
+
 static int
 test_state_names(void) {
     if (strcmp(p25_sm_state_name(P25_SM_IDLE), "IDLE") != 0) {
@@ -3037,6 +3178,8 @@ main(void) {
     fail += test_anonymous_followup_restarts_crypto_pending();
     fail += test_source_less_duplicate_grant_republishes_crypto();
     fail += test_unassigned_companion_start_is_rejected();
+    fail += test_external_cc_tune_hands_off_assignment();
+    fail += test_external_cc_tune_pending_waits_for_completion();
     fail += test_state_names();
     fail += test_config_defaults();
     fail += test_singleton();

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -28,6 +28,7 @@
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/threading.h>
+#include <dsd-neo/protocol/p25/p25_cc_candidates.h>
 #include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/scan_mode.h>
@@ -1261,6 +1262,81 @@ test_lockout_hands_p25_sm_back_to_cc(void) {
     rc |= expect_int("return-to-CC tuned the CC", g_cc_tune_calls, 1);
     rc |= expect_int("return-to-CC parks the P25 SM on the CC", p25_sm_get_state(sm), P25_SM_ON_CC);
     rc |= expect_true("return-to-CC clears the SM voice channel", sm->vc_freq_hz == 0);
+
+    p25_sm_init_ctx(sm, NULL, NULL);
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    dsd_trunk_tuning_requests_reset();
+    freeState(&state);
+    return rc;
+}
+
+/* #506 follow-up: the manual channel cycle moves the radio exactly the way the
+ * lockout and the return-to-CC do -- through the tuning hooks, past
+ * p25_sm_release() -- on both of its legs. Either one left the SM judging later
+ * grants as preemptions of the assignment it was still following. */
+static int
+test_channel_cycle_hands_p25_sm_back_to_cc(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);
+    opts.trunk_tune_group_calls = 1;
+    state.trunk_chan_map[0x1234] = 852000000L;
+    state.trunk_chan_map[0x1235] = 853000000L;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){.tune_to_freq_request = stub_tune_to_freq_ok});
+
+    p25_sm_ctx_t* sm = p25_sm_get_ctx();
+    p25_sm_init_ctx(sm, &opts, &state);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 852000000L, 1201, 1202, 0);
+    p25_sm_event(sm, &opts, &state, &ev);
+    ev = p25_sm_ev_active_call(0, 1201, 0, 1202, 1, 0);
+    p25_sm_event(sm, &opts, &state, &ev);
+    rc |= expect_int("SM follows the seeded assignment", p25_sm_get_state(sm), P25_SM_TUNED);
+    rc |= expect_int("SM slot carries voice before the cycle", sm->slots[0].voice_active, 1);
+
+    // Candidate leg: p25_prefer_candidates routes the cycle through the P25 CC hook.
+    opts.p25_prefer_candidates = 1;
+    rc |= expect_int("candidate seeded", p25_cc_add_candidate(&state, 857000000L, 1), 1);
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
+    rc |= expect_int("candidate cycle queued", dsd_app_command_action(DSD_APP_CMD_CHANNEL_CYCLE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("candidate cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("candidate cycle tuned the candidate", g_cc_tune_calls, 1);
+    rc |= expect_true("candidate cycle used the candidate frequency", g_cc_tune_freq == 857000000L);
+    rc |= expect_int("candidate cycle parks the P25 SM on the CC", p25_sm_get_state(sm), P25_SM_ON_CC);
+    rc |= expect_int("candidate cycle clears the SM slot voice", sm->slots[0].voice_active, 0);
+    rc |= expect_true("candidate cycle clears the SM voice channel", sm->vc_freq_hz == 0);
+    rc |= expect_int("candidate cycle gates grants until the CC decodes", sm->cc_sync_pending, 1);
+
+    // The site keeps trunking: the next grant is followed instead of refused as a
+    // preemption of the call the SM was still holding.
+    state.p25_last_cc_msg_time_m = dsd_time_now_monotonic_s() + 0.01;
+    ev = p25_sm_ev_group_grant(0x1235, 853000000L, 1300, 1301, 0);
+    p25_sm_event(sm, &opts, &state, &ev);
+    rc |= expect_int("next grant is followed after a candidate cycle", p25_sm_get_state(sm), P25_SM_TUNED);
+    rc |= expect_true("next grant tunes the new voice channel", sm->vc_freq_hz == 853000000L);
+    ev = p25_sm_ev_active_call(0, 1300, 0, 1301, 1, 0);
+    p25_sm_event(sm, &opts, &state, &ev);
+    rc |= expect_int("SM slot carries voice again", sm->slots[0].voice_active, 1);
+
+    // LCN leg: with no candidate preference the same key falls through to the raw
+    // channel cycle, which moves the radio just as far past the SM.
+    opts.p25_prefer_candidates = 0;
+    state.lcn_freq_count = 1;
+    state.lcn_freq_roll = 0;
+    state.trunk_lcn_freq[0] = 851000000L;
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
+    rc |= expect_int("channel cycle queued", dsd_app_command_action(DSD_APP_CMD_CHANNEL_CYCLE),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("channel cycle drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("channel cycle used the raw tune", g_io_control_tune_calls, 1);
+    rc |= expect_int("channel cycle parks the P25 SM on the CC", p25_sm_get_state(sm), P25_SM_ON_CC);
+    rc |= expect_int("channel cycle clears the SM slot voice", sm->slots[0].voice_active, 0);
+    rc |= expect_true("channel cycle clears the SM voice channel", sm->vc_freq_hz == 0);
+    rc |= expect_int("channel cycle gates grants until the CC decodes", sm->cc_sync_pending, 1);
 
     p25_sm_init_ctx(sm, NULL, NULL);
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
@@ -3452,6 +3528,7 @@ main(void) {
 #ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
     rc |= test_manual_tune_commands_commit_only_after_acceptance();
     rc |= test_lockout_hands_p25_sm_back_to_cc();
+    rc |= test_channel_cycle_hands_p25_sm_back_to_cc();
 #ifdef USE_RADIO
     rc |= test_manual_tune_trunking_gate_and_reacquisition();
 #endif

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -11,6 +11,7 @@
 #include <dsd-neo/app_control/frontend_runtime.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/channel_mode.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/enc_lockout.h>
 #include <dsd-neo/core/events.h>
 #include <dsd-neo/core/init.h>
@@ -27,6 +28,7 @@
 #include <dsd-neo/io/rtl_stream_c.h>
 #include <dsd-neo/platform/file_compat.h>
 #include <dsd-neo/platform/threading.h>
+#include <dsd-neo/protocol/p25/p25_trunk_sm.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/scan_options.h>
@@ -59,7 +61,7 @@ static int g_cc_profile_at_tune = -1;
 // NOLINTBEGIN(bugprone-reserved-identifier, cert-dcl37-c, cert-dcl51-cpp, misc-use-internal-linkage)
 int __wrap_io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq);
 dsd_trunk_tune_result __wrap_dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq,
-                                                              int ted_sps);
+                                                              int ted_sps, uint64_t* out_request_id);
 
 int
 __wrap_io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
@@ -71,8 +73,12 @@ __wrap_io_control_set_freq(dsd_opts* opts, dsd_state* state, long int freq) {
 }
 
 dsd_trunk_tune_result
-__wrap_dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps) {
+__wrap_dsd_trunk_tuning_hook_tune_to_cc(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
+                                        uint64_t* out_request_id) {
     (void)opts;
+    if (out_request_id) {
+        *out_request_id = 0U;
+    }
     g_cc_tune_calls++;
     g_cc_tune_freq = freq;
     g_cc_tune_ted_sps = ted_sps;
@@ -1181,6 +1187,85 @@ test_manual_tune_commands_commit_only_after_acceptance(void) {
 
     reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
     reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
+    return rc;
+}
+
+static dsd_trunk_tune_result
+stub_tune_to_freq_ok(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
+    (void)opts;
+    (void)state;
+    (void)ted_sps;
+    (void)request_id;
+    return freq > 0 ? DSD_TRUNK_TUNE_RESULT_OK : DSD_TRUNK_TUNE_RESULT_FAILED;
+}
+
+/* #506: the user lockout retunes the radio to the control channel itself, bypassing
+ * p25_sm_release(). The P25 SM must still be handed its parked state, or it keeps
+ * judging every later grant as a preemption of the assignment it was following. */
+static int
+test_lockout_hands_p25_sm_back_to_cc(void) {
+    int rc = 0;
+    static dsd_opts opts;
+    static dsd_state state;
+    init_test_context(&opts, &state);
+    seed_active_p25_voice(&opts, &state, 851000000L, 852000000L, 1201);
+    opts.trunk_tune_group_calls = 1;
+    state.trunk_chan_map[0x1234] = 852000000L;
+    state.trunk_chan_map[0x1235] = 853000000L;
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){.tune_to_freq_request = stub_tune_to_freq_ok});
+
+    p25_sm_ctx_t* sm = p25_sm_get_ctx();
+    p25_sm_init_ctx(sm, &opts, &state);
+    p25_sm_event_t ev = p25_sm_ev_group_grant(0x1234, 852000000L, 1201, 1202, 0);
+    p25_sm_event(sm, &opts, &state, &ev);
+    ev = p25_sm_ev_active_call(0, 1201, 0, 1202, 1, 0);
+    p25_sm_event(sm, &opts, &state, &ev);
+    rc |= expect_int("SM follows the seeded assignment", p25_sm_get_state(sm), P25_SM_TUNED);
+    rc |= expect_int("SM slot carries voice before lockout", sm->slots[0].voice_active, 1);
+
+    // A refused CC tune leaves the assignment, and the SM, exactly where they were.
+    reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_DEFERRED);
+    rc |= expect_int("deferred lockout queued", dsd_app_command_set_u8(DSD_APP_CMD_LOCKOUT_SLOT, 0U),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("deferred lockout drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("deferred lockout leaves the SM tuned", p25_sm_get_state(sm), P25_SM_TUNED);
+    rc |= expect_int("deferred lockout keeps the SM slot voice", sm->slots[0].voice_active, 1);
+    rc |= expect_true("deferred lockout keeps the SM voice channel", sm->vc_freq_hz == 852000000L);
+
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
+    rc |= expect_int("lockout queued", dsd_app_command_set_u8(DSD_APP_CMD_LOCKOUT_SLOT, 0U),
+                     DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("lockout drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("lockout tuned the CC", g_cc_tune_calls, 1);
+    rc |= expect_int("lockout clears trunk tuned", opts.trunk_is_tuned, 0);
+    rc |= expect_int("lockout parks the P25 SM on the CC", p25_sm_get_state(sm), P25_SM_ON_CC);
+    rc |= expect_int("lockout clears the SM slot voice", sm->slots[0].voice_active, 0);
+    rc |= expect_true("lockout clears the SM voice channel", sm->vc_freq_hz == 0);
+    rc |= expect_int("lockout gates grants until the CC decodes", sm->cc_sync_pending, 1);
+
+    // The site keeps trunking: once the CC decodes again, a grant for another
+    // talkgroup is followed instead of being refused as a preemption.
+    state.p25_last_cc_msg_time_m = dsd_time_now_monotonic_s() + 0.01;
+    ev = p25_sm_ev_group_grant(0x1235, 853000000L, 1300, 1301, 0);
+    p25_sm_event(sm, &opts, &state, &ev);
+    rc |= expect_int("next grant is followed after lockout", p25_sm_get_state(sm), P25_SM_TUNED);
+    rc |= expect_true("next grant tunes the new voice channel", sm->vc_freq_hz == 853000000L);
+    rc |= expect_int("next grant marks trunk tuned", opts.trunk_is_tuned, 1);
+
+    // The manual return-to-CC command takes the same shortcut past the SM.
+    reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
+    rc |=
+        expect_int("return-to-CC queued", dsd_app_command_action(DSD_APP_CMD_RETURN_CC), DSD_APP_COMMAND_SUBMIT_QUEUED);
+    rc |= expect_int("return-to-CC drained", dsd_app_drain_cmds(&opts, &state), 1);
+    rc |= expect_int("return-to-CC tuned the CC", g_cc_tune_calls, 1);
+    rc |= expect_int("return-to-CC parks the P25 SM on the CC", p25_sm_get_state(sm), P25_SM_ON_CC);
+    rc |= expect_true("return-to-CC clears the SM voice channel", sm->vc_freq_hz == 0);
+
+    p25_sm_init_ctx(sm, NULL, NULL);
+    dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
+    dsd_trunk_tuning_requests_reset();
+    freeState(&state);
     return rc;
 }
 
@@ -3366,6 +3451,7 @@ main(void) {
     rc |= test_scan_voice_gate_commands();
 #ifdef DSD_NEO_TEST_IO_CONTROL_WRAP
     rc |= test_manual_tune_commands_commit_only_after_acceptance();
+    rc |= test_lockout_hands_p25_sm_back_to_cc();
 #ifdef USE_RADIO
     rc |= test_manual_tune_trunking_gate_and_reacquisition();
 #endif


### PR DESCRIPTION
Fixes #506

## Problem

Blocking a talkgroup from a P25 slot with `!` or `@` (and the manual return-to-CC key) retunes the radio to the control channel directly through the tuning hooks, bypassing `p25_sm_release()`. The P25 trunk state machine stays `TUNED` with the old assignment's voice channel and slot activity, so it judges every later grant as a preemption of that phantom call and refuses it. The decoder sits on the control channel without following any activity until the SM's stale-context recovery eventually kicks in, which matches the "after a while it seems to get back to normal" in the report. This happens with and without `--trunk-scan`.

## Fix

- Add `p25_sm_on_external_cc_tune()`: after a frontend-driven CC tune, a `TUNED` SM drops its followed calls and assignment context, a parked or hunting SM keeps its context, and either way the same decoded-CC acquisition gate every other return uses is re-armed (including the pending-tune leg for asynchronous tuners).
- The user-lockout and manual return-to-CC commands now report their tune result and request id, and hand the SM off after the tune and decoder resets. When the P25 SM owns the trunk, the tune, resets and handoff run under the watchdog tick guard so a tick cannot issue a second CC return in between. DMR and NXDN keep their existing path.

## Tests

- `P25_SM_UNIFIED_CORE`: new cases reproduce the phantom-call refusal on an uninformed SM, then verify the handoff parks the SM, gates grants until the CC decodes, preserves a parked SM's stale-regrant guard, and handles PENDING tune results.
- `APP_COMMAND_QUEUE`: new case drives the lockout and return-to-CC commands end to end and checks the next grant for another talkgroup is followed. With the command-queue wiring reverted to `main`, this test fails at "next grant tunes the new voice channel", the reported symptom.
- `tools/preflight_ci.sh --base origin/main` passes (clang-format, IWYU, clang-tidy, cppcheck, GCC -fanalyzer, Semgrep, Lizard, guardrails).

## Not changed

The report also notes that `Groups.csv` is rewritten with mode `B` rows when a talkgroup is blocked. That is the documented behaviour of talkgroup-list edits when a group file is configured (see `docs/csv-formats.md`, "edits atomically rewrite that file"); making lockouts session-only would be a separate design change and is out of scope here.
