### PR TITLE
feat(scan): add an optional maximum time per target visit (#507)

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -832,6 +832,8 @@ individual systems' source, endpoint, PPM, bandwidth and bias-tee settings.
 Scan lists use the app's voice hang time; per-system hang-time overrides do not apply.
 `-t` is separate from idle dwell on every target and the activity hold on conventional
 targets. The list editor can select imported group/source CSVs from the existing library.
+It has no field for the per-visit cap; add `--scan-max-visit-ms <ms>` to Extra decoder
+arguments to cap every target in the session.
 Per-system groups and keys remain isolated on rotation; source aliases are global
 and differing system alias files produce a warning. Unsupported settings are
 refused rather than dropped. See [scan-list rules](../docs/trunk-scan.md#qt-and-android-scan-lists).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -528,7 +528,7 @@ Notes
   - Conventional DMR/P25/NXDN activity hold (both NXDN rates): `--trunk-scan-activity-hold-ms <250..600000>`
     (default `1200`).
   - Maximum time per visit: `--scan-max-visit-ms <ms>` (`0` disables, otherwise `1000..3600000`; default `0`).
-    Unlike the two windows above it applies to every target type, trunked and conventional, and it is a ceiling
+    Unlike the activity hold above it applies to every target type, trunked and conventional, and it is a ceiling
     rather than a reason to stay: it can cut an ongoing call short, which is the point on a busy system that would
     otherwise starve the rest of the list. A target's `options` column can override it, and `0` there exempts that
     target. Full rules in `docs/trunk-scan.md`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -558,6 +558,9 @@ Notes
 - Hang time after voice/sync loss (seconds): `-t <secs>`
   - This is not the idle dwell between `--trunk-scan` targets. DMR control/rest-channel acquisition has its own
     two-second window; use target `dwell_ms` to budget each visit. See [trunk-scan timing](trunk-scan.md).
+  - Under `-Y` without `--scan-voice-only`, the terminal's `Scan Timing` row counts this value down from the last
+    sync as `Hangtime`. The rotation rule itself compares whole seconds, so the hop can land up to a second after the
+    countdown reaches `0.0s`; the countdown is a readout of the same anchor, and the policy is unchanged.
   - P25 Talk Complete, TDU, TDULC, MAC_END_PTT, MAC_IDLE, and MAC_HANGTIME mark a transmission boundary. They close
     that slot's media and start or refresh the traffic-carrier inactivity timer without returning to the control
     channel. A follow-up PTT/ACTIVE on the retained carrier opens a clean call epoch without retuning.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ Friendly, practical overview of the `dsd-neo` command line. This covers what you
 - Levels/Audio: `-g 0|1..50`, `-n 0..100`, `-nm`, `-8`, `-V 0|1|2|3`, `-z 0|1|2`, `-y`, `-v 0xF`
 - Modes: `-fa | -fs | -fr | -f1 | -f2 | -fd | -fx | -fy | -fz | -fU | -fi | -fn | -fp | -fh | -fH | -fe | -fE | -fm`
 - Inversions/filtering: `-xx`, `-xr`, `-xd`, `-xz`, `-l`, `-q`
-- Trunking/scan: `-T`, `-Y`, `--trunk-scan targets.csv` (P25/DMR/NXDN96/NXDN48 trunk and conventional targets; each type selects its decoder class), `-C chan.csv`, `-G group.csv`, `--src-csv src.csv`, `--p25-bandplan plan.csv`, `--p25-bandplan-export plan.csv`, `-W`, `-E`, `-p`, `-e`, `-I 1234`, `-U 4532`, `-B 12000`, `-t 1`, `--enc-lockout|--enc-follow`, `--scan-voice-only`, `--scan-voice-qualify-ms <ms>`, `--scan-voice-hold-ms <ms>`
+- Trunking/scan: `-T`, `-Y`, `--trunk-scan targets.csv` (P25/DMR/NXDN96/NXDN48 trunk and conventional targets; each type selects its decoder class), `-C chan.csv`, `-G group.csv`, `--src-csv src.csv`, `--p25-bandplan plan.csv`, `--p25-bandplan-export plan.csv`, `-W`, `-E`, `-p`, `-e`, `-I 1234`, `-U 4532`, `-B 12000`, `-t 1`, `--enc-lockout|--enc-follow`, `--scan-voice-only`, `--scan-voice-qualify-ms <ms>`, `--scan-voice-hold-ms <ms>`, `--scan-max-visit-ms <ms>`
 - RTL‑SDR strings: `-i rtl:dev:freq:gain:ppm:bw:sql:vol[:bias=on|off]` or `-i rtltcp:host:port:freq:gain:ppm:bw:sql:vol[:bias=on|off]`
 - Soapy selection: `-i soapy`, `-i soapy:driver=airspy[,serial=...]`, or `-i soapy[:args]:freq[:gain[:ppm[:bw[:sql[:vol]]]]]` (discover args with `SoapySDRUtil --find`)
 - RTL retune control: `--rtl-udp-control <port>` binds to loopback by default; use
@@ -488,6 +488,20 @@ Notes
   voice without a key holds unless the talkgroup policy blocks it; unknown identity counts as voice. The last-media
   time survives an over-the-air terminator, so the full hold still runs when a protocol closes the call before the
   scanner's next tick.
+  Per-visit ceiling: `--scan-max-visit-ms <ms>` (also `--scan-max-visit-ms=<ms>`; `0` disables, otherwise
+  `1000..3600000`; default `0`) is the longest one visit to a row may last, with or without `--scan-voice-only`. It is a
+  ceiling, not a reason to stay, so it can cut an ongoing call short: that is the point on an open microphone, and why
+  it is off by default. The clock starts when the row parks and starts again from zero on every re-park; sync, decoded
+  voice, the voice-gate hold and the `-t` hangtime never restart it. Expiry hops only while at least two rows are usable
+  (a non-zero frequency, not avoided); with fewer the limit re-arms instead of firing, so a one-row list is unaffected
+  and a row that becomes usable later gets a full limit rather than an immediate hop. A `Y` hold suspends the limit and
+  releasing it starts a fresh full limit, not the remainder; an `-I` talkgroup hold suspends it only while the call
+  being followed matches the held talkgroup, and the limit runs again from zero once that call ends. Other calls on the
+  row are still capped. A typed row can carry its own `--scan-max-visit-ms <ms>` in the `options` column, where `0`
+  exempts that row; legacy untyped rows apply row keys but not row options, so they always use the global value. Two
+  caveats on legacy lists: a row whose frequency also appears on the next row "hops" to the same frequency, ending the
+  call as an explicit hop rather than moving the receiver, and a low `-t` already steps a quiet row about a second after
+  its last sync, so the cap only changes what happens on a row that keeps syncing.
   Optional channel-map `mode` values select `p25`, `dmr`, `nxdn96`, `nxdn48`, `dpmr`, `dstar`, `ysf`, or `m17` for
   each row. See [the mixed-mode example](../examples/conventional_scan_modes.csv). Declared rows work even when
   excluded by the global preset; blank rows inherit it. Modes take effect at the first scheduled row entry, including
@@ -513,6 +527,11 @@ Notes
   - Idle dwell: `--trunk-scan-dwell-ms <250..600000>` (default `3000`).
   - Conventional DMR/P25/NXDN activity hold (both NXDN rates): `--trunk-scan-activity-hold-ms <250..600000>`
     (default `1200`).
+  - Maximum time per visit: `--scan-max-visit-ms <ms>` (`0` disables, otherwise `1000..3600000`; default `0`).
+    Unlike the two windows above it applies to every target type, trunked and conventional, and it is a ceiling
+    rather than a reason to stay: it can cut an ongoing call short, which is the point on a busy system that would
+    otherwise starve the rest of the list. A target's `options` column can override it, and `0` there exempts that
+    target. Full rules in `docs/trunk-scan.md`.
   - `p25-conventional` parks without a trunking state machine and holds after voice starts allowed by the
     group/private and encrypted-call policy. PDU data never refreshes its hold, so `-e` has no effect on that row.
     Phase 1 decode captures are available for replay checks, not proof of on-air target holds; Phase 2 conventional
@@ -558,6 +577,8 @@ Notes
 - Hang time after voice/sync loss (seconds): `-t <secs>`
   - This is not the idle dwell between `--trunk-scan` targets. DMR control/rest-channel acquisition has its own
     two-second window; use target `dwell_ms` to budget each visit. See [trunk-scan timing](trunk-scan.md).
+  - Hangtime and dwell decide when a quiet channel is done; `--scan-max-visit-ms` ends a visit that is not done, so
+    neither substitutes for the other.
   - Under `-Y` without `--scan-voice-only`, the terminal's `Scan Timing` row counts this value down from the last
     sync as `Hangtime`. The rotation rule itself compares whole seconds, so the hop can land up to a second after the
     countdown reaches `0.0s`; the countdown is a readout of the same anchor, and the policy is unchanged. NXDN holds

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -497,10 +497,13 @@ Notes
   and a row that becomes usable later gets a full limit rather than an immediate hop. A `Y` hold suspends the limit and
   releasing it starts a fresh full limit, not the remainder; an `-I` talkgroup hold suspends it only while the call
   being followed matches the held talkgroup, and the limit runs again from zero once that call ends. Other calls on the
-  row are still capped. A typed row can carry its own `--scan-max-visit-ms <ms>` in the `options` column, where `0`
-  exempts that row; legacy untyped rows apply row keys but not row options, so they always use the global value. Two
-  caveats on legacy lists: a row whose frequency also appears on the next row "hops" to the same frequency, ending the
-  call as an explicit hop rather than moving the receiver, and a low `-t` already steps a quiet row about a second after
+  row are still capped. Suspensions observed across stalled input restart at the first eligible decoder tick;
+  operator hold release restarts at the command. A typed row can carry its own `--scan-max-visit-ms <ms>` in the
+  `options` column, where `0` exempts that row; legacy untyped rows apply row keys but not row options, so they always
+  use the global value. A failed legacy hop keeps the row and restarts the visit and qualification windows so decoding
+  can resume before another attempt. Two caveats on legacy lists: a row whose frequency also appears on the next row
+  "hops" to the same frequency, ending the call as an explicit hop rather than moving the receiver, and a low `-t`
+  already steps a quiet row about a second after
   its last sync, so the cap only changes what happens on a row that keeps syncing.
   Optional channel-map `mode` values select `p25`, `dmr`, `nxdn96`, `nxdn48`, `dpmr`, `dstar`, `ysf`, or `m17` for
   each row. See [the mixed-mode example](../examples/conventional_scan_modes.csv). Declared rows work even when

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -560,7 +560,8 @@ Notes
     two-second window; use target `dwell_ms` to budget each visit. See [trunk-scan timing](trunk-scan.md).
   - Under `-Y` without `--scan-voice-only`, the terminal's `Scan Timing` row counts this value down from the last
     sync as `Hangtime`. The rotation rule itself compares whole seconds, so the hop can land up to a second after the
-    countdown reaches `0.0s`; the countdown is a readout of the same anchor, and the policy is unchanged.
+    countdown reaches `0.0s`; the countdown is a readout of the same anchor, and the policy is unchanged. NXDN holds
+    the scan two extra seconds after each confirmed frame, so on an NXDN row the countdown starts above `-t`.
   - P25 Talk Complete, TDU, TDULC, MAC_END_PTT, MAC_IDLE, and MAC_HANGTIME mark a transmission boundary. They close
     that slot's media and start or refresh the traffic-carrier inactivity timer without returning to the control
     channel. A follow-up PTT/ACTIVE on the retained carrier opens a clean call epoch without retuning.

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -719,6 +719,8 @@ External dependencies (resolved via CMake):
   channel maps run the typed scanner. `dsd_scan_settings_equal()` compares acquisition settings only; the row-scoped
   options (forcing, CRC, mutes, voice gate, group file) are folded through `dsd_scan_mode_resume()` without
   resetting acquisition. Conventional trunk-scan targets take their voice-gate hold/qualify from the row profile.
+  `DSD_SCAN_OPT_MAX_VISIT` is the one row option accepted on trunked types as well, and its `scan_max_visit_ms`
+  travels in the same row-option block, outside `dsd_scan_settings_equal()`, so a row cap never restages a tune.
 - App-control scopes force/CRC/voice configuration commands and group imports, while live row policy mutations stay
   with the active context. Configuration export reads saved group paths and voice settings from the configured scope.
 

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -48,7 +48,11 @@ Generated (do not edit/commit):
   - Voice-gated scan for -Y and trunk scan (issue #381): `src/engine/scan_voice_gate.c` behind
     `include/dsd-neo/engine/scan_voice_gate.h`; its probe returns separate active and retained last-media clocks so
     a protocol terminator cannot erase the scanner's tail anchor (tests: `ENGINE_SCAN_VOICE_GATE`,
-    `ENGINE_NO_CARRIER_RESET`, `ENGINE_TRUNK_SCAN`)
+    `ENGINE_NO_CARRIER_RESET`, `ENGINE_TRUNK_SCAN`). The same file owns the scan-timing publication
+    (`dsd_scan_timing_clear()` / `dsd_scan_timing_publish()`) and the -Y timing tick
+    `dsd_engine_scan_y_timing_tick()`, which stamps `dsd_state::scan_timing` with the stay reason and the absolute
+    monotonic deadline of the window that is running (issue #508); the deadline it publishes is the same instant
+    `dsd_scan_voice_gate_should_step()` flips, so the readout cannot drift from the rotation it describes
   - Installs runtime hook tables used by DSP/frame-sync code
     (`src/engine/frame_sync_hooks_install.c`, `include/dsd-neo/runtime/frame_sync_hooks.h`)
 - Build files: `src/engine/CMakeLists.txt`
@@ -82,6 +86,12 @@ behavior, the CSV columns, and the CLI/config options live in `docs/trunk-scan.m
 - Conventional activity reports: `dsd_engine_trunk_scan_dmr_conventional_activity()`,
   `dsd_engine_trunk_scan_nxdn_conventional_activity()`, and `dsd_engine_trunk_scan_p25_conventional_activity()`,
   reached from protocol code through the runtime hooks.
+
+Beside the active-target publication the coordinator also publishes the stay reason and live timing for the parked
+target into `dsd_state::scan_timing` once per tick (issue #508), from the same effective dwell/hold resolvers the
+rotation itself uses. It is a readout, not a decision: the reason function is pure and the old held/not-held verdict
+is a one-line wrapper over it, so no rotation, hold or step moves because of it. `app_control/scan_timing_view`
+turns it into a row (see below).
 
 Every parked target keeps its own snapshot of decoder state — channel map, trunking/LCN state, call and P25 identity
 metadata (the IDEN tables and the user band plan behind them), the encrypted-target lockout ledger, and the NXDN
@@ -316,6 +326,14 @@ installs from `src/engine/trunk_tuning.c` in `src/engine/trunk_tuning_hooks_inst
   Such sessions therefore report the defaults — no carrier lock, no CFO, no output/symbol rate, and the
   invalid-SNR sentinel — and a frontend should omit those rows rather than render them as zeros. Applies to
   every frontend, not just the Android app
+- Shared display decisions, so no frontend has to restate one: `include/dsd-neo/app_control/call_view.h` and
+  `src/app_control/call_view.c` fold the canonical call state into a per-slot line, and
+  `include/dsd-neo/app_control/scan_timing_view.h` and `src/app_control/scan_timing_view.c` fold
+  `dsd_state::scan_timing` into the Scan Timing row — the stay phrase, the remaining/total of the window that is
+  running, and which of dwell/hold/hang is worth printing (issue #508). The decoder owns every deadline; these
+  views only difference it against the caller's monotonic clock, which is what keeps the terminal row, the Qt panel
+  and the Android app from drifting on what "suspended" or "hold" means. Tests: `APP_CONTROL_CALL_VIEW`,
+  `APP_CONTROL_SCAN_TIMING_VIEW`, and the terminal goldens in `UI_NCURSES_PRINTER_HELPERS`.
 - Decode quality: `include/dsd-neo/app_control/p25_metrics.h` and `src/app_control/p25_metrics.c`
   copy FEC ok percentages, populated P25 voice-error averages, and non-P25 last-frame
   errors from the caller's held snapshot. The core vocoder maintains ring counts;

--- a/docs/code_map.md
+++ b/docs/code_map.md
@@ -719,8 +719,9 @@ External dependencies (resolved via CMake):
   channel maps run the typed scanner. `dsd_scan_settings_equal()` compares acquisition settings only; the row-scoped
   options (forcing, CRC, mutes, voice gate, group file) are folded through `dsd_scan_mode_resume()` without
   resetting acquisition. Conventional trunk-scan targets take their voice-gate hold/qualify from the row profile.
-  `DSD_SCAN_OPT_MAX_VISIT` is the one row option accepted on trunked types as well, and its `scan_max_visit_ms`
-  travels in the same row-option block, outside `dsd_scan_settings_equal()`, so a row cap never restages a tune.
+  `DSD_SCAN_OPT_MAX_VISIT` is the one **scan-timing** row option accepted on trunked types as well, and its
+  `scan_max_visit_ms` travels in the same row-option block, outside `dsd_scan_settings_equal()`, so a row cap never
+  restages a tune.
 - App-control scopes force/CRC/voice configuration commands and group imports, while live row policy mutations stay
   with the active context. Configuration export reads saved group paths and voice settings from the configured scope.
 

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -346,6 +346,7 @@ small subset is exposed as config keys for convenience (for example
 | `scan_voice_only` | BOOL | Step `-Y`/conventional scan on unless decoded voice holds the row | `false` |
 | `scan_voice_qualify_ms` | INT (100-600000) | Window after sync in which voice must appear or the scan moves on | `1000` |
 | `scan_voice_hold_ms` | INT (100-600000) | Time to stay after the last voice frame | `2000` |
+| `scan_max_visit_ms` | INT (0-3600000) | Maximum time on one `-Y`/trunk-scan target per visit; `0` disables, else `1000..3600000` | `0` |
 | `p25_prefer_candidates` | BOOL | Prefer learned P25 control-channel candidates when hunting (`-^`) | `false` |
 **[trunk_scan] section:**
 | Key | Type | Description | Default |
@@ -683,6 +684,9 @@ Config/CLI interaction:
 
 - `--validate-config` reports an error when `trunk_scan.enabled = true` lacks `targets_csv`.
 - `--validate-config` reports an error when trunk scan and `[trunking] chan_csv` are both enabled.
+- `--validate-config` reports a warning when `[trunking] scan_max_visit_ms` is `1..999`. Config loading is range-free
+  by design, so such a value loads, but the decoder treats anything below `1000` as disabled; use `0` to disable the
+  per-visit cap or `1000..3600000` to set one. The CLI switch rejects `1..999` outright.
 - If trunk scan is inherited from a config file, one-off CLI arguments that select another input, mode, channel map,
   file/replay input, trunking mode, or conventional `-Y` scan mode disable the inherited scan for that run. UI-only
   flags such as

--- a/docs/config-system.md
+++ b/docs/config-system.md
@@ -346,7 +346,7 @@ small subset is exposed as config keys for convenience (for example
 | `scan_voice_only` | BOOL | Step `-Y`/conventional scan on unless decoded voice holds the row | `false` |
 | `scan_voice_qualify_ms` | INT (100-600000) | Window after sync in which voice must appear or the scan moves on | `1000` |
 | `scan_voice_hold_ms` | INT (100-600000) | Time to stay after the last voice frame | `2000` |
-| `scan_max_visit_ms` | INT (0-3600000) | Maximum time on one `-Y`/trunk-scan target per visit; `0` disables, else `1000..3600000` | `0` |
+| `scan_max_visit_ms` | INT (0-3600000) | Maximum time on one `-Y`/trunk-scan target per visit; can cut an ongoing call short; `0` disables, else `1000..3600000` | `0` |
 | `p25_prefer_candidates` | BOOL | Prefer learned P25 control-channel candidates when hunting (`-^`) | `false` |
 **[trunk_scan] section:**
 | Key | Type | Description | Default |

--- a/docs/csv-formats.md
+++ b/docs/csv-formats.md
@@ -212,12 +212,15 @@ Options are parsed once when the list is loaded. They are a restricted argument 
 | `--enc-lockout`, `--enc-follow` | Disable/enable encrypted-call following; all modes. |
 | `--scan-voice-only`, `--no-scan-voice-only` | Enable/disable the conventional voice gate. |
 | `--scan-voice-qualify-ms`, `--scan-voice-hold-ms` | Conventional voice-gate intervals, `100..600000` milliseconds. |
+| `--scan-max-visit-ms <ms>` | Maximum time on this row or target per visit; `0` disables the cap for it, otherwise `1000..3600000` milliseconds. All modes, and every trunk-target type. |
 
 Protocol-specific options require a declared `mode`; trunk targets use their `type`. A channel map whose rows carry
 `options` but no `mode` still runs through the typed scanner (blank rows inherit the configured decoder), since the
-legacy `-Y` scanner applies row keys but not row options. Trunk-system targets reject voice-gate options: their
-existing `dwell_ms` and `activity_hold_ms` columns retain their roles, while a conventional target's voice-gate
-intervals replace those two columns while the gate is on (see `docs/trunk-scan.md`). Input/output, frontend
+legacy `-Y` scanner applies row keys but not row options, so a legacy list always uses the global
+`--scan-max-visit-ms`. Trunk-system targets reject voice-gate options: their existing `dwell_ms` and
+`activity_hold_ms` columns retain their roles, while a conventional target's voice-gate intervals replace those two
+columns while the gate is on (see `docs/trunk-scan.md`). `--scan-max-visit-ms` is the one scan-timing switch
+trunk-system targets do accept, since the per-visit cap applies to every target type. Input/output, frontend
 selection, decoder flags and scanner-wide `-t` are not accepted in `options`.
 
 Omitted settings inherit the outer CLI/configuration, including forcing. Use `--no-force-key` on a normal mixed

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -187,9 +187,10 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
   `--scan-voice-qualify-ms` and `--scan-voice-hold-ms` timings apply to the `-Y` conventional scan only, not to
   trunk-scan targets; a conventional target can carry its own intervals in its `options` column (see
   [Per-target options](#per-target-options)).
-- `--scan-max-visit-ms` is not conventional-only: it is the one scan-timing switch that applies to trunked targets
-  as well, because a trunked system following call after call is exactly what it exists to interrupt. It is a ceiling
-  on the visit, not another reason to stay, so it can end an ongoing call; that is why it is off by default.
+- `--scan-max-visit-ms` is not conventional-only: it is the one scan-timing switch a trunked target can also carry
+  in its `options` column, because a trunked system following call after call is exactly what it exists to interrupt.
+  It is a ceiling on the visit, not another reason to stay, so it can end an ongoing call; that is why it is off by
+  default.
 
 Each target's `type` selects its decoder class regardless of the configured global preset. Both `p25-trunk` and
 `p25-conventional` enable both phases and exclude DMR and X2-TDMA; DMR and NXDN targets enable only their declared class and rate. Mixed

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -142,6 +142,10 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
 - `--trunk-scan-activity-hold-ms <ms>` sets the default hold time after allowed conventional DMR/P25/NXDN activity
   (NXDN96 and NXDN48 alike). Default: `1200`.
 - Per-target CSV values override these defaults.
+- The terminal's `Scan Timing` row reports the *effective* dwell and hold for the target on air — the values left
+  after the CSV column and the CLI/config default have been resolved — and labels `-t` as `hang`, never as a dwell.
+  `(suspended)` beside the dwell means it is disarmed while something holds the target, not that it expired. See
+  [the terminal UI guide](ui-terminal.md).
 - `-t <seconds>` is voice/sync-loss hangtime, not the interval between trunk-scan targets. Zero does not
   bypass target dwell or control-channel acquisition. After a followed trunked call releases, a fresh idle
   dwell starts; repeated calls can keep a busy system parked.
@@ -274,6 +278,11 @@ During scanning:
   and a `| Target: county-p25` line at the top of Call Info, which is the one that survives compact view.
   While idle, Call Info follows the parked target's protocol panel; an unknown NXDN RAN or IDAS area
   is shown as `--`.
+- A `| Scan Timing:` row directly under the Trunk Scan row says why the receiver is staying on that target —
+  `Acquiring control`, `Following call`, `Retune pending`, `Retune retry`, `Manual hold`, `Idle dwell`, and the
+  conventional `Voice` / `Voice tail` / `Activity hold` / `Qualify` — with a countdown on whichever window is
+  running and the target's effective dwell and hold beside it. The phrase table is in
+  [the terminal UI guide](ui-terminal.md); the Qt and Android panels show the same thing.
 - Idle targets rotate after their dwell time.
 - The rotation can be driven from the terminal (Trunking menu, or the hotkeys): `Y` holds the scan on the parked
   target, `b` avoids the parked target for the rest of the session and moves on, `L` moves to the next eligible target

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -134,6 +134,7 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
   --trunk-scan ~/radio/trunk_scan_targets.csv \
   --trunk-scan-dwell-ms 5000 \
   --trunk-scan-activity-hold-ms 2000 \
+  --scan-max-visit-ms 20000 \
   --frontend terminal
 ```
 
@@ -141,6 +142,10 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
   `3000`.
 - `--trunk-scan-activity-hold-ms <ms>` sets the default hold time after allowed conventional DMR/P25/NXDN activity
   (NXDN96 and NXDN48 alike). Default: `1200`.
+- `--scan-max-visit-ms <ms>` caps how long one visit to a target may last: `0` disables it, any other value is
+  `1000..3600000` milliseconds. Default: `0`, so nothing changes unless you ask for it. Config: `[trunking]
+  scan_max_visit_ms`. There is no dedicated CSV column; a target overrides the cap from its `options` column. In a
+  list of two busy systems the rotation alternates between them, spending the full limit on each.
 - Per-target CSV values override these defaults.
 - The terminal's `Scan Timing` row reports the *effective* dwell and hold for the target on air — the values left
   after the CSV column and the CLI/config default have been resolved — and labels `-t` as `hang`, never as a dwell.
@@ -182,6 +187,9 @@ dsd-neo -ft -i rtl:0:851.0125M:22:0:48:0:2 \
   `--scan-voice-qualify-ms` and `--scan-voice-hold-ms` timings apply to the `-Y` conventional scan only, not to
   trunk-scan targets; a conventional target can carry its own intervals in its `options` column (see
   [Per-target options](#per-target-options)).
+- `--scan-max-visit-ms` is not conventional-only: it is the one scan-timing switch that applies to trunked targets
+  as well, because a trunked system following call after call is exactly what it exists to interrupt. It is a ceiling
+  on the visit, not another reason to stay, so it can end an ongoing call; that is why it is off by default.
 
 Each target's `type` selects its decoder class regardless of the configured global preset. Both `p25-trunk` and
 `p25-conventional` enable both phases and exclude DMR and X2-TDMA; DMR and NXDN targets enable only their declared class and rate. Mixed
@@ -239,6 +247,10 @@ Voice-only scan from a config file lives in `[trunking]` (`scan_voice_only`, `sc
 `scan_voice_hold_ms`): conventional targets reuse `dwell_ms` as the qualify window and `activity_hold_ms` as the
 hold, refreshed only from decoded voice; trunked targets are unchanged.
 
+The per-visit cap lives in the same section, as `[trunking] scan_max_visit_ms`, and applies to every target type:
+`0` (the default) disables it, otherwise use `1000..3600000`. Config loading does not clamp the value, so a
+hand-written `1..999` reaches the decoder, which treats it as disabled.
+
 Set `tune_enc_calls = false` to enable key-aware encryption lockout. Otherwise eligible encrypted or
 encryption-unknown P25 trunk voice grants are visited briefly and classified silently; only clear calls or calls with a
 complete matching key for a supported algorithm continue. Missing-key calls remain silent and are released at
@@ -258,6 +270,8 @@ Config notes:
 - `targets_csv` supports the same path expansion as other config paths (`~`, `$VAR`, and `${VAR}`).
 - `targets_csv` is required when `enabled = true`.
 - `[trunking] chan_csv` is rejected when trunk scan is enabled.
+- `--validate-config` reports a warning when `[trunking] scan_max_visit_ms` is `1..999`: the decoder ignores such a
+  value, so use `0` to disable the cap or `1000..3600000` to set one.
 - Profiles can enable trunk scan. A profile may inherit `trunk_scan.targets_csv` from the base config.
 - If trunk scan is inherited from a config file, one-off CLI arguments that select another input, mode, channel map,
   file/replay input, trunking mode, or conventional `-Y` scan mode disable the inherited scan for that run. UI-only
@@ -284,6 +298,20 @@ During scanning:
   running and the target's effective dwell and hold beside it. The phrase table is in
   [the terminal UI guide](ui-terminal.md); the Qt and Android panels show the same thing.
 - Idle targets rotate after their dwell time.
+- With `--scan-max-visit-ms` (or `[trunking] scan_max_visit_ms`) set, a visit also ends when it reaches the cap,
+  whatever the target is doing: a trunked call being followed, a conventional hold, a control-channel hunt. The clock
+  starts at the instant the target parks and starts again from zero on every re-park, so activity, grants and the
+  state machine's own control/voice-channel retunes never extend it; a retune the coordinator is still waiting on
+  never expires, and a completed one anchors at its own completion. Expiry advances only when another eligible target
+  exists — one that is neither avoided for the session nor still cooling down from a failed retune — and otherwise
+  re-arms, so a one-target list and an all-avoided list are unaffected and a target that becomes eligible later gets a
+  full limit rather than an immediate hop. A `Y` hold suspends the cap, and releasing it starts a fresh full limit
+  rather than the remainder; an `-I` talkgroup hold suspends it only while the followed call matches the held
+  talkgroup, and the limit runs from zero again once that call ends, so other calls on the target are still capped.
+  When the cap evicts a target mid-call, the carrier is released first, so revisiting it later restores an idle target
+  rather than a stale call. If every alternate then fails to retune and the receiver falls back onto the same target,
+  the call has still been released and the visit simply starts over, idle. A target's `options` column can carry its
+  own `--scan-max-visit-ms <ms>`, and `0` there exempts that target while the global cap is set.
 - The rotation can be driven from the terminal (Trunking menu, or the hotkeys): `Y` holds the scan on the parked
   target, `b` avoids the parked target for the rest of the session and moves on, `L` moves to the next eligible target
   now, and "Clear avoids" puts every avoided target back. A hold only pauses the idle dwell: the parked target's
@@ -470,6 +498,12 @@ target's `--scan-voice-hold-ms` replaces its `activity_hold_ms` as the hold afte
 keep the column values. Row metadata in a target's `chan_csv` is validated and discarded; put system options on the
 target itself.
 
+`--scan-max-visit-ms <ms>` is the exception to that conventional-only rule: every target type accepts it, trunked
+included. A target that carries it wins over the global `--scan-max-visit-ms` / `[trunking] scan_max_visit_ms`
+outright, including a row `0`, which exempts that target while the global cap stays in force elsewhere; a target
+without it inherits the global. Accepted values are `0` or `1000..3600000`, the same bounds as the CLI switch. Saving
+configuration while a target is parked records the configured global, not the parked target's override.
+
 A row that names key material in `options` (`-b`, `-H`, `-1`, `-R`, `-K`, `-k`) may still fill the legacy key
 columns for the other families; the merge rejects a column that duplicates an option. Optional header names,
 including `options` and its `relevant_CLI_switches` alias, match ASCII case-insensitively.
@@ -504,6 +538,9 @@ PPM/modulation inherit their corresponding defaults. Nonzero dwell/hold must be
 250–600000 ms. Lists use the app's voice hang time, not per-system hang-time overrides;
 Extra decoder arguments containing `-t` still take precedence. Voice/sync-loss hang time
 is separate from idle dwell on every target and the activity hold on conventional targets.
+The editor does not model the per-visit cap: put `--scan-max-visit-ms <ms>` in Extra decoder
+arguments to cap every target in the session, or run `--trunk-scan` with a target CSV of your
+own, whose `options` cells can cap individual targets.
 The older channel-scanning mode enabled with `-Y` instead uses `-t` as its dwell
 timer, so changing the app default or a saved-system hang-time override also
 changes that mode's rotation timing.

--- a/docs/trunk-scan.md
+++ b/docs/trunk-scan.md
@@ -310,11 +310,15 @@ During scanning:
   full limit rather than an immediate hop. A `Y` hold suspends the cap, and releasing it starts a fresh full limit
   rather than the remainder; an `-I` talkgroup hold suspends it only while the followed call matches the held
   talkgroup, and the limit runs from zero again once that call ends, so other calls on the target are still capped.
+  Operator hold release and clearing the last alternate's avoid restart the cap at the command; other suspension
+  changes restart it at the first eligible decoder tick. Time spent waiting for input between those ticks cannot
+  consume the fresh interval.
   When the cap evicts a target mid-call, the carrier is released first, so revisiting it later restores an idle target
-  rather than a stale call. If every alternate then fails to retune and the receiver falls back onto the same target,
-  the call stays released. If the fallback park also fails, the coordinator retries that target's control channel
-  after the retune cooldown instead of waiting through its idle dwell. A pending fallback does not start the visit
-  clock until parking completes. A target's `options` column can carry its
+  rather than a stale call or activity hold. Buffered partial P25 Phase 2 audio is flushed before the release.
+  If every alternate then fails to retune and the receiver falls back onto the same target, the call stays released
+  and its end is recorded only once. If the fallback park also fails, the coordinator retries
+  that target's control channel after the retune cooldown instead of waiting through its idle dwell. A pending fallback
+  does not start the visit clock until parking completes. A target's `options` column can carry its
   own `--scan-max-visit-ms <ms>`, and `0` there exempts that target while the global cap is set.
 - The rotation can be driven from the terminal (Trunking menu, or the hotkeys): `Y` holds the scan on the parked
   target, `b` avoids the parked target for the rest of the session and moves on, `L` moves to the next eligible target

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -571,7 +571,8 @@ The values that follow are the *effective* ones for the row on air, after CSV an
 - `hang` is `-t`, and appears only while a trunked call is being followed.
 - `Visit: <remaining>/<cap>` is the per-visit cap (`--scan-max-visit-ms`, or the row's own value), and appears only
   when a cap applies to the row on air. `Visit: paused` means the cap is not counting down right now — a hold
-  suspends it, for one, and so does a visit with nothing yet to count from.
+  suspends it, a visit with nothing yet to count from has nothing to count, and a rotation with nowhere else to go
+  (a single target, or every alternate avoided or cooling down) re-arms the cap instead of ever firing it.
 
 The row is not shown in compact view. The countdown is a published deadline differenced against the terminal's own
 clock, so it keeps running while the input is stalled and stops at `0.0s`; the phrase beside it is only as fresh as the

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -569,6 +569,9 @@ The values that follow are the *effective* ones for the row on air, after CSV an
   the air has disarmed it — a call, a retune, a control-channel hunt — and `(paused)` means the operator hold has.
 - `hold` is the activity hold. It appears on conventional and `-Y` rows only; a trunked target has none.
 - `hang` is `-t`, and appears only while a trunked call is being followed.
+- `Visit: <remaining>/<cap>` is the per-visit cap (`--scan-max-visit-ms`, or the row's own value), and appears only
+  when a cap applies to the row on air. `Visit: paused` means the cap is not counting down right now — a hold
+  suspends it, for one, and so does a visit with nothing yet to count from.
 
 The row is not shown in compact view. The countdown is a published deadline differenced against the terminal's own
 clock, so it keeps running while the input is stalled and stops at `0.0s`; the phrase beside it is only as fresh as the

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -529,6 +529,51 @@ With `--trunk-scan` the same section names the target on air and its place in th
 shows no frequency: the protocol panels below it already carry the one being decoded. While a target is on air the
 Scan Mode row above it shows no name, so the screen never names two channels at once.
 
+### Scan Timing
+
+Directly under whichever scanner row is active — Scan Mode under `-Y`, Trunk Scan under `--trunk-scan`, and only the
+Trunk Scan one when both are running — a `Scan Timing` row says why the receiver is staying where it is and how much
+of that is left:
+
+```
+| Scan Timing: Idle dwell 1.8s/3.0s  hold 2.0s
+| Scan Timing: Following call  dwell 3.0s (suspended)  hang 2.0s
+| Scan Timing: Voice tail 1.5s/2.0s  dwell 3.0s (suspended)
+| Scan Timing: Manual hold  dwell 3.0s (paused)
+| Scan Timing: Hangtime 1.4s/2.0s
+```
+
+The phrase names the reason; the `remaining/total` pair after it, when there is one, is whichever window is actually
+running out.
+
+| Phrase | Staying because | Running timer |
+| --- | --- | --- |
+| `Retune pending` | a backend retune request has not resolved | none |
+| `Retune retry` | the retune failed; cooling down before retrying in place | the retry cooldown |
+| `Acquiring control` | the trunking state machine is hunting a control channel | none |
+| `Following call` | the trunking state machine is following a call | none; `hang` is the budget |
+| `Voice` | conventional voice media is active | the activity hold |
+| `Voice tail` | holding past the last voice frame (`--scan-voice-only`) | the activity hold |
+| `Activity hold` | allowed conventional activity was decoded | the activity hold |
+| `Manual hold` | `Y` holds the scan here | none |
+| `Qualify` | synced under `--scan-voice-only`, no allowed voice yet | the qualify window |
+| `Idle dwell` | nothing holds the row | the idle dwell |
+| `Hangtime` | `-Y` without `--scan-voice-only`: waiting out `-t` since the last sync | `-t` |
+
+Which phrases you can see depends on the protocol: an NXDN trunked target has no state machine to report control
+acquisition, so it only ever reads `Following call` or `Idle dwell`.
+
+The values that follow are the *effective* ones for the row on air, after CSV and option overrides:
+
+- `dwell` is the idle dwell, printed only when it is not itself the running timer. `(suspended)` means something on
+  the air has disarmed it — a call, a retune, a control-channel hunt — and `(paused)` means the operator hold has.
+- `hold` is the activity hold. It appears on conventional and `-Y` rows only; a trunked target has none.
+- `hang` is `-t`, and appears only while a trunked call is being followed.
+
+The row is not shown in compact view. The countdown is a published deadline differenced against the monotonic clock,
+and snapshots are published only while samples flow, so it freezes if the input stalls instead of running past zero on
+its own. A narrow terminal cuts the row at the edge rather than wrapping it.
+
 Call Info repeats the answer on its own first line, because compact view hides the Input Output section:
 
 ```

--- a/docs/ui-terminal.md
+++ b/docs/ui-terminal.md
@@ -561,7 +561,7 @@ running out.
 | `Hangtime` | `-Y` without `--scan-voice-only`: waiting out `-t` since the last sync | `-t` |
 
 Which phrases you can see depends on the protocol: an NXDN trunked target has no state machine to report control
-acquisition, so it only ever reads `Following call` or `Idle dwell`.
+acquisition, so it never reads `Acquiring control`.
 
 The values that follow are the *effective* ones for the row on air, after CSV and option overrides:
 
@@ -570,9 +570,11 @@ The values that follow are the *effective* ones for the row on air, after CSV an
 - `hold` is the activity hold. It appears on conventional and `-Y` rows only; a trunked target has none.
 - `hang` is `-t`, and appears only while a trunked call is being followed.
 
-The row is not shown in compact view. The countdown is a published deadline differenced against the monotonic clock,
-and snapshots are published only while samples flow, so it freezes if the input stalls instead of running past zero on
-its own. A narrow terminal cuts the row at the edge rather than wrapping it.
+The row is not shown in compact view. The countdown is a published deadline differenced against the terminal's own
+clock, so it keeps running while the input is stalled and stops at `0.0s`; the phrase beside it is only as fresh as the
+last snapshot, which is published while samples flow. A narrow terminal cuts the row at the edge rather than wrapping
+it. On an NXDN row under `-Y`, the decoder keeps the scan two seconds past each confirmed frame, so the `Hangtime`
+countdown starts above `-t`.
 
 Call Info repeats the answer on its own first line, because compact view hides the Input Output section:
 

--- a/examples/conventional_scan_options.csv
+++ b/examples/conventional_scan_options.csv
@@ -2,5 +2,5 @@ channel,frequency_hz,name,mode,options
 1,143950000,RC4 example,dmr,-1 0123456789 -0 -F
 2,160237500,Hytera forced example,dmr,-H 0123456789 -4 -F --scan-voice-only --scan-voice-hold-ms 4000
 3,164662500,Clear and BP1 example,dmr,-b 1 --no-force-key --strict-crc
-4,472000000,Clear P25 example,p25,--no-force-key --strict-crc
+4,472000000,Clear P25 example,p25,--no-force-key --strict-crc --scan-max-visit-ms 15000
 5,456425000,NXDN scrambler example,nxdn48,-R 1 --no-force-key

--- a/examples/trunk_scan_targets.csv
+++ b/examples/trunk_scan_targets.csv
@@ -1,5 +1,5 @@
 id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,modulation,rtl_gain,keys_hex_csv,single_key_dec,single_key_hex,options,p25_bandplan_csv
-county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learned from control-channel data,auto,,example_aes_keys.csv,,,--enc-lockout,p25_bandplan.csv
+county-p25,p25-trunk,851012500,,3000,,P25 control channel; channels may be learned from control-channel data,auto,,example_aes_keys.csv,,,--enc-lockout --scan-max-visit-ms 20000,p25_bandplan.csv
 field-p25,p25-conventional,851500000,,1500,1200,one-frequency P25,c4fm,,,,,,
 city-dmr,dmr-trunk,456318750,dmr_t3_chan.csv,3000,,DMR Tier III control channel using examples/dmr_t3_chan.csv,auto,,,,,,
 plant-dmr,dmr-conventional,461112500,,1500,1200,one-frequency DMR conventional channel,gfsk,,,1,0000001F00,--no-force-key,

--- a/include/dsd-neo/app_control/scan_timing_view.h
+++ b/include/dsd-neo/app_control/scan_timing_view.h
@@ -53,6 +53,13 @@ typedef struct {
     uint32_t hold_ms;      /**< Effective activity hold. */
     uint8_t show_hang;     /**< 1 = @c hang_ms governs the current stay (-t). */
     uint32_t hang_ms;      /**< Voice/sync-loss hangtime, from -t. */
+    /* The per-visit cap (issue #507). Not a stay reason and not one of the reason-driven
+       budgets above: it caps the whole visit, so it applies to the row on air whatever is
+       holding it, and a surface reports it beside the reason rather than instead of it. */
+    uint8_t show_visit;          /**< 1 = a cap applies to the row on air. */
+    uint32_t visit_ms;           /**< Effective cap for the row (--scan-max-visit-ms); 0 = off. */
+    uint8_t visit_live;          /**< 1 = @c visit_remaining_ms is counting; 0 = suspended/unanchored. */
+    uint32_t visit_remaining_ms; /**< max(0, visit deadline - now); 0 unless @c visit_live. */
 } dsd_app_scan_timing;
 
 /**

--- a/include/dsd-neo/app_control/scan_timing_view.h
+++ b/include/dsd-neo/app_control/scan_timing_view.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/**
+ * @file
+ * @brief Frontend-neutral decisions about what the scan timing line should say (issue #508).
+ *
+ * The decoder publishes why the scanner is staying on the row on air and the monotonic
+ * deadline of whichever window is running (dsd_state::scan_timing). A status surface has
+ * to turn that into a phrase, a remaining time and a set of "show this budget" verdicts.
+ * That translation lives here, shared, so the terminal row, the Qt panel and the Android
+ * app cannot drift apart on what "suspended" or "hold" means.
+ */
+
+#ifndef DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_SCAN_TIMING_VIEW_H_
+#define DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_SCAN_TIMING_VIEW_H_
+
+#include <dsd-neo/core/opts_fwd.h>
+#include <dsd-neo/core/state_fwd.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief What the idle dwell budget is doing while the row is on air. */
+enum {
+    DSD_APP_SCAN_DWELL_NONE = 0,  /**< No dwell budget applies (or it is the live window). */
+    DSD_APP_SCAN_DWELL_RUNNING,   /**< The dwell is the live window counting down. */
+    DSD_APP_SCAN_DWELL_SUSPENDED, /**< Disarmed while something else holds the row. */
+    DSD_APP_SCAN_DWELL_PAUSED,    /**< Disarmed by the operator hold. */
+};
+
+/**
+ * @brief Display-ready scan timing for the row on air.
+ *
+ * @c phrase is a static English label; frontends that translate wrap it themselves.
+ * Every millisecond field is already clamped and derived, so a surface only formats.
+ */
+typedef struct {
+    uint8_t active;        /**< 0 = no scanner on, or nothing published: render nothing. */
+    uint8_t reason;        /**< dsd_scan_stay_reason. */
+    const char* phrase;    /**< Static label for @c reason (and the voice-gate phase). */
+    uint8_t timer_live;    /**< 1 = @c remaining_ms / @c span_ms describe a running window. */
+    uint32_t remaining_ms; /**< max(0, deadline - now). */
+    uint32_t span_ms;      /**< Full width of the running window. */
+    uint8_t show_dwell;    /**< 1 = @c dwell_ms is worth printing beside the phrase. */
+    uint32_t dwell_ms;     /**< Effective idle dwell (or -Y qualify window). */
+    uint8_t dwell_state;   /**< One of the DSD_APP_SCAN_DWELL_* values. */
+    uint8_t show_hold;     /**< 1 = @c hold_ms applies (conventional rows only). */
+    uint32_t hold_ms;      /**< Effective activity hold. */
+    uint8_t show_hang;     /**< 1 = @c hang_ms governs the current stay (-t). */
+    uint32_t hang_ms;      /**< Voice/sync-loss hangtime, from -t. */
+} dsd_app_scan_timing;
+
+/**
+ * @brief Fill @p out from the published scan timing.
+ *
+ * Zeroes @p out first. @p now_m is monotonic seconds, the clock the decoder stamps the
+ * deadlines from. Returns 1 when there is something to show (@c active), 0 when the row
+ * should be left blank, and -1 for invalid arguments.
+ */
+int dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double now_m, dsd_app_scan_timing* out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DSD_NEO_INCLUDE_DSD_NEO_APP_CONTROL_SCAN_TIMING_VIEW_H_ */

--- a/include/dsd-neo/app_control/scan_timing_view.h
+++ b/include/dsd-neo/app_control/scan_timing_view.h
@@ -53,7 +53,6 @@ typedef struct {
     uint32_t hold_ms;      /**< Effective activity hold. */
     uint8_t show_hang;     /**< 1 = @c hang_ms governs the current stay (-t). */
     uint32_t hang_ms;      /**< Active protocol's effective voice/sync-loss hangtime. */
-    /**< Voice/sync-loss hangtime, from -t. */
     /* The per-visit cap (issue #507). Not a stay reason and not one of the reason-driven
        budgets above: it caps the whole visit, so it applies to the row on air whatever is
        holding it, and a surface reports it beside the reason rather than instead of it. */

--- a/include/dsd-neo/core/dsd_time.h
+++ b/include/dsd-neo/core/dsd_time.h
@@ -29,6 +29,15 @@ dsd_time_now_monotonic_s(void) {
     return (double)dsd_time_monotonic_ns() / 1e9;
 }
 
+/**
+ * @brief Return wall-clock time in seconds, on the same epoch as time(NULL) but with
+ * sub-second precision, for converting a time_t anchor into a monotonic deadline.
+ */
+static inline double
+dsd_time_now_realtime_s(void) {
+    return (double)dsd_time_realtime_ns() / 1e9;
+}
+
 /** @brief Stamp current time as control-channel sync (monotonic + wall clock). */
 void dsd_mark_cc_sync(dsd_state* state);
 

--- a/include/dsd-neo/core/opts.h
+++ b/include/dsd-neo/core/opts.h
@@ -261,6 +261,8 @@ struct dsd_opts {
     int scan_voice_only;
     int scan_voice_qualify_ms;
     int scan_voice_hold_ms;
+    /* 0 disables; else 1000..3600000 ms cap on one scan-target visit (issue #507) */
+    int scan_max_visit_ms;
     int setmod_bw;
     int slot_preference;
     int slot1_on;

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -1741,6 +1741,7 @@ struct dsd_state {
      * returns early with the gate off. Rides the vertex_ks_count..ui_msg range. */
     double scan_visit_since_m;
     int scan_visit_roll_seen;
+    uint8_t scan_visit_rearm_pending; /**< resume a suspended visit at the next eligible tick */
     /* Scan state + live timing for the Scan Timing row (issue #508). Written by the
      * --trunk-scan coordinator for its parked target, or by the -Y timing tick when trunk
      * scan is off; the two never both write it. Rides the vertex_ks_count..ui_msg range. */

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -399,6 +399,35 @@ typedef enum {
     DSD_SCAN_VOICE_GATE_TAIL = 3,
 } dsd_scan_voice_gate_phase;
 
+/** Why the receiver is staying on the scanner's current row (issue #508). Frontend-neutral:
+ * the decoder owns every deadline and the UI only renders what is published. NONE means
+ * nothing holds the row -- for --trunk-scan that is exactly the old "not held" verdict. */
+typedef enum {
+    DSD_SCAN_STAY_NONE = 0,
+    DSD_SCAN_STAY_RETUNE_PENDING = 1, /**< a backend retune request has not resolved */
+    DSD_SCAN_STAY_RETUNE_RETRY = 2,   /**< retune failed; cooling down before retrying in place */
+    DSD_SCAN_STAY_CC_ACQUIRE = 3,     /**< trunking SM is acquiring a control channel */
+    DSD_SCAN_STAY_CALL_FOLLOW = 4,    /**< trunking SM is following a call, hangtime included */
+    DSD_SCAN_STAY_VOICE = 5,          /**< conventional row: voice media is active */
+    DSD_SCAN_STAY_ACTIVITY_HOLD = 6,  /**< conventional row: activity hold / voice tail running */
+    DSD_SCAN_STAY_MANUAL_HOLD = 7,    /**< operator hold (Y): the dwell is paused, not expired */
+    DSD_SCAN_STAY_IDLE_DWELL = 8,     /**< nothing holds it; the idle dwell / qualify window runs */
+    DSD_SCAN_STAY_HANGTIME = 9,       /**< -Y legacy rule: waiting out -t since the last sync */
+} dsd_scan_stay_reason;
+
+/** Live scan timing for the frontends' Scan Timing row (issue #508). Plain inline
+ * scalars: it rides the vertex_ks_count..ui_msg snapshot copy range (ui_snapshot.c static
+ * assert) and must never grow a pointer, or the byte-range copy would alias decoder memory. */
+struct dsd_scan_timing_publication {
+    double started_m;     /**< monotonic start of the live window; < 0 when there is none */
+    double deadline_m;    /**< monotonic expiry; < 0 = no live timer (suspended/paused/unanchored) */
+    uint32_t span_ms;     /**< full width of the live window; 0 when there is no timer */
+    uint32_t dwell_ms;    /**< effective idle dwell (or -Y qualify) for the row on air; 0 = n/a */
+    uint32_t hold_ms;     /**< effective activity hold; 0 on trunked rows and when n/a */
+    uint8_t reason;       /**< dsd_scan_stay_reason */
+    uint8_t conventional; /**< 1 = conventional / -Y row, so hold_ms means something */
+};
+
 // dsd_state is a C aggregate, not a C++ class: it is allocated once and zeroed by
 // initState() before anything reads it, and C code — which is most of its users —
 // has no constructors to write. A C++ TU that includes this header would otherwise
@@ -1696,6 +1725,10 @@ struct dsd_state {
     int scan_voice_gate_roll_seen;
     uint8_t scan_voice_gate_hold_seen;
     uint8_t scan_voice_gate_phase;
+    /* Scan state + live timing for the Scan Timing row (issue #508). Written by the
+     * --trunk-scan coordinator for its parked target, or by the -Y timing tick when trunk
+     * scan is off; the two never both write it. Rides the vertex_ks_count..ui_msg range. */
+    dsd_scan_timing_publication scan_timing;
 
     // Transient UI message (shown briefly in ncurses printer)
     char ui_msg[128];

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -419,11 +419,17 @@ typedef enum {
  * scalars: it rides the vertex_ks_count..ui_msg snapshot copy range (ui_snapshot.c static
  * assert) and must never grow a pointer, or the byte-range copy would alias decoder memory. */
 struct dsd_scan_timing_publication {
-    double started_m;     /**< monotonic start of the live window; < 0 when there is none */
-    double deadline_m;    /**< monotonic expiry; < 0 = no live timer (suspended/paused/unanchored) */
-    uint32_t span_ms;     /**< full width of the live window; 0 when there is no timer */
-    uint32_t dwell_ms;    /**< effective idle dwell (or -Y qualify) for the row on air; 0 = n/a */
-    uint32_t hold_ms;     /**< effective activity hold; 0 on trunked rows and when n/a */
+    double started_m;  /**< monotonic start of the live window; < 0 when there is none */
+    double deadline_m; /**< monotonic expiry; < 0 = no live timer (suspended/paused/unanchored) */
+    /** Monotonic expiry of the per-visit cap (issue #507); < 0 = no live cap, whether it is
+     * disabled, not yet anchored, or suspended by a hold. Never zeroed into place: 0.0 would
+     * read as a deadline at monotonic 0, which is long past. */
+    double visit_deadline_m;
+    uint32_t span_ms;  /**< full width of the live window; 0 when there is no timer */
+    uint32_t dwell_ms; /**< effective idle dwell (or -Y qualify) for the row on air; 0 = n/a */
+    uint32_t hold_ms;  /**< effective activity hold; 0 on trunked rows and when n/a */
+    /** Effective per-visit cap for the row on air in ms; 0 = off (issue #507). */
+    uint32_t visit_limit_ms;
     uint8_t reason;       /**< dsd_scan_stay_reason */
     uint8_t conventional; /**< 1 = conventional / -Y row, so hold_ms means something */
 };

--- a/include/dsd-neo/core/state.h
+++ b/include/dsd-neo/core/state.h
@@ -1731,6 +1731,15 @@ struct dsd_state {
     int scan_voice_gate_roll_seen;
     uint8_t scan_voice_gate_hold_seen;
     uint8_t scan_voice_gate_phase;
+    /* Per-visit cap bookkeeping for -Y (issue #507). scan_visit_since_m is the monotonic instant
+     * the row on air was tuned (-1.0 = no visit anchored, so the cap cannot fire) and
+     * scan_visit_roll_seen is the lcn_freq_roll this bookkeeping last saw, so an untyped `L` or
+     * avoid that moves the row without a retune note re-anchors. Deliberately separate from the
+     * scan_voice_gate_* anchors above: the cap applies under the voice gate and under the legacy
+     * hangtime rule alike, so it must not depend on gate-only code running -- the gate tick
+     * returns early with the gate off. Rides the vertex_ks_count..ui_msg range. */
+    double scan_visit_since_m;
+    int scan_visit_roll_seen;
     /* Scan state + live timing for the Scan Timing row (issue #508). Written by the
      * --trunk-scan coordinator for its parked target, or by the -Y timing tick when trunk
      * scan is off; the two never both write it. Rides the vertex_ks_count..ui_msg range. */

--- a/include/dsd-neo/core/state_fwd.h
+++ b/include/dsd-neo/core/state_fwd.h
@@ -20,6 +20,7 @@ extern "C" {
 
 typedef struct dsd_state dsd_state;
 typedef struct Event_History_I Event_History_I;
+typedef struct dsd_scan_timing_publication dsd_scan_timing_publication;
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/engine/scan_voice_gate.h
+++ b/include/dsd-neo/engine/scan_voice_gate.h
@@ -41,6 +41,17 @@ typedef struct {
  */
 int dsd_scan_voice_probe(const dsd_opts* opts, const dsd_state* state, dsd_scan_voice_probe_result* out);
 
+/**
+ * Non-zero when the operator's talkgroup hold is on a call that is being followed right now:
+ * some slot carries an active, non-data call whose target -- after policy remapping -- is the
+ * held talkgroup, or, on a private call, whose source is.
+ *
+ * Both scanners suspend the per-visit limit while this holds (issue #507), so the limit cannot
+ * cut short the very call the hold exists to follow, and a fresh limit starts once that call
+ * ends. Read-only and null-safe.
+ */
+int dsd_scan_tg_hold_call_active(const dsd_state* state);
+
 /** Restart the per-visit gate memory on a scan hop. */
 void dsd_scan_voice_gate_note_retune(dsd_state* state, double now_m);
 

--- a/include/dsd-neo/engine/scan_voice_gate.h
+++ b/include/dsd-neo/engine/scan_voice_gate.h
@@ -90,10 +90,10 @@ void dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state, doubl
  * own per-target anchor.
  *
  * Separate from dsd_scan_voice_gate_tick() because the cap applies with the voice gate off as
- * well as on, and that tick returns early there. The anchor itself is written only here and by
- * dsd_scan_voice_gate_note_retune(); sync and voice activity never touch it. While the limit
- * cannot count -- suspended by a hold, or with no second row to advance to -- the anchor slides
- * to now_m, so the limit re-arms rather than ageing toward an instant hop.
+ * well as on, and that tick returns early there. Parking and operator hold release also reset
+ * the anchor; sync and voice activity never touch it. While the limit cannot count -- suspended
+ * by a hold, or with no second row to advance to -- it remembers the suspension. The first
+ * eligible tick starts a fresh interval even if input stalled since the last suspended tick.
  */
 void dsd_engine_scan_visit_tick(const dsd_opts* opts, dsd_state* state, double now_m);
 

--- a/include/dsd-neo/engine/scan_voice_gate.h
+++ b/include/dsd-neo/engine/scan_voice_gate.h
@@ -62,10 +62,13 @@ void dsd_scan_timing_publish(dsd_state* state, const dsd_scan_timing_publication
 /**
  * Publish the -Y scanner's stay reason and step deadline. A no-op unless
  * scanner_mode == 1 && trunk_scan_enabled != 1: under --trunk-scan the coordinator owns
- * the publication, exactly as it owns scan_voice_gate_phase. Every published anchor is
- * absolute, so the caller passes no clock; the renderer differences them against its own.
+ * the publication, exactly as it owns scan_voice_gate_phase.
+ *
+ * The legacy hangtime rule anchors on the wall-clock last_cc_sync_time (which NXDN can
+ * stamp two seconds into the future), so the publisher takes both clocks, sampled
+ * together, to express that anchor as a monotonic deadline the renderer can difference.
  */
-void dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state);
+void dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state, double now_m, double now_wall_s);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/engine/scan_voice_gate.h
+++ b/include/dsd-neo/engine/scan_voice_gate.h
@@ -91,15 +91,17 @@ void dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state, doubl
  *
  * Separate from dsd_scan_voice_gate_tick() because the cap applies with the voice gate off as
  * well as on, and that tick returns early there. The anchor itself is written only here and by
- * dsd_scan_voice_gate_note_retune(); sync and voice activity never touch it.
+ * dsd_scan_voice_gate_note_retune(); sync and voice activity never touch it. While the limit
+ * cannot count -- suspended by a hold, or with no second row to advance to -- the anchor slides
+ * to now_m, so the limit re-arms rather than ageing toward an instant hop.
  */
 void dsd_engine_scan_visit_tick(const dsd_opts* opts, dsd_state* state, double now_m);
 
 /**
  * The monotonic instant the visit on air runs out, or < 0 when no cap is counting: the cap is
- * disabled, no visit is anchored, a hold suspends it, a row transaction is outstanding, or there
- * is no second eligible row to advance to. Pure; the predicate and the publication both read it
- * so the countdown on screen is the one that fires.
+ * disabled, no visit is anchored, a hold suspends it, a row transaction is outstanding, the row on
+ * air has changed since the last tick, or there is no second eligible row to advance to. Pure; the
+ * predicate and the publication both read it so the countdown on screen is the one that fires.
  */
 double dsd_engine_scan_visit_deadline_m(const dsd_opts* opts, const dsd_state* state);
 

--- a/include/dsd-neo/engine/scan_voice_gate.h
+++ b/include/dsd-neo/engine/scan_voice_gate.h
@@ -53,6 +53,20 @@ int dsd_scan_voice_gate_owns_step(const dsd_opts* opts, const dsd_state* state);
 /** Non-zero when the gate says the -Y visit is over and the scan should step. */
 int dsd_scan_voice_gate_should_step(const dsd_opts* opts, const dsd_state* state, double now_m);
 
+/** Take the scan timing publication back down (scan off, shutdown, between targets). */
+void dsd_scan_timing_clear(dsd_state* state);
+
+/** Publish one scan timing report for the row on air (issue #508). */
+void dsd_scan_timing_publish(dsd_state* state, const dsd_scan_timing_publication* report);
+
+/**
+ * Publish the -Y scanner's stay reason and step deadline. A no-op unless
+ * scanner_mode == 1 && trunk_scan_enabled != 1: under --trunk-scan the coordinator owns
+ * the publication, exactly as it owns scan_voice_gate_phase. Every published anchor is
+ * absolute, so the caller passes no clock; the renderer differences them against its own.
+ */
+void dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/dsd-neo/engine/scan_voice_gate.h
+++ b/include/dsd-neo/engine/scan_voice_gate.h
@@ -52,7 +52,10 @@ int dsd_scan_voice_probe(const dsd_opts* opts, const dsd_state* state, dsd_scan_
  */
 int dsd_scan_tg_hold_call_active(const dsd_state* state);
 
-/** Restart the per-visit gate memory on a scan hop. */
+/**
+ * Restart the per-visit gate memory on a scan hop, and open the visit the per-visit cap
+ * measures (issue #507): this is the one place a successful park stamps that anchor.
+ */
 void dsd_scan_voice_gate_note_retune(dsd_state* state, double now_m);
 
 /** Per-frame tick while parked on a -Y row; a no-op unless scanner_mode is on. */
@@ -80,6 +83,28 @@ void dsd_scan_timing_publish(dsd_state* state, const dsd_scan_timing_publication
  * together, to express that anchor as a monotonic deadline the renderer can difference.
  */
 void dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state, double now_m, double now_wall_s);
+
+/**
+ * Maintain the -Y per-visit anchor (issue #507). A no-op unless
+ * scanner_mode == 1 && trunk_scan_enabled != 1: under --trunk-scan the coordinator keeps its
+ * own per-target anchor.
+ *
+ * Separate from dsd_scan_voice_gate_tick() because the cap applies with the voice gate off as
+ * well as on, and that tick returns early there. The anchor itself is written only here and by
+ * dsd_scan_voice_gate_note_retune(); sync and voice activity never touch it.
+ */
+void dsd_engine_scan_visit_tick(const dsd_opts* opts, dsd_state* state, double now_m);
+
+/**
+ * The monotonic instant the visit on air runs out, or < 0 when no cap is counting: the cap is
+ * disabled, no visit is anchored, a hold suspends it, a row transaction is outstanding, or there
+ * is no second eligible row to advance to. Pure; the predicate and the publication both read it
+ * so the countdown on screen is the one that fires.
+ */
+double dsd_engine_scan_visit_deadline_m(const dsd_opts* opts, const dsd_state* state);
+
+/** Non-zero when the per-visit cap says the -Y visit is over and the scan must advance. */
+int dsd_engine_scan_visit_expired(const dsd_opts* opts, const dsd_state* state, double now_m);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/engine/trunk_scan.h
+++ b/include/dsd-neo/engine/trunk_scan.h
@@ -115,7 +115,7 @@ int dsd_engine_trunk_scan_init(dsd_opts* opts, dsd_state* state, char* err, size
 void dsd_engine_trunk_scan_shutdown(dsd_opts* opts, dsd_state* state);
 void dsd_engine_trunk_scan_tick(dsd_opts* opts, dsd_state* state);
 /** Maintain the visit clock and report expiry without tuning or releasing the call.
- * Decoder thread only, with the SM guard already held. Used by long protocol loops
+ * Decoder thread only; the caller must hold the SM guard. Used by long protocol loops
  * to unwind before the next coordinator tick performs the advance. */
 int dsd_engine_trunk_scan_visit_expired(const dsd_opts* opts, dsd_state* state);
 /**

--- a/include/dsd-neo/engine/trunk_tuning.h
+++ b/include/dsd-neo/engine/trunk_tuning.h
@@ -30,6 +30,13 @@ dsd_trunk_tune_result dsd_engine_trunk_tune_to_cc_request(dsd_opts* opts, dsd_st
 dsd_trunk_tune_result dsd_engine_return_to_cc_request(dsd_opts* opts, dsd_state* state, uint64_t request_id);
 dsd_trunk_tune_result dsd_engine_scan_tune_to_freq(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps,
                                                    uint64_t* out_request_id);
+/**
+ * @brief Release the call state a tuned voice channel owns, without tuning.
+ *
+ * Ends the canonical call rows with DSD_CALL_END_EXPLICIT, clears the VC frequency mirrors and
+ * the crypto/audio gating state, and drops trunk_is_tuned; does not tune.
+ */
+void dsd_engine_release_tuned_call_state(dsd_opts* opts, dsd_state* state);
 
 #ifdef __cplusplus
 }

--- a/include/dsd-neo/protocol/dmr/dmr_trunk_sm.h
+++ b/include/dsd-neo/protocol/dmr/dmr_trunk_sm.h
@@ -134,6 +134,11 @@ void dmr_sm_begin_cc_acquisition(dmr_sm_ctx_t* ctx, const dsd_opts* opts, const 
 /** Return to the explicit DMR control/rest frequency, clearing an obsolete P25
  * alias only on acceptance. Preserve the previous destination on failure. */
 dsd_trunk_tune_result dmr_sm_return_to_cc(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, long freq_hz);
+/** End the tuned call and come to rest on the control channel WITHOUT tuning: the release
+ * teardown minus the CC return, for a caller that owns the tuner and is already moving it
+ * (trunk scan evicting a target that reached its per-visit limit, issue #507). Tuning here
+ * would fight that move, so nothing is asked of the tuner. */
+void dmr_sm_abandon_carrier(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason);
 /** Accepted control/rest-channel evidence. Zero frequency queries the active
  * tuner only if no completed tune/decoded attribution is available for the
  * current generation; nonzero frequency must match the received channel. */

--- a/include/dsd-neo/protocol/p25/p25_trunk_sm.h
+++ b/include/dsd-neo/protocol/p25/p25_trunk_sm.h
@@ -454,6 +454,23 @@ double p25_sm_hangtime_started_m(const p25_sm_ctx_t* ctx);
 void p25_sm_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason);
 
 /**
+ * @brief End the tuned call and come to rest on the control channel WITHOUT tuning.
+ *
+ * p25_sm_release() minus the return-to-CC tune, for a caller that owns the tuner and is
+ * already moving it somewhere else: the trunk-scan coordinator evicting a target that reached
+ * its per-visit limit (issue #507). Tuning here would fight that move, so this never asks the
+ * tuner for anything -- it ends both call slots, clears the voice-channel context and decoder
+ * mirrors, drops trunk_is_tuned and settles in P25_SM_ON_CC. Session state an ordinary release
+ * keeps is kept: the counters and the encryption-reprobe memo survive.
+ *
+ * @param ctx State machine context (NULL uses the global singleton).
+ * @param opts Decoder options.
+ * @param state Decoder state.
+ * @param reason Log tag for the release reason.
+ */
+void p25_sm_abandon_carrier(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason);
+
+/**
  * @brief Record exact P25P2 frame sync while acquiring a tuned voice channel.
  *
  * This confirms demodulator acquisition and cancels no-sync recovery without

--- a/include/dsd-neo/runtime/config.h
+++ b/include/dsd-neo/runtime/config.h
@@ -623,6 +623,7 @@ typedef struct dsdneoUserConfig {
     int trunk_scan_voice_only;
     int trunk_scan_voice_qualify_ms;
     int trunk_scan_voice_hold_ms;
+    int trunk_scan_max_visit_ms;
 
     /* [radioreference] */
     int has_radioreference;

--- a/include/dsd-neo/runtime/scan_mode.h
+++ b/include/dsd-neo/runtime/scan_mode.h
@@ -45,6 +45,7 @@ typedef struct {
     int scan_voice_only;
     int scan_voice_qualify_ms;
     int scan_voice_hold_ms;
+    int scan_max_visit_ms;
     int dmr_mute_encL;
     int dmr_mute_encR;
     int unmute_encrypted_p25;

--- a/include/dsd-neo/runtime/scan_options.h
+++ b/include/dsd-neo/runtime/scan_options.h
@@ -35,6 +35,8 @@ enum {
     DSD_SCAN_OPT_DMR_MAP = 1U << 17,
     DSD_SCAN_OPT_CLEAR_KEYS = 1U << 18,
     DSD_SCAN_OPT_KEY_PROFILE_REF = 1U << 19,
+    /** The row caps how long one scan-target visit may last (issue #507). */
+    DSD_SCAN_OPT_MAX_VISIT = 1U << 20,
     DSD_SCAN_OPT_DIRECT = DSD_SCAN_OPT_BP | DSD_SCAN_OPT_HYTERA | DSD_SCAN_OPT_SCALAR | DSD_SCAN_OPT_SCRAMBLER,
     DSD_SCAN_OPT_FILES = DSD_SCAN_OPT_HEX_FILE | DSD_SCAN_OPT_DEC_FILE
 };
@@ -54,6 +56,8 @@ typedef struct {
     int voice_only;
     int qualify_ms;
     int hold_ms;
+    /** 0 = explicit per-row disable */
+    int max_visit_ms;
     int mute_dmr;
     int tune_data_calls;
     int tune_enc_calls;

--- a/src/app_control/CMakeLists.txt
+++ b/src/app_control/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(
         notification_status.c
         p25_metrics.c
         rr_import_apply.c
+        scan_timing_view.c
         symbol_profile.c
         tcp_audio_connect.c
         telemetry_hooks_install.c

--- a/src/app_control/app_command_queue.c
+++ b/src/app_control/app_command_queue.c
@@ -4565,6 +4565,9 @@ apply_manual_scan_hold_toggle(dsd_state* state) {
         // The rotation left the dwell timer alone while held; give the row a full hangtime
         // now rather than hopping on the very next no-carrier pass.
         mark_cc_sync(state, 1);
+        state->scan_visit_since_m = state->last_cc_sync_time_m;
+        state->scan_visit_roll_seen = state->lcn_freq_roll;
+        state->scan_visit_rearm_pending = 0U;
     }
     ui_set_toast(state, 3, "Scan hold %s", state->lcn_scan_hold ? "on" : "off");
 }
@@ -5116,6 +5119,7 @@ dsd_app_drain_cmds(dsd_opts* opts, dsd_state* state) {
             // Controls can change visits or hold state inside a long input wait.
             // Refresh the gate and its publication before exposing that command.
             dsd_scan_voice_gate_tick(opts, state, 0, now_m);
+            dsd_engine_scan_visit_tick(opts, state, now_m);
             dsd_engine_scan_y_timing_tick(opts, state, now_m, dsd_time_now_realtime_s());
         }
         dsd_telemetry_publish_opts_snapshot(opts);

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -393,6 +393,9 @@ chan_map_adopt(dsd_opts* opts, dsd_state* dst, dsd_state* src) {
     dsd_state_trunk_lcn_avoid_free(dst);
     dst->lcn_avoid_count = 0;
     dst->lcn_scan_hold = 0;
+    // The visit the per-visit cap was measuring belonged to a row that no longer exists.
+    dst->scan_visit_since_m = -1.0;
+    dst->scan_visit_roll_seen = 0;
     DSD_MEMSET(dst->dmr_lcn_trust, 0, sizeof dst->dmr_lcn_trust);
     dst->trunk_chan_map_seq++;
     return 0;
@@ -507,6 +510,9 @@ svc_clear_channel_map(dsd_opts* opts, dsd_state* state) {
     state->lcn_freq_roll = 0;
     state->lcn_avoid_count = 0;
     state->lcn_scan_hold = 0;
+    // Nothing left to visit, so the per-visit cap has nothing to measure from.
+    state->scan_visit_since_m = -1.0;
+    state->scan_visit_roll_seen = 0;
     // Provenance goes with the map, exactly as in chan_map_adopt(): a surviving
     // "learned on the control channel" byte would authorize an off-CC tune to a
     // frequency no longer in the map.

--- a/src/app_control/menu_services.c
+++ b/src/app_control/menu_services.c
@@ -396,6 +396,7 @@ chan_map_adopt(dsd_opts* opts, dsd_state* dst, dsd_state* src) {
     // The visit the per-visit cap was measuring belonged to a row that no longer exists.
     dst->scan_visit_since_m = -1.0;
     dst->scan_visit_roll_seen = 0;
+    dst->scan_visit_rearm_pending = 0U;
     DSD_MEMSET(dst->dmr_lcn_trust, 0, sizeof dst->dmr_lcn_trust);
     dst->trunk_chan_map_seq++;
     return 0;
@@ -513,6 +514,7 @@ svc_clear_channel_map(dsd_opts* opts, dsd_state* state) {
     // Nothing left to visit, so the per-visit cap has nothing to measure from.
     state->scan_visit_since_m = -1.0;
     state->scan_visit_roll_seen = 0;
+    state->scan_visit_rearm_pending = 0U;
     // Provenance goes with the map, exactly as in chan_map_adopt(): a surviving
     // "learned on the control channel" byte would authorize an off-CC tune to a
     // frequency no longer in the map.

--- a/src/app_control/scan_timing_view.c
+++ b/src/app_control/scan_timing_view.c
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+#include <dsd-neo/app_control/scan_timing_view.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <stdint.h>
+
+/* Step 0 contract stub: the reason/phrase table lands with the terminal renderer. */
+int
+dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double now_m, dsd_app_scan_timing* out) {
+    if (!out) {
+        return -1;
+    }
+    DSD_MEMSET(out, 0, sizeof(*out));
+    if (!opts || !state) {
+        return -1;
+    }
+    (void)now_m;
+    return 0;
+}

--- a/src/app_control/scan_timing_view.c
+++ b/src/app_control/scan_timing_view.c
@@ -5,8 +5,10 @@
 
 #include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
+#include <dsd-neo/core/state_fwd.h>
 #include <stdint.h>
 
 /**

--- a/src/app_control/scan_timing_view.c
+++ b/src/app_control/scan_timing_view.c
@@ -9,16 +9,161 @@
 #include <dsd-neo/core/state.h>
 #include <stdint.h>
 
-/* Step 0 contract stub: the reason/phrase table lands with the terminal renderer. */
+/**
+ * @brief What one stay reason renders as, before the row's own numbers are applied.
+ *
+ * A table rather than a switch so the display rule is one readable list: the terminal
+ * row, the Qt panel and the Android app all render from this, and a rule spelled out in
+ * three places is a rule that drifts. Each flag is a verdict about whether the budget is
+ * worth a column at all; whether it has a value to print is the publication's business.
+ */
+typedef struct {
+    const char* phrase;  /**< Static English label; a phase variant may override it. */
+    uint8_t dwell_state; /**< DSD_APP_SCAN_DWELL_* to report while the dwell is shown. */
+    uint8_t show_dwell;  /**< 0 where the dwell is the live window, so the span already says it. */
+    uint8_t show_hold;   /**< 0 where the hold is the live window, or the row is trunked. */
+    uint8_t show_hang;   /**< 1 only where -t is what ends the stay. */
+} dsd_scan_timing_row;
+
+/* Indexed by dsd_scan_stay_reason. NONE is present so the array covers the enum and an
+   out-of-range reason from a newer decoder is rejected by a bound rather than by luck. */
+static const dsd_scan_timing_row k_scan_timing_rows[] = {
+    [DSD_SCAN_STAY_NONE] = {"", DSD_APP_SCAN_DWELL_NONE, 0U, 0U, 0U},
+    [DSD_SCAN_STAY_RETUNE_PENDING] = {"Retune pending", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 1U, 0U},
+    [DSD_SCAN_STAY_RETUNE_RETRY] = {"Retune retry", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 1U, 0U},
+    [DSD_SCAN_STAY_CC_ACQUIRE] = {"Acquiring control", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 0U, 0U},
+    [DSD_SCAN_STAY_CALL_FOLLOW] = {"Following call", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 0U, 1U},
+    [DSD_SCAN_STAY_VOICE] = {"Voice", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 0U, 0U},
+    [DSD_SCAN_STAY_ACTIVITY_HOLD] = {"Activity hold", DSD_APP_SCAN_DWELL_SUSPENDED, 1U, 0U, 0U},
+    [DSD_SCAN_STAY_MANUAL_HOLD] = {"Manual hold", DSD_APP_SCAN_DWELL_PAUSED, 1U, 1U, 0U},
+    [DSD_SCAN_STAY_IDLE_DWELL] = {"Idle dwell", DSD_APP_SCAN_DWELL_NONE, 0U, 1U, 0U},
+    [DSD_SCAN_STAY_HANGTIME] = {"Hangtime", DSD_APP_SCAN_DWELL_NONE, 0U, 0U, 0U},
+};
+
+/* A reason the decoder can publish but this table cannot render would reach the surfaces
+   as a blank phrase. Sized against the last enumerator so adding one fails the build. */
+_Static_assert((int)(sizeof(k_scan_timing_rows) / sizeof(k_scan_timing_rows[0])) == (int)DSD_SCAN_STAY_HANGTIME + 1,
+               "every dsd_scan_stay_reason needs a display row");
+
+/** @brief Longest countdown the view will report, guarding the cast below. */
+#define DSD_APP_SCAN_REMAINING_MAX_S 86400.0
+
+/**
+ * @brief Whether there is a stay worth rendering at all.
+ *
+ * Both halves matter. A stale publication survives the scanner being switched off --
+ * nothing clears it on the way out -- so the scanner flags are what make it current; and
+ * a reason this build does not know is from a newer decoder writing the same snapshot
+ * bytes, which must render nothing rather than an empty phrase.
+ */
+static int
+scan_timing_is_active(const dsd_opts* opts, const dsd_scan_timing_publication* pub) {
+    if (opts->trunk_scan_enabled != 1 && opts->scanner_mode != 1) {
+        return 0;
+    }
+    if (pub->reason == (uint8_t)DSD_SCAN_STAY_NONE) {
+        return 0;
+    }
+    return pub->reason < (uint8_t)(sizeof(k_scan_timing_rows) / sizeof(k_scan_timing_rows[0]));
+}
+
+/**
+ * @brief The two rows whose label depends on what the voice gate is doing.
+ *
+ * The gate's phase is the only thing that separates a hold that is still following voice
+ * from one counting out its tail, and an idle dwell from the qualify window that shares
+ * its clock. Both are cosmetic refinements of the same stay, which is why they are a
+ * phrase choice here rather than reasons of their own.
+ */
+static const char*
+scan_timing_phrase(const dsd_scan_timing_row* row, uint8_t reason, uint8_t phase) {
+    if (reason == (uint8_t)DSD_SCAN_STAY_ACTIVITY_HOLD && phase == (uint8_t)DSD_SCAN_VOICE_GATE_TAIL) {
+        return "Voice tail";
+    }
+    if (reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL && phase == (uint8_t)DSD_SCAN_VOICE_GATE_QUALIFY) {
+        return "Qualify";
+    }
+    return row->phrase;
+}
+
+/**
+ * @brief Milliseconds left on the published deadline, clamped at zero.
+ *
+ * The decoder decides when the receiver moves; a poll that lands after the deadline is a
+ * frame late, not a scanner that overstayed. Clamping through the comparison's negation
+ * also settles a NaN clock, which would otherwise cast to an arbitrary count.
+ */
+static uint32_t
+scan_timing_remaining_ms(double deadline_m, double now_m) {
+    double remaining_s = deadline_m - now_m;
+    if (!(remaining_s > 0.0)) {
+        return 0U;
+    }
+    if (remaining_s > DSD_APP_SCAN_REMAINING_MAX_S) {
+        remaining_s = DSD_APP_SCAN_REMAINING_MAX_S;
+    }
+    return (uint32_t)((remaining_s * 1000.0) + 0.5);
+}
+
+/** @brief -t in milliseconds, rounded, or 0 when it is not configured. */
+static uint32_t
+scan_timing_hang_ms(const dsd_opts* opts) {
+    double hang_s = (double)opts->trunk_hangtime;
+    if (!(hang_s > 0.0)) {
+        return 0U;
+    }
+    if (hang_s > DSD_APP_SCAN_REMAINING_MAX_S) {
+        hang_s = DSD_APP_SCAN_REMAINING_MAX_S;
+    }
+    return (uint32_t)((hang_s * 1000.0) + 0.5);
+}
+
+/**
+ * @brief Fill in the budgets beside the phrase.
+ *
+ * Every effective value is copied through whether or not it is shown -- a surface with
+ * room for more than one line can still report the dwell that is counting down -- while
+ * the show_ flags carry the display rule.
+ */
+static void
+scan_timing_fill_budgets(dsd_app_scan_timing* out, const dsd_scan_timing_row* row,
+                         const dsd_scan_timing_publication* pub, const dsd_opts* opts) {
+    out->dwell_ms = pub->dwell_ms;
+    if (row->show_dwell != 0U && pub->dwell_ms != 0U) {
+        out->show_dwell = 1U;
+        out->dwell_state = row->dwell_state;
+    }
+    out->hold_ms = pub->hold_ms;
+    if (row->show_hold != 0U && pub->conventional == 1U && pub->hold_ms != 0U) {
+        out->show_hold = 1U;
+    }
+    if (row->show_hang != 0U) {
+        out->hang_ms = scan_timing_hang_ms(opts);
+        out->show_hang = (out->hang_ms != 0U) ? 1U : 0U;
+    }
+}
+
 int
 dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double now_m, dsd_app_scan_timing* out) {
-    if (!out) {
+    if (out) {
+        DSD_MEMSET(out, 0, sizeof(*out));
+    }
+    if (!opts || !state || !out) {
         return -1;
     }
-    DSD_MEMSET(out, 0, sizeof(*out));
-    if (!opts || !state) {
-        return -1;
+    const dsd_scan_timing_publication* pub = &state->scan_timing;
+    if (!scan_timing_is_active(opts, pub)) {
+        return 0;
     }
-    (void)now_m;
-    return 0;
+    const dsd_scan_timing_row* row = &k_scan_timing_rows[pub->reason];
+    out->active = 1U;
+    out->reason = pub->reason;
+    out->phrase = scan_timing_phrase(row, pub->reason, state->scan_voice_gate_phase);
+    if (pub->deadline_m >= 0.0) {
+        out->timer_live = 1U;
+        out->remaining_ms = scan_timing_remaining_ms(pub->deadline_m, now_m);
+        out->span_ms = pub->span_ms;
+    }
+    scan_timing_fill_budgets(out, row, pub, opts);
+    return 1;
 }

--- a/src/app_control/scan_timing_view.c
+++ b/src/app_control/scan_timing_view.c
@@ -145,6 +145,28 @@ scan_timing_fill_budgets(dsd_app_scan_timing* out, const dsd_scan_timing_row* ro
     }
 }
 
+/**
+ * @brief Fill in the per-visit cap, which every row carries (issue #507).
+ *
+ * Deliberately outside k_scan_timing_rows[]: the cap is a ceiling on the whole visit
+ * rather than a budget one stay reason owns, so no reason may withhold it -- the receiver
+ * moves on when it expires whatever is on the air. The deadline decides only whether it
+ * is counting: negative means disabled, not yet anchored, or suspended by a hold, and a
+ * surface has to say so in words, because a zero countdown reads as a visit that expired.
+ */
+static void
+scan_timing_fill_visit(dsd_app_scan_timing* out, const dsd_scan_timing_publication* pub, double now_m) {
+    out->visit_ms = pub->visit_limit_ms;
+    if (pub->visit_limit_ms == 0U) {
+        return;
+    }
+    out->show_visit = 1U;
+    if (pub->visit_deadline_m >= 0.0) {
+        out->visit_live = 1U;
+        out->visit_remaining_ms = scan_timing_remaining_ms(pub->visit_deadline_m, now_m);
+    }
+}
+
 int
 dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double now_m, dsd_app_scan_timing* out) {
     if (out) {
@@ -167,5 +189,6 @@ dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double no
         out->span_ms = pub->span_ms;
     }
     scan_timing_fill_budgets(out, row, pub, opts);
+    scan_timing_fill_visit(out, pub, now_m);
     return 1;
 }

--- a/src/app_control/ui_snapshot.c
+++ b/src/app_control/ui_snapshot.c
@@ -151,7 +151,7 @@ _Static_assert(offsetof(dsd_state, trunk_scan_active_id) >= offsetof(dsd_state, 
 /* Voice-gated scan memory and the per-visit cap bookkeeping beside it ride the same range so the
  * status line sees the phase and the Scan Timing row sees the cap. */
 _Static_assert(offsetof(dsd_state, scan_voice_gate_arrive_m) >= offsetof(dsd_state, vertex_ks_count)
-                   && UI_SNAPSHOT_FIELD_END(scan_visit_roll_seen) <= UI_SNAPSHOT_FIELD_END(ui_msg),
+                   && UI_SNAPSHOT_FIELD_END(scan_visit_rearm_pending) <= UI_SNAPSHOT_FIELD_END(ui_msg),
                "scan_voice_gate_*/scan_visit_* must ride the vertex_ks_count..ui_msg range");
 /* The scan timing publication is plain inline bytes beside the voice-gate memory, so like
  * them it has to be inside a copy range -- left out of one it would silently never reach

--- a/src/app_control/ui_snapshot.c
+++ b/src/app_control/ui_snapshot.c
@@ -152,6 +152,12 @@ _Static_assert(offsetof(dsd_state, trunk_scan_active_id) >= offsetof(dsd_state, 
 _Static_assert(offsetof(dsd_state, scan_voice_gate_arrive_m) >= offsetof(dsd_state, vertex_ks_count)
                    && UI_SNAPSHOT_FIELD_END(scan_voice_gate_phase) <= UI_SNAPSHOT_FIELD_END(ui_msg),
                "scan_voice_gate_* must ride the vertex_ks_count..ui_msg range");
+/* The scan timing publication is plain inline bytes beside the voice-gate memory, so like
+ * them it has to be inside a copy range -- left out of one it would silently never reach
+ * the UI. */
+_Static_assert(offsetof(dsd_state, scan_timing) >= offsetof(dsd_state, vertex_ks_count)
+                   && UI_SNAPSHOT_FIELD_END(scan_timing) <= UI_SNAPSHOT_FIELD_END(ui_msg),
+               "scan_timing must ride the vertex_ks_count..ui_msg range");
 
 /* The embedded trunk_lcn_freq[] is a plain array copied by the byte ranges
  * above; the scan-list heap tail past it needs an explicit deep copy.

--- a/src/app_control/ui_snapshot.c
+++ b/src/app_control/ui_snapshot.c
@@ -148,10 +148,11 @@ _Static_assert(UI_SNAPSHOT_FIELD_END(scan_keys_active_set) <= offsetof(dsd_state
 _Static_assert(offsetof(dsd_state, trunk_scan_active_id) >= offsetof(dsd_state, vertex_ks_count)
                    && UI_SNAPSHOT_FIELD_END(trunk_scan_avoided_count) <= UI_SNAPSHOT_FIELD_END(ui_msg),
                "trunk_scan_active_id..trunk_scan_avoided_count must ride the vertex_ks_count..ui_msg range");
-/* Voice-gated scan memory rides the same range so the status line sees the phase. */
+/* Voice-gated scan memory and the per-visit cap bookkeeping beside it ride the same range so the
+ * status line sees the phase and the Scan Timing row sees the cap. */
 _Static_assert(offsetof(dsd_state, scan_voice_gate_arrive_m) >= offsetof(dsd_state, vertex_ks_count)
-                   && UI_SNAPSHOT_FIELD_END(scan_voice_gate_phase) <= UI_SNAPSHOT_FIELD_END(ui_msg),
-               "scan_voice_gate_* must ride the vertex_ks_count..ui_msg range");
+                   && UI_SNAPSHOT_FIELD_END(scan_visit_roll_seen) <= UI_SNAPSHOT_FIELD_END(ui_msg),
+               "scan_voice_gate_*/scan_visit_* must ride the vertex_ks_count..ui_msg range");
 /* The scan timing publication is plain inline bytes beside the voice-gate memory, so like
  * them it has to be inside a copy range -- left out of one it would silently never reach
  * the UI. */

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -344,6 +344,7 @@ init_opts_trunking_and_filter_defaults(dsd_opts* opts) {
     opts->scan_voice_only = 0;
     opts->scan_voice_qualify_ms = 1000;
     opts->scan_voice_hold_ms = 2000;
+    opts->scan_max_visit_ms = 0;
     opts->trunk_cli_seen = 0;
 
     //reverse mute
@@ -943,6 +944,7 @@ init_state_trunk_scan_publication(dsd_state* state) {
     DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
     state->scan_timing.started_m = -1.0;
     state->scan_timing.deadline_m = -1.0;
+    state->scan_timing.visit_deadline_m = -1.0;
 }
 
 static void

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -941,6 +941,9 @@ init_state_trunk_scan_publication(dsd_state* state) {
     state->scan_voice_gate_roll_seen = 0;
     state->scan_voice_gate_hold_seen = 0;
     state->scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_OFF;
+    /* No visit anchored: -1.0, never 0.0, which would read as a park at monotonic 0. */
+    state->scan_visit_since_m = -1.0;
+    state->scan_visit_roll_seen = 0;
     DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
     state->scan_timing.started_m = -1.0;
     state->scan_timing.deadline_m = -1.0;

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -940,6 +940,9 @@ init_state_trunk_scan_publication(dsd_state* state) {
     state->scan_voice_gate_roll_seen = 0;
     state->scan_voice_gate_hold_seen = 0;
     state->scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_OFF;
+    DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
+    state->scan_timing.started_m = -1.0;
+    state->scan_timing.deadline_m = -1.0;
 }
 
 static void

--- a/src/core/util/dsd_init.c
+++ b/src/core/util/dsd_init.c
@@ -944,6 +944,7 @@ init_state_trunk_scan_publication(dsd_state* state) {
     /* No visit anchored: -1.0, never 0.0, which would read as a park at monotonic 0. */
     state->scan_visit_since_m = -1.0;
     state->scan_visit_roll_seen = 0;
+    state->scan_visit_rearm_pending = 0U;
     DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
     state->scan_timing.started_m = -1.0;
     state->scan_timing.deadline_m = -1.0;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1386,6 +1386,13 @@ no_carrier_step_retune(const dsd_opts* opts, dsd_state* state, long int freq, in
 // call still open as an explicit release rather than a sync loss.
 static int
 no_carrier_scanner_step_is_due(const dsd_opts* opts, const dsd_state* state, time_t now) {
+    /* The per-visit cap (issue #507) outranks every reason to stay, because every reason to stay
+     * can outlast it: sync refreshes the hangtime anchor for as long as a repeater transmits, and
+     * the voice gate holds for as long as media keeps arriving. Opt-in, so with the cap off this
+     * is a no-op and the rules below decide alone. */
+    if (dsd_engine_scan_visit_expired(opts, state, dsd_time_now_monotonic_s())) {
+        return 1;
+    }
     if (dsd_scan_voice_gate_owns_step(opts, state)) {
         return dsd_scan_voice_gate_should_step(opts, state, dsd_time_now_monotonic_s());
     }
@@ -2615,11 +2622,20 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
                 break;
             }
         }
-        /* Outside the voice-gate block on purpose: this loop can spin here for seconds
-         * while frames keep syncing, and the legacy hangtime anchor moves the whole
-         * time, so the Scan Timing row would freeze mid-countdown if it only refreshed
-         * under -Y --scan-voice-only. */
+        /* Both of these sit outside the voice-gate block on purpose: this loop can spin here for
+         * seconds while frames keep syncing, and the legacy hangtime anchor moves the whole time,
+         * so the Scan Timing row would freeze mid-countdown -- and the per-visit cap would never
+         * be consulted at all -- if they only ran under -Y --scan-voice-only. The cap's tick comes
+         * first so the predicate below reads an anchor maintained as of this instant. */
+        dsd_engine_scan_visit_tick(opts, state, dsd_time_now_monotonic_s());
         dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
+        if (dsd_engine_scan_visit_expired(opts, state, dsd_time_now_monotonic_s())) {
+            /* noCarrier() owns the hop, and it only runs once this loop exits. Dropping sync is how
+             * the voice-gate escape above hands control back, and the cap needs the same door: a
+             * row that keeps syncing would otherwise never let the outer loop reach the step. */
+            state->synctype = DSD_SYNC_NONE;
+            break;
+        }
         dsd_runtime_pump_controls(opts, state);
         if (!dsd_engine_channel_scan_service_sync(opts, state)) {
             break;
@@ -2649,6 +2665,7 @@ live_scanner_main_loop(dsd_opts* opts, dsd_state* state) {
         }
         dsd_trunk_scan_hook_tick(opts, state);
         dsd_scan_voice_gate_tick(opts, state, 0, dsd_time_now_monotonic_s());
+        dsd_engine_scan_visit_tick(opts, state, dsd_time_now_monotonic_s());
         dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
         dsd_runtime_pump_controls(opts, state);
 

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -1399,6 +1399,19 @@ no_carrier_scanner_step_is_due(const dsd_opts* opts, const dsd_state* state, tim
     return (now - state->last_cc_sync_time) > opts->trunk_hangtime;
 }
 
+static void
+no_carrier_rearm_abandoned_scan(const dsd_opts* opts, dsd_state* state, time_t now) {
+    if (opts->scan_max_visit_ms < 1000 && opts->scan_voice_only != 1) {
+        return;
+    }
+    /* The receiver stayed on this row. An expired cap or voice gate would keep unwinding
+     * every decoded frame until a tune succeeds. Reopen its windows so decoding can resume
+     * and another attempt waits an interval, including when no tuner is available. */
+    state->last_cc_sync_time = now;
+    state->last_cc_sync_time_m = dsd_time_now_monotonic_s();
+    dsd_scan_voice_gate_note_retune(state, state->last_cc_sync_time_m);
+}
+
 static int
 no_carrier_step_scanner_mode_if_needed(dsd_opts* opts, dsd_state* state, time_t now) {
     if (opts->scanner_mode != 1 || opts->trunk_scan_enabled == 1 || !no_carrier_scanner_step_is_due(opts, state, now)) {
@@ -1411,7 +1424,11 @@ no_carrier_step_scanner_mode_if_needed(dsd_opts* opts, dsd_state* state, time_t 
     }
 
     if (dsd_channel_modes_present(state)) {
-        return dsd_engine_channel_scan_step(opts, state) > 0;
+        const int result = dsd_engine_channel_scan_step(opts, state);
+        if (result < 0) {
+            no_carrier_rearm_abandoned_scan(opts, state, now);
+        }
+        return result > 0;
     }
     no_carrier_reset_nxdn_scan_markers(state);
     if (state->lcn_freq_roll >= state->lcn_freq_count) {
@@ -1436,6 +1453,7 @@ no_carrier_step_scanner_mode_if_needed(dsd_opts* opts, dsd_state* state, time_t 
     // reacquirable by whatever decodes next -- on a different frequency.
     int moved = 0;
     if (freq != 0 && no_carrier_step_retune(opts, state, freq, &moved) != 0) {
+        no_carrier_rearm_abandoned_scan(opts, state, now);
         return moved;
     }
     state->lcn_freq_roll++;

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2615,6 +2615,11 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
                 break;
             }
         }
+        /* Outside the voice-gate block on purpose: this loop can spin here for seconds
+         * while frames keep syncing, and the legacy hangtime anchor moves the whole
+         * time, so the Scan Timing row would freeze mid-countdown if it only refreshed
+         * under -Y --scan-voice-only. */
+        dsd_engine_scan_y_timing_tick(opts, state);
         dsd_runtime_pump_controls(opts, state);
         if (!dsd_engine_channel_scan_service_sync(opts, state)) {
             break;
@@ -2644,6 +2649,7 @@ live_scanner_main_loop(dsd_opts* opts, dsd_state* state) {
         }
         dsd_trunk_scan_hook_tick(opts, state);
         dsd_scan_voice_gate_tick(opts, state, 0, dsd_time_now_monotonic_s());
+        dsd_engine_scan_y_timing_tick(opts, state);
         dsd_runtime_pump_controls(opts, state);
 
         if (dsd_engine_channel_scan_pending(opts, state)) {

--- a/src/engine/engine.c
+++ b/src/engine/engine.c
@@ -2619,7 +2619,7 @@ live_scanner_process_synced_frames(dsd_opts* opts, dsd_state* state, int* last_m
          * while frames keep syncing, and the legacy hangtime anchor moves the whole
          * time, so the Scan Timing row would freeze mid-countdown if it only refreshed
          * under -Y --scan-voice-only. */
-        dsd_engine_scan_y_timing_tick(opts, state);
+        dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
         dsd_runtime_pump_controls(opts, state);
         if (!dsd_engine_channel_scan_service_sync(opts, state)) {
             break;
@@ -2649,7 +2649,7 @@ live_scanner_main_loop(dsd_opts* opts, dsd_state* state) {
         }
         dsd_trunk_scan_hook_tick(opts, state);
         dsd_scan_voice_gate_tick(opts, state, 0, dsd_time_now_monotonic_s());
-        dsd_engine_scan_y_timing_tick(opts, state);
+        dsd_engine_scan_y_timing_tick(opts, state, dsd_time_now_monotonic_s(), dsd_time_now_realtime_s());
         dsd_runtime_pump_controls(opts, state);
 
         if (dsd_engine_channel_scan_pending(opts, state)) {

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -10,6 +10,7 @@
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
 
+#include <math.h>
 #include <stdint.h>
 
 #include "dsd-neo/core/opts_fwd.h"
@@ -230,4 +231,98 @@ dsd_scan_timing_publish(dsd_state* state, const dsd_scan_timing_publication* rep
         return;
     }
     state->scan_timing = *report;
+}
+
+/* Seed the -Y report. The effective windows are the row's, not the live timer's: they
+ * stay visible while a hold pauses the countdown, and are 0 when the voice gate is off
+ * because the legacy hangtime rule has neither a qualify nor a hold window. */
+static void
+scan_y_timing_seed(const dsd_opts* opts, dsd_scan_timing_publication* out) {
+    DSD_MEMSET(out, 0, sizeof(*out));
+    out->started_m = -1.0;
+    out->deadline_m = -1.0;
+    out->conventional = 1U;
+    if (!scan_voice_gate_enabled(opts)) {
+        return;
+    }
+    out->dwell_ms = (uint32_t)scan_voice_resolve_ms(opts->scan_voice_qualify_ms, DSD_SCAN_VOICE_DEFAULT_QUALIFY_MS);
+    out->hold_ms = (uint32_t)scan_voice_resolve_ms(opts->scan_voice_hold_ms, DSD_SCAN_VOICE_DEFAULT_HOLD_MS);
+}
+
+/* Anti-drift: dsd_scan_voice_gate_should_step() flips at anchor + span_ms / 1000.0, so
+ * the published deadline is that same expression rather than a second approximation. */
+static void
+scan_y_timing_arm(dsd_scan_timing_publication* out, double started_m, uint32_t span_ms) {
+    out->started_m = started_m;
+    out->deadline_m = started_m + ((double)span_ms / 1000.0);
+    out->span_ms = span_ms;
+}
+
+/* The gate owns the step: voice (or its tail) counts down the hold window from the last
+ * media frame, and a synced-but-silent visit counts down the qualify window. */
+static void
+scan_y_timing_fill_gate(const dsd_state* state, dsd_scan_timing_publication* out) {
+    if (state->scan_voice_gate_voice_m >= 0.0) {
+        out->reason = state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_VOICE
+                          ? (uint8_t)DSD_SCAN_STAY_VOICE
+                          : (uint8_t)DSD_SCAN_STAY_ACTIVITY_HOLD;
+        scan_y_timing_arm(out, state->scan_voice_gate_voice_m, out->hold_ms);
+        return;
+    }
+    /* dsd_scan_voice_gate_owns_step() is true and no voice anchor exists, so the sync
+     * anchor is the one that is set. */
+    out->reason = (uint8_t)DSD_SCAN_STAY_IDLE_DWELL;
+    scan_y_timing_arm(out, state->scan_voice_gate_sync_m, out->dwell_ms);
+}
+
+/* -t parses any non-negative double, so the second-to-millisecond conversion has to
+ * saturate rather than wrap on its way into the publication's uint32_t. */
+static uint32_t
+scan_y_timing_span_ms(double seconds) {
+    const double span_ms = seconds * 1000.0;
+    if (span_ms >= (double)UINT32_MAX) {
+        return UINT32_MAX;
+    }
+    return (uint32_t)lround(span_ms);
+}
+
+/* The legacy rule waits out -t since the last sync and knows nothing else, so it reports
+ * no dwell and no hold. Without an anchor or with -t 0 there is nothing to count down. */
+static void
+scan_y_timing_fill_hangtime(const dsd_opts* opts, const dsd_state* state, dsd_scan_timing_publication* out) {
+    out->reason = (uint8_t)DSD_SCAN_STAY_HANGTIME;
+    out->dwell_ms = 0U;
+    out->hold_ms = 0U;
+    if (state->last_cc_sync_time_m <= 0.0 || opts->trunk_hangtime <= 0.0f) {
+        return;
+    }
+    out->started_m = state->last_cc_sync_time_m;
+    out->deadline_m = out->started_m + (double)opts->trunk_hangtime;
+    out->span_ms = scan_y_timing_span_ms((double)opts->trunk_hangtime);
+}
+
+void
+dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return;
+    }
+    /* Under --trunk-scan the coordinator publishes for its parked target; the two must
+     * never both write the field. With no scanner running there is nothing to report. */
+    if (opts->scanner_mode != 1 || opts->trunk_scan_enabled == 1) {
+        return;
+    }
+    dsd_scan_timing_publication report;
+    scan_y_timing_seed(opts, &report);
+    if (state->lcn_scan_hold) {
+        /* The rotation is parked by the operator: the window is paused, not expired.
+         * dsd_scan_voice_gate_should_step() returns 0 here and the no-carrier step
+         * returns early, so publishing a deadline would count down to a hop that the
+         * release, not the clock, actually causes. */
+        report.reason = (uint8_t)DSD_SCAN_STAY_MANUAL_HOLD;
+    } else if (dsd_scan_voice_gate_owns_step(opts, state)) {
+        scan_y_timing_fill_gate(state, &report);
+    } else {
+        scan_y_timing_fill_hangtime(opts, state, &report);
+    }
+    dsd_scan_timing_publish(state, &report);
 }

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -8,6 +8,7 @@
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
 
 #include <math.h>
@@ -147,6 +148,9 @@ dsd_scan_voice_gate_note_retune(dsd_state* state, double now_m) {
     if (!state) {
         return;
     }
+    /* The successful park opens the visit for the per-visit cap too (issue #507). Nothing else
+     * writes this anchor except dsd_engine_scan_visit_tick(): activity must never restart it. */
+    state->scan_visit_since_m = now_m;
     state->scan_voice_gate_arrive_m = now_m;
     state->scan_voice_gate_sync_m = -1.0;
     state->scan_voice_gate_voice_m = -1.0;
@@ -244,6 +248,100 @@ dsd_scan_voice_gate_should_step(const dsd_opts* opts, const dsd_state* state, do
     return 0;
 }
 
+/* ---- Per-visit cap for the -Y row (issue #507) ------------------------------ */
+
+/* The cap the row on air is subject to, in ms, with anything below 1000 meaning off. Deliberately
+ * not scan_voice_resolve_ms(): that maps 0 to a default window, and here 0 is the default and it
+ * means disabled. Config loading is range-free by design, so a hand-written 1..999 reaches the
+ * engine and must read as off rather than as a millisecond-long visit. */
+static int
+scan_visit_cap_enabled(const dsd_opts* opts) {
+    return opts->scan_max_visit_ms >= 1000;
+}
+
+/* The -Y scanner owns this anchor only while it is the scanner that is running: under
+ * --trunk-scan the coordinator keeps its own per-target anchor (trunk_scan.c), and with no
+ * scanner there is no visit to measure. */
+static int
+scan_visit_scanner_owns(const dsd_opts* opts) {
+    return opts->scanner_mode == 1 && opts->trunk_scan_enabled != 1;
+}
+
+/* While this holds the cap neither counts down nor expires: the operator's row hold, and a
+ * talkgroup hold on the very call being followed -- cutting that call short is exactly what the
+ * operator asked the hold to prevent. Read-only, because the tick and the deadline have to agree. */
+static int
+scan_visit_suspended(const dsd_state* state) {
+    return state->lcn_scan_hold || dsd_scan_tg_hold_call_active(state);
+}
+
+void
+dsd_engine_scan_visit_tick(const dsd_opts* opts, dsd_state* state, double now_m) {
+    if (!opts || !state) {
+        return;
+    }
+    if (!scan_visit_scanner_owns(opts)) {
+        return;
+    }
+    if (!scan_visit_cap_enabled(opts)) {
+        /* Disabled leaves no anchor behind, so enabling the cap later grants a full fresh limit
+         * instead of expiring against a park from minutes ago. */
+        state->scan_visit_since_m = -1.0;
+        state->scan_visit_roll_seen = state->lcn_freq_roll;
+        return;
+    }
+    if (state->lcn_freq_roll != state->scan_visit_roll_seen) {
+        /* The untyped `L` cycle and an avoid move the roll without a retune note, so the row under
+         * the anchor changed and the new one is owed its own full limit. */
+        state->scan_visit_roll_seen = state->lcn_freq_roll;
+        state->scan_visit_since_m = now_m;
+        return;
+    }
+    if (state->scan_visit_since_m < 0.0) {
+        state->scan_visit_since_m = now_m;
+        return;
+    }
+    if (scan_visit_suspended(state)) {
+        /* Slide the anchor rather than remember a pause: the first unsuspended tick then starts a
+         * full fresh limit, which is what an operator who has just let go expects. */
+        state->scan_visit_since_m = now_m;
+    }
+}
+
+double
+dsd_engine_scan_visit_deadline_m(const dsd_opts* opts, const dsd_state* state) {
+    if (!opts || !state) {
+        return -1.0;
+    }
+    if (!scan_visit_scanner_owns(opts) || !scan_visit_cap_enabled(opts)) {
+        return -1.0;
+    }
+    if (state->scan_visit_since_m < 0.0) {
+        /* No park to measure from. */
+        return -1.0;
+    }
+    if (scan_visit_suspended(state)) {
+        return -1.0;
+    }
+    if (dsd_engine_channel_scan_waiting(state)) {
+        /* A row transaction owns the receiver: the cap must not fire into a tune already on its
+         * way, and the commit re-opens the visit itself. */
+        return -1.0;
+    }
+    if (dsd_state_trunk_lcn_usable_count(state) < 2) {
+        /* Nowhere to go: a hop back onto the same row would only interrupt its audio, so the limit
+         * re-arms instead of firing. */
+        return -1.0;
+    }
+    return state->scan_visit_since_m + ((double)opts->scan_max_visit_ms / 1000.0);
+}
+
+int
+dsd_engine_scan_visit_expired(const dsd_opts* opts, const dsd_state* state, double now_m) {
+    const double deadline_m = dsd_engine_scan_visit_deadline_m(opts, state);
+    return deadline_m >= 0.0 && now_m >= deadline_m;
+}
+
 void
 dsd_scan_timing_clear(dsd_state* state) {
     if (!state) {
@@ -275,6 +373,9 @@ scan_y_timing_seed(const dsd_opts* opts, dsd_scan_timing_publication* out) {
      * zeroed double would read as a deadline at monotonic 0. */
     out->visit_deadline_m = -1.0;
     out->conventional = 1U;
+    /* Also above the early return: the cap is independent of the voice gate, so it stays visible
+     * in legacy hangtime mode, where there is neither a qualify nor a hold window to report. */
+    out->visit_limit_ms = scan_visit_cap_enabled(opts) ? (uint32_t)opts->scan_max_visit_ms : 0U;
     if (!scan_voice_gate_enabled(opts)) {
         return;
     }
@@ -365,5 +466,9 @@ dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state, double now
     } else {
         scan_y_timing_fill_hangtime(opts, state, now_m, now_wall_s, &report);
     }
+    /* The cap rides beside the step timer instead of folding into deadline_m/reason: both can be
+     * counting down at once, and the reason names the rule the hop would be blamed on. Under a
+     * hold the deadline function returns < 0, so MANUAL_HOLD reports the cap as paused. */
+    report.visit_deadline_m = dsd_engine_scan_visit_deadline_m(opts, state);
     dsd_scan_timing_publish(state, &report);
 }

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -296,6 +296,12 @@ dsd_engine_scan_visit_tick(const dsd_opts* opts, dsd_state* state, double now_m)
         return;
     }
     if (!scan_visit_scanner_owns(opts)) {
+        /* Not this scanner's rotation: drop the anchor rather than leave one behind. A runtime
+         * switch into --trunk-scan hands the rotation to the coordinator, and an anchor from the
+         * visit before it would otherwise be minutes stale by the time -Y takes it back -- and
+         * fire the instant it did. The first owning tick anchors a fresh full limit. */
+        state->scan_visit_since_m = -1.0;
+        state->scan_visit_roll_seen = state->lcn_freq_roll;
         return;
     }
     if (!scan_visit_cap_enabled(opts)) {

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -148,10 +148,11 @@ dsd_scan_voice_gate_note_retune(dsd_state* state, double now_m) {
     if (!state) {
         return;
     }
-    /* The successful park opens the visit for the per-visit cap too (issue #507). Nothing else
-     * writes this anchor except dsd_engine_scan_visit_tick(): activity must never restart it. */
+    /* Successful parking opens the per-visit cap too. Suspension handling can restart it,
+     * but sync and voice activity must never extend a visit. */
     state->scan_visit_since_m = now_m;
     state->scan_visit_roll_seen = state->lcn_freq_roll;
+    state->scan_visit_rearm_pending = 0U;
     state->scan_voice_gate_arrive_m = now_m;
     state->scan_voice_gate_sync_m = -1.0;
     state->scan_voice_gate_voice_m = -1.0;
@@ -303,6 +304,7 @@ dsd_engine_scan_visit_tick(const dsd_opts* opts, dsd_state* state, double now_m)
          * fire the instant it did. The first owning tick anchors a fresh full limit. */
         state->scan_visit_since_m = -1.0;
         state->scan_visit_roll_seen = state->lcn_freq_roll;
+        state->scan_visit_rearm_pending = 0U;
         return;
     }
     if (!scan_visit_cap_enabled(opts)) {
@@ -310,6 +312,7 @@ dsd_engine_scan_visit_tick(const dsd_opts* opts, dsd_state* state, double now_m)
          * instead of expiring against a park from minutes ago. */
         state->scan_visit_since_m = -1.0;
         state->scan_visit_roll_seen = state->lcn_freq_roll;
+        state->scan_visit_rearm_pending = 0U;
         return;
     }
     if (state->lcn_freq_roll != state->scan_visit_roll_seen) {
@@ -317,18 +320,18 @@ dsd_engine_scan_visit_tick(const dsd_opts* opts, dsd_state* state, double now_m)
          * the anchor changed and the new one is owed its own full limit. */
         state->scan_visit_roll_seen = state->lcn_freq_roll;
         state->scan_visit_since_m = now_m;
-        return;
+        state->scan_visit_rearm_pending = 0U;
     }
     if (state->scan_visit_since_m < 0.0) {
         state->scan_visit_since_m = now_m;
-        return;
     }
-    if (scan_visit_rearms(state)) {
-        /* Slide the anchor rather than remember a pause: the first tick that can count again then
-         * starts a full fresh limit, which is what an operator who has just let go -- or who has
-         * just given the rotation a second row -- expects. */
+    const int rearm = scan_visit_rearms(state);
+    if (rearm || state->scan_visit_rearm_pending) {
+        /* Remember the suspension across input stalls: time since the last suspended tick
+         * cannot consume the fresh interval owed when a hold or an avoid stops applying. */
         state->scan_visit_since_m = now_m;
     }
+    state->scan_visit_rearm_pending = rearm ? 1U : 0U;
 }
 
 double
@@ -339,7 +342,7 @@ dsd_engine_scan_visit_deadline_m(const dsd_opts* opts, const dsd_state* state) {
     if (!scan_visit_scanner_owns(opts) || !scan_visit_cap_enabled(opts)) {
         return -1.0;
     }
-    if (state->scan_visit_since_m < 0.0) {
+    if (state->scan_visit_since_m < 0.0 || state->scan_visit_rearm_pending) {
         /* No park to measure from. */
         return -1.0;
     }

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -113,6 +113,35 @@ dsd_scan_voice_probe(const dsd_opts* opts, const dsd_state* state, dsd_scan_voic
     return out->retained_media_m >= 0.0 ? 1 : 0;
 }
 
+int
+dsd_scan_tg_hold_call_active(const dsd_state* state) {
+    if (!state || state->tg_hold == 0U) {
+        return 0;
+    }
+    const uint64_t hold = (uint64_t)state->tg_hold;
+    for (int slot_i = 0; slot_i < DSD_CALL_STATE_SLOT_COUNT; slot_i++) {
+        dsd_call_snapshot call;
+        /* dsd_call_state_get() fills the whole snapshot on success; a failed get skips the slot. */
+        if (dsd_call_state_get(state, (uint8_t)slot_i, &call) <= 0) {
+            continue;
+        }
+        if (call.phase != DSD_CALL_PHASE_ACTIVE || call.kind == DSD_CALL_KIND_DATA) {
+            continue;
+        }
+        /* The remapped policy target is the identity the hold is compared against everywhere
+         * else (talkgroup_policy.c); the OTA target stands in when no remap applies. */
+        const uint64_t target = call.policy_target_id != 0U ? call.policy_target_id : call.ota_target_id;
+        if (hold == target) {
+            return 1;
+        }
+        /* A private call is held by either end, exactly as the policy layer holds it. */
+        if (call.kind == DSD_CALL_KIND_PRIVATE_VOICE && hold == call.ota_source_id) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 void
 dsd_scan_voice_gate_note_retune(dsd_state* state, double now_m) {
     if (!state) {
@@ -223,6 +252,7 @@ dsd_scan_timing_clear(dsd_state* state) {
     DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
     state->scan_timing.started_m = -1.0;
     state->scan_timing.deadline_m = -1.0;
+    state->scan_timing.visit_deadline_m = -1.0;
 }
 
 void
@@ -241,6 +271,9 @@ scan_y_timing_seed(const dsd_opts* opts, dsd_scan_timing_publication* out) {
     DSD_MEMSET(out, 0, sizeof(*out));
     out->started_m = -1.0;
     out->deadline_m = -1.0;
+    /* Above the early return: the per-visit cap is independent of the voice gate, and a
+     * zeroed double would read as a deadline at monotonic 0. */
+    out->visit_deadline_m = -1.0;
     out->conventional = 1U;
     if (!scan_voice_gate_enabled(opts)) {
         return;

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -283,26 +283,34 @@ scan_y_timing_span_ms(double seconds) {
     if (span_ms >= (double)UINT32_MAX) {
         return UINT32_MAX;
     }
-    return (uint32_t)lround(span_ms);
+    return (uint32_t)llround(span_ms);
 }
 
 /* The legacy rule waits out -t since the last sync and knows nothing else, so it reports
- * no dwell and no hold. Without an anchor or with -t 0 there is nothing to count down. */
+ * no dwell and no hold. Without an anchor or with -t 0 there is nothing to count down.
+ *
+ * The anchor is the wall-clock last_cc_sync_time the step rule itself compares
+ * (engine.c no_carrier_scanner_step_is_due), not its monotonic twin: NXDN stamps the
+ * wall clock two seconds ahead after a confirmed frame without touching the monotonic
+ * field, and a countdown read from the twin would reach zero two seconds early. The
+ * window is re-expressed on the monotonic clock through the two clocks sampled together,
+ * so it can start in the future and stays put from tick to tick. */
 static void
-scan_y_timing_fill_hangtime(const dsd_opts* opts, const dsd_state* state, dsd_scan_timing_publication* out) {
+scan_y_timing_fill_hangtime(const dsd_opts* opts, const dsd_state* state, double now_m, double now_wall_s,
+                            dsd_scan_timing_publication* out) {
     out->reason = (uint8_t)DSD_SCAN_STAY_HANGTIME;
     out->dwell_ms = 0U;
     out->hold_ms = 0U;
-    if (state->last_cc_sync_time_m <= 0.0 || opts->trunk_hangtime <= 0.0f) {
+    if (state->last_cc_sync_time == 0 || opts->trunk_hangtime <= 0.0f) {
         return;
     }
-    out->started_m = state->last_cc_sync_time_m;
+    out->started_m = now_m + ((double)state->last_cc_sync_time - now_wall_s);
     out->deadline_m = out->started_m + (double)opts->trunk_hangtime;
     out->span_ms = scan_y_timing_span_ms((double)opts->trunk_hangtime);
 }
 
 void
-dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state) {
+dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state, double now_m, double now_wall_s) {
     if (!opts || !state) {
         return;
     }
@@ -322,7 +330,7 @@ dsd_engine_scan_y_timing_tick(const dsd_opts* opts, dsd_state* state) {
     } else if (dsd_scan_voice_gate_owns_step(opts, state)) {
         scan_y_timing_fill_gate(state, &report);
     } else {
-        scan_y_timing_fill_hangtime(opts, state, &report);
+        scan_y_timing_fill_hangtime(opts, state, now_m, now_wall_s, &report);
     }
     dsd_scan_timing_publish(state, &report);
 }

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -5,6 +5,7 @@
 
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/talkgroup_policy.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
@@ -211,4 +212,22 @@ dsd_scan_voice_gate_should_step(const dsd_opts* opts, const dsd_state* state, do
     }
     /* Never synced this visit: the caller falls back to the legacy hangtime rule. */
     return 0;
+}
+
+void
+dsd_scan_timing_clear(dsd_state* state) {
+    if (!state) {
+        return;
+    }
+    DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
+    state->scan_timing.started_m = -1.0;
+    state->scan_timing.deadline_m = -1.0;
+}
+
+void
+dsd_scan_timing_publish(dsd_state* state, const dsd_scan_timing_publication* report) {
+    if (!state || !report) {
+        return;
+    }
+    state->scan_timing = *report;
 }

--- a/src/engine/scan_voice_gate.c
+++ b/src/engine/scan_voice_gate.c
@@ -269,10 +269,25 @@ scan_visit_scanner_owns(const dsd_opts* opts) {
 
 /* While this holds the cap neither counts down nor expires: the operator's row hold, and a
  * talkgroup hold on the very call being followed -- cutting that call short is exactly what the
- * operator asked the hold to prevent. Read-only, because the tick and the deadline have to agree. */
+ * operator asked the hold to prevent. */
 static int
 scan_visit_suspended(const dsd_state* state) {
     return state->lcn_scan_hold || dsd_scan_tg_hold_call_active(state);
+}
+
+/*
+ * The visit cannot end right now, and it must not be allowed to age in the meantime either: the
+ * tick re-arms it and the deadline hides it, which is the one question both have to ask the same
+ * way (requirement 5, and the shape trunk_scan.c already uses).
+ *
+ * Either the visit is suspended, or there is nowhere to go: a rotation with fewer than two usable
+ * rows would only hop back onto the row it is already on and interrupt its audio. Freezing the
+ * anchor instead of re-arming would let it age for as long as that lasts, and then fire the
+ * instant the operator clears an avoid or a placeholder gets a frequency.
+ */
+static int
+scan_visit_rearms(const dsd_state* state) {
+    return scan_visit_suspended(state) || dsd_state_trunk_lcn_usable_count(state) < 2;
 }
 
 void
@@ -301,9 +316,10 @@ dsd_engine_scan_visit_tick(const dsd_opts* opts, dsd_state* state, double now_m)
         state->scan_visit_since_m = now_m;
         return;
     }
-    if (scan_visit_suspended(state)) {
-        /* Slide the anchor rather than remember a pause: the first unsuspended tick then starts a
-         * full fresh limit, which is what an operator who has just let go expects. */
+    if (scan_visit_rearms(state)) {
+        /* Slide the anchor rather than remember a pause: the first tick that can count again then
+         * starts a full fresh limit, which is what an operator who has just let go -- or who has
+         * just given the rotation a second row -- expects. */
         state->scan_visit_since_m = now_m;
     }
 }
@@ -320,17 +336,19 @@ dsd_engine_scan_visit_deadline_m(const dsd_opts* opts, const dsd_state* state) {
         /* No park to measure from. */
         return -1.0;
     }
-    if (scan_visit_suspended(state)) {
+    if (state->lcn_freq_roll != state->scan_visit_roll_seen) {
+        /* An untyped `L` or avoid moved the row and no tick has reconciled it yet, so the anchor
+         * still describes the row before it. The pump can do that between the tick and the step
+         * predicate; firing on it would cut the new visit to zero. The next tick re-anchors. */
         return -1.0;
     }
     if (dsd_engine_channel_scan_waiting(state)) {
         /* A row transaction owns the receiver: the cap must not fire into a tune already on its
-         * way, and the commit re-opens the visit itself. */
+         * way, and the commit re-opens the visit itself. Unlike the cases below this one is not a
+         * re-arm -- the commit stamps its own anchor, so there is nothing to slide. */
         return -1.0;
     }
-    if (dsd_state_trunk_lcn_usable_count(state) < 2) {
-        /* Nowhere to go: a hop back onto the same row would only interrupt its audio, so the limit
-         * re-arms instead of firing. */
+    if (scan_visit_rearms(state)) {
         return -1.0;
     }
     return state->scan_visit_since_m + ((double)opts->scan_max_visit_ms / 1000.0);

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -218,7 +218,12 @@ typedef struct {
     dsd_scan_row_profile* profile;
     p25_sm_ctx_t p25_ctx;
     dmr_sm_ctx_t dmr_ctx;
-    double parked_since_m;
+    /* The monotonic instant the receiver actually parked on this target: the one anchor the
+     * per-visit cap measures from (#507). `< 0` is disarmed -- never parked, the park failed, or
+     * a retune is in flight. Only a park success or a suspension slide writes it; activity,
+     * grants, SM-driven retunes and idle-timer resets must not, or a busy system would push the
+     * cap out forever and the limit would never end a visit. */
+    double visit_since_m;
     double idle_since_m;
     double retry_until_m;
     double last_allowed_activity_m;
@@ -250,6 +255,9 @@ typedef struct {
     size_t count;
     size_t active;
     int hold_active; /* operator hold: the idle dwell never expires while set (#380) */
+    /* One-shot: the switch this coordinator is about to perform is a forced eviction, so the
+     * outgoing carrier is released before its snapshot is saved (#507). Consumed in the switch. */
+    int forced_visit_release;
     int saved_trunk_enable;
     int saved_trunk_is_tuned;
     int saved_mod_c4fm;
@@ -2283,7 +2291,8 @@ trunk_scan_build_target_runtime(dsd_trunk_scan_coord* coord, dsd_opts* opts, dsd
         dmr_sm_init_ctx(&rt->dmr_ctx, opts, state);
         trunk_scan_save_snapshot(state, &rt->snapshot);
         trunk_scan_note_chan_map_seq(coord, rt->snapshot.trunk_chan_map_seq);
-        rt->parked_since_m = now_m;
+        /* Nothing is parked yet: the first switch anchors the visit when its retune lands. */
+        rt->visit_since_m = -1.0;
         rt->idle_since_m = now_m;
     }
     return 0;
@@ -2446,6 +2455,51 @@ trunk_scan_prepare_switch(const dsd_opts* opts, dsd_state* state, const dsd_key_
 /* The receiver never left the active target; nothing was saved, published or retuned. */
 enum { TRUNK_SCAN_PREPARE_FAILED = -2 };
 
+/*
+ * Anchor the per-visit cap at the instant the receiver actually parked. `parked_m` is the
+ * tuner's own completion stamp when one exists, and is believed only while it lies in the
+ * coordinator's past: a stamp from any other clock -- or one recorded after this read -- could
+ * only lengthen the visit, and the tick measures against trunk_scan_now_m() alone.
+ */
+static void
+trunk_scan_arm_visit(dsd_trunk_scan_target_runtime* rt, double parked_m) {
+    const double now_m = trunk_scan_now_m();
+    rt->visit_since_m = (parked_m > 0.0 && parked_m <= now_m) ? parked_m : now_m;
+}
+
+/*
+ * Hand the tuned carrier back before the receiver is moved off it. Only a forced advance owes
+ * this: an ordinary rotation leaves a row that is not following anything. Both trunked state
+ * machines come to rest on their control channel without tuning -- the coordinator owns the
+ * tuner and is already moving it -- and the shared call-state release then clears what the
+ * protocol layer does not: the canonical call rows, the VC mirrors and trunk_is_tuned.
+ */
+static void
+trunk_scan_release_active_carrier(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_target_runtime* rt) {
+    if (!opts || !state || !rt) {
+        return;
+    }
+    /* Exhaustive, no default: a new target type must say here whether it owns a carrier the
+     * coordinator has to hand back. */
+    switch (rt->target.type) {
+        case DSD_TRUNK_SCAN_TARGET_P25_TRUNK:
+            p25_sm_abandon_carrier(&rt->p25_ctx, opts, state, "scan-visit-limit");
+            break;
+        case DSD_TRUNK_SCAN_TARGET_DMR_TRUNK:
+            dmr_sm_abandon_carrier(&rt->dmr_ctx, opts, state, "scan-visit-limit");
+            break;
+        /* NXDN trunking keeps no coordinator-visible state machine, and a conventional row is
+         * never tuned away from its own frequency: the shared release below is all they owe. */
+        case DSD_TRUNK_SCAN_TARGET_NXDN_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_TRUNK:
+        case DSD_TRUNK_SCAN_TARGET_DMR_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_P25_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN_CONVENTIONAL:
+        case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: break;
+    }
+    dsd_engine_release_tuned_call_state(opts, state);
+}
+
 static int
 trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord, size_t next, int save_current) {
     if (!coord || next >= coord->count) {
@@ -2456,7 +2510,16 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
         return TRUNK_SCAN_PREPARE_FAILED;
     }
     if (save_current && coord->active < coord->count) {
-        trunk_scan_save_target_snapshot(coord, state, &coord->targets[coord->active]);
+        dsd_trunk_scan_target_runtime* outgoing = &coord->targets[coord->active];
+        /* A forced advance is the one rotation allowed to interrupt a call (#507). The release
+         * sits here on purpose: after the prepare succeeded, so a prepare failure never kills a
+         * call the receiver then stays on, and before the snapshot, so the saved state is idle by
+         * construction and revisiting the target cannot restore a call that ended a rotation ago. */
+        if (coord->forced_visit_release) {
+            trunk_scan_release_active_carrier(opts, state, outgoing);
+            coord->forced_visit_release = 0;
+        }
+        trunk_scan_save_target_snapshot(coord, state, outgoing);
     }
 
     coord->active = next;
@@ -2479,7 +2542,9 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     dsd_frame_sync_reset_acquisition(opts, state, 0);
 
     double now_m = trunk_scan_now_m();
-    rt->parked_since_m = now_m;
+    /* Every attempt starts disarmed: only a retune that actually lands anchors the visit, so a
+     * failed park or a request still in flight can never spend a target's limit. */
+    rt->visit_since_m = -1.0;
     rt->idle_since_m = now_m;
     /* The incoming target publishes its own voice-gate phase on the next tick. */
     state->scan_voice_gate_phase = (uint8_t)DSD_SCAN_VOICE_GATE_OFF;
@@ -2512,6 +2577,7 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
                 completed_m = trunk_scan_now_m();
             }
             (void)p25_sm_restart_pending_cc_acquisition(&rt->p25_ctx, opts, state, completed_m, "scan-retune");
+            trunk_scan_arm_visit(rt, completed_m);
         }
     } else if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING && tune_request_id != 0U) {
         rt->tune_request_id = tune_request_id;
@@ -2519,6 +2585,9 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     } else {
         rt->tune_request_id = 0U;
         rt->tune_pending = 0;
+        double completed_m = 0.0;
+        (void)dsd_trunk_tuning_request_status(tune_request_id, &completed_m);
+        trunk_scan_arm_visit(rt, completed_m);
     }
     rt->retry_until_m = 0.0;
     LOG_INFO("NOTICE: Trunk scan target '%s' at %ld Hz\n", rt->target.id, trunk_scan_retune_freq(state, &rt->target));
@@ -2640,6 +2709,40 @@ trunk_scan_target_dwell_ms(const dsd_opts* opts, const dsd_trunk_scan_target_run
         return rt->profile->values.qualify_ms;
     }
     return rt->target.dwell_ms;
+}
+
+/*
+ * The effective per-visit cap in ms (#507). Unlike the voice-gate windows above this is not
+ * gated on scan_voice_only: the cap applies to every target type. A row that carries the option
+ * wins outright, including the row `0` that switches the cap off while the global is set.
+ * Callers treat anything below 1000 as disabled -- config loading is range-free by design, so a
+ * hand-written 1..999 reaches the engine and must mean off, not a millisecond visit.
+ */
+static int
+trunk_scan_target_max_visit_ms(const dsd_opts* opts, const dsd_trunk_scan_target_runtime* rt) {
+    if (rt->profile && (rt->profile->values.present & DSD_SCAN_OPT_MAX_VISIT)) {
+        return rt->profile->values.max_visit_ms;
+    }
+    return opts->scan_max_visit_ms;
+}
+
+/*
+ * While this holds, the cap neither counts down nor expires: the operator's target hold, and a
+ * talkgroup hold on the very call being followed (requirements 6 and 7) -- cutting that call
+ * short is exactly what the operator asked the hold to prevent. A trunked row additionally has
+ * to be on the voice channel, because its call rows can still describe a call the tuner left.
+ * Read-only: the tick and the publication must agree, so they ask the same question.
+ */
+static int
+trunk_scan_visit_suspended(const dsd_opts* opts, const dsd_state* state, const dsd_trunk_scan_coord* coord,
+                           const dsd_trunk_scan_target_runtime* rt) {
+    if (coord->hold_active) {
+        return 1;
+    }
+    if (!dsd_scan_tg_hold_call_active(state)) {
+        return 0;
+    }
+    return !trunk_scan_target_is_trunked(rt->target.type) || opts->trunk_is_tuned == 1;
 }
 
 /* A trunked row stays for whatever its protocol state machine is doing. The SM owns those
@@ -2810,7 +2913,8 @@ trunk_scan_resolve_pending_retune(dsd_state* state, dsd_trunk_scan_target_runtim
         return 1;
     }
     const uint64_t request_id = rt->tune_request_id;
-    dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(request_id, NULL);
+    double completed_m = 0.0;
+    dsd_trunk_tune_result result = dsd_trunk_tuning_request_status(request_id, &completed_m);
     if (result == DSD_TRUNK_TUNE_RESULT_PENDING) {
         return 0;
     }
@@ -2819,11 +2923,19 @@ trunk_scan_resolve_pending_retune(dsd_state* state, dsd_trunk_scan_target_runtim
         rt->tune_request_id = 0U;
         rt->tune_pending = 0;
         rt->idle_since_m = -1.0;
+        /* The visit began when the backend finished the tune, not when this tick noticed. */
+        trunk_scan_arm_visit(rt, completed_m);
         return 1;
     }
 
     const int p25_recovery = trunk_scan_reconcile_p25_retune_recovery(rt, request_id);
     if (p25_recovery >= 0) {
+        if (p25_recovery == 1) {
+            /* A replacement tune the P25 SM owned completed while the coordinator was not
+             * looking; its completion stamp belongs to a request this target no longer tracks,
+             * so the visit starts from the tick that found the receiver parked again. */
+            trunk_scan_arm_visit(rt, now_m);
+        }
         return p25_recovery;
     }
 
@@ -2939,8 +3051,85 @@ trunk_scan_publish_timing(const dsd_opts* opts, dsd_state* state, const dsd_trun
     report.conventional = conventional ? 1U : 0U;
     report.dwell_ms = dwell_ms > 0 ? (uint32_t)dwell_ms : 0U;
     report.hold_ms = hold_ms > 0 ? (uint32_t)hold_ms : 0U;
+    /* The cap the row on air is subject to, and the deadline only while one is really counting:
+     * the same suspension the tick honours, and nothing to count from before the park lands. */
+    const int visit_limit_ms = trunk_scan_target_max_visit_ms(opts, rt);
+    report.visit_limit_ms = visit_limit_ms >= 1000 ? (uint32_t)visit_limit_ms : 0U;
+    if (report.visit_limit_ms != 0U && rt->visit_since_m >= 0.0 && !rt->tune_pending
+        && !trunk_scan_visit_suspended(opts, state, coord, rt)) {
+        report.visit_deadline_m = rt->visit_since_m + (double)visit_limit_ms / 1000.0;
+    }
     trunk_scan_timing_select_reason(opts, state, coord, now_m, &report);
     dsd_scan_timing_publish(state, &report);
+}
+
+/* Somewhere else to go: the same candidate filter trunk_scan_advance() walks, so the cap can
+ * never fire on a rotation the advance would refuse. An alternate avoided for the session or
+ * still cooling down from a failed retune is not an alternate. */
+static int
+trunk_scan_visit_alternate_is_eligible(const dsd_trunk_scan_coord* coord, double now_m) {
+    if (coord->count < 2) {
+        return 0;
+    }
+    for (size_t i = 0; i < coord->count; i++) {
+        if (i == coord->active) {
+            continue;
+        }
+        if (!coord->targets[i].avoided && coord->targets[i].retry_until_m <= now_m) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/*
+ * The per-visit cap (issue #507): the ceiling on how long one visit may last, opt-in and off by
+ * default. Without it a busy trunked system or an open microphone on a conventional row keeps
+ * the receiver on one target indefinitely, because every reason to stay disarms the idle dwell.
+ * Runs before the tick's hold short-circuit -- evicting a row that is holding is the whole
+ * point -- and returns 1 when the tick must stop because the rotation moved or tried to.
+ */
+static int
+trunk_scan_service_visit_limit(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord,
+                               dsd_trunk_scan_target_runtime* rt, double now_m) {
+    const int limit_ms = trunk_scan_target_max_visit_ms(opts, rt);
+    if (limit_ms < 1000) {
+        /* Disabled. Writes nothing at all, so the default rotation is byte-for-byte the old one. */
+        return 0;
+    }
+    if (rt->tune_pending || rt->visit_since_m < 0.0) {
+        /* No park to measure from: a retune is in flight, or the last one never landed. */
+        return 0;
+    }
+    if (trunk_scan_visit_suspended(opts, state, coord, rt)) {
+        /* Slide the anchor rather than remember a pause: the first unsuspended tick then starts
+         * a full fresh limit, which is what an operator who just let go expects. */
+        rt->visit_since_m = now_m;
+        return 0;
+    }
+    if ((now_m - rt->visit_since_m) < (double)limit_ms / 1000.0) {
+        return 0;
+    }
+    if (!trunk_scan_visit_alternate_is_eligible(coord, now_m)) {
+        /* Nowhere to go: re-arm instead of firing, so a single-target list neither spins on this
+         * decision every tick nor tears down audio it would immediately have to rebuild. */
+        rt->visit_since_m = now_m;
+        return 0;
+    }
+    LOG_INFO("NOTICE: Trunk scan target '%s' reached its %d ms visit limit; advancing\n", rt->target.id, limit_ms);
+    const size_t before = coord->active;
+    coord->forced_visit_release = 1;
+    trunk_scan_advance(opts, state, coord);
+    /* Cleared unconditionally: a flag left armed would tear down a call on the next ordinary
+     * dwell rotation, which is not a forced advance at all. */
+    coord->forced_visit_release = 0;
+    if (coord->active == before) {
+        /* Every alternate failed and the receiver is back on this row -- or nothing was eligible
+         * by the time the advance walked its list. Re-arm, so the eviction is retried on the next
+         * cap boundary rather than on every tick from here on. */
+        coord->targets[before].visit_since_m = now_m;
+    }
+    return 1;
 }
 
 static void
@@ -2968,6 +3157,9 @@ trunk_scan_tick_targets_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_
         trunk_scan_share_peer_idens(coord, state, rt);
     }
     trunk_scan_refresh_voice_media_hold(opts, state, rt, now_m);
+    if (trunk_scan_service_visit_limit(opts, state, coord, rt, now_m)) {
+        return;
+    }
     if (trunk_scan_active_is_held(opts, state, coord, now_m)) {
         rt->idle_since_m = -1.0;
         return;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -3022,6 +3022,25 @@ trunk_scan_timing_select_reason(const dsd_opts* opts, const dsd_state* state, co
     }
 }
 
+/* Somewhere else to go: the same candidate filter trunk_scan_advance() walks, so the cap can
+ * never fire on a rotation the advance would refuse. An alternate avoided for the session or
+ * still cooling down from a failed retune is not an alternate. */
+static int
+trunk_scan_visit_alternate_is_eligible(const dsd_trunk_scan_coord* coord, double now_m) {
+    if (coord->count < 2) {
+        return 0;
+    }
+    for (size_t i = 0; i < coord->count; i++) {
+        if (i == coord->active) {
+            continue;
+        }
+        if (!coord->targets[i].avoided && coord->targets[i].retry_until_m <= now_m) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 /*
  * One scan-timing report for the target on air (issue #508). Absolute monotonic anchors only:
  * the frontends difference them against their own clock, so a stalled UI cannot invent a
@@ -3052,34 +3071,20 @@ trunk_scan_publish_timing(const dsd_opts* opts, dsd_state* state, const dsd_trun
     report.dwell_ms = dwell_ms > 0 ? (uint32_t)dwell_ms : 0U;
     report.hold_ms = hold_ms > 0 ? (uint32_t)hold_ms : 0U;
     /* The cap the row on air is subject to, and the deadline only while one is really counting:
-     * the same suspension the tick honours, and nothing to count from before the park lands. */
+     * the same suspension the tick honours, nothing to count from before the park lands, and
+     * somewhere for the expiry to go. Without that last test a rotation with no eligible
+     * alternate -- a single target, or every other row avoided or cooling down -- would publish a
+     * countdown the tick re-arms at each boundary instead of firing, drawing a sawtooth the
+     * operator can never see end. The effective limit stays published either way. */
     const int visit_limit_ms = trunk_scan_target_max_visit_ms(opts, rt);
     report.visit_limit_ms = visit_limit_ms >= 1000 ? (uint32_t)visit_limit_ms : 0U;
     if (report.visit_limit_ms != 0U && rt->visit_since_m >= 0.0 && !rt->tune_pending
-        && !trunk_scan_visit_suspended(opts, state, coord, rt)) {
+        && !trunk_scan_visit_suspended(opts, state, coord, rt)
+        && trunk_scan_visit_alternate_is_eligible(coord, now_m)) {
         report.visit_deadline_m = rt->visit_since_m + (double)visit_limit_ms / 1000.0;
     }
     trunk_scan_timing_select_reason(opts, state, coord, now_m, &report);
     dsd_scan_timing_publish(state, &report);
-}
-
-/* Somewhere else to go: the same candidate filter trunk_scan_advance() walks, so the cap can
- * never fire on a rotation the advance would refuse. An alternate avoided for the session or
- * still cooling down from a failed retune is not an alternate. */
-static int
-trunk_scan_visit_alternate_is_eligible(const dsd_trunk_scan_coord* coord, double now_m) {
-    if (coord->count < 2) {
-        return 0;
-    }
-    for (size_t i = 0; i < coord->count; i++) {
-        if (i == coord->active) {
-            continue;
-        }
-        if (!coord->targets[i].avoided && coord->targets[i].retry_until_m <= now_m) {
-            return 1;
-        }
-    }
-    return 0;
 }
 
 /*

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -2500,6 +2500,39 @@ trunk_scan_release_active_carrier(dsd_opts* opts, dsd_state* state, dsd_trunk_sc
     dsd_engine_release_tuned_call_state(opts, state);
 }
 
+/*
+ * Close out a retune the tuner accepted. A request still in flight is remembered so the tick can
+ * resolve it later; one the backend already completed anchors the visit at the stamp it completed
+ * on. A P25 target additionally hands its state machine the same request, so the control-channel
+ * acquisition the SM waits on is the one the coordinator asked for.
+ */
+static void
+trunk_scan_arm_tune_completion(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_target_runtime* rt,
+                               dsd_trunk_tune_result tune_result, uint64_t tune_request_id) {
+    const int p25 = rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK;
+    if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING && tune_request_id != 0U) {
+        if (p25) {
+            (void)p25_sm_await_pending_cc_tune(&rt->p25_ctx, opts, state, tune_request_id, "scan-retune");
+        }
+        /* The P25 SM can observe completion before the scan coordinator's
+         * next tick. Track the same request here so dwell still restarts. */
+        rt->tune_request_id = tune_request_id;
+        rt->tune_pending = 1;
+        return;
+    }
+    rt->tune_request_id = 0U;
+    rt->tune_pending = 0;
+    double completed_m = 0.0;
+    (void)dsd_trunk_tuning_request_status(tune_request_id, &completed_m);
+    if (p25) {
+        if (completed_m <= 0.0) {
+            completed_m = trunk_scan_now_m();
+        }
+        (void)p25_sm_restart_pending_cc_acquisition(&rt->p25_ctx, opts, state, completed_m, "scan-retune");
+    }
+    trunk_scan_arm_visit(rt, completed_m);
+}
+
 static int
 trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord, size_t next, int save_current) {
     if (!coord || next >= coord->count) {
@@ -2561,34 +2594,7 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
                                     tune_request_id);
     }
 
-    if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
-        if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING && tune_request_id != 0U) {
-            (void)p25_sm_await_pending_cc_tune(&rt->p25_ctx, opts, state, tune_request_id, "scan-retune");
-            /* The P25 SM can observe completion before the scan coordinator's
-             * next tick. Track the same request here so dwell still restarts. */
-            rt->tune_request_id = tune_request_id;
-            rt->tune_pending = 1;
-        } else {
-            rt->tune_request_id = 0U;
-            rt->tune_pending = 0;
-            double completed_m = 0.0;
-            (void)dsd_trunk_tuning_request_status(tune_request_id, &completed_m);
-            if (completed_m <= 0.0) {
-                completed_m = trunk_scan_now_m();
-            }
-            (void)p25_sm_restart_pending_cc_acquisition(&rt->p25_ctx, opts, state, completed_m, "scan-retune");
-            trunk_scan_arm_visit(rt, completed_m);
-        }
-    } else if (tune_result == DSD_TRUNK_TUNE_RESULT_PENDING && tune_request_id != 0U) {
-        rt->tune_request_id = tune_request_id;
-        rt->tune_pending = 1;
-    } else {
-        rt->tune_request_id = 0U;
-        rt->tune_pending = 0;
-        double completed_m = 0.0;
-        (void)dsd_trunk_tuning_request_status(tune_request_id, &completed_m);
-        trunk_scan_arm_visit(rt, completed_m);
-    }
+    trunk_scan_arm_tune_completion(opts, state, rt, tune_result, tune_request_id);
     rt->retry_until_m = 0.0;
     LOG_INFO("NOTICE: Trunk scan target '%s' at %ld Hz\n", rt->target.id, trunk_scan_retune_freq(state, &rt->target));
     return 0;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -62,6 +62,11 @@
 #define DSD_TRUNK_SCAN_MAX_FREQUENCY_HZ UINT32_MAX
 #endif
 
+/* How long a failed retune cools down before the coordinator tries the same target again.
+ * Published as the RETUNE_RETRY window, so the policy and the countdown a frontend draws
+ * can never disagree about the length of the wait. */
+#define TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S 2.0
+
 typedef struct {
     unsigned long long p2_wacn;
     unsigned long long p2_sysid;
@@ -394,6 +399,11 @@ trunk_scan_type_is_conventional(dsd_trunk_scan_target_type type) {
         case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: return 1;
     }
     return 0;
+}
+
+static int
+trunk_scan_target_is_trunked(dsd_trunk_scan_target_type type) {
+    return !trunk_scan_type_is_conventional(type);
 }
 
 static int
@@ -1859,6 +1869,7 @@ trunk_scan_clear_published_target(dsd_state* state) {
     state->trunk_scan_hold = 0U;
     state->trunk_scan_active_avoided = 0U;
     state->trunk_scan_avoided_count = 0U;
+    dsd_scan_timing_clear(state);
 }
 
 static size_t
@@ -2475,7 +2486,7 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
     uint64_t tune_request_id = 0U;
     dsd_trunk_tune_result tune_result = trunk_scan_retune_active(opts, state, rt, &tune_request_id);
     if (!dsd_trunk_tune_result_is_ok(tune_result)) {
-        rt->retry_until_m = now_m + 2.0;
+        rt->retry_until_m = now_m + TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S;
         LOG_WARN("WARNING: Trunk scan target '%s' retune failed; cooling down briefly\n", rt->target.id);
         return -1;
     }
@@ -2605,7 +2616,7 @@ trunk_scan_retry_active_if_due(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_
         return;
     }
     if (trunk_scan_switch_to(opts, state, coord, coord->active, 0) == TRUNK_SCAN_PREPARE_FAILED) {
-        rt->retry_until_m = now_m + 2.0;
+        rt->retry_until_m = now_m + TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S;
     }
 }
 
@@ -2631,25 +2642,79 @@ trunk_scan_target_dwell_ms(const dsd_opts* opts, const dsd_trunk_scan_target_run
     return rt->target.dwell_ms;
 }
 
-static int
-trunk_scan_active_is_held(const dsd_opts* opts, const dsd_trunk_scan_coord* coord, double now_m) {
-    const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
-    if (rt->tune_pending) {
-        return 1;
-    }
+/* A trunked row stays for whatever its protocol state machine is doing. The SM owns those
+ * deadlines, not the coordinator, so none of these reasons carries a window. */
+static dsd_scan_stay_reason
+trunk_scan_trunked_stay_reason(const dsd_opts* opts, const dsd_trunk_scan_target_runtime* rt) {
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_P25_TRUNK) {
-        return (rt->p25_ctx.cc_tune_pending || opts->trunk_is_tuned == 1
-                || p25_sm_get_state(&rt->p25_ctx) == P25_SM_TUNED);
+        if (rt->p25_ctx.cc_tune_pending) {
+            return DSD_SCAN_STAY_CC_ACQUIRE;
+        }
+        return (opts->trunk_is_tuned == 1 || p25_sm_get_state(&rt->p25_ctx) == P25_SM_TUNED) ? DSD_SCAN_STAY_CALL_FOLLOW
+                                                                                             : DSD_SCAN_STAY_NONE;
     }
     if (rt->target.type == DSD_TRUNK_SCAN_TARGET_DMR_TRUNK) {
-        return (rt->dmr_ctx.cc_tune_request_id != 0U || opts->trunk_is_tuned == 1
-                || dmr_sm_get_state(&rt->dmr_ctx) == DMR_SM_TUNED);
+        if (rt->dmr_ctx.cc_tune_request_id != 0U) {
+            return DSD_SCAN_STAY_CC_ACQUIRE;
+        }
+        return (opts->trunk_is_tuned == 1 || dmr_sm_get_state(&rt->dmr_ctx) == DMR_SM_TUNED) ? DSD_SCAN_STAY_CALL_FOLLOW
+                                                                                             : DSD_SCAN_STAY_NONE;
     }
-    if (trunk_scan_type_is_nxdn_trunk(rt->target.type)) {
-        return opts->trunk_is_tuned == 1;
+    /* NXDN trunking keeps no coordinator-visible state machine: tuned is all it can say. */
+    return opts->trunk_is_tuned == 1 ? DSD_SCAN_STAY_CALL_FOLLOW : DSD_SCAN_STAY_NONE;
+}
+
+/* The one window the coordinator owns outright: a conventional row holds for its effective
+ * activity hold, measured from the last activity the policy allowed. */
+static dsd_scan_stay_reason
+trunk_scan_conventional_stay_reason(const dsd_opts* opts, const dsd_state* state,
+                                    const dsd_trunk_scan_target_runtime* rt, double now_m, double* started_m,
+                                    double* deadline_m, uint32_t* span_ms) {
+    const int hold_ms = trunk_scan_target_hold_ms(opts, rt);
+    const double hold_s = (double)hold_ms / 1000.0;
+    if (!(rt->last_allowed_activity_m > 0.0 && (now_m - rt->last_allowed_activity_m) < hold_s)) {
+        return DSD_SCAN_STAY_NONE;
     }
-    double hold_s = (double)trunk_scan_target_hold_ms(opts, rt) / 1000.0;
-    return rt->last_allowed_activity_m > 0.0 && (now_m - rt->last_allowed_activity_m) < hold_s;
+    if (started_m) {
+        *started_m = rt->last_allowed_activity_m;
+    }
+    if (deadline_m) {
+        *deadline_m = rt->last_allowed_activity_m + hold_s;
+    }
+    if (span_ms) {
+        *span_ms = hold_ms > 0 ? (uint32_t)hold_ms : 0U;
+    }
+    return (state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_VOICE) ? DSD_SCAN_STAY_VOICE
+                                                                                : DSD_SCAN_STAY_ACTIVITY_HOLD;
+}
+
+/*
+ * Why the receiver is staying on the active target, in the branch order the old boolean
+ * verdict used: every reason but DSD_SCAN_STAY_NONE is exactly what the tick used to treat
+ * as "held", so no rotation decision moves.
+ *
+ * Evaluated twice per tick -- once for the rotation policy, once for the publication -- and
+ * must therefore stay side-effect free: it only reads opts, state and the target runtime.
+ * started_m/deadline_m/span_ms describe the live window, may each be NULL, and are left
+ * untouched by the reasons that have no coordinator-owned deadline.
+ */
+static dsd_scan_stay_reason
+trunk_scan_active_stay_reason(const dsd_opts* opts, const dsd_state* state, const dsd_trunk_scan_coord* coord,
+                              double now_m, double* started_m, double* deadline_m, uint32_t* span_ms) {
+    const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    if (rt->tune_pending) {
+        return DSD_SCAN_STAY_RETUNE_PENDING;
+    }
+    if (trunk_scan_target_is_trunked(rt->target.type)) {
+        return trunk_scan_trunked_stay_reason(opts, rt);
+    }
+    return trunk_scan_conventional_stay_reason(opts, state, rt, now_m, started_m, deadline_m, span_ms);
+}
+
+static int
+trunk_scan_active_is_held(const dsd_opts* opts, const dsd_state* state, const dsd_trunk_scan_coord* coord,
+                          double now_m) {
+    return trunk_scan_active_stay_reason(opts, state, coord, now_m, NULL, NULL, NULL) != DSD_SCAN_STAY_NONE;
 }
 
 static void
@@ -2764,15 +2829,10 @@ trunk_scan_resolve_pending_retune(dsd_state* state, dsd_trunk_scan_target_runtim
 
     rt->tune_request_id = 0U;
     rt->tune_pending = 0;
-    rt->retry_until_m = now_m + 2.0;
+    rt->retry_until_m = now_m + TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S;
     LOG_WARN("WARNING: Trunk scan target '%s' asynchronous retune failed; cooling down briefly\n", rt->target.id);
     (void)state;
     return -1;
-}
-
-static int
-trunk_scan_target_is_trunked(dsd_trunk_scan_target_type type) {
-    return !trunk_scan_type_is_conventional(type);
 }
 
 /* Voice-only scan (issue #381): conventional targets hold only from decoded voice
@@ -2806,9 +2866,83 @@ trunk_scan_refresh_voice_media_hold(const dsd_opts* opts, dsd_state* state, dsd_
     }
 }
 
+/* Pick the reason the row on air is staying, and the window it runs for when the coordinator
+ * owns one. Split out of trunk_scan_publish_timing() so both stay small; the report arrives
+ * with no timer armed and its effective dwell/hold already resolved. */
 static void
-trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord) {
-    double now_m = trunk_scan_now_m();
+trunk_scan_timing_select_reason(const dsd_opts* opts, const dsd_state* state, const dsd_trunk_scan_coord* coord,
+                                double now_m, dsd_scan_timing_publication* report) {
+    const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    if (rt->tune_pending) {
+        /* The backend owns an unresolved request; there is no deadline to name. */
+        report->reason = (uint8_t)DSD_SCAN_STAY_RETUNE_PENDING;
+        return;
+    }
+    if (rt->retry_until_m > now_m) {
+        report->reason = (uint8_t)DSD_SCAN_STAY_RETUNE_RETRY;
+        report->started_m = rt->retry_until_m - TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S;
+        report->deadline_m = rt->retry_until_m;
+        report->span_ms = (uint32_t)(TRUNK_SCAN_RETUNE_RETRY_COOLDOWN_S * 1000.0);
+        return;
+    }
+    double started_m = -1.0;
+    double deadline_m = -1.0;
+    uint32_t span_ms = 0U;
+    const dsd_scan_stay_reason stay =
+        trunk_scan_active_stay_reason(opts, state, coord, now_m, &started_m, &deadline_m, &span_ms);
+    if (stay != DSD_SCAN_STAY_NONE) {
+        report->reason = (uint8_t)stay;
+        report->started_m = started_m;
+        report->deadline_m = deadline_m;
+        report->span_ms = span_ms;
+        return;
+    }
+    if (coord->hold_active) {
+        /* The operator hold disarms the dwell rather than expiring it: nothing counts down. */
+        report->reason = (uint8_t)DSD_SCAN_STAY_MANUAL_HOLD;
+        return;
+    }
+    report->reason = (uint8_t)DSD_SCAN_STAY_IDLE_DWELL;
+    if (rt->idle_since_m >= 0.0) {
+        report->started_m = rt->idle_since_m;
+        report->deadline_m = rt->idle_since_m + (double)trunk_scan_target_dwell_ms(opts, rt) / 1000.0;
+        report->span_ms = report->dwell_ms;
+    }
+}
+
+/*
+ * One scan-timing report for the target on air (issue #508). Absolute monotonic anchors only:
+ * the frontends difference them against their own clock, so a stalled UI cannot invent a
+ * countdown the decoder is not running. Additive -- it decides nothing.
+ */
+static void
+trunk_scan_publish_timing(const dsd_opts* opts, dsd_state* state, const dsd_trunk_scan_coord* coord, double now_m) {
+    if (!opts || !state) {
+        return;
+    }
+    if (!coord || coord->active >= coord->count) {
+        dsd_scan_timing_clear(state);
+        return;
+    }
+    const dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    const int conventional = !trunk_scan_target_is_trunked(rt->target.type);
+    const int dwell_ms = trunk_scan_target_dwell_ms(opts, rt);
+    /* A trunked row has no activity hold to speak of, and publishing one would only invite
+     * the frontends to draw a timer the coordinator never runs. */
+    const int hold_ms = conventional ? trunk_scan_target_hold_ms(opts, rt) : 0;
+    dsd_scan_timing_publication report;
+    DSD_MEMSET(&report, 0, sizeof report);
+    report.started_m = -1.0;
+    report.deadline_m = -1.0;
+    report.conventional = conventional ? 1U : 0U;
+    report.dwell_ms = dwell_ms > 0 ? (uint32_t)dwell_ms : 0U;
+    report.hold_ms = hold_ms > 0 ? (uint32_t)hold_ms : 0U;
+    trunk_scan_timing_select_reason(opts, state, coord, now_m, &report);
+    dsd_scan_timing_publish(state, &report);
+}
+
+static void
+trunk_scan_tick_targets_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord, double now_m) {
     dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
     if (rt->tune_pending && rt->dmr_ctx.cc_tune_request_id != 0U) {
         /* Resolve the DMR backend deadline even while the initial park keeps
@@ -2832,7 +2966,7 @@ trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* c
         trunk_scan_share_peer_idens(coord, state, rt);
     }
     trunk_scan_refresh_voice_media_hold(opts, state, rt, now_m);
-    if (trunk_scan_active_is_held(opts, coord, now_m)) {
+    if (trunk_scan_active_is_held(opts, state, coord, now_m)) {
         rt->idle_since_m = -1.0;
         return;
     }
@@ -2851,6 +2985,15 @@ trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* c
     if ((now_m - rt->idle_since_m) >= dwell_s) {
         trunk_scan_advance(opts, state, coord);
     }
+}
+
+/* The body above has a dozen early returns and can rotate; publishing here, once, means the
+ * report always describes whichever target the tick actually left on air. */
+static void
+trunk_scan_tick_locked(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coord) {
+    const double now_m = trunk_scan_now_m();
+    trunk_scan_tick_targets_locked(opts, state, coord, now_m);
+    trunk_scan_publish_timing(opts, state, coord, now_m);
 }
 
 void

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -3120,10 +3120,24 @@ trunk_scan_service_visit_limit(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_
     const size_t before = coord->active;
     coord->forced_visit_release = 1;
     trunk_scan_advance(opts, state, coord);
+    /* The switch clears the flag exactly when it hands the carrier back, so a flag still set means
+     * no attempt ever got that far and there is nothing to scrub below. */
+    const int released = coord->forced_visit_release == 0;
     /* Cleared unconditionally: a flag left armed would tear down a call on the next ordinary
      * dwell rotation, which is not a forced advance at all. */
     coord->forced_visit_release = 0;
     if (coord->active == before) {
+        if (released) {
+            /* The receiver is back on the row whose carrier was just handed back, and the
+             * advance restores the snapshot it took *before* that release -- canonical call rows
+             * and VC frequency mirrors included -- while the protocol SM has already abandoned
+             * the carrier. Scrub the engine side again so the two cannot disagree: left alone,
+             * that resurrected ACTIVE row never ages out, is saved into this target's snapshot
+             * on its next ordinary departure and restored on every revisit after that, and a row
+             * matching state->tg_hold would suspend the cap for as long as it lived. The SM does
+             * not need abandoning twice; only the decoder state was restored under it. */
+            dsd_engine_release_tuned_call_state(opts, state);
+        }
         /* Every alternate failed and the receiver is back on this row -- or nothing was eligible
          * by the time the advance walked its list. Re-arm, so the eviction is retried on the next
          * cap boundary rather than on every tick from here on. */

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -224,6 +224,7 @@ typedef struct {
      * grants, SM-driven retunes and idle-timer resets must not, or a busy system would push the
      * cap out forever and the limit would never end a visit. */
     double visit_since_m;
+    int visit_rearm_pending;
     double idle_since_m;
     double retry_until_m;
     double last_allowed_activity_m;
@@ -2466,6 +2467,7 @@ static void
 trunk_scan_arm_visit(dsd_trunk_scan_target_runtime* rt, double parked_m) {
     const double now_m = trunk_scan_now_m();
     rt->visit_since_m = (parked_m > 0.0 && parked_m <= now_m) ? parked_m : now_m;
+    rt->visit_rearm_pending = 0;
     rt->retry_released_park = 0;
 }
 
@@ -2500,6 +2502,7 @@ trunk_scan_release_active_carrier(dsd_opts* opts, dsd_state* state, dsd_trunk_sc
         case DSD_TRUNK_SCAN_TARGET_NXDN48_CONVENTIONAL: break;
     }
     dsd_engine_release_tuned_call_state(opts, state);
+    rt->last_allowed_activity_m = 0.0;
 }
 
 /*
@@ -2552,6 +2555,9 @@ trunk_scan_switch_to(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_coord* coo
          * construction and revisiting the target cannot restore a call that ended a rotation ago. */
         if (coord->forced_visit_release) {
             trunk_scan_release_active_carrier(opts, state, outgoing);
+            /* Rollback must preserve this release too. Restoring the pre-release call and
+             * ending it again duplicates its history event if every park fails. */
+            trunk_scan_save_snapshot(state, &coord->scratch_snapshot);
             coord->forced_visit_release = 0;
         }
         trunk_scan_save_target_snapshot(coord, state, outgoing);
@@ -3063,7 +3069,7 @@ trunk_scan_timing_fill_visit(const dsd_opts* opts, const dsd_state* state, const
      * operator can never see end. The effective limit stays published either way. */
     const int visit_limit_ms = trunk_scan_target_max_visit_ms(opts, rt);
     report->visit_limit_ms = visit_limit_ms >= 1000 ? (uint32_t)visit_limit_ms : 0U;
-    if (report->visit_limit_ms != 0U && rt->visit_since_m >= 0.0 && !rt->tune_pending
+    if (report->visit_limit_ms != 0U && rt->visit_since_m >= 0.0 && !rt->tune_pending && !rt->visit_rearm_pending
         && !trunk_scan_visit_suspended(opts, state, coord, rt)
         && trunk_scan_visit_alternate_is_eligible(coord, now_m)) {
         report->visit_deadline_m = rt->visit_since_m + (double)visit_limit_ms / 1000.0;
@@ -3138,11 +3144,15 @@ trunk_scan_visit_expired(const dsd_opts* opts, const dsd_state* state, const dsd
         return 0;
     }
     if (trunk_scan_visit_suspended(opts, state, coord, rt) || !trunk_scan_visit_alternate_is_eligible(coord, now_m)) {
-        /* Slide the anchor rather than remember a pause: the first unsuspended tick then starts
-         * a full fresh limit. Do the same while no alternate is eligible, so clearing an avoid
-         * or ending a cooldown cannot immediately interrupt the current call. */
+        /* Remember the suspension so an input stall between ticks cannot spend the fresh
+         * interval owed when a hold ends or an alternate becomes eligible. */
         rt->visit_since_m = now_m;
+        rt->visit_rearm_pending = 1;
         return 0;
+    }
+    if (rt->visit_rearm_pending) {
+        rt->visit_since_m = now_m;
+        rt->visit_rearm_pending = 0;
     }
     return (now_m - rt->visit_since_m) >= (double)limit_ms / 1000.0;
 }
@@ -3178,14 +3188,8 @@ trunk_scan_service_visit_limit(dsd_opts* opts, dsd_state* state, dsd_trunk_scan_
     coord->forced_visit_release = 0;
     if (coord->active == before) {
         if (released) {
-            /* The receiver is back on the row whose carrier was just handed back, and the
-             * advance restores the snapshot it took *before* that release -- canonical call rows
-             * and VC frequency mirrors included -- while the protocol SM has already abandoned
-             * the carrier. Scrub the engine side again so the two cannot disagree: left alone,
-             * that resurrected ACTIVE row never ages out, is saved into this target's snapshot
-             * on its next ordinary departure and restored on every revisit after that, and a row
-             * matching state->tg_hold would suspend the cap for as long as it lived. The SM does
-             * not need abandoning twice; only the decoder state was restored under it. */
+            /* Clear transient decoder state from failed candidates. The rollback snapshot
+             * already contains the ended call, so this cannot emit its end a second time. */
             dsd_engine_release_tuned_call_state(opts, state);
         }
         dsd_trunk_scan_target_runtime* restored = &coord->targets[before];
@@ -3302,15 +3306,27 @@ trunk_scan_control_hold_toggle(dsd_state* state, dsd_trunk_scan_coord* coord) {
     // Disarm at the command boundary: both toggles can arrive before another
     // tick observes the hold. Release must still grant a fresh idle dwell.
     coord->targets[coord->active].idle_since_m = -1.0;
+    dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    if (rt->visit_since_m >= 0.0) {
+        rt->visit_since_m = trunk_scan_now_m();
+        rt->visit_rearm_pending = 0;
+    }
     trunk_scan_publish_active_target(state, coord);
     return coord->hold_active;
 }
 
 static int
 trunk_scan_control_avoid_clear(dsd_state* state, dsd_trunk_scan_coord* coord) {
+    const double now_m = trunk_scan_now_m();
+    const int had_alternate = trunk_scan_visit_alternate_is_eligible(coord, now_m);
     const size_t cleared = trunk_scan_avoided_count(coord);
     for (size_t i = 0; i < coord->count; i++) {
         coord->targets[i].avoided = 0;
+    }
+    dsd_trunk_scan_target_runtime* rt = &coord->targets[coord->active];
+    if (!had_alternate && trunk_scan_visit_alternate_is_eligible(coord, now_m) && rt->visit_since_m >= 0.0) {
+        rt->visit_since_m = now_m;
+        rt->visit_rearm_pending = 0;
     }
     trunk_scan_publish_active_target(state, coord);
     return cleared > INT_MAX ? INT_MAX : (int)cleared;

--- a/src/engine/trunk_scan.c
+++ b/src/engine/trunk_scan.c
@@ -2934,6 +2934,8 @@ trunk_scan_publish_timing(const dsd_opts* opts, dsd_state* state, const dsd_trun
     DSD_MEMSET(&report, 0, sizeof report);
     report.started_m = -1.0;
     report.deadline_m = -1.0;
+    /* A zeroed double would read as a deadline at monotonic 0, so "no cap" is explicit. */
+    report.visit_deadline_m = -1.0;
     report.conventional = conventional ? 1U : 0U;
     report.dwell_ms = dwell_ms > 0 ? (uint32_t)dwell_ms : 0U;
     report.hold_ms = hold_ms > 0 ? (uint32_t)hold_ms : 0U;

--- a/src/engine/trunk_tuning.c
+++ b/src/engine/trunk_tuning.c
@@ -147,8 +147,11 @@ dsd_engine_apply_cc_symbol_timing(const dsd_opts* opts, dsd_state* state) {
     dsd_engine_select_p25_sps_profile(state, state->p25_cc_is_tdma == 1);
 }
 
-static void DSD_ATTR_USED
-dsd_engine_reset_return_to_cc_state(dsd_opts* opts, dsd_state* state) {
+void
+dsd_engine_release_tuned_call_state(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return;
+    }
     const double ended_m = dsd_time_now_monotonic_s();
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
         // The state machine is leaving this voice channel by decision, not because the carrier
@@ -610,7 +613,7 @@ dsd_engine_return_to_cc_request(dsd_opts* opts, dsd_state* state, uint64_t reque
         }
     }
 
-    dsd_engine_reset_return_to_cc_state(opts, state);
+    dsd_engine_release_tuned_call_state(opts, state);
 
     /* Keep symbol timing aligned with the current control-channel mode. */
     dsd_engine_apply_cc_symbol_timing(opts, state);

--- a/src/protocol/dmr/dmr_trunk_sm.c
+++ b/src/protocol/dmr/dmr_trunk_sm.c
@@ -394,30 +394,13 @@ dmr_sm_release_without_cc(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
     ctx->cc_tune_request_id = 0U;
 }
 
+/* The teardown every release shares, once the destination of the tuner is settled. `cc_returned`
+ * says whether a control-channel tune is following this release: when none is -- no CC to return
+ * to, or a caller that owns the tuner and is moving it itself -- the call rows and DMR block
+ * state have to be cleared here, because nothing downstream will do it. */
 static void
-do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason) {
-    int had_force_release = 0;
-    if (!ctx) {
-        return;
-    }
-
-    if (state) {
-        had_force_release = (state->trunk_sm_force_release != 0) ? 1 : 0;
-        state->trunk_sm_force_release = 0;
-    }
-
-    sm_log(opts, reason);
-
-    const long cc = state && state->trunk_cc_freq > 0 ? state->trunk_cc_freq : ctx->cc_freq_hz;
-    dsd_trunk_tune_result tune_result = cc > 0 ? dmr_sm_return_to_cc(ctx, opts, state, cc) : DSD_TRUNK_TUNE_RESULT_OK;
-    if (!dsd_trunk_tune_result_is_ok(tune_result)) {
-        sm_log(opts, "release-tune-deferred");
-        if (state && had_force_release) {
-            state->trunk_sm_force_release = 1;
-        }
-        return;
-    }
-
+dmr_sm_clear_released_carrier(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, int cc_returned,
+                              dmr_sm_state_e next_state, const char* reason) {
     for (int s = 0; s < 2; s++) {
         ctx->slots[s].voice_active = 0;
         ctx->slots[s].last_active_m = 0.0;
@@ -445,10 +428,54 @@ do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reas
         state->p25_sm_release_count++;
     }
 
-    if (cc <= 0) {
+    if (!cc_returned) {
         dmr_sm_release_without_cc(ctx, opts, state);
     }
-    set_state(ctx, opts, cc > 0 ? DMR_SM_ON_CC : DMR_SM_HUNTING, reason);
+    set_state(ctx, opts, next_state, reason);
+}
+
+static void
+do_release(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason) {
+    int had_force_release = 0;
+    if (!ctx) {
+        return;
+    }
+
+    if (state) {
+        had_force_release = (state->trunk_sm_force_release != 0) ? 1 : 0;
+        state->trunk_sm_force_release = 0;
+    }
+
+    sm_log(opts, reason);
+
+    const long cc = state && state->trunk_cc_freq > 0 ? state->trunk_cc_freq : ctx->cc_freq_hz;
+    dsd_trunk_tune_result tune_result = cc > 0 ? dmr_sm_return_to_cc(ctx, opts, state, cc) : DSD_TRUNK_TUNE_RESULT_OK;
+    if (!dsd_trunk_tune_result_is_ok(tune_result)) {
+        sm_log(opts, "release-tune-deferred");
+        if (state && had_force_release) {
+            state->trunk_sm_force_release = 1;
+        }
+        return;
+    }
+
+    dmr_sm_clear_released_carrier(ctx, opts, state, cc > 0, cc > 0 ? DMR_SM_ON_CC : DMR_SM_HUNTING, reason);
+}
+
+void
+dmr_sm_abandon_carrier(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason) {
+    if (!ctx) {
+        return;
+    }
+    if (state) {
+        /* The teardown the latch asks for is happening right here; left armed, the next tick
+         * would try its own release, and that one tunes back to a control channel -- against a
+         * caller that is already moving the tuner. */
+        state->trunk_sm_force_release = 0;
+    }
+    sm_log(opts, reason);
+    /* ON_CC, not HUNTING: nothing about this release says the control channel was lost, and a
+     * revisit expects to find the target resting exactly where an ordinary release leaves it. */
+    dmr_sm_clear_released_carrier(ctx, opts, state, 0, DMR_SM_ON_CC, reason ? reason : "abandon-carrier");
 }
 
 static int

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -6695,6 +6695,44 @@ p25_sm_release(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* 
     do_release(ctx, opts, state, reason ? reason : "explicit-release", 1);
 }
 
+void
+p25_sm_abandon_carrier(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason) {
+    if (!ctx) {
+        ctx = p25_sm_get_ctx();
+    }
+    const char* safe_reason = reason ? reason : "abandon-carrier";
+
+    // The same guard do_release() takes. Two teardowns of one carrier would double-count the
+    // release and race each other's slot clears, so the loser leaves the work to the winner --
+    // which performs an equivalent teardown under its own reason.
+    int expected = 0;
+    if (!atomic_compare_exchange_strong(&g_p25_sm_release_lock, &expected, 1)) {
+        p25_sm_diagf(opts, state, ctx, "release_contended", "reason=%s", safe_reason);
+        return;
+    }
+
+    // The teardown the force-release latch asks for is happening right here. Leaving it armed
+    // would have the next SM tick attempt its own release, and that one does tune back to a
+    // control channel -- against a caller that is already moving the tuner.
+    const int had_force_release = p25_release_take_force_request(state);
+    p25_sm_diagf(opts, state, ctx, "abandon_carrier", "reason=%s force=%d", safe_reason, had_force_release);
+    sm_log(opts, state, safe_reason);
+    p25_release_log_channel(ctx, opts, state, safe_reason);
+
+    const double ended_m = dsd_time_now_monotonic_s();
+    p25_call_end_slot(opts, state, 0, ended_m);
+    p25_call_end_slot(opts, state, 1, ended_m);
+
+    // Counted as a release on both sides, exactly like the returning path: the carrier is gone.
+    // Deliberately not p25_sm_init_ctx(): the reprobe memo and the session counters outlive a
+    // release, and a target the scan coordinator will come back to must not forget them.
+    p25_release_clear_context(ctx, 1);
+    p25_release_clear_decoder_state(opts, state, 1);
+    set_state(ctx, opts, state, P25_SM_ON_CC, safe_reason);
+
+    atomic_store(&g_p25_sm_release_lock, 0);
+}
+
 /* ============================================================================
  * Encryption Lockout Helper
  * ============================================================================ */

--- a/src/protocol/p25/p25_trunk_sm.c
+++ b/src/protocol/p25/p25_trunk_sm.c
@@ -6741,6 +6741,10 @@ p25_sm_abandon_carrier(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, cons
         return;
     }
     const int had_carrier = p25_release_should_return_to_cc(ctx, opts);
+    if (had_carrier && ctx->vc_is_tdma && opts && state) {
+        /* Deliver the partial superframe while the outgoing call and audio gates still exist. */
+        dsd_p25_optional_hook_p25p2_flush_partial_audio(opts, state);
+    }
 
     // The teardown the force-release latch asks for is happening right here. Leaving it armed
     // would have the next SM tick attempt its own release, and that one does tune back to a

--- a/src/runtime/cli/args.c
+++ b/src/runtime/cli/args.c
@@ -449,6 +449,25 @@ cli_parse_ms_range_option(const char* option_name, const char* in, int min_ms, i
     return 1;
 }
 
+/* Same window check as cli_parse_ms_range_option(), except an explicit 0 is always accepted.
+ * Opt-in limits whose active window starts well above 1 use 0 to mean "off", so 0 must not be
+ * read as an out-of-range request. */
+static int
+cli_parse_ms_range_or_off_option(const char* option_name, const char* in, int min_ms, int max_ms, int* out,
+                                 int* out_exit_rc) {
+    long parsed = 0;
+    if (!cli_parse_long_option(option_name, in, 10, &parsed, out_exit_rc)) {
+        return 0;
+    }
+    if (parsed != 0 && (parsed < min_ms || parsed > max_ms)) {
+        LOG_ERROR("Invalid %s value \"%s\" (expected 0 or %d..%d)\n", option_name, in ? in : "", min_ms, max_ms);
+        cli_set_exit_rc(out_exit_rc, 1);
+        return 0;
+    }
+    *out = (int)parsed;
+    return 1;
+}
+
 static int
 cli_set_iqreplay_audio_dev(dsd_opts* opts, const char* path) {
     if (!opts || !path) {
@@ -979,6 +998,25 @@ cli_parse_airspy_option(int argc, char** argv, int i, dsd_opts* opts) {
         if (strncmp(argv[i], "--scan-voice-hold-ms=", 21) == 0) {                                                      \
             if (!cli_parse_ms_range_option("--scan-voice-hold-ms", argv[i] + 21, 100, 600000,                          \
                                            &opts->scan_voice_hold_ms, out_exit_rc)) {                                  \
+                return DSD_PARSE_ERROR;                                                                                \
+            }                                                                                                          \
+            continue;                                                                                                  \
+        }                                                                                                              \
+        if (strcmp(argv[i], "--scan-max-visit-ms") == 0) {                                                             \
+            if (i + 1 >= argc) {                                                                                       \
+                LOG_ERROR("--scan-max-visit-ms requires a millisecond value\n");                                       \
+                cli_set_exit_rc(out_exit_rc, 1);                                                                       \
+                return DSD_PARSE_ERROR;                                                                                \
+            }                                                                                                          \
+            if (!cli_parse_ms_range_or_off_option("--scan-max-visit-ms", DSD_PARSE_ARGS_NEXT_ARG(), 1000, 3600000,     \
+                                                  &opts->scan_max_visit_ms, out_exit_rc)) {                            \
+                return DSD_PARSE_ERROR;                                                                                \
+            }                                                                                                          \
+            continue;                                                                                                  \
+        }                                                                                                              \
+        if (strncmp(argv[i], "--scan-max-visit-ms=", 20) == 0) {                                                       \
+            if (!cli_parse_ms_range_or_off_option("--scan-max-visit-ms", argv[i] + 20, 1000, 3600000,                  \
+                                                  &opts->scan_max_visit_ms, out_exit_rc)) {                            \
                 return DSD_PARSE_ERROR;                                                                                \
             }                                                                                                          \
             continue;                                                                                                  \
@@ -2866,6 +2904,9 @@ dsd_warn_ineffective_short_opts(const dsd_opts* opts, const dsd_state* state) {
     }
     if (opts->scan_voice_only && !opts->scanner_mode && !opts->trunk_scan_enabled) {
         LOG_WARN("WARNING: --scan-voice-only has no effect without -Y or --trunk-scan.\n");
+    }
+    if (opts->scan_max_visit_ms > 0 && !opts->scanner_mode && !opts->trunk_scan_enabled) {
+        LOG_WARN("WARNING: --scan-max-visit-ms has no effect without -Y or --trunk-scan.\n");
     }
 }
 

--- a/src/runtime/cli/compact.c
+++ b/src/runtime/cli/compact.c
@@ -132,6 +132,7 @@ static const char* const k_skip_exact_next_any[] = {
     "--trunk-scan-activity-hold-ms",
     "--scan-voice-qualify-ms",
     "--scan-voice-hold-ms",
+    "--scan-max-visit-ms",
     "--calc-lcn",
     "--calc-step",
     "--calc-cc-freq",
@@ -189,6 +190,7 @@ static const char* const k_skip_prefix[] = {
     "--trunk-scan-activity-hold-ms=",
     "--scan-voice-qualify-ms=",
     "--scan-voice-hold-ms=",
+    "--scan-max-visit-ms=",
     "--frontend=",
 };
 

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -427,6 +427,9 @@ dsd_cli_usage_section_trunking_and_tools(void) {
     printf("      --scan-voice-qualify-ms <ms>  Window after sync in which voice must appear or the scan moves on "
            "(100..600000, default 1000).\n");
     printf("      --scan-voice-hold-ms <ms>  Time to stay after the last voice frame (100..600000, default 2000).\n");
+    printf("      --scan-max-visit-ms <ms>  Maximum time on one scan target per visit (0 disables, else "
+           "1000..3600000; default 0).\n");
+    printf("                 Applies to -Y and --trunk-scan; can cut an ongoing call short.\n");
     printf("                 Global qualify/hold timings apply to -Y; trunk-scan conventional rows use\n");
     printf("                 dwell_ms/activity_hold_ms, or their own row options.\n");
     printf("  -W            Use Imported Group List as a Trunking Allow/White List -- Only Tune with Mode A\n");

--- a/src/runtime/cli/usage.c
+++ b/src/runtime/cli/usage.c
@@ -427,11 +427,11 @@ dsd_cli_usage_section_trunking_and_tools(void) {
     printf("      --scan-voice-qualify-ms <ms>  Window after sync in which voice must appear or the scan moves on "
            "(100..600000, default 1000).\n");
     printf("      --scan-voice-hold-ms <ms>  Time to stay after the last voice frame (100..600000, default 2000).\n");
+    printf("                 Global qualify/hold timings apply to -Y; trunk-scan conventional rows use\n");
+    printf("                 dwell_ms/activity_hold_ms, or their own row options.\n");
     printf("      --scan-max-visit-ms <ms>  Maximum time on one scan target per visit (0 disables, else "
            "1000..3600000; default 0).\n");
     printf("                 Applies to -Y and --trunk-scan; can cut an ongoing call short.\n");
-    printf("                 Global qualify/hold timings apply to -Y; trunk-scan conventional rows use\n");
-    printf("                 dwell_ms/activity_hold_ms, or their own row options.\n");
     printf("  -W            Use Imported Group List as a Trunking Allow/White List -- Only Tune with Mode A\n");
     printf("  -p            Disable Tune to Private Calls (DMR TIII, P25, NXDN Type-C and Type-D)\n");
     printf("  -E            Disable Tune to Group Calls (DMR TIII, Con+, Cap+, P25, NXDN Type-C, and Type-D)\n");

--- a/src/runtime/config_schema.c
+++ b/src/runtime/config_schema.c
@@ -107,6 +107,8 @@ static const dsdcfg_schema_entry_t s_schema[] = {
      NULL, DSDCFG_TYPE_INT, 100, 600000},
     {"trunking", "scan_voice_hold_ms", "Time to stay after the last voice frame", "2000", NULL, DSDCFG_TYPE_INT, 100,
      600000},
+    {"trunking", "scan_max_visit_ms", "Maximum time on one scan target per visit (0 disables; else 1000..3600000)", "0",
+     NULL, DSDCFG_TYPE_INT, 0, 3600000},
 
     /* [radioreference] section */
     {"radioreference", "username", "RadioReference account username", "", NULL, DSDCFG_TYPE_STRING, 0, 0},

--- a/src/runtime/config_user.cpp
+++ b/src/runtime/config_user.cpp
@@ -192,6 +192,7 @@ user_cfg_reset(dsdneoUserConfig* cfg) {
     cfg->trunk_scan_voice_only = 0;
     cfg->trunk_scan_voice_qualify_ms = 1000;
     cfg->trunk_scan_voice_hold_ms = 2000;
+    cfg->trunk_scan_max_visit_ms = 0;
     cfg->rtl_auto_ppm = 0;
     dsd_airspy_config_defaults(&cfg->airspy);
     cfg->soapy_bandwidth_hz = -1;
@@ -1039,6 +1040,7 @@ render_trunking_section(FILE* out, const dsdneoUserConfig* cfg) {
     DSD_FPRINTF(out, "scan_voice_only = %s\n", ini_bool(cfg->trunk_scan_voice_only));
     DSD_FPRINTF(out, "scan_voice_qualify_ms = %d\n", cfg->trunk_scan_voice_qualify_ms);
     DSD_FPRINTF(out, "scan_voice_hold_ms = %d\n", cfg->trunk_scan_voice_hold_ms);
+    DSD_FPRINTF(out, "scan_max_visit_ms = %d\n", cfg->trunk_scan_max_visit_ms);
     DSD_FPRINTF(out, "\n");
 }
 
@@ -1451,6 +1453,7 @@ apply_trunking_config(const dsdneoUserConfig* cfg, dsd_opts* opts) {
     opts->scan_voice_only = cfg->trunk_scan_voice_only ? 1 : 0;
     opts->scan_voice_qualify_ms = cfg->trunk_scan_voice_qualify_ms;
     opts->scan_voice_hold_ms = cfg->trunk_scan_voice_hold_ms;
+    opts->scan_max_visit_ms = cfg->trunk_scan_max_visit_ms;
 }
 
 static void
@@ -1816,6 +1819,7 @@ snapshot_trunking_config(const dsd_opts* opts, const dsd_state* state, dsdneoUse
     cfg->trunk_scan_voice_only = (configured ? configured->scan_voice_only : opts->scan_voice_only) ? 1 : 0;
     cfg->trunk_scan_voice_qualify_ms = configured ? configured->scan_voice_qualify_ms : opts->scan_voice_qualify_ms;
     cfg->trunk_scan_voice_hold_ms = configured ? configured->scan_voice_hold_ms : opts->scan_voice_hold_ms;
+    cfg->trunk_scan_max_visit_ms = configured ? configured->scan_max_visit_ms : opts->scan_max_visit_ms;
 }
 
 static void

--- a/src/runtime/config_user_loader.cpp
+++ b/src/runtime/config_user_loader.cpp
@@ -462,7 +462,7 @@ apply_trunking_section_path_key(dsdneoUserConfig* cfg, const char* key_lc, const
 }
 
 static int
-apply_trunking_section_voice_gate_key(dsdneoUserConfig* cfg, const char* key_lc, const char* val) {
+apply_trunking_section_scan_timing_key(dsdneoUserConfig* cfg, const char* key_lc, const char* val) {
     if (strcmp(key_lc, "scan_voice_only") == 0) {
         assign_bool_key(&cfg->trunk_scan_voice_only, val);
     } else if (strcmp(key_lc, "scan_voice_qualify_ms") == 0) {
@@ -475,6 +475,11 @@ apply_trunking_section_voice_gate_key(dsdneoUserConfig* cfg, const char* key_lc,
         if (user_config_parse_int_value(val, &parsed) == 0) {
             cfg->trunk_scan_voice_hold_ms = parsed;
         }
+    } else if (strcmp(key_lc, "scan_max_visit_ms") == 0) {
+        int parsed = 0;
+        if (user_config_parse_int_value(val, &parsed) == 0) {
+            cfg->trunk_scan_max_visit_ms = parsed;
+        }
     } else {
         return 0;
     }
@@ -483,7 +488,7 @@ apply_trunking_section_voice_gate_key(dsdneoUserConfig* cfg, const char* key_lc,
 
 static void
 apply_trunking_section_key(dsdneoUserConfig* cfg, const char* key_lc, const char* val) {
-    if (apply_trunking_section_voice_gate_key(cfg, key_lc, val)) {
+    if (apply_trunking_section_scan_timing_key(cfg, key_lc, val)) {
         return;
     }
     if (apply_trunking_section_path_key(cfg, key_lc, val)) {

--- a/src/runtime/config_user_validation.cpp
+++ b/src/runtime/config_user_validation.cpp
@@ -370,12 +370,26 @@ validate_composed_lrrp_ports(const dsdneoUserConfig* cfg, const char* section, c
     }
 }
 
+/* INT keys only get a schema window check, and this key's window has to start at 0 so the
+   always-emitted default validates. A 1..999 cap therefore passes the schema walk while the
+   engine treats it as disabled, so say so here. A warning, not an error: the value loads. */
+static void
+validate_composed_scan_max_visit_ms(const dsdneoUserConfig* cfg, const char* section, const char* key,
+                                    dsdcfg_diagnostics_t* diags) {
+    if (!cfg || !diags || cfg->trunk_scan_max_visit_ms <= 0 || cfg->trunk_scan_max_visit_ms >= 1000) {
+        return;
+    }
+    dsdcfg_diags_add(diags, DSDCFG_DIAG_WARNING, 0, section ? section : "trunking", key ? key : "scan_max_visit_ms",
+                     "scan_max_visit_ms below 1000 ms is ignored; use 0 to disable or 1000..3600000");
+}
+
 static void
 validate_composed_config_base(const dsdneoUserConfig* cfg, dsdcfg_diagnostics_t* diags) {
     validate_composed_trunk_scan_requirements(cfg, "trunk_scan", "targets_csv", diags);
     validate_composed_trunk_scan_channel_map_conflict(cfg, "trunking", "chan_csv", diags);
     validate_composed_trunk_scan_p25_bandplan_conflict(cfg, "trunking", "p25_bandplan_csv", diags);
     validate_composed_lrrp_ports(cfg, "mode", "dmr_lrrp_ports", diags);
+    validate_composed_scan_max_visit_ms(cfg, "trunking", "scan_max_visit_ms", diags);
 }
 
 static void
@@ -387,6 +401,7 @@ validate_composed_profile_config(const char* profile_name, const dsdneoUserConfi
     validate_composed_trunk_scan_channel_map_conflict(cfg, section, "trunking.chan_csv", diags);
     validate_composed_trunk_scan_p25_bandplan_conflict(cfg, section, "trunking.p25_bandplan_csv", diags);
     validate_composed_lrrp_ports(cfg, section, "mode.dmr_lrrp_ports", diags);
+    validate_composed_scan_max_visit_ms(cfg, section, "trunking.scan_max_visit_ms", diags);
 }
 
 static void

--- a/src/runtime/scan_mode.c
+++ b/src/runtime/scan_mode.c
@@ -88,6 +88,7 @@ dsd_scan_settings_capture(const dsd_opts* opts, const dsd_state* state, dsd_scan
     out->scan_voice_only = opts->scan_voice_only;
     out->scan_voice_qualify_ms = opts->scan_voice_qualify_ms;
     out->scan_voice_hold_ms = opts->scan_voice_hold_ms;
+    out->scan_max_visit_ms = opts->scan_max_visit_ms;
     out->dmr_mute_encL = opts->dmr_mute_encL;
     out->dmr_mute_encR = opts->dmr_mute_encR;
     out->unmute_encrypted_p25 = opts->unmute_encrypted_p25;
@@ -145,6 +146,7 @@ scan_settings_restore_row_opts(const dsd_scan_settings* saved, dsd_opts* opts) {
     opts->scan_voice_only = saved->scan_voice_only;
     opts->scan_voice_qualify_ms = saved->scan_voice_qualify_ms;
     opts->scan_voice_hold_ms = saved->scan_voice_hold_ms;
+    opts->scan_max_visit_ms = saved->scan_max_visit_ms;
     opts->dmr_mute_encL = saved->dmr_mute_encL;
     opts->dmr_mute_encR = saved->dmr_mute_encR;
     opts->unmute_encrypted_p25 = saved->unmute_encrypted_p25;
@@ -164,6 +166,7 @@ scan_settings_copy_row_opts(dsd_scan_settings* dst, const dsd_scan_settings* src
     dst->scan_voice_only = src->scan_voice_only;
     dst->scan_voice_qualify_ms = src->scan_voice_qualify_ms;
     dst->scan_voice_hold_ms = src->scan_voice_hold_ms;
+    dst->scan_max_visit_ms = src->scan_max_visit_ms;
     dst->dmr_mute_encL = src->dmr_mute_encL;
     dst->dmr_mute_encR = src->dmr_mute_encR;
     dst->unmute_encrypted_p25 = src->unmute_encrypted_p25;
@@ -367,6 +370,9 @@ scan_options_apply(dsd_opts* opts, dsd_state* state, const dsd_scan_option_value
     }
     if (present & DSD_SCAN_OPT_HOLD) {
         opts->scan_voice_hold_ms = values->hold_ms;
+    }
+    if (present & DSD_SCAN_OPT_MAX_VISIT) {
+        opts->scan_max_visit_ms = values->max_visit_ms;
     }
     if (present & DSD_SCAN_OPT_MUTE_DMR) {
         opts->dmr_mute_encL = values->mute_dmr;

--- a/src/runtime/scan_options.c
+++ b/src/runtime/scan_options.c
@@ -53,6 +53,9 @@ static const scan_option_spec specifications[] = {
     {"--no-scan-voice-only", DSD_SCAN_OPT_VOICE, ALL_MODES, 0, 1, 0},
     {"--scan-voice-qualify-ms", DSD_SCAN_OPT_QUALIFY, ALL_MODES, 1, 1, 0},
     {"--scan-voice-hold-ms", DSD_SCAN_OPT_HOLD, ALL_MODES, 1, 1, 0},
+    /* The per-visit cap applies to every trunk-scan target type, so unlike the voice-gate
+     * switches above it is not conventional-only. */
+    {"--scan-max-visit-ms", DSD_SCAN_OPT_MAX_VISIT, ALL_MODES, 1, 0, 0},
 };
 
 static int
@@ -237,6 +240,14 @@ option_set_number(const scan_option_spec* spec, const char* argument, dsd_scan_o
                 parsed->values.hold_ms = (int)number;
             }
             return 0;
+        case DSD_SCAN_OPT_MAX_VISIT:
+            /* A row disables the cap outright with 0; any other value is a real cap and
+             * shares the CLI bounds, so the voice-gate bounds above do not apply. */
+            if (option_decimal(argument, 3600000UL, &number) || (number != 0UL && number < 1000UL)) {
+                return -1;
+            }
+            parsed->values.max_visit_ms = (int)number;
+            return 0;
         default: return -1;
     }
 }
@@ -291,7 +302,8 @@ option_set(const scan_option_spec* spec, const char* argument, unsigned int mode
         case DSD_SCAN_OPT_BP:
         case DSD_SCAN_OPT_SCRAMBLER:
         case DSD_SCAN_OPT_QUALIFY:
-        case DSD_SCAN_OPT_HOLD: return option_set_number(spec, argument, parsed);
+        case DSD_SCAN_OPT_HOLD:
+        case DSD_SCAN_OPT_MAX_VISIT: return option_set_number(spec, argument, parsed);
         case DSD_SCAN_OPT_CRC: parsed->values.strict_crc = spec->value; return 0;
         case DSD_SCAN_OPT_VOICE: parsed->values.voice_only = spec->value; return 0;
         case DSD_SCAN_OPT_DATA: parsed->values.tune_data_calls = spec->value; return 0;

--- a/src/runtime/scan_options.c
+++ b/src/runtime/scan_options.c
@@ -285,9 +285,26 @@ option_set_path(const scan_option_spec* spec, const char* argument, dsd_scan_opt
     return 0;
 }
 
+/* The plain on/off switches: the spec already carries the value the row asked for, so there is
+ * nothing to parse. Returns 0 when the field was one of them and -1 when it belongs elsewhere. */
+static int
+option_set_flag(const scan_option_spec* spec, dsd_scan_options* parsed) {
+    switch (spec->field) {
+        case DSD_SCAN_OPT_CRC: parsed->values.strict_crc = spec->value; return 0;
+        case DSD_SCAN_OPT_VOICE: parsed->values.voice_only = spec->value; return 0;
+        case DSD_SCAN_OPT_DATA: parsed->values.tune_data_calls = spec->value; return 0;
+        case DSD_SCAN_OPT_ENC: parsed->values.tune_enc_calls = spec->value; return 0;
+        default: return -1;
+    }
+}
+
 static int
 option_set(const scan_option_spec* spec, const char* argument, unsigned int mode, dsd_scan_options* parsed) {
-    if (spec->field == DSD_SCAN_OPT_CLEAR_KEYS) {
+    /* Recognised here and acted on elsewhere: neither carries a value of its own to store. */
+    if (spec->field == DSD_SCAN_OPT_CLEAR_KEYS || spec->field == DSD_SCAN_OPT_P25_CANDIDATES) {
+        return 0;
+    }
+    if (option_set_flag(spec, parsed) == 0) {
         return 0;
     }
     switch (spec->field) {
@@ -304,11 +321,6 @@ option_set(const scan_option_spec* spec, const char* argument, unsigned int mode
         case DSD_SCAN_OPT_QUALIFY:
         case DSD_SCAN_OPT_HOLD:
         case DSD_SCAN_OPT_MAX_VISIT: return option_set_number(spec, argument, parsed);
-        case DSD_SCAN_OPT_CRC: parsed->values.strict_crc = spec->value; return 0;
-        case DSD_SCAN_OPT_VOICE: parsed->values.voice_only = spec->value; return 0;
-        case DSD_SCAN_OPT_DATA: parsed->values.tune_data_calls = spec->value; return 0;
-        case DSD_SCAN_OPT_ENC: parsed->values.tune_enc_calls = spec->value; return 0;
-        case DSD_SCAN_OPT_P25_CANDIDATES: return 0;
         default: return option_set_path(spec, argument, parsed);
     }
 }

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -424,6 +424,10 @@ MetricsModel::fillScanTimingView(View& next, const dsd_opts* opts_snapshot, cons
     next.scan_dwell_state = view.dwell_state;
     next.scan_hold_ms = view.show_hold != 0U ? static_cast<int>(view.hold_ms) : 0;
     next.scan_hang_ms = view.show_hang != 0U ? static_cast<int>(view.hang_ms) : 0;
+    /* The cap on the whole visit (#507), withheld the same way when none applies. */
+    next.scan_visit_ms = view.show_visit != 0U ? static_cast<int>(view.visit_ms) : 0;
+    next.scan_visit_live = view.visit_live != 0U;
+    next.scan_visit_remaining_ds = static_cast<int>(view.visit_remaining_ms / 100U);
 }
 
 namespace {

--- a/src/ui/qt/metrics_model.cpp
+++ b/src/ui/qt/metrics_model.cpp
@@ -25,6 +25,7 @@
 #include <QtGlobal>
 #include <dsd-neo/app_control/call_view.h>
 #include <dsd-neo/app_control/frontend.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/core/audio.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/enc_lockout.h>
@@ -387,6 +388,42 @@ MetricsModel::fillScanControlView(View& next, const dsd_opts* opts_snapshot, con
     next.scan_hold = trunk_scan ? (snapshot->trunk_scan_hold != 0) : (snapshot->lcn_scan_hold != 0);
     next.scan_avoid_count = trunk_scan ? snapshot->trunk_scan_avoided_count : snapshot->lcn_avoid_count;
     next.scan_target_avoided = trunk_scan && snapshot->trunk_scan_active_avoided != 0;
+}
+
+/**
+ * @brief Why the rotation is staying on the row on air, and how long is left (#508).
+ *
+ * Every decision behind the row -- the phrase, whether a window is counting down,
+ * which of the dwell/hold/hang budgets is worth printing -- is made once in
+ * app-control, from a publication whose deadlines the decoder owns. A frontend only
+ * copies and formats, so this panel, the terminal row and Android cannot drift apart
+ * on what "suspended" means or on when a trunked row may show a conventional hold.
+ *
+ * The withheld budgets are zeroed rather than carried: QML gates each group on its
+ * own reading being positive, so a value the view declined to show must not arrive
+ * as a number the row could print.
+ */
+void
+MetricsModel::fillScanTimingView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot,
+                                 double now_m) const {
+    dsd_app_scan_timing view;
+    if (dsd_app_scan_timing_view(opts_snapshot, snapshot, now_m, &view) != 1) {
+        return;
+    }
+    next.scan_timing_visible = view.active != 0U;
+    next.scan_stay_reason = view.reason;
+    /* A static English label out of a fixed set, translated at run time. lupdate
+     * cannot extract through the pointer; the set is small enough that a catalogue
+     * lists it beside the terminal's own wording rather than duplicating it here. */
+    next.scan_stay_phrase = view.phrase != nullptr ? tr(view.phrase) : QString();
+    next.scan_timer_live = view.timer_live != 0U;
+    /* Tenths, truncated: see scanTimerRemainingDs(). */
+    next.scan_timer_remaining_ds = static_cast<int>(view.remaining_ms / 100U);
+    next.scan_timer_span_ms = static_cast<int>(view.span_ms);
+    next.scan_dwell_ms = view.show_dwell != 0U ? static_cast<int>(view.dwell_ms) : 0;
+    next.scan_dwell_state = view.dwell_state;
+    next.scan_hold_ms = view.show_hold != 0U ? static_cast<int>(view.hold_ms) : 0;
+    next.scan_hang_ms = view.show_hang != 0U ? static_cast<int>(view.hang_ms) : 0;
 }
 
 namespace {
@@ -773,6 +810,10 @@ MetricsModel::refresh(const dsd_opts* opts_snapshot, const dsd_state* snapshot) 
     next.held_tg = static_cast<qulonglong>(snapshot->tg_hold);
     next.enc_lockout_count = dsd_enc_lockout_active_count(snapshot);
     fillScanControlView(next, opts_snapshot, snapshot);
+    /* The same monotonic reading the call lines were aged against, not a second
+     * clock read: one frame has to describe one instant, or the countdown and the
+     * call durations beside it would come from moments either side of the poll. */
+    fillScanTimingView(next, opts_snapshot, snapshot, now_m);
 
     /* The engine's command acknowledgement, shown until its own expiry stamp. The
      * timer takes an expired message down without waiting for another publish —

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -158,6 +158,10 @@ class MetricsModel : public QObject {
     Q_PROPERTY(int scanDwellState READ scanDwellState NOTIFY controlChanged)
     Q_PROPERTY(int scanHoldMs READ scanHoldMs NOTIFY controlChanged)
     Q_PROPERTY(int scanHangMs READ scanHangMs NOTIFY controlChanged)
+    /* #507: the ceiling on the whole visit, which rides the same row. */
+    Q_PROPERTY(int scanVisitMs READ scanVisitMs NOTIFY controlChanged)
+    Q_PROPERTY(bool scanVisitLive READ scanVisitLive NOTIFY controlChanged)
+    Q_PROPERTY(int scanVisitRemainingDs READ scanVisitRemainingDs NOTIFY controlChanged)
     Q_PROPERTY(bool syncedHere READ syncedHere NOTIFY tunerChanged)
     Q_PROPERTY(QString syncLabel READ syncLabel NOTIFY tunerChanged)
     Q_PROPERTY(bool trunkableSync READ trunkableSync NOTIFY tunerChanged)
@@ -814,6 +818,35 @@ class MetricsModel : public QObject {
     }
 
     /**
+     * @brief Effective per-visit cap for this row (#507), 0 when no cap applies.
+     *
+     * Unlike the dwell, hold and hang budgets this one is not chosen by the stay
+     * reason: it caps the visit whatever is on the air, so it reads out beside the
+     * reason rather than in place of it.
+     */
+    int
+    scanVisitMs() const {
+        return m_view.scan_visit_ms;
+    }
+
+    /**
+     * @brief Whether the cap is counting down right now.
+     *
+     * False while a hold suspends it and before the visit has anchored. The row has
+     * to say so in words: a zero countdown reads as a visit that just ran out.
+     */
+    bool
+    scanVisitLive() const {
+        return m_view.scan_visit_live;
+    }
+
+    /** @brief Time left on the cap, in tenths; see scanTimerRemainingDs() for why. */
+    int
+    scanVisitRemainingDs() const {
+        return m_view.scan_visit_remaining_ds;
+    }
+
+    /**
      * @brief The engine's transient command acknowledgement, empty when none.
      *
      * Commands only enqueue a request; this is the engine saying what actually
@@ -1128,8 +1161,12 @@ class MetricsModel : public QObject {
         int scan_dwell_state = 0;
         int scan_hold_ms = 0;
         int scan_hang_ms = 0;
+        /* #507: the per-visit cap for the row on air, and whether it is counting. */
+        int scan_visit_ms = 0;
+        int scan_visit_remaining_ds = 0;
         bool scan_timing_visible = false;
         bool scan_timer_live = false;
+        bool scan_visit_live = false;
 
         /* Exact comparison is right for the two doubles: they are carried through
          * unmodified from the metrics boundary, so "unchanged" means the identical
@@ -1165,7 +1202,9 @@ class MetricsModel : public QObject {
                    && scan_timer_remaining_ds == other.scan_timer_remaining_ds
                    && scan_timer_span_ms == other.scan_timer_span_ms && scan_dwell_ms == other.scan_dwell_ms
                    && scan_dwell_state == other.scan_dwell_state && scan_hold_ms == other.scan_hold_ms
-                   && scan_hang_ms == other.scan_hang_ms;
+                   && scan_hang_ms == other.scan_hang_ms && scan_visit_ms == other.scan_visit_ms
+                   && scan_visit_live == other.scan_visit_live
+                   && scan_visit_remaining_ds == other.scan_visit_remaining_ds;
         }
 
         bool

--- a/src/ui/qt/metrics_model.h
+++ b/src/ui/qt/metrics_model.h
@@ -146,6 +146,18 @@ class MetricsModel : public QObject {
     Q_PROPERTY(bool scanHold READ scanHold NOTIFY controlChanged)
     Q_PROPERTY(int scanAvoidCount READ scanAvoidCount NOTIFY controlChanged)
     Q_PROPERTY(bool scanTargetAvoided READ scanTargetAvoided NOTIFY controlChanged)
+    /* #508: why the rotation is staying on the row on air, and how long is left.
+       One group, one signal: they are read together by one row. */
+    Q_PROPERTY(bool scanTimingVisible READ scanTimingVisible NOTIFY controlChanged)
+    Q_PROPERTY(int scanStayReason READ scanStayReason NOTIFY controlChanged)
+    Q_PROPERTY(QString scanStayPhrase READ scanStayPhrase NOTIFY controlChanged)
+    Q_PROPERTY(bool scanTimerLive READ scanTimerLive NOTIFY controlChanged)
+    Q_PROPERTY(int scanTimerRemainingDs READ scanTimerRemainingDs NOTIFY controlChanged)
+    Q_PROPERTY(int scanTimerSpanMs READ scanTimerSpanMs NOTIFY controlChanged)
+    Q_PROPERTY(int scanDwellMs READ scanDwellMs NOTIFY controlChanged)
+    Q_PROPERTY(int scanDwellState READ scanDwellState NOTIFY controlChanged)
+    Q_PROPERTY(int scanHoldMs READ scanHoldMs NOTIFY controlChanged)
+    Q_PROPERTY(int scanHangMs READ scanHangMs NOTIFY controlChanged)
     Q_PROPERTY(bool syncedHere READ syncedHere NOTIFY tunerChanged)
     Q_PROPERTY(QString syncLabel READ syncLabel NOTIFY tunerChanged)
     Q_PROPERTY(bool trunkableSync READ trunkableSync NOTIFY tunerChanged)
@@ -729,6 +741,79 @@ class MetricsModel : public QObject {
     }
 
     /**
+     * @brief Whether there is a scan stay reason to show at all (#508).
+     *
+     * False whenever no rotation is running, and false for a rotation that has
+     * published nothing yet. Decided in app-control, not here, so this panel, the
+     * terminal row and Android cannot disagree about when the row appears.
+     */
+    bool
+    scanTimingVisible() const {
+        return m_view.scan_timing_visible;
+    }
+
+    /** @brief dsd_scan_stay_reason for the row on air; the phrase is its label. */
+    int
+    scanStayReason() const {
+        return m_view.scan_stay_reason;
+    }
+
+    /** @brief "Following call", "Idle dwell", "Manual hold" -- why it is staying. */
+    const QString&
+    scanStayPhrase() const {
+        return m_view.scan_stay_phrase;
+    }
+
+    /** @brief A window is counting down; without it the stay has no deadline to show. */
+    bool
+    scanTimerLive() const {
+        return m_view.scan_timer_live;
+    }
+
+    /**
+     * @brief Time left in the running window, in tenths of a second.
+     *
+     * Tenths rather than milliseconds because this reading decides whether
+     * controlChanged fires: at millisecond resolution every 250 ms poll would move
+     * it and re-evaluate every binding on the control group, for a row that renders
+     * one decimal place. Truncated, so it never claims more time than is left.
+     */
+    int
+    scanTimerRemainingDs() const {
+        return m_view.scan_timer_remaining_ds;
+    }
+
+    /** @brief Full width of the running window, so the countdown reads as a fraction. */
+    int
+    scanTimerSpanMs() const {
+        return m_view.scan_timer_span_ms;
+    }
+
+    /** @brief Effective idle dwell for this row, 0 when it is not worth showing. */
+    int
+    scanDwellMs() const {
+        return m_view.scan_dwell_ms;
+    }
+
+    /** @brief DSD_APP_SCAN_DWELL_*: running, suspended under a hold, or paused by the operator. */
+    int
+    scanDwellState() const {
+        return m_view.scan_dwell_state;
+    }
+
+    /** @brief Effective activity hold; 0 on trunked rows, which have none. */
+    int
+    scanHoldMs() const {
+        return m_view.scan_hold_ms;
+    }
+
+    /** @brief The -t hangtime, when it is what governs the current stay. */
+    int
+    scanHangMs() const {
+        return m_view.scan_hang_ms;
+    }
+
+    /**
      * @brief The engine's transient command acknowledgement, empty when none.
      *
      * Commands only enqueue a request; this is the engine saying what actually
@@ -1034,6 +1119,17 @@ class MetricsModel : public QObject {
         int scan_target_count = 0;
         bool scan_hold = false;
         bool scan_target_avoided = false;
+        /* #508: the stay reason and the live window, copied from the app-control view. */
+        QString scan_stay_phrase;
+        int scan_stay_reason = 0;
+        int scan_timer_remaining_ds = 0;
+        int scan_timer_span_ms = 0;
+        int scan_dwell_ms = 0;
+        int scan_dwell_state = 0;
+        int scan_hold_ms = 0;
+        int scan_hang_ms = 0;
+        bool scan_timing_visible = false;
+        bool scan_timer_live = false;
 
         /* Exact comparison is right for the two doubles: they are carried through
          * unmodified from the metrics boundary, so "unchanged" means the identical
@@ -1059,6 +1155,19 @@ class MetricsModel : public QObject {
                    && scan_avoid_count == other.scan_avoid_count && scan_target_avoided == other.scan_target_avoided;
         }
 
+        /* Split out for the same reason as scanControlEquals: it rides controlChanged
+           with the rest, and folding ten more readings into one comparison would put
+           it over the complexity ceiling. */
+        bool
+        scanTimingEquals(const View& other) const {
+            return scan_timing_visible == other.scan_timing_visible && scan_stay_reason == other.scan_stay_reason
+                   && scan_stay_phrase == other.scan_stay_phrase && scan_timer_live == other.scan_timer_live
+                   && scan_timer_remaining_ds == other.scan_timer_remaining_ds
+                   && scan_timer_span_ms == other.scan_timer_span_ms && scan_dwell_ms == other.scan_dwell_ms
+                   && scan_dwell_state == other.scan_dwell_state && scan_hold_ms == other.scan_hold_ms
+                   && scan_hang_ms == other.scan_hang_ms;
+        }
+
         bool
         decryptionEquals(const View& other) const {
             return configured_force == other.configured_force && effective_force == other.effective_force
@@ -1078,8 +1187,8 @@ class MetricsModel : public QObject {
             return audio_muted == other.audio_muted && held_tg == other.held_tg
                    && enc_lockout_count == other.enc_lockout_count && tuner_controlled == other.tuner_controlled
                    && trunking_enabled == other.trunking_enabled && scanner_mode == other.scanner_mode
-                   && scanControlEquals(other) && scan_mode == other.scan_mode && decode_mode == other.decode_mode
-                   && decryptionEquals(other) && radioControlsEqual(other);
+                   && scanControlEquals(other) && scanTimingEquals(other) && scan_mode == other.scan_mode
+                   && decode_mode == other.decode_mode && decryptionEquals(other) && radioControlsEqual(other);
         }
     };
 
@@ -1100,6 +1209,8 @@ class MetricsModel : public QObject {
     void fillDecoderView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot, double now_m);
     /** @brief Scan hold and avoids (#380), read from whichever rotation is running. */
     static void fillScanControlView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot);
+    /** @brief Why the rotation is staying on this row and how long is left (#508). */
+    void fillScanTimingView(View& next, const dsd_opts* opts_snapshot, const dsd_state* snapshot, double now_m) const;
 
   public:
 #ifdef DSD_NEO_TEST_HOOKS

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -142,6 +142,49 @@ Item {
                 elide: Text.ElideRight
             }
 
+            // Why the rotation is staying on the row above and how long is left
+            // (#508). The same grammar as the terminal's `| Scan Timing:` row --
+            // one space before the countdown, two between groups, seconds to one
+            // decimal place -- so a reader moving between the two surfaces reads
+            // the same line. Which budgets appear at all was decided in
+            // app-control; a zero here means "the view withheld it".
+            Text {
+                width: parent.width
+                objectName: "scanTimingRow"
+                visible: metrics.scanTimingVisible
+                text: {
+                    var out = metrics.scanStayPhrase;
+                    if (metrics.scanTimerLive) {
+                        out += " " + qsTr("%1s/%2s").arg((metrics.scanTimerRemainingDs / 10).toFixed(1)).arg((metrics.scanTimerSpanMs / 1000).toFixed(1));
+                    }
+                    if (metrics.scanDwellMs > 0) {
+                        out += "  " + qsTr("dwell %1s").arg((metrics.scanDwellMs / 1000).toFixed(1));
+                        // DSD_APP_SCAN_DWELL_SUSPENDED / _PAUSED: disarmed while
+                        // something else holds the row, versus stopped by the
+                        // operator. Neither is a dwell that expired.
+                        if (metrics.scanDwellState === 2) {
+                            out += " " + qsTr("(suspended)");
+                        } else if (metrics.scanDwellState === 3) {
+                            out += " " + qsTr("(paused)");
+                        }
+                    }
+                    if (metrics.scanHoldMs > 0) {
+                        out += "  " + qsTr("hold %1s").arg((metrics.scanHoldMs / 1000).toFixed(1));
+                    }
+                    if (metrics.scanHangMs > 0) {
+                        out += "  " + qsTr("hang %1s").arg((metrics.scanHangMs / 1000).toFixed(1));
+                    }
+                    return out;
+                }
+                font.family: Theme.mono
+                font.pixelSize: Theme.fontSize(11)
+                font.letterSpacing: 0.8
+                color: Theme.textSubdued
+                // A phone is 411 dp wide and the budgets cap at 600 s: the row has to
+                // give way rather than push the header controls off screen.
+                elide: Text.ElideRight
+            }
+
             TapHandler {
                 onLongPressed: screen.editSystem()
             }

--- a/src/ui/qt/qml/MonitorScreen.qml
+++ b/src/ui/qt/qml/MonitorScreen.qml
@@ -174,6 +174,14 @@ Item {
                     if (metrics.scanHangMs > 0) {
                         out += "  " + qsTr("hang %1s").arg((metrics.scanHangMs / 1000).toFixed(1));
                     }
+                    // Last, the ceiling on the whole visit (#507). A word rather than
+                    // 0.0s while a hold suspends it: a zero countdown would read as a
+                    // visit that just ran out.
+                    if (metrics.scanVisitMs > 0) {
+                        out += "  " + (metrics.scanVisitLive
+                            ? qsTr("Visit: %1s/%2s").arg((metrics.scanVisitRemainingDs / 10).toFixed(1)).arg((metrics.scanVisitMs / 1000).toFixed(1))
+                            : qsTr("Visit: paused"));
+                    }
                     return out;
                 }
                 font.family: Theme.mono

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -21,6 +21,7 @@
 #include <curses.h>
 #include <dsd-neo/app_control/frontend.h>
 #include <dsd-neo/app_control/history.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/channel_label.h>
 #include <dsd-neo/core/dsd_time.h>
@@ -992,6 +993,96 @@ ui_render_trunk_scan_status(const dsd_opts* opts, const dsd_state* state) {
     printw("\n");
 }
 
+/* Declared here because the Scan Timing row has to truncate to the panel width, and the
+   width helper lives with the panel renderers much further down the file. */
+static int ui_get_panel_cols(void);
+
+static void ui_scan_timing_appendf(char* buf, size_t buf_sz, size_t* used, const char* fmt, ...)
+    DSD_ATTR_FORMAT(printf, 4, 5);
+
+/* Append one group of the Scan Timing row. Overflow is clamped rather than reported: the
+   row is a status line that a narrow terminal truncates anyway, and a caller that had to
+   check every group would be the thing most likely to get the grammar wrong. */
+static void
+ui_scan_timing_appendf(char* buf, size_t buf_sz, size_t* used, const char* fmt, ...) {
+    if (*used + 1U >= buf_sz) {
+        return;
+    }
+    va_list ap;
+    va_start(ap, fmt);
+    int wrote = DSD_VSNPRINTF(buf + *used, buf_sz - *used, fmt, ap);
+    va_end(ap);
+    if (wrote < 0) {
+        return;
+    }
+    *used += (size_t)wrote;
+    if (*used >= buf_sz) {
+        *used = buf_sz - 1U;
+    }
+}
+
+/* Why the idle dwell is not the thing counting down: suspended means something on the air
+   holds the row, paused means the operator does. */
+static const char*
+ui_scan_timing_dwell_suffix(uint8_t dwell_state) {
+    switch (dwell_state) {
+        case DSD_APP_SCAN_DWELL_SUSPENDED: return " (suspended)";
+        case DSD_APP_SCAN_DWELL_PAUSED: return " (paused)";
+        default: return "";
+    }
+}
+
+/* The Scan Timing row without its newline (issue #508): why the scanner is staying on the
+   row above and how long is left of it, from the shared app-control view so the terminal
+   and the Qt panel cannot drift on what "suspended" or "hold" means. Pure, and taking the
+   clock as an argument, so the goldens can pin the exact bytes. Returns the length
+   written, or 0 when there is no scan timing to show. */
+static int
+ui_format_scan_timing_row(const dsd_opts* opts, const dsd_state* state, double now_m, char* buf, size_t buf_sz) {
+    if (!buf || buf_sz == 0U) {
+        return 0;
+    }
+    buf[0] = '\0';
+    dsd_app_scan_timing view;
+    if (dsd_app_scan_timing_view(opts, state, now_m, &view) != 1) {
+        return 0;
+    }
+    size_t used = 0U;
+    ui_scan_timing_appendf(buf, buf_sz, &used, "| Scan Timing: %s", view.phrase);
+    if (view.timer_live) {
+        ui_scan_timing_appendf(buf, buf_sz, &used, " %.1fs/%.1fs", (double)view.remaining_ms / 1000.0,
+                               (double)view.span_ms / 1000.0);
+    }
+    if (view.show_dwell) {
+        ui_scan_timing_appendf(buf, buf_sz, &used, "  dwell %.1fs%s", (double)view.dwell_ms / 1000.0,
+                               ui_scan_timing_dwell_suffix(view.dwell_state));
+    }
+    if (view.show_hold) {
+        ui_scan_timing_appendf(buf, buf_sz, &used, "  hold %.1fs", (double)view.hold_ms / 1000.0);
+    }
+    if (view.show_hang) {
+        ui_scan_timing_appendf(buf, buf_sz, &used, "  hang %.1fs", (double)view.hang_ms / 1000.0);
+    }
+    return (int)used;
+}
+
+/* Cut to the panel width rather than wrapped: this row redraws several times a second as
+   the countdown moves, and a wrapped one would push every row below it down by one line
+   for as long as the phrase stayed long. */
+static void
+ui_render_scan_timing_row(const dsd_opts* opts, const dsd_state* state) {
+    char line[192];
+    int len = ui_format_scan_timing_row(opts, state, dsd_time_now_monotonic_s(), line, sizeof(line));
+    if (len <= 0) {
+        return;
+    }
+    int cols = ui_get_panel_cols();
+    if (len > cols) {
+        len = cols;
+    }
+    printw("%.*s\n", len, line);
+}
+
 static void
 ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* state) {
     if (opts->scanner_mode == 1) {
@@ -1033,9 +1124,18 @@ ui_render_scanner_and_reverse_status(const dsd_opts* opts, const dsd_state* stat
             printw(" Avoids: %u", (unsigned int)state->lcn_avoid_count);
         }
         printw(" \n");
+        // The timing row belongs directly under the scanner row that owns the stay. With
+        // --trunk-scan running that is the Trunk Scan row below, which publishes the target's
+        // own effective dwell and hold, so the -Y row only claims it when trunk scan is off.
+        if (opts->trunk_scan_enabled != 1) {
+            ui_render_scan_timing_row(opts, state);
+        }
     }
 
     ui_render_trunk_scan_status(opts, state);
+    if (opts->trunk_scan_enabled == 1) {
+        ui_render_scan_timing_row(opts, state);
+    }
 
     if (opts->reverse_mute == 1) {
         printw("| Reverse Mute - Muting Unencrypted Voice\n");

--- a/src/ui/terminal/dsd_ncurses_printer.c
+++ b/src/ui/terminal/dsd_ncurses_printer.c
@@ -1063,6 +1063,17 @@ ui_format_scan_timing_row(const dsd_opts* opts, const dsd_state* state, double n
     if (view.show_hang) {
         ui_scan_timing_appendf(buf, buf_sz, &used, "  hang %.1fs", (double)view.hang_ms / 1000.0);
     }
+    /* Last, the ceiling on the whole visit (#507). A word rather than 0.0s when it is not
+       counting: a hold suspends the cap, and a zero countdown would read as a visit that
+       just ran out and a receiver that should already have moved on. */
+    if (view.show_visit) {
+        if (view.visit_live) {
+            ui_scan_timing_appendf(buf, buf_sz, &used, "  Visit: %.1fs/%.1fs", (double)view.visit_remaining_ms / 1000.0,
+                                   (double)view.visit_ms / 1000.0);
+        } else {
+            ui_scan_timing_appendf(buf, buf_sz, &used, "  Visit: paused");
+        }
+    }
     return (int)used;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -600,6 +600,13 @@ dsd_neo_add_public_header_smoke_test(
   dsd-neo/app_control/call_view.h
   C
 )
+
+dsd_neo_add_public_header_smoke_test(
+  dsd-neo_test_headers_public_app_control_scan_timing_view
+  HEADERS_PUBLIC_APP_CONTROL_SCAN_TIMING_VIEW
+  dsd-neo/app_control/scan_timing_view.h
+  C
+)
 dsd_neo_add_public_header_smoke_test(
   dsd-neo_test_headers_public_app_control_commands
   HEADERS_PUBLIC_APP_CONTROL_COMMANDS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2003,6 +2003,24 @@ target_link_libraries(
 add_test(NAME APP_CONTROL_CALL_VIEW COMMAND dsd-neo_test_app_control_call_view)
 
 add_executable(
+    dsd-neo_test_app_control_scan_timing_view
+    ui/test_app_control_scan_timing_view.c
+    ${PROJECT_SOURCE_DIR}/src/app_control/scan_timing_view.c
+)
+target_include_directories(
+    dsd-neo_test_app_control_scan_timing_view
+    PRIVATE ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/app_control
+)
+target_link_libraries(
+    dsd-neo_test_app_control_scan_timing_view
+    PRIVATE dsd-neo_test_call_state_support
+)
+add_test(
+    NAME APP_CONTROL_SCAN_TIMING_VIEW
+    COMMAND dsd-neo_test_app_control_scan_timing_view
+)
+
+add_executable(
     dsd-neo_test_app_control_notification_status
     ui/test_app_control_notification_status.c
     ${PROJECT_SOURCE_DIR}/src/app_control/notification_status.c
@@ -2069,9 +2087,12 @@ if(DSD_ENABLE_TERMINAL_UI)
         COMMAND dsd-neo_test_ui_ncurses_p25_display_helpers
     )
 
+    # The shared scan-timing view comes in as a source rather than a stub: the Scan Timing
+    # goldens are only worth anything if they run through the real display table.
     add_executable(
         dsd-neo_test_ui_ncurses_printer_helpers
         ui/test_ui_ncurses_printer_helpers.c
+        ${PROJECT_SOURCE_DIR}/src/app_control/scan_timing_view.c
     )
     target_compile_definitions(
         dsd-neo_test_ui_ncurses_printer_helpers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4923,8 +4923,10 @@ add_test(
 
 add_executable(
     dsd-neo_test_engine_scan_voice_gate
+    test_support/scan_group_stubs.c
     engine/test_engine_scan_voice_gate.c
     ${PROJECT_SOURCE_DIR}/src/engine/scan_voice_gate.c
+    ${PROJECT_SOURCE_DIR}/src/core/util/dsd_state_trunk_lcn.c
 )
 target_include_directories(
     dsd-neo_test_engine_scan_voice_gate

--- a/tests/core/test_core_scan_profile.c
+++ b/tests/core/test_core_scan_profile.c
@@ -64,8 +64,8 @@ test_keys_and_scope(void) {
         uint64_t k;
         unsigned int mode;
         int force;
-    } rows[] = {{"-1 0123456789 -0 -F --scan-voice-only --scan-voice-hold-ms 4000", 0x123456789ULL, 0x123456789ULL, 0,
-                 DSD_SCAN_MODE_DMR, 0x21},
+    } rows[] = {{"-1 0123456789 -0 -F --scan-voice-only --scan-voice-hold-ms 4000 --scan-max-visit-ms 20000",
+                 0x123456789ULL, 0x123456789ULL, 0, DSD_SCAN_MODE_DMR, 0x21},
                 {"-H 0000001f00 -4", 0, 0, 0, DSD_SCAN_MODE_DMR, 1},
                 {"-b 1 --no-force-key --strict-crc --no-scan-voice-only", 0, 0, 1, DSD_SCAN_MODE_DMR, 0},
                 {"-R 1 --no-force-key", 1, 0, 0, DSD_SCAN_MODE_NXDN48, 0}};
@@ -88,9 +88,14 @@ test_keys_and_scope(void) {
         assert(state->keyloader == 0);
         if (i == 0) {
             assert(opts->scan_voice_hold_ms == 4000 && opts->scan_voice_only == 1 && opts->dmr_crc_relaxed_default);
+            /* The per-visit cap (issue #507) survives parse -> profile -> row scope. */
+            assert((profile->values.present & DSD_SCAN_OPT_MAX_VISIT) && profile->values.max_visit_ms == 20000);
+            assert(opts->scan_max_visit_ms == 20000);
         }
         if (i == 1) {
             assert(state->K1 == 0x1f00 && opts->scan_voice_hold_ms == 2000 && !opts->scan_voice_only);
+            /* A row without the switch inherits the global again. */
+            assert(opts->scan_max_visit_ms == 0);
         }
         if (i == 2) {
             assert(opts->aggressive_framesync == 1 && !opts->dmr_crc_relaxed_default && opts->dmr_mute_encL == 0);

--- a/tests/engine/test_engine_channel_scan.c
+++ b/tests/engine/test_engine_channel_scan.c
@@ -100,6 +100,9 @@ dsd_frame_sync_reset_acquisition(const dsd_opts* opts, dsd_state* state, int for
 void
 dsd_scan_voice_gate_note_retune(dsd_state* state, double now) {
     state->last_cc_sync_time_m = now;
+    /* The production note_retune opens the per-visit window for the cap (issue #507) as well
+     * as for the voice gate, so the rows below can see that the commit anchored a visit. */
+    state->scan_visit_since_m = now;
 }
 
 static void
@@ -169,38 +172,49 @@ test_option_only_rows_and_policy_edits(void) {
     opts->dmr_mute_encL = opts->dmr_mute_encR = 1;
     opts->scan_voice_hold_ms = 2000;
     opts->scan_voice_qualify_ms = 1000;
+    opts->scan_max_visit_ms = 15000;
     state->samplesPerSymbol = 10;
     state->lcn_freq_count = 1;
     *dsd_state_trunk_lcn_slot(state, 0) = 150000000;
     assert(!dsd_channel_modes_present(state));
     dsd_scan_row_profile* profile = (dsd_scan_row_profile*)calloc(1, sizeof(*profile));
     assert(profile);
-    profile->values.present = DSD_SCAN_OPT_HOLD | DSD_SCAN_OPT_MUTE_DMR;
+    profile->values.present = DSD_SCAN_OPT_HOLD | DSD_SCAN_OPT_MUTE_DMR | DSD_SCAN_OPT_MAX_VISIT;
     profile->values.hold_ms = 4000;
     profile->values.mute_dmr = 0;
+    profile->values.max_visit_ms = 45000;
     assert(dsd_channel_profile_set(state, 0, profile) == 0);
     assert(dsd_channel_modes_present(state) && dsd_channel_mode_get(state, 0) == DSD_SCAN_MODE_INHERIT);
 
     expected_nxdn = 0;
     tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    state->scan_visit_since_m = -1.0;
     assert(dsd_engine_channel_scan_step(opts, state) == 1);
     assert(opts->scan_voice_hold_ms == 4000 && opts->dmr_mute_encL == 0 && opts->dmr_mute_encR == 0);
     assert(opts->frame_dstar == 1);
+    /* The commit is what parks the receiver, so the commit is what opens the per-visit window the
+     * cap measures (issue #507) -- with the row's own cap in force, not the global. */
+    assert(opts->scan_max_visit_ms == 45000 && state->scan_visit_since_m >= 0.0);
 
     /* A policy edit during an outstanding request: the commit proceeds without a retry. */
     state->lcn_freq_roll = 0;
     tune_result = DSD_TRUNK_TUNE_RESULT_PENDING;
     assert(dsd_engine_channel_scan_step(opts, state) == 0);
     assert(dsd_scan_mode_suspend(opts, state));
-    assert(opts->scan_voice_hold_ms == 2000 && opts->dmr_mute_encL == 1);
+    assert(opts->scan_voice_hold_ms == 2000 && opts->dmr_mute_encL == 1 && opts->scan_max_visit_ms == 15000);
     opts->scan_voice_qualify_ms = 1500;
+    opts->scan_max_visit_ms = 20000;
     opts->unmute_encrypted_p25 = 1;
     assert(dsd_scan_mode_resume(opts, state) == 0);
     assert(opts->scan_voice_hold_ms == 4000 && opts->dmr_mute_encL == 0 && opts->scan_voice_qualify_ms == 1500);
+    /* An edited global beneath a staged tune does not dislodge the row's cap. */
+    assert(opts->scan_max_visit_ms == 45000);
     const int before_policy_edit = tunes;
     dsd_trunk_tuning_request_publish(request, DSD_TRUNK_TUNE_RESULT_OK);
     assert(dsd_engine_channel_scan_pending(opts, state) == 0);
     assert(tunes == before_policy_edit && opts->scan_voice_qualify_ms == 1500 && opts->unmute_encrypted_p25 == 1);
+    /* And a row cap is policy, not acquisition: the cycle above restaged nothing. */
+    assert(opts->scan_max_visit_ms == 45000);
 
     /* A keyring change during an outstanding request restages, and the eventual leave hands
      * back the globals as edited rather than the copy prepared before the edit. */
@@ -253,6 +267,58 @@ test_option_only_rows_and_policy_edits(void) {
     dsd_scan_keys_leave(state);
     assert(state->R == 0 && state->rkey_array[3] == 777 && state->rkey_array_loaded[3]);
     assert(opts->scan_voice_hold_ms == 2000 && opts->dmr_mute_encL == 1 && opts->scan_voice_qualify_ms == 1500);
+    assert(opts->scan_max_visit_ms == 20000);
+    dsd_state_trunk_lcn_free(state);
+    dsd_state_ext_free_all(state);
+    free(state);
+    free(opts);
+    tunes = reset_count = 0;
+}
+
+/* The per-visit cap is a row-scoped option like the voice-gate windows (issue #507): a row that
+ * carries one wins while it is on air, a row that carries none inherits the global, a row `0`
+ * switches the cap off for that row alone, and leaving the scan hands the configured global back
+ * rather than saving whichever row happened to be parked. */
+static void
+test_row_max_visit_override_and_inherit(void) {
+    dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
+    assert(opts && state);
+    opts->scanner_mode = 1;
+    opts->audio_in_type = AUDIO_IN_WAV;
+    opts->wav_sample_rate = 48000;
+    opts->frame_dstar = 1;
+    opts->scan_max_visit_ms = 15000;
+    state->samplesPerSymbol = 10;
+    state->lcn_freq_count = 3;
+    for (int row = 0; row < 3; row++) {
+        *dsd_state_trunk_lcn_slot(state, row) = 150000000;
+    }
+    dsd_scan_row_profile* row_override = (dsd_scan_row_profile*)calloc(1, sizeof(*row_override));
+    assert(row_override);
+    row_override->values.present = DSD_SCAN_OPT_MAX_VISIT;
+    row_override->values.max_visit_ms = 45000;
+    assert(dsd_channel_profile_set(state, 0, row_override) == 0);
+    dsd_scan_row_profile* row_off = (dsd_scan_row_profile*)calloc(1, sizeof(*row_off));
+    assert(row_off);
+    row_off->values.present = DSD_SCAN_OPT_MAX_VISIT;
+    row_off->values.max_visit_ms = 0;
+    assert(dsd_channel_profile_set(state, 2, row_off) == 0);
+
+    expected_nxdn = 0;
+    tune_result = DSD_TRUNK_TUNE_RESULT_OK;
+    state->scan_visit_since_m = -1.0;
+    assert(dsd_engine_channel_scan_step(opts, state) == 1);
+    assert(opts->scan_max_visit_ms == 45000 && state->lcn_freq_roll == 1);
+    assert(state->scan_visit_since_m >= 0.0);
+    /* Row 1 carries no override, so the global applies again. */
+    assert(dsd_engine_channel_scan_step(opts, state) == 1);
+    assert(opts->scan_max_visit_ms == 15000 && state->lcn_freq_roll == 2);
+    /* Row 2 asks for 0: off for that row even though the global is set. */
+    assert(dsd_engine_channel_scan_step(opts, state) == 1);
+    assert(opts->scan_max_visit_ms == 0 && state->lcn_freq_roll == 3);
+    dsd_engine_channel_scan_leave(opts, state);
+    assert(opts->scan_max_visit_ms == 15000);
     dsd_state_trunk_lcn_free(state);
     dsd_state_ext_free_all(state);
     free(state);
@@ -264,6 +330,7 @@ int
 main(void) {
     test_option_commit_boundary();
     test_option_only_rows_and_policy_edits();
+    test_row_max_visit_override_and_inherit();
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(*opts));
     dsd_state* state = (dsd_state*)calloc(1, sizeof(*state));
     assert(opts && state);
@@ -308,8 +375,12 @@ main(void) {
     assert(dsd_engine_channel_scan_step(opts, state) == 1);
     assert(state->lcn_freq_roll == 2 && opts->frame_p25p1 && opts->frame_p25p2 && !opts->frame_dmr);
     const int before_zero = tunes;
+    state->scan_visit_since_m = -1.0;
     assert(dsd_engine_channel_scan_step(opts, state) == 0);
     assert(tunes == before_zero && state->lcn_freq_roll == 3 && opts->frame_p25p1);
+    /* A zero-frequency placeholder parks in place instead of retuning, and it is still a new
+     * visit: the cap has to measure it from here (issue #507). */
+    assert(state->scan_visit_since_m >= 0.0);
     assert(dsd_engine_channel_scan_step(opts, state) == 1);
     assert(state->lcn_freq_roll == 4 && opts->frame_dstar == 1 && !opts->frame_p25p1);
     state->lcn_freq_roll = 2;

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -428,6 +428,159 @@ test_typed_scan_tune_boundaries(void) {
     dsd_trunk_tuning_requests_reset();
     return rc;
 }
+
+/*
+ * The -Y per-visit cap (issue #507) through the real noCarrier() step. Every case here needs the
+ * cap to be the only thing that could hop: the legacy -t 10 deadline is fresh, or the voice gate
+ * is holding on media that keeps arriving. Frequencies are unique to this case because engine.c
+ * caches its last tune in file statics that outlive free_test_runtime().
+ */
+static int
+test_visit_cap_scanner_hops(void) {
+    dsd_opts* opts = NULL;
+    dsd_state* state = NULL;
+    if (init_test_runtime(&opts, &state) != 0) {
+        return 1;
+    }
+    int rc = 0;
+    reset_rtl_profile_fakes();
+    dsd_trunk_tuning_requests_reset();
+    opts->scanner_mode = 1;
+    opts->audio_in_type = AUDIO_IN_RTL;
+    opts->trunk_hangtime = 10;
+    opts->scan_max_visit_ms = 2000;
+    state->rtl_ctx = (RtlSdrContext*)state;
+    state->trunk_lcn_freq[0] = 952012500;
+    state->trunk_lcn_freq[1] = 953012500;
+    state->trunk_lcn_freq[2] = 954012500;
+    state->lcn_freq_count = 3;
+    state->lcn_freq_roll = 0;
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+
+    // Legacy hangtime mode: the -t 10 deadline is 10 s away, so nothing but the cap can move the
+    // rotation. The visit is 5 s old against a 2 s cap, and the call open on the outgoing row has
+    // to close as an explicit release rather than a sync loss -- the frequency moved under it.
+    double now_m = dsd_time_now_monotonic_s();
+    state->last_cc_sync_time = time(NULL);
+    dsd_scan_voice_gate_note_retune(state, now_m - 5.0);
+    dsd_call_observation capped_call = {0};
+    capped_call.protocol = DSD_SYNC_NXDN_POS;
+    capped_call.slot = 0U;
+    capped_call.kind = DSD_CALL_KIND_GROUP_VOICE;
+    capped_call.ota_target_id = 7301U;
+    capped_call.policy_target_id = 7301U;
+    capped_call.ota_source_id = 8301U;
+    capped_call.observed_m = now_m - 4.0;
+    rc |= expect_true("visit-cap-legacy-seeds-call",
+                      dsd_call_state_observe(state, &capped_call, DSD_CALL_BOUNDARY_BEGIN) == 1);
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("visit-cap-legacy-retuned", g_rtl_tune_calls > 0 && g_rtl_tune_freq == 952012500U);
+    rc |= expect_true("visit-cap-legacy-advanced", state->lcn_freq_roll == 1);
+    dsd_call_snapshot capped_snapshot;
+    rc |= expect_true("visit-cap-legacy-retains-snapshot", dsd_call_state_get(state, 0U, &capped_snapshot) == 1);
+    rc |= expect_true("visit-cap-legacy-ends-call", capped_snapshot.phase == DSD_CALL_PHASE_ENDED);
+    rc |= expect_true("visit-cap-legacy-ends-call-explicitly",
+                      capped_snapshot.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
+    // The hop anchors a fresh visit, so an immediate second pass has nothing to expire.
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("visit-cap-fresh-anchor-no-second-hop", g_rtl_tune_calls == 0 && state->lcn_freq_roll == 1);
+
+    // Voice-gate mode with media still arriving: the gate holds the row for as long as voice keeps
+    // coming, which is exactly the open-microphone case the cap exists for.
+    opts->scan_voice_only = 1;
+    opts->scan_voice_qualify_ms = 1000;
+    opts->scan_voice_hold_ms = 2000;
+    state->lcn_freq_roll = 1;
+    state->last_cc_sync_time = time(NULL);
+    now_m = dsd_time_now_monotonic_s();
+    dsd_scan_voice_gate_note_retune(state, now_m - 5.0);
+    dsd_call_observation live_call = {0};
+    live_call.protocol = DSD_SYNC_NXDN_POS;
+    live_call.slot = 0U;
+    live_call.kind = DSD_CALL_KIND_GROUP_VOICE;
+    live_call.ota_target_id = 7302U;
+    live_call.policy_target_id = 7302U;
+    live_call.ota_source_id = 8302U;
+    live_call.observed_m = now_m - 0.4;
+    rc |= expect_true("visit-cap-gate-seeds-call",
+                      dsd_call_state_observe(state, &live_call, DSD_CALL_BOUNDARY_BEGIN) == 1);
+    rc |= expect_true("visit-cap-gate-seeds-media", dsd_call_state_update_media(state, 0U, 1, now_m - 0.4) == 1
+                                                        && dsd_call_state_update_media(state, 0U, 1, now_m) == 1);
+    dsd_scan_voice_gate_tick(opts, state, 1, now_m);
+    rc |= expect_true("visit-cap-gate-holds",
+                      dsd_scan_voice_gate_should_step(opts, state, dsd_time_now_monotonic_s()) == 0);
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("visit-cap-gate-retuned", g_rtl_tune_calls > 0 && g_rtl_tune_freq == 953012500U);
+    rc |= expect_true("visit-cap-gate-advanced", state->lcn_freq_roll == 2);
+    opts->scan_voice_only = 0;
+
+    // The operator hold suspends the cap: the receiver stays, the roll stands still, and the
+    // legacy dwell anchor is left alone so the release grants a full window.
+    state->lcn_scan_hold = 1;
+    state->lcn_freq_roll = 2;
+    state->last_cc_sync_time = time(NULL);
+    const time_t held_dwell_anchor = state->last_cc_sync_time;
+    now_m = dsd_time_now_monotonic_s();
+    dsd_scan_voice_gate_note_retune(state, now_m - 5.0);
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("visit-cap-hold-no-retune", g_rtl_tune_calls == 0);
+    rc |= expect_true("visit-cap-hold-keeps-roll", state->lcn_freq_roll == 2);
+    rc |= expect_true("visit-cap-hold-leaves-dwell-alone", state->last_cc_sync_time == held_dwell_anchor);
+    state->lcn_scan_hold = 0;
+
+    // Disabled (the default): an ancient anchor changes nothing, and the hangtime rule still
+    // decides the rotation entirely on its own.
+    opts->scan_max_visit_ms = 0;
+    state->lcn_freq_roll = 2;
+    state->last_cc_sync_time = time(NULL);
+    now_m = dsd_time_now_monotonic_s();
+    dsd_scan_voice_gate_note_retune(state, now_m - 600.0);
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("visit-cap-disabled-no-retune", g_rtl_tune_calls == 0 && state->lcn_freq_roll == 2);
+    state->last_cc_sync_time = time(NULL) - 11;
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("visit-cap-disabled-keeps-hangtime",
+                      g_rtl_tune_calls > 0 && g_rtl_tune_freq == 954012500U && state->lcn_freq_roll == 3);
+
+    // One usable row: a hop would land back on the same frequency, so the cap re-arms instead of
+    // tearing down audio it would immediately have to rebuild.
+    opts->scan_max_visit_ms = 2000;
+    state->trunk_lcn_freq[0] = 955012500;
+    state->lcn_freq_count = 1;
+    state->lcn_freq_roll = 0;
+    state->last_cc_sync_time = time(NULL);
+    now_m = dsd_time_now_monotonic_s();
+    dsd_scan_voice_gate_note_retune(state, now_m - 5.0);
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("visit-cap-single-row-no-retune", g_rtl_tune_calls == 0 && state->lcn_freq_roll == 0);
+
+    // The cap's hop walks the avoid list exactly as the dwell's does: the avoided row is stepped
+    // over in the same pass rather than costing a visit of its own.
+    state->trunk_lcn_freq[1] = 956012500;
+    state->trunk_lcn_freq[2] = 957012500;
+    state->lcn_freq_count = 3;
+    rc |= expect_true("visit-cap-avoid-set", dsd_state_trunk_lcn_avoid_set(state, 1U, 1) == 0);
+    state->lcn_freq_roll = 1;
+    state->last_cc_sync_time = time(NULL);
+    now_m = dsd_time_now_monotonic_s();
+    dsd_scan_voice_gate_note_retune(state, now_m - 5.0);
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("visit-cap-avoid-skips-row", g_rtl_tune_calls > 0 && g_rtl_tune_freq == 957012500U);
+    rc |= expect_true("visit-cap-avoid-advanced-past", state->lcn_freq_roll == 3);
+
+    state->rtl_ctx = NULL;
+    free_test_runtime(opts, state);
+    dsd_trunk_tuning_requests_reset();
+    return rc;
+}
 #endif
 
 int
@@ -2106,6 +2259,7 @@ main(void) {
 
 #if defined(USE_RADIO) && defined(DSD_NEO_TEST_RTL_WRAP)
     rc |= test_typed_scan_tune_boundaries();
+    rc |= test_visit_cap_scanner_hops();
     rc |= test_trunk_cache_with_mode_metadata();
     rc |= test_dmr_explicit_return_destination();
 #endif

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -595,6 +595,40 @@ test_visit_cap_scanner_hops(void) {
     rc |= expect_true("visit-cap-avoid-skips-row", g_rtl_tune_calls > 0 && g_rtl_tune_freq == 957012500U);
     rc |= expect_true("visit-cap-avoid-advanced-past", state->lcn_freq_roll == 3);
 
+    // A failed hop must reopen the current row's windows so sync can be decoded again.
+    // Also cover the preexisting voice-gate escape with the visit cap disabled.
+    (void)dsd_state_trunk_lcn_avoid_clear(state);
+    static const int failed_tunes[] = {RTL_STREAM_TUNE_TIMEOUT, RTL_STREAM_TUNE_DEFERRED, RTL_STREAM_TUNE_FAILED};
+    for (int gate = 0; gate < 2; gate++) {
+        opts->scan_max_visit_ms = gate ? 0 : 1000;
+        opts->scan_voice_only = gate;
+        for (size_t i = 0; i < sizeof failed_tunes / sizeof failed_tunes[0]; i++) {
+            state->lcn_freq_roll = 0;
+            state->trunk_lcn_freq[0] = 958012500;
+            now_m = dsd_time_now_monotonic_s();
+            seed_visit_anchor(state, now_m - 5.0);
+            state->scan_voice_gate_sync_m = gate ? now_m - 4.0 : -1.0;
+            state->last_cc_sync_time = time(NULL) - (gate ? 11 : 0);
+            g_rtl_tune_result = failed_tunes[i];
+            g_rtl_tune_calls = 0;
+            noCarrier(opts, state);
+            rc |= expect_true("abandoned-scan-attempted", g_rtl_tune_calls == 1 && state->lcn_freq_roll == 0);
+            rc |= expect_true("abandoned-scan-cap-rearmed",
+                              !dsd_engine_scan_visit_expired(opts, state, dsd_time_now_monotonic_s()));
+            rc |= expect_true("abandoned-scan-gate-rearmed",
+                              !dsd_scan_voice_gate_should_step(opts, state, dsd_time_now_monotonic_s()));
+            noCarrier(opts, state);
+            rc |= expect_true("abandoned-scan-no-immediate-retry", g_rtl_tune_calls == 1);
+        }
+    }
+    // Recovery remains possible once the fresh interval expires.
+    opts->scan_max_visit_ms = 1000;
+    opts->scan_voice_only = 0;
+    seed_visit_anchor(state, dsd_time_now_monotonic_s() - 2.0);
+    g_rtl_tune_result = RTL_STREAM_TUNE_OK;
+    noCarrier(opts, state);
+    rc |= expect_true("abandoned-scan-recovers", g_rtl_tune_calls == 2 && state->lcn_freq_roll == 1);
+
     state->rtl_ctx = NULL;
     free_test_runtime(opts, state);
     dsd_trunk_tuning_requests_reset();

--- a/tests/engine/test_engine_no_carrier_reset.c
+++ b/tests/engine/test_engine_no_carrier_reset.c
@@ -429,6 +429,15 @@ test_typed_scan_tune_boundaries(void) {
     return rc;
 }
 
+// The live-scanner loop runs dsd_engine_scan_visit_tick() immediately before every noCarrier()
+// pass, so by the time the step predicate runs the row on air has always been reconciled with the
+// anchor. These cases drive noCarrier() in isolation, so they stand in for that tick.
+static void
+seed_visit_anchor(dsd_state* state, double anchor_m) {
+    dsd_scan_voice_gate_note_retune(state, anchor_m);
+    state->scan_visit_roll_seen = state->lcn_freq_roll;
+}
+
 /*
  * The -Y per-visit cap (issue #507) through the real noCarrier() step. Every case here needs the
  * cap to be the only thing that could hop: the legacy -t 10 deadline is fresh, or the voice gate
@@ -462,7 +471,7 @@ test_visit_cap_scanner_hops(void) {
     // to close as an explicit release rather than a sync loss -- the frequency moved under it.
     double now_m = dsd_time_now_monotonic_s();
     state->last_cc_sync_time = time(NULL);
-    dsd_scan_voice_gate_note_retune(state, now_m - 5.0);
+    seed_visit_anchor(state, now_m - 5.0);
     dsd_call_observation capped_call = {0};
     capped_call.protocol = DSD_SYNC_NXDN_POS;
     capped_call.slot = 0U;
@@ -482,7 +491,9 @@ test_visit_cap_scanner_hops(void) {
     rc |= expect_true("visit-cap-legacy-ends-call", capped_snapshot.phase == DSD_CALL_PHASE_ENDED);
     rc |= expect_true("visit-cap-legacy-ends-call-explicitly",
                       capped_snapshot.end_reason == (uint8_t)DSD_CALL_END_EXPLICIT);
-    // The hop anchors a fresh visit, so an immediate second pass has nothing to expire.
+    // The hop anchors a fresh visit, so an immediate second pass has nothing to expire. The row it
+    // moved to is reconciled first, so this tests the anchor and not the row change.
+    state->scan_visit_roll_seen = state->lcn_freq_roll;
     g_rtl_tune_calls = 0;
     noCarrier(opts, state);
     rc |= expect_true("visit-cap-fresh-anchor-no-second-hop", g_rtl_tune_calls == 0 && state->lcn_freq_roll == 1);
@@ -495,7 +506,7 @@ test_visit_cap_scanner_hops(void) {
     state->lcn_freq_roll = 1;
     state->last_cc_sync_time = time(NULL);
     now_m = dsd_time_now_monotonic_s();
-    dsd_scan_voice_gate_note_retune(state, now_m - 5.0);
+    seed_visit_anchor(state, now_m - 5.0);
     dsd_call_observation live_call = {0};
     live_call.protocol = DSD_SYNC_NXDN_POS;
     live_call.slot = 0U;
@@ -524,7 +535,7 @@ test_visit_cap_scanner_hops(void) {
     state->last_cc_sync_time = time(NULL);
     const time_t held_dwell_anchor = state->last_cc_sync_time;
     now_m = dsd_time_now_monotonic_s();
-    dsd_scan_voice_gate_note_retune(state, now_m - 5.0);
+    seed_visit_anchor(state, now_m - 5.0);
     g_rtl_tune_calls = 0;
     noCarrier(opts, state);
     rc |= expect_true("visit-cap-hold-no-retune", g_rtl_tune_calls == 0);
@@ -538,7 +549,7 @@ test_visit_cap_scanner_hops(void) {
     state->lcn_freq_roll = 2;
     state->last_cc_sync_time = time(NULL);
     now_m = dsd_time_now_monotonic_s();
-    dsd_scan_voice_gate_note_retune(state, now_m - 600.0);
+    seed_visit_anchor(state, now_m - 600.0);
     g_rtl_tune_calls = 0;
     noCarrier(opts, state);
     rc |= expect_true("visit-cap-disabled-no-retune", g_rtl_tune_calls == 0 && state->lcn_freq_roll == 2);
@@ -556,21 +567,29 @@ test_visit_cap_scanner_hops(void) {
     state->lcn_freq_roll = 0;
     state->last_cc_sync_time = time(NULL);
     now_m = dsd_time_now_monotonic_s();
-    dsd_scan_voice_gate_note_retune(state, now_m - 5.0);
+    seed_visit_anchor(state, now_m - 5.0);
     g_rtl_tune_calls = 0;
     noCarrier(opts, state);
     rc |= expect_true("visit-cap-single-row-no-retune", g_rtl_tune_calls == 0 && state->lcn_freq_roll == 0);
 
+    // Requirement 5 is a re-arm, not a freeze: the loop's tick slides the anchor while the rotation
+    // has nowhere to go, so handing it a second row does not hop the instant that row appears.
+    dsd_engine_scan_visit_tick(opts, state, dsd_time_now_monotonic_s());
+    state->trunk_lcn_freq[1] = 956012500;
+    state->lcn_freq_count = 2;
+    g_rtl_tune_calls = 0;
+    noCarrier(opts, state);
+    rc |= expect_true("visit-cap-rearmed-row-no-instant-hop", g_rtl_tune_calls == 0 && state->lcn_freq_roll == 0);
+
     // The cap's hop walks the avoid list exactly as the dwell's does: the avoided row is stepped
     // over in the same pass rather than costing a visit of its own.
-    state->trunk_lcn_freq[1] = 956012500;
     state->trunk_lcn_freq[2] = 957012500;
     state->lcn_freq_count = 3;
     rc |= expect_true("visit-cap-avoid-set", dsd_state_trunk_lcn_avoid_set(state, 1U, 1) == 0);
     state->lcn_freq_roll = 1;
     state->last_cc_sync_time = time(NULL);
     now_m = dsd_time_now_monotonic_s();
-    dsd_scan_voice_gate_note_retune(state, now_m - 5.0);
+    seed_visit_anchor(state, now_m - 5.0);
     g_rtl_tune_calls = 0;
     noCarrier(opts, state);
     rc |= expect_true("visit-cap-avoid-skips-row", g_rtl_tune_calls > 0 && g_rtl_tune_freq == 957012500U);

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -1080,12 +1080,12 @@ test_visit_cap_manual_hold_suspends_and_release_restarts(void) {
     dsd_engine_scan_visit_tick(fix.opts, fix.state, 400.0);
     CHECK("the hold keeps sliding", fabs(fix.state->scan_visit_since_m - 400.0) < 1e-9);
     fix.state->lcn_scan_hold = 0;
-    dsd_engine_scan_visit_tick(fix.opts, fix.state, 401.0);
-    CHECK("the release keeps the slid anchor", fabs(fix.state->scan_visit_since_m - 400.0) < 1e-9);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 500.0);
+    CHECK("the delayed release starts here", fabs(fix.state->scan_visit_since_m - 500.0) < 1e-9);
     CHECK("the release restarts the full limit",
-          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 430.0) < 1e-9);
-    CHECK("the released limit holds", dsd_engine_scan_visit_expired(fix.opts, fix.state, 429.999) == 0);
-    CHECK("the released limit expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 430.001) == 1);
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 530.0) < 1e-9);
+    CHECK("the released limit holds", dsd_engine_scan_visit_expired(fix.opts, fix.state, 529.999) == 0);
+    CHECK("the released limit expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 530.001) == 1);
     fixture_free(&fix);
 }
 
@@ -1114,9 +1114,9 @@ test_visit_cap_tg_hold_match_suspends(void) {
     /* Another talkgroup's call is not the one the hold follows. */
     fix.state->tg_hold = 99;
     dsd_engine_scan_visit_tick(fix.opts, fix.state, 112.0);
-    CHECK("another talkgroup does not suspend", fabs(fix.state->scan_visit_since_m - 111.0) < 1e-9);
+    CHECK("another talkgroup resumes the cap", fabs(fix.state->scan_visit_since_m - 112.0) < 1e-9);
     CHECK("another talkgroup keeps the deadline",
-          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 141.0) < 1e-9);
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 142.0) < 1e-9);
     /* A private call is held by either end. */
     fix.state->tg_hold = 22;
     (void)dsd_call_state_end_ex(fix.state, 0U, 112.5, DSD_CALL_END_EXPLICIT);
@@ -1127,13 +1127,13 @@ test_visit_cap_tg_hold_match_suspends(void) {
     (void)dsd_call_state_end_ex(fix.state, 1U, 114.5, DSD_CALL_END_EXPLICIT);
     open_call_identity(&fix, 1U, DSD_CALL_KIND_DATA, 11, 22, 22, 115.0);
     dsd_engine_scan_visit_tick(fix.opts, fix.state, 116.0);
-    CHECK("a data call does not suspend", fabs(fix.state->scan_visit_since_m - 114.0) < 1e-9);
-    /* Once the followed call ends, a fresh full limit runs from the last suspended tick. */
+    CHECK("a data call resumes the cap", fabs(fix.state->scan_visit_since_m - 116.0) < 1e-9);
+    /* Ending an unheld data call does not restart the running cap. */
     (void)dsd_call_state_end_ex(fix.state, 1U, 116.5, DSD_CALL_END_EXPLICIT);
     dsd_engine_scan_visit_tick(fix.opts, fix.state, 117.0);
-    CHECK("the ended call leaves the anchor", fabs(fix.state->scan_visit_since_m - 114.0) < 1e-9);
+    CHECK("the ended call leaves the anchor", fabs(fix.state->scan_visit_since_m - 116.0) < 1e-9);
     CHECK("the ended call resumes the limit",
-          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 144.0) < 1e-9);
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 146.0) < 1e-9);
     fixture_free(&fix);
 }
 
@@ -1199,15 +1199,17 @@ test_visit_cap_needs_a_second_usable_row(void) {
     CHECK("a placeholder row publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
     dsd_engine_scan_visit_tick(fix.opts, fix.state, 400.0);
     CHECK("a placeholder alternate re-arms the visit", fabs(fix.state->scan_visit_since_m - 400.0) < 1e-9);
-    /* Restored, the row gets a full fresh limit measured from the last tick -- not the original
-     * park, which would have expired three hundred seconds ago. */
+    /* Eligibility can return after input stalls longer than the cap. The first eligible tick
+     * must start a fresh interval, and publication must hide the stale suspended anchor. */
     *dsd_state_trunk_lcn_slot(fix.state, 1) = saved_freq;
+    CHECK("resume awaits a tick", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 500.0);
     CHECK("a second usable row arms a fresh limit",
-          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 430.0) < 1e-9);
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 530.0) < 1e-9);
     CHECK("a second usable row does not expire at once",
-          dsd_engine_scan_visit_expired(fix.opts, fix.state, 400.001) == 0);
-    CHECK("the fresh limit holds", dsd_engine_scan_visit_expired(fix.opts, fix.state, 429.999) == 0);
-    CHECK("the fresh limit expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 430.001) == 1);
+          dsd_engine_scan_visit_expired(fix.opts, fix.state, 500.001) == 0);
+    CHECK("the fresh limit holds", dsd_engine_scan_visit_expired(fix.opts, fix.state, 529.999) == 0);
+    CHECK("the fresh limit expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 530.001) == 1);
     fixture_free(&fix);
 }
 

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -11,7 +11,9 @@
  * holds through the tail from the last media time even when a terminator ends
  * the call before the first gate tick, 0.10 s span debounce, policy gating
  * (blocked encrypted, private evaluator, unknown identity), DATA ignored,
- * operator hold, and visit resets.
+ * operator hold, and visit resets. Also pins the scan timing publication the
+ * Scan Timing row renders (issue #508): reason, effective windows, and a deadline
+ * that agrees with dsd_scan_voice_gate_should_step() to the millisecond.
  */
 
 #include <dsd-neo/core/call_state.h>
@@ -541,6 +543,219 @@ test_tick_leaves_phase_alone_without_scanner_mode(void) {
     fixture_free(&fix);
 }
 
+/* ---- Scan timing publication for the -Y row (issue #508) ------------------- */
+
+static void
+check_timing_window(const char* started_tag, const char* deadline_tag, const char* span_tag,
+                    const dsd_scan_timing_publication* timing, double started_m, double deadline_m, uint32_t span_ms) {
+    CHECK(started_tag, fabs(timing->started_m - started_m) < 1e-6);
+    CHECK(deadline_tag, fabs(timing->deadline_m - deadline_m) < 1e-6);
+    CHECK(span_tag, timing->span_ms == span_ms);
+}
+
+/* Anti-drift: the published deadline is only useful if it is the instant
+ * dsd_scan_voice_gate_should_step() first says yes. A countdown that reaches 0.0 a
+ * frame before or after the hop is a bug report waiting to happen. */
+static void
+check_deadline_matches_should_step(const gate_fixture* fix, const char* early_tag, const char* late_tag) {
+    const double deadline_m = fix->state->scan_timing.deadline_m;
+    CHECK(early_tag, dsd_scan_voice_gate_should_step(fix->opts, fix->state, deadline_m - 1e-3) == 0);
+    CHECK(late_tag, dsd_scan_voice_gate_should_step(fix->opts, fix->state, deadline_m + 1e-3) == 1);
+}
+
+static void
+test_y_timing_silent_under_trunk_scan(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    /* Under --trunk-scan the coordinator owns the publication for its parked target,
+     * exactly as it owns scan_voice_gate_phase. */
+    fix.opts->trunk_scan_enabled = 1;
+    dsd_scan_timing_clear(fix.state);
+    fix.state->scan_timing.reason = (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW;
+    fix.state->scan_timing.deadline_m = 142.0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("trunk scan keeps reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW);
+    CHECK("trunk scan keeps deadline", fabs(fix.state->scan_timing.deadline_m - 142.0) < 1e-6);
+    /* No scanner running at all publishes nothing either. */
+    fix.opts->trunk_scan_enabled = 0;
+    fix.opts->scanner_mode = 0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("no scanner keeps reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW);
+    CHECK("no scanner keeps deadline", fabs(fix.state->scan_timing.deadline_m - 142.0) < 1e-6);
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_legacy_hangtime_window(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_voice_only = 0;
+    fix.opts->trunk_hangtime = 2.0f;
+    fix.state->last_cc_sync_time_m = 100.0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("hangtime reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    CHECK("hangtime is conventional", fix.state->scan_timing.conventional == 1U);
+    check_timing_window("hangtime start", "hangtime deadline", "hangtime span", &fix.state->scan_timing, 100.0, 102.0,
+                        2000U);
+    CHECK("hangtime has no dwell", fix.state->scan_timing.dwell_ms == 0U);
+    CHECK("hangtime has no hold", fix.state->scan_timing.hold_ms == 0U);
+    /* A gate that is enabled but has never synced this visit abstains, so the legacy
+     * rule still owns the step -- and it has neither window to report. */
+    fix.opts->scan_voice_only = 1;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 0, 100.5);
+    CHECK("unsynced gate abstains", dsd_scan_voice_gate_owns_step(fix.opts, fix.state) == 0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("unsynced gate reports hangtime", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    CHECK("unsynced gate hides dwell", fix.state->scan_timing.dwell_ms == 0U);
+    CHECK("unsynced gate hides hold", fix.state->scan_timing.hold_ms == 0U);
+    /* -t takes any non-negative double, so the millisecond span saturates instead of
+     * wrapping into the publication's uint32_t. */
+    fix.opts->scan_voice_only = 0;
+    fix.opts->trunk_hangtime = 1.0e9f;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("absurd hangtime saturates the span", fix.state->scan_timing.span_ms == UINT32_MAX);
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_hangtime_without_anchor(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_voice_only = 0;
+    fix.opts->trunk_hangtime = 2.0f;
+    fix.state->last_cc_sync_time_m = 0.0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("unanchored reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    CHECK("unanchored has no start", fix.state->scan_timing.started_m < 0.0);
+    CHECK("unanchored has no deadline", fix.state->scan_timing.deadline_m < 0.0);
+    CHECK("unanchored has no span", fix.state->scan_timing.span_ms == 0U);
+    /* -t 0 has an anchor but no window to count down. */
+    fix.state->last_cc_sync_time_m = 100.0;
+    fix.opts->trunk_hangtime = 0.0f;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("zero hangtime reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    CHECK("zero hangtime has no deadline", fix.state->scan_timing.deadline_m < 0.0);
+    CHECK("zero hangtime has no span", fix.state->scan_timing.span_ms == 0U);
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_manual_hold_pauses_the_timer(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    fix.state->lcn_scan_hold = 1;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("manual hold reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_MANUAL_HOLD);
+    CHECK("manual hold has no start", fix.state->scan_timing.started_m < 0.0);
+    CHECK("manual hold has no deadline", fix.state->scan_timing.deadline_m < 0.0);
+    CHECK("manual hold has no span", fix.state->scan_timing.span_ms == 0U);
+    /* The row's effective windows stay visible: they are paused, not gone. */
+    CHECK("manual hold keeps dwell", fix.state->scan_timing.dwell_ms == 1000U);
+    CHECK("manual hold keeps hold", fix.state->scan_timing.hold_ms == 2000U);
+    CHECK("manual hold never steps", dsd_scan_voice_gate_should_step(fix.opts, fix.state, 400.0) == 0);
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_qualify_window(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_voice_qualify_ms = 3000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("qualify reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
+    CHECK("qualify is conventional", fix.state->scan_timing.conventional == 1U);
+    CHECK("qualify publishes the effective dwell", fix.state->scan_timing.dwell_ms == 3000U);
+    CHECK("qualify publishes the effective hold", fix.state->scan_timing.hold_ms == 2000U);
+    check_timing_window("qualify start", "qualify deadline", "qualify span", &fix.state->scan_timing, 100.0, 103.0,
+                        3000U);
+    check_deadline_matches_should_step(&fix, "qualify holds before the deadline", "qualify steps after the deadline");
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_voice_and_tail_share_the_hold_window(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    open_voice_epoch(&fix, 100.2, 0.15, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.4);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("voice reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_VOICE);
+    check_timing_window("voice start", "voice deadline", "voice span", &fix.state->scan_timing, 100.35, 102.35, 2000U);
+    check_deadline_matches_should_step(&fix, "voice holds before the deadline", "voice steps after the deadline");
+    /* The tail is the same window from the same last-media anchor; only the reason moves. */
+    (void)dsd_call_state_end_ex(fix.state, 0, 100.5, DSD_CALL_END_SYNC_LOSS);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 0, 100.6);
+    CHECK("tail phase", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_TAIL);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("tail reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_ACTIVITY_HOLD);
+    check_timing_window("tail start", "tail deadline", "tail span", &fix.state->scan_timing, 100.35, 102.35, 2000U);
+    check_deadline_matches_should_step(&fix, "tail holds before the deadline", "tail steps after the deadline");
+    fixture_free(&fix);
+}
+
+static void
+test_y_timing_hop_restarts_the_window(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->trunk_hangtime = 2.0f;
+    fix.state->last_cc_sync_time_m = 100.0;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    check_timing_window("first visit start", "first visit deadline", "first visit span", &fix.state->scan_timing, 100.0,
+                        101.0, 1000U);
+    /* A hop stamps a fresh legacy anchor and re-opens the gate's visit, so the
+     * countdown restarts on the new row instead of carrying the old one over. */
+    fix.state->last_cc_sync_time_m = 200.0;
+    dsd_scan_voice_gate_note_retune(fix.state, 200.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("hop falls back to hangtime", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    check_timing_window("hop start", "hop deadline", "hop span", &fix.state->scan_timing, 200.0, 202.0, 2000U);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 200.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    CHECK("new visit qualifies", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
+    check_timing_window("new visit start", "new visit deadline", "new visit span", &fix.state->scan_timing, 200.0,
+                        201.0, 1000U);
+    check_deadline_matches_should_step(&fix, "new visit holds", "new visit steps");
+    fixture_free(&fix);
+}
+
 int
 main(void) {
     test_tick_leaves_phase_alone_without_scanner_mode();
@@ -557,6 +772,13 @@ main(void) {
     test_operator_hold_and_visit_reset();
     test_stale_epoch_cannot_rearm();
     test_zero_ms_falls_back_to_defaults();
+    test_y_timing_silent_under_trunk_scan();
+    test_y_timing_legacy_hangtime_window();
+    test_y_timing_hangtime_without_anchor();
+    test_y_timing_manual_hold_pauses_the_timer();
+    test_y_timing_qualify_window();
+    test_y_timing_voice_and_tail_share_the_hold_window();
+    test_y_timing_hop_restarts_the_window();
     if (g_failures != 0) {
         DSD_FPRINTF(stderr, "%d voice-gate check(s) failed\n", g_failures);
         return 1;

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -996,7 +996,8 @@ test_visit_cap_ignores_sync_refresh(void) {
     for (int step = 0; step <= 29; step++) {
         const double now_m = 100.0 + (double)step;
         /* Sync keeps refreshing on both clocks, exactly as a live row does. */
-        fix.state->last_cc_sync_time = (time_t)(1000 + step);
+        const time_t sync_time = (time_t)1000 + (time_t)step;
+        fix.state->last_cc_sync_time = sync_time;
         fix.state->last_cc_sync_time_m = now_m;
         dsd_engine_scan_visit_tick(fix.opts, fix.state, now_m);
         CHECK("sync refresh leaves the anchor", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
@@ -1022,7 +1023,10 @@ test_visit_cap_ignores_continuous_voice(void) {
     }
     fix.opts->scan_max_visit_ms = 30000;
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
-    for (double media_m = 100.2; media_m <= 135.0; media_m += 1.0) {
+    /* An integer induction variable: the media stamps are derived from it, one second apart,
+     * from 100.2 through 134.2. */
+    for (int step = 0; step <= 34; step++) {
+        const double media_m = 100.2 + (double)step;
         const double now_m = media_m + 0.2;
         open_voice_epoch(&fix, media_m, 0.15, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
         dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, now_m);

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -968,13 +968,14 @@ test_visit_cap_expires_from_the_tune_anchor(void) {
     fix.opts->trunk_scan_enabled = 0;
     fix.opts->scanner_mode = 0;
     CHECK("no scanner abstains", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
-    /* Neither of those may write the anchor either: the scanner that owns it is not running. */
+    /* Neither of those owns the anchor, and a visit measured before the switch must not survive
+     * it: the non-owner tick drops the anchor, so the owner's first tick starts a fresh limit. */
     dsd_engine_scan_visit_tick(fix.opts, fix.state, 500.0);
+    CHECK("an idle scanner drops the anchor", fix.state->scan_visit_since_m < 0.0);
     fix.opts->scanner_mode = 1;
-    fix.opts->trunk_scan_enabled = 1;
+    CHECK("the dropped anchor publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
     dsd_engine_scan_visit_tick(fix.opts, fix.state, 600.0);
-    fix.opts->trunk_scan_enabled = 0;
-    CHECK("an idle scanner leaves the anchor", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
+    CHECK("the owning tick re-anchors", fabs(fix.state->scan_visit_since_m - 600.0) < 1e-9);
     fixture_free(&fix);
 }
 
@@ -1278,6 +1279,39 @@ test_visit_cap_publication_pauses_under_hold(void) {
     fixture_free(&fix);
 }
 
+/*
+ * A runtime switch out of --trunk-scan must not hand -Y an anchor the coordinator's rotation left
+ * behind: while the coordinator owns the rotation the -Y tick disarms the anchor, so the first
+ * tick after the switch starts a fresh full limit instead of expiring at once.
+ */
+static void
+test_visit_cap_trunk_scan_switch_starts_fresh(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_max_visit_ms = 30000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    CHECK("the -Y visit is anchored", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
+    /* --trunk-scan takes over: the coordinator keeps its own per-target anchor. */
+    fix.opts->trunk_scan_enabled = 1;
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 200.0);
+    CHECK("the coordinator's tick disarms the -Y anchor", fix.state->scan_visit_since_m < 0.0);
+    CHECK("the disarmed anchor tracks the row", fix.state->scan_visit_roll_seen == fix.state->lcn_freq_roll);
+    /* Back to -Y, minutes later: the visit starts here, not at the park before the switch. */
+    fix.opts->trunk_scan_enabled = 0;
+    CHECK("the switch back publishes no stale deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    CHECK("the switch back does not expire", dsd_engine_scan_visit_expired(fix.opts, fix.state, 500.0) == 0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 500.0);
+    CHECK("the first owning tick anchors at now", fabs(fix.state->scan_visit_since_m - 500.0) < 1e-9);
+    CHECK("the fresh limit is a full one", fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 530.0) < 1e-9);
+    CHECK("the fresh limit holds", dsd_engine_scan_visit_expired(fix.opts, fix.state, 529.999) == 0);
+    CHECK("the fresh limit expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 530.001) == 1);
+    fixture_free(&fix);
+}
+
 int
 main(void) {
     test_tick_leaves_phase_alone_without_scanner_mode();
@@ -1305,6 +1339,7 @@ main(void) {
     test_y_timing_seeds_visit_cap_off();
     test_visit_cap_disabled_never_expires();
     test_visit_cap_expires_from_the_tune_anchor();
+    test_visit_cap_trunk_scan_switch_starts_fresh();
     test_visit_cap_ignores_sync_refresh();
     test_visit_cap_ignores_continuous_voice();
     test_visit_cap_manual_hold_suspends_and_release_restarts();

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -1132,11 +1132,19 @@ test_visit_cap_row_change_restarts(void) {
     CHECK("the row change is remembered", fix.state->scan_visit_roll_seen == 1);
     CHECK("the new row holds", dsd_engine_scan_visit_expired(fix.opts, fix.state, 179.999) == 0);
     CHECK("the new row expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 180.001) == 1);
+    /* Between the row change and the tick that reconciles it the anchor still describes the row
+     * before it, and the control pump can land an `L` in exactly that window. */
+    fix.state->lcn_freq_roll = 2;
+    CHECK("an unreconciled row change publishes no deadline",
+          dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    CHECK("an unreconciled row change never expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 1.0e6) == 0);
     fixture_free(&fix);
 }
 
 /* With nowhere else to go the limit re-arms instead of firing: a hop back onto the same row would
- * only interrupt its audio, and a retry loop is worse than staying. */
+ * only interrupt its audio, and a retry loop is worse than staying. Re-arming, not freezing: an
+ * anchor left to age while the rotation has nowhere to go would fire the instant a second row turns
+ * up, tearing down whatever is on air (requirement 5). */
 static void
 test_visit_cap_needs_a_second_usable_row(void) {
     gate_fixture fix;
@@ -1150,21 +1158,31 @@ test_visit_cap_needs_a_second_usable_row(void) {
     fix.state->lcn_freq_count = 1;
     CHECK("one row publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
     CHECK("one row never expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 1.0e6) == 0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 200.0);
+    CHECK("one row re-arms the visit", fabs(fix.state->scan_visit_since_m - 200.0) < 1e-9);
     /* Two rows with one avoided is still one place to be. */
     fix.state->lcn_freq_count = 2;
     CHECK("the avoid is recorded", dsd_state_trunk_lcn_avoid_set(fix.state, 1U, 1) == 0);
     CHECK("one usable row publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
     CHECK("one usable row never expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 1.0e6) == 0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 300.0);
+    CHECK("an avoided alternate re-arms the visit", fabs(fix.state->scan_visit_since_m - 300.0) < 1e-9);
     /* A zero-frequency placeholder is not somewhere to go either. */
     CHECK("the avoid is cleared", dsd_state_trunk_lcn_avoid_set(fix.state, 1U, 0) == 0);
     const long saved_freq = *dsd_state_trunk_lcn_slot(fix.state, 1);
     *dsd_state_trunk_lcn_slot(fix.state, 1) = 0;
     CHECK("a placeholder row publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
-    /* Restored, the cap fires from the anchor it kept the whole time. */
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 400.0);
+    CHECK("a placeholder alternate re-arms the visit", fabs(fix.state->scan_visit_since_m - 400.0) < 1e-9);
+    /* Restored, the row gets a full fresh limit measured from the last tick -- not the original
+     * park, which would have expired three hundred seconds ago. */
     *dsd_state_trunk_lcn_slot(fix.state, 1) = saved_freq;
-    CHECK("a second usable row arms the cap",
-          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 130.0) < 1e-9);
-    CHECK("a second usable row expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 130.001) == 1);
+    CHECK("a second usable row arms a fresh limit",
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 430.0) < 1e-9);
+    CHECK("a second usable row does not expire at once",
+          dsd_engine_scan_visit_expired(fix.opts, fix.state, 400.001) == 0);
+    CHECK("the fresh limit holds", dsd_engine_scan_visit_expired(fix.opts, fix.state, 429.999) == 0);
+    CHECK("the fresh limit expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 430.001) == 1);
     fixture_free(&fix);
 }
 

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -544,6 +544,73 @@ test_tick_leaves_phase_alone_without_scanner_mode(void) {
     fixture_free(&fix);
 }
 
+/* ---- Shared talkgroup-hold probe (issue #507) ------------------------------ */
+
+/* Open one call epoch with explicit identities. The hold probe reads phase, kind and the
+ * identity fields only, so these epochs deliberately carry no media. */
+static void
+open_call_identity(gate_fixture* fix, uint8_t slot, dsd_call_kind kind, uint64_t src, uint64_t ota_target,
+                   uint64_t policy_target, double t) {
+    dsd_call_observation obs;
+    DSD_MEMSET(&obs, 0, sizeof(obs));
+    obs.protocol = 1;
+    obs.slot = slot;
+    obs.kind = kind;
+    obs.ota_source_id = src;
+    obs.ota_target_id = ota_target;
+    obs.policy_target_id = policy_target;
+    obs.observed_m = t;
+    (void)dsd_call_state_observe(fix->state, &obs, DSD_CALL_BOUNDARY_BEGIN);
+}
+
+/* Both scanners suspend the per-visit limit only while the held talkgroup's call is the one
+ * being followed, so the probe has to be exact about which call counts. */
+static void
+test_tg_hold_call_active(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    CHECK("null state is not a held call", dsd_scan_tg_hold_call_active(NULL) == 0);
+    fix.state->tg_hold = 22;
+    CHECK("hold without any call", dsd_scan_tg_hold_call_active(fix.state) == 0);
+
+    /* Slot 0: a group call to 22. */
+    open_call_identity(&fix, 0U, DSD_CALL_KIND_GROUP_VOICE, 11, 22, 22, 100.0);
+    fix.state->tg_hold = 0;
+    CHECK("no hold", dsd_scan_tg_hold_call_active(fix.state) == 0);
+    fix.state->tg_hold = 22;
+    CHECK("held group call", dsd_scan_tg_hold_call_active(fix.state) == 1);
+    fix.state->tg_hold = 99;
+    CHECK("hold on another talkgroup", dsd_scan_tg_hold_call_active(fix.state) == 0);
+    fix.state->tg_hold = 22;
+    (void)dsd_call_state_end_ex(fix.state, 0U, 100.5, DSD_CALL_END_EXPLICIT);
+    CHECK("ended call", dsd_scan_tg_hold_call_active(fix.state) == 0);
+
+    /* A data call to the held talkgroup is not a call being followed. */
+    open_call_identity(&fix, 0U, DSD_CALL_KIND_DATA, 11, 22, 22, 101.0);
+    CHECK("data call", dsd_scan_tg_hold_call_active(fix.state) == 0);
+    (void)dsd_call_state_end_ex(fix.state, 0U, 101.5, DSD_CALL_END_EXPLICIT);
+
+    /* A private call is held by either end, so the held id may be the source. */
+    open_call_identity(&fix, 1U, DSD_CALL_KIND_PRIVATE_VOICE, 22, 77, 77, 102.0);
+    CHECK("held private call source", dsd_scan_tg_hold_call_active(fix.state) == 1);
+    (void)dsd_call_state_end_ex(fix.state, 1U, 102.5, DSD_CALL_END_EXPLICIT);
+    /* A group call's source is not an identity the hold follows. */
+    open_call_identity(&fix, 1U, DSD_CALL_KIND_GROUP_VOICE, 22, 77, 77, 103.0);
+    CHECK("group call source", dsd_scan_tg_hold_call_active(fix.state) == 0);
+    (void)dsd_call_state_end_ex(fix.state, 1U, 103.5, DSD_CALL_END_EXPLICIT);
+
+    /* The remapped policy target is the identity the hold is compared against. */
+    open_call_identity(&fix, 1U, DSD_CALL_KIND_GROUP_VOICE, 11, 500, 22, 104.0);
+    CHECK("held remapped target", dsd_scan_tg_hold_call_active(fix.state) == 1);
+    fix.state->tg_hold = 500;
+    CHECK("hold on the pre-remap target", dsd_scan_tg_hold_call_active(fix.state) == 0);
+    fixture_free(&fix);
+}
+
 /* ---- Scan timing publication for the -Y row (issue #508) ------------------- */
 
 static void
@@ -773,6 +840,43 @@ test_y_timing_hop_restarts_the_window(void) {
     fixture_free(&fix);
 }
 
+/* The per-visit cap rides the same publication (issue #507 extends #508). Nothing arms it
+ * yet, and "off" is an explicit negative deadline: a zeroed double would render as a
+ * deadline at monotonic 0, which is long past. */
+static void
+test_y_timing_seeds_visit_cap_off(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.state->scan_timing.visit_deadline_m = 42.0;
+    fix.state->scan_timing.visit_limit_ms = 7000U;
+    dsd_scan_timing_clear(fix.state);
+    CHECK("clear disarms the visit cap", fix.state->scan_timing.visit_deadline_m < 0.0);
+    CHECK("clear zeroes the visit limit", fix.state->scan_timing.visit_limit_ms == 0U);
+    /* The gate-owned path seeds it off ... */
+    fix.state->scan_timing.visit_deadline_m = 42.0;
+    fix.state->scan_timing.visit_limit_ms = 7000U;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
+    CHECK("qualify seeds no visit deadline", fix.state->scan_timing.visit_deadline_m < 0.0);
+    CHECK("qualify seeds no visit limit", fix.state->scan_timing.visit_limit_ms == 0U);
+    /* ... and so does the legacy hangtime path, which leaves the seed early. */
+    fix.state->scan_timing.visit_deadline_m = 42.0;
+    fix.state->scan_timing.visit_limit_ms = 7000U;
+    fix.opts->scan_voice_only = 0;
+    fix.opts->trunk_hangtime = 2.0f;
+    fix.state->last_cc_sync_time = (time_t)1000;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.25, 1000.25);
+    CHECK("hangtime reason still published", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    CHECK("hangtime seeds no visit deadline", fix.state->scan_timing.visit_deadline_m < 0.0);
+    CHECK("hangtime seeds no visit limit", fix.state->scan_timing.visit_limit_ms == 0U);
+    fixture_free(&fix);
+}
+
 int
 main(void) {
     test_tick_leaves_phase_alone_without_scanner_mode();
@@ -789,6 +893,7 @@ main(void) {
     test_operator_hold_and_visit_reset();
     test_stale_epoch_cannot_rearm();
     test_zero_ms_falls_back_to_defaults();
+    test_tg_hold_call_active();
     test_y_timing_silent_under_trunk_scan();
     test_y_timing_legacy_hangtime_window();
     test_y_timing_hangtime_without_anchor();
@@ -796,6 +901,7 @@ main(void) {
     test_y_timing_qualify_window();
     test_y_timing_voice_and_tail_share_the_hold_window();
     test_y_timing_hop_restarts_the_window();
+    test_y_timing_seeds_visit_cap_off();
     if (g_failures != 0) {
         DSD_FPRINTF(stderr, "%d voice-gate check(s) failed\n", g_failures);
         return 1;

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -26,6 +26,7 @@
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <time.h>
 
 #include "dsd-neo/core/opts_fwd.h"
 #include "dsd-neo/core/safe_api.h"
@@ -579,13 +580,13 @@ test_y_timing_silent_under_trunk_scan(void) {
     dsd_scan_timing_clear(fix.state);
     fix.state->scan_timing.reason = (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW;
     fix.state->scan_timing.deadline_m = 142.0;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("trunk scan keeps reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW);
     CHECK("trunk scan keeps deadline", fabs(fix.state->scan_timing.deadline_m - 142.0) < 1e-6);
     /* No scanner running at all publishes nothing either. */
     fix.opts->trunk_scan_enabled = 0;
     fix.opts->scanner_mode = 0;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("no scanner keeps reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_CALL_FOLLOW);
     CHECK("no scanner keeps deadline", fabs(fix.state->scan_timing.deadline_m - 142.0) < 1e-6);
     fixture_free(&fix);
@@ -601,21 +602,36 @@ test_y_timing_legacy_hangtime_window(void) {
     }
     fix.opts->scan_voice_only = 0;
     fix.opts->trunk_hangtime = 2.0f;
-    fix.state->last_cc_sync_time_m = 100.0;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    /* The step rule compares the wall-clock anchor, so that is what the countdown is
+     * built from: wall 1000 with the clocks read at wall 1000.25 / monotonic 100.25. */
+    fix.state->last_cc_sync_time = (time_t)1000;
+    fix.state->last_cc_sync_time_m = 0.0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.25, 1000.25);
     CHECK("hangtime reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     CHECK("hangtime is conventional", fix.state->scan_timing.conventional == 1U);
     check_timing_window("hangtime start", "hangtime deadline", "hangtime span", &fix.state->scan_timing, 100.0, 102.0,
                         2000U);
     CHECK("hangtime has no dwell", fix.state->scan_timing.dwell_ms == 0U);
     CHECK("hangtime has no hold", fix.state->scan_timing.hold_ms == 0U);
+    /* A later tick re-expresses the same wall anchor and lands on the same deadline. */
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 101.5, 1001.5);
+    check_timing_window("hangtime start again", "hangtime deadline again", "hangtime span again",
+                        &fix.state->scan_timing, 100.0, 102.0, 2000U);
+    /* NXDN stamps the wall anchor two seconds ahead after a confirmed frame (and leaves
+     * the monotonic twin alone), so the window starts in the future and the countdown
+     * begins above -t rather than reaching zero two seconds before the hop. */
+    fix.state->last_cc_sync_time = (time_t)1002;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.25, 1000.25);
+    check_timing_window("nxdn future start", "nxdn future deadline", "nxdn future span", &fix.state->scan_timing, 102.0,
+                        104.0, 2000U);
+    fix.state->last_cc_sync_time = (time_t)1000;
     /* A gate that is enabled but has never synced this visit abstains, so the legacy
      * rule still owns the step -- and it has neither window to report. */
     fix.opts->scan_voice_only = 1;
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 0, 100.5);
     CHECK("unsynced gate abstains", dsd_scan_voice_gate_owns_step(fix.opts, fix.state) == 0);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("unsynced gate reports hangtime", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     CHECK("unsynced gate hides dwell", fix.state->scan_timing.dwell_ms == 0U);
     CHECK("unsynced gate hides hold", fix.state->scan_timing.hold_ms == 0U);
@@ -623,7 +639,7 @@ test_y_timing_legacy_hangtime_window(void) {
      * wrapping into the publication's uint32_t. */
     fix.opts->scan_voice_only = 0;
     fix.opts->trunk_hangtime = 1.0e9f;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("absurd hangtime saturates the span", fix.state->scan_timing.span_ms == UINT32_MAX);
     fixture_free(&fix);
 }
@@ -638,16 +654,17 @@ test_y_timing_hangtime_without_anchor(void) {
     }
     fix.opts->scan_voice_only = 0;
     fix.opts->trunk_hangtime = 2.0f;
-    fix.state->last_cc_sync_time_m = 0.0;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    fix.state->last_cc_sync_time = (time_t)0;
+    fix.state->last_cc_sync_time_m = 100.0;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("unanchored reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     CHECK("unanchored has no start", fix.state->scan_timing.started_m < 0.0);
     CHECK("unanchored has no deadline", fix.state->scan_timing.deadline_m < 0.0);
     CHECK("unanchored has no span", fix.state->scan_timing.span_ms == 0U);
     /* -t 0 has an anchor but no window to count down. */
-    fix.state->last_cc_sync_time_m = 100.0;
+    fix.state->last_cc_sync_time = (time_t)100;
     fix.opts->trunk_hangtime = 0.0f;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("zero hangtime reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     CHECK("zero hangtime has no deadline", fix.state->scan_timing.deadline_m < 0.0);
     CHECK("zero hangtime has no span", fix.state->scan_timing.span_ms == 0U);
@@ -665,7 +682,7 @@ test_y_timing_manual_hold_pauses_the_timer(void) {
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
     fix.state->lcn_scan_hold = 1;
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("manual hold reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_MANUAL_HOLD);
     CHECK("manual hold has no start", fix.state->scan_timing.started_m < 0.0);
     CHECK("manual hold has no deadline", fix.state->scan_timing.deadline_m < 0.0);
@@ -688,7 +705,7 @@ test_y_timing_qualify_window(void) {
     fix.opts->scan_voice_qualify_ms = 3000;
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("qualify reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
     CHECK("qualify is conventional", fix.state->scan_timing.conventional == 1U);
     CHECK("qualify publishes the effective dwell", fix.state->scan_timing.dwell_ms == 3000U);
@@ -710,7 +727,7 @@ test_y_timing_voice_and_tail_share_the_hold_window(void) {
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     open_voice_epoch(&fix, 100.2, 0.15, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.4);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("voice reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_VOICE);
     check_timing_window("voice start", "voice deadline", "voice span", &fix.state->scan_timing, 100.35, 102.35, 2000U);
     check_deadline_matches_should_step(&fix, "voice holds before the deadline", "voice steps after the deadline");
@@ -718,7 +735,7 @@ test_y_timing_voice_and_tail_share_the_hold_window(void) {
     (void)dsd_call_state_end_ex(fix.state, 0, 100.5, DSD_CALL_END_SYNC_LOSS);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 0, 100.6);
     CHECK("tail phase", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_TAIL);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     CHECK("tail reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_ACTIVITY_HOLD);
     check_timing_window("tail start", "tail deadline", "tail span", &fix.state->scan_timing, 100.35, 102.35, 2000U);
     check_deadline_matches_should_step(&fix, "tail holds before the deadline", "tail steps after the deadline");
@@ -734,21 +751,21 @@ test_y_timing_hop_restarts_the_window(void) {
         return;
     }
     fix.opts->trunk_hangtime = 2.0f;
-    fix.state->last_cc_sync_time_m = 100.0;
+    fix.state->last_cc_sync_time = (time_t)100;
     dsd_scan_voice_gate_note_retune(fix.state, 100.0);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
     check_timing_window("first visit start", "first visit deadline", "first visit span", &fix.state->scan_timing, 100.0,
                         101.0, 1000U);
     /* A hop stamps a fresh legacy anchor and re-opens the gate's visit, so the
      * countdown restarts on the new row instead of carrying the old one over. */
-    fix.state->last_cc_sync_time_m = 200.0;
+    fix.state->last_cc_sync_time = (time_t)200;
     dsd_scan_voice_gate_note_retune(fix.state, 200.0);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 200.0, 200.0);
     CHECK("hop falls back to hangtime", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
     check_timing_window("hop start", "hop deadline", "hop span", &fix.state->scan_timing, 200.0, 202.0, 2000U);
     dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 200.0);
-    dsd_engine_scan_y_timing_tick(fix.opts, fix.state);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 200.0, 200.0);
     CHECK("new visit qualifies", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
     check_timing_window("new visit start", "new visit deadline", "new visit span", &fix.state->scan_timing, 200.0,
                         201.0, 1000U);

--- a/tests/engine/test_engine_scan_voice_gate.c
+++ b/tests/engine/test_engine_scan_voice_gate.c
@@ -13,7 +13,10 @@
  * (blocked encrypted, private evaluator, unknown identity), DATA ignored,
  * operator hold, and visit resets. Also pins the scan timing publication the
  * Scan Timing row renders (issue #508): reason, effective windows, and a deadline
- * that agrees with dsd_scan_voice_gate_should_step() to the millisecond.
+ * that agrees with dsd_scan_voice_gate_should_step() to the millisecond, and the
+ * per-visit cap (issue #507): it counts the visit and nothing else, so neither a
+ * refreshing sync nor unbroken voice may postpone it, while an operator hold or a
+ * talkgroup hold on the call being followed suspends it outright.
  */
 
 #include <dsd-neo/core/call_state.h>
@@ -21,6 +24,7 @@
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
 #include <dsd-neo/core/talkgroup_policy.h>
+#include <dsd-neo/engine/channel_scan.h>
 #include <dsd-neo/engine/scan_voice_gate.h>
 
 #include <math.h>
@@ -94,6 +98,16 @@ dsd_tg_policy_evaluate_private_call(const dsd_opts* opts, const dsd_state* state
     return 0;
 }
 
+/* The visit cap refuses to fire while a typed row transaction is outstanding. Only
+ * scan_voice_gate.c is under test here, so the transaction is a flag the cases drive. */
+static int g_scan_waiting = 0;
+
+int
+dsd_engine_channel_scan_waiting(const dsd_state* state) {
+    (void)state;
+    return g_scan_waiting;
+}
+
 typedef struct {
     dsd_opts* opts;
     dsd_state* state;
@@ -104,8 +118,11 @@ static dsd_state g_state;
 
 static int
 fixture_init(gate_fixture* fix) {
+    /* The avoid store is heap-backed; release it before the memset drops the pointer. */
+    dsd_state_trunk_lcn_avoid_free(&g_state);
     DSD_MEMSET(&g_opts, 0, sizeof(g_opts));
     DSD_MEMSET(&g_state, 0, sizeof(g_state));
+    g_scan_waiting = 0;
     if (dsd_call_state_ensure(&g_state) <= 0) {
         return -1;
     }
@@ -118,6 +135,16 @@ fixture_init(gate_fixture* fix) {
     g_opts.scan_voice_qualify_ms = 1000;
     g_opts.scan_voice_hold_ms = 2000;
     g_state.lcn_freq_roll = 3;
+    /* Three real rows, so dsd_state_trunk_lcn_usable_count() sees somewhere to go and the
+     * per-visit cap is free to fire; the cases that need a dead end shrink the list. */
+    g_state.lcn_freq_count = 3;
+    for (int row = 0; row < 3; row++) {
+        *dsd_state_trunk_lcn_slot(&g_state, row) = 150000000 + (12500 * (long)row);
+    }
+    /* initState()'s seeds, which the memset above cannot express: an unanchored visit is
+     * -1.0, not monotonic 0, and the bookkeeping has already seen the row on air. */
+    g_state.scan_visit_since_m = -1.0;
+    g_state.scan_visit_roll_seen = g_state.lcn_freq_roll;
     fix->opts = &g_opts;
     fix->state = &g_state;
     return 0;
@@ -128,6 +155,7 @@ fixture_free(gate_fixture* fix) {
     if (!fix || !fix->state) {
         return;
     }
+    dsd_state_trunk_lcn_avoid_free(fix->state);
     dsd_state_ext_free_all(fix->state);
 }
 
@@ -877,6 +905,361 @@ test_y_timing_seeds_visit_cap_off(void) {
     fixture_free(&fix);
 }
 
+/* ---- Per-visit cap for the -Y row (issue #507) ------------------------------ */
+
+/* Anti-drift, the cap's half of check_deadline_matches_should_step(): a published cap deadline
+ * is only useful if it is the instant dsd_engine_scan_visit_expired() first says yes. */
+static void
+check_visit_deadline_matches_expired(const gate_fixture* fix, const char* early_tag, const char* late_tag) {
+    const double deadline_m = fix->state->scan_timing.visit_deadline_m;
+    CHECK(early_tag, dsd_engine_scan_visit_expired(fix->opts, fix->state, deadline_m - 1e-3) == 0);
+    CHECK(late_tag, dsd_engine_scan_visit_expired(fix->opts, fix->state, deadline_m + 1e-3) == 1);
+}
+
+/* Off is the default, and it has to be inert: no deadline, no expiry, and no anchor left behind
+ * so that enabling the cap later grants a full fresh limit rather than expiring at once. */
+static void
+test_visit_cap_disabled_never_expires(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    CHECK("the retune opens the visit", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
+    CHECK("cap off publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    CHECK("cap off never expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 1.0e6) == 0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 200.0);
+    CHECK("the disabled tick drops the anchor", fix.state->scan_visit_since_m < 0.0);
+    CHECK("the disabled tick tracks the row", fix.state->scan_visit_roll_seen == fix.state->lcn_freq_roll);
+    /* Enabling it mid-visit counts from the first tick that sees it, not from the old park. */
+    fix.opts->scan_max_visit_ms = 30000;
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 300.0);
+    CHECK("enabling anchors at the tick", fabs(fix.state->scan_visit_since_m - 300.0) < 1e-9);
+    CHECK("the fresh limit holds", dsd_engine_scan_visit_expired(fix.opts, fix.state, 329.999) == 0);
+    CHECK("the fresh limit expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 330.001) == 1);
+    /* 1..999 ms means off too: config loading is range-free by design, so those values reach
+     * the engine and must not be read as a millisecond-scale visit. */
+    fix.opts->scan_max_visit_ms = 999;
+    CHECK("a sub-second cap is off", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    CHECK("a sub-second cap never expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 1.0e6) == 0);
+    fixture_free(&fix);
+}
+
+/* The limit is measured from the instant the row was parked on, and only the -Y scanner owns it:
+ * under --trunk-scan the coordinator keeps its own per-target anchor. */
+static void
+test_visit_cap_expires_from_the_tune_anchor(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_max_visit_ms = 30000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    CHECK("deadline is the anchor plus the cap",
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 130.0) < 1e-9);
+    CHECK("holds a millisecond early", dsd_engine_scan_visit_expired(fix.opts, fix.state, 129.999) == 0);
+    CHECK("expires a millisecond late", dsd_engine_scan_visit_expired(fix.opts, fix.state, 130.001) == 1);
+    fix.opts->trunk_scan_enabled = 1;
+    CHECK("trunk scan abstains", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    fix.opts->trunk_scan_enabled = 0;
+    fix.opts->scanner_mode = 0;
+    CHECK("no scanner abstains", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    /* Neither of those may write the anchor either: the scanner that owns it is not running. */
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 500.0);
+    fix.opts->scanner_mode = 1;
+    fix.opts->trunk_scan_enabled = 1;
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 600.0);
+    fix.opts->trunk_scan_enabled = 0;
+    CHECK("an idle scanner leaves the anchor", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
+    fixture_free(&fix);
+}
+
+/* The legacy hangtime rule's anchor moves with every sync, which is how a repeater streaming
+ * IDLE parks the scan forever. The cap counts the visit, so no amount of sync may postpone it. */
+static void
+test_visit_cap_ignores_sync_refresh(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_voice_only = 0;
+    fix.opts->trunk_hangtime = 2.0f;
+    fix.opts->scan_max_visit_ms = 30000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    for (int step = 0; step <= 29; step++) {
+        const double now_m = 100.0 + (double)step;
+        /* Sync keeps refreshing on both clocks, exactly as a live row does. */
+        fix.state->last_cc_sync_time = (time_t)(1000 + step);
+        fix.state->last_cc_sync_time_m = now_m;
+        dsd_engine_scan_visit_tick(fix.opts, fix.state, now_m);
+        CHECK("sync refresh leaves the anchor", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
+        CHECK("unexpired before the cap", dsd_engine_scan_visit_expired(fix.opts, fix.state, now_m) == 0);
+    }
+    fix.state->last_cc_sync_time = (time_t)1031;
+    fix.state->last_cc_sync_time_m = 130.5;
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 130.5);
+    CHECK("still the tune anchor", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
+    CHECK("expires against a sync from this instant", dsd_engine_scan_visit_expired(fix.opts, fix.state, 130.5) == 1);
+    fixture_free(&fix);
+}
+
+/* The open-microphone case the cap exists for: media keeps arriving, so the gate's hold window
+ * never lapses and the gate alone would never step. The cap has to fire under it. */
+static void
+test_visit_cap_ignores_continuous_voice(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_max_visit_ms = 30000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    for (double media_m = 100.2; media_m <= 135.0; media_m += 1.0) {
+        const double now_m = media_m + 0.2;
+        open_voice_epoch(&fix, media_m, 0.15, DSD_CALL_KIND_GROUP_VOICE, 11, 22, DSD_CALL_CRYPTO_CLEAR);
+        dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, now_m);
+        dsd_engine_scan_visit_tick(fix.opts, fix.state, now_m);
+        CHECK("voice phase", fix.state->scan_voice_gate_phase == (uint8_t)DSD_SCAN_VOICE_GATE_VOICE);
+        CHECK("voice never moves the anchor", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
+        CHECK("the gate holds through the voice", dsd_scan_voice_gate_should_step(fix.opts, fix.state, now_m) == 0);
+        CHECK("the cap flips at its own deadline",
+              dsd_engine_scan_visit_expired(fix.opts, fix.state, now_m) == (now_m >= 130.0 ? 1 : 0));
+    }
+    fixture_free(&fix);
+}
+
+/* The operator hold suspends the limit rather than pausing it: the anchor slides while held, so
+ * the release starts a fresh full limit instead of expiring the moment the hold comes off. */
+static void
+test_visit_cap_manual_hold_suspends_and_release_restarts(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_max_visit_ms = 30000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    fix.state->lcn_scan_hold = 1;
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 120.0);
+    CHECK("the hold slides the anchor", fabs(fix.state->scan_visit_since_m - 120.0) < 1e-9);
+    CHECK("the hold publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    CHECK("the hold never expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 1.0e6) == 0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 400.0);
+    CHECK("the hold keeps sliding", fabs(fix.state->scan_visit_since_m - 400.0) < 1e-9);
+    fix.state->lcn_scan_hold = 0;
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 401.0);
+    CHECK("the release keeps the slid anchor", fabs(fix.state->scan_visit_since_m - 400.0) < 1e-9);
+    CHECK("the release restarts the full limit",
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 430.0) < 1e-9);
+    CHECK("the released limit holds", dsd_engine_scan_visit_expired(fix.opts, fix.state, 429.999) == 0);
+    CHECK("the released limit expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 430.001) == 1);
+    fixture_free(&fix);
+}
+
+/* A talkgroup hold suspends the limit only while the call being followed is the held one: cutting
+ * that call short is exactly what the hold exists to prevent, and its end starts a fresh limit. */
+static void
+test_visit_cap_tg_hold_match_suspends(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_max_visit_ms = 30000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    /* A hold with nothing on air suspends nothing. */
+    fix.state->tg_hold = 22;
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 101.0);
+    CHECK("a hold without a call leaves the anchor", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
+    CHECK("a hold without a call expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 130.001) == 1);
+    /* The held talkgroup's own call. */
+    open_call_identity(&fix, 0U, DSD_CALL_KIND_GROUP_VOICE, 11, 22, 22, 110.0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 111.0);
+    CHECK("the held call slides the anchor", fabs(fix.state->scan_visit_since_m - 111.0) < 1e-9);
+    CHECK("the held call publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    /* Another talkgroup's call is not the one the hold follows. */
+    fix.state->tg_hold = 99;
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 112.0);
+    CHECK("another talkgroup does not suspend", fabs(fix.state->scan_visit_since_m - 111.0) < 1e-9);
+    CHECK("another talkgroup keeps the deadline",
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 141.0) < 1e-9);
+    /* A private call is held by either end. */
+    fix.state->tg_hold = 22;
+    (void)dsd_call_state_end_ex(fix.state, 0U, 112.5, DSD_CALL_END_EXPLICIT);
+    open_call_identity(&fix, 1U, DSD_CALL_KIND_PRIVATE_VOICE, 22, 77, 77, 113.0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 114.0);
+    CHECK("a held private source slides the anchor", fabs(fix.state->scan_visit_since_m - 114.0) < 1e-9);
+    /* A data call to the held talkgroup is not a call being followed. */
+    (void)dsd_call_state_end_ex(fix.state, 1U, 114.5, DSD_CALL_END_EXPLICIT);
+    open_call_identity(&fix, 1U, DSD_CALL_KIND_DATA, 11, 22, 22, 115.0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 116.0);
+    CHECK("a data call does not suspend", fabs(fix.state->scan_visit_since_m - 114.0) < 1e-9);
+    /* Once the followed call ends, a fresh full limit runs from the last suspended tick. */
+    (void)dsd_call_state_end_ex(fix.state, 1U, 116.5, DSD_CALL_END_EXPLICIT);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 117.0);
+    CHECK("the ended call leaves the anchor", fabs(fix.state->scan_visit_since_m - 114.0) < 1e-9);
+    CHECK("the ended call resumes the limit",
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 144.0) < 1e-9);
+    fixture_free(&fix);
+}
+
+/* An untyped `L` cycle or an avoid moves lcn_freq_roll without a retune note, so the row under
+ * the anchor changed: the new row gets its own full limit rather than inheriting the old one. */
+static void
+test_visit_cap_row_change_restarts(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_max_visit_ms = 30000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 101.0);
+    CHECK("a settled visit keeps its anchor", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
+    fix.state->lcn_freq_roll = 1;
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 150.0);
+    CHECK("the row change re-anchors", fabs(fix.state->scan_visit_since_m - 150.0) < 1e-9);
+    CHECK("the row change is remembered", fix.state->scan_visit_roll_seen == 1);
+    CHECK("the new row holds", dsd_engine_scan_visit_expired(fix.opts, fix.state, 179.999) == 0);
+    CHECK("the new row expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 180.001) == 1);
+    fixture_free(&fix);
+}
+
+/* With nowhere else to go the limit re-arms instead of firing: a hop back onto the same row would
+ * only interrupt its audio, and a retry loop is worse than staying. */
+static void
+test_visit_cap_needs_a_second_usable_row(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_max_visit_ms = 30000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    fix.state->lcn_freq_count = 1;
+    CHECK("one row publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    CHECK("one row never expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 1.0e6) == 0);
+    /* Two rows with one avoided is still one place to be. */
+    fix.state->lcn_freq_count = 2;
+    CHECK("the avoid is recorded", dsd_state_trunk_lcn_avoid_set(fix.state, 1U, 1) == 0);
+    CHECK("one usable row publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    CHECK("one usable row never expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 1.0e6) == 0);
+    /* A zero-frequency placeholder is not somewhere to go either. */
+    CHECK("the avoid is cleared", dsd_state_trunk_lcn_avoid_set(fix.state, 1U, 0) == 0);
+    const long saved_freq = *dsd_state_trunk_lcn_slot(fix.state, 1);
+    *dsd_state_trunk_lcn_slot(fix.state, 1) = 0;
+    CHECK("a placeholder row publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    /* Restored, the cap fires from the anchor it kept the whole time. */
+    *dsd_state_trunk_lcn_slot(fix.state, 1) = saved_freq;
+    CHECK("a second usable row arms the cap",
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 130.0) < 1e-9);
+    CHECK("a second usable row expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 130.001) == 1);
+    fixture_free(&fix);
+}
+
+/* A row transaction in flight owns the receiver; firing into it would abandon a tune that is
+ * already on its way. The anchor stands: the transaction re-opens the visit at its own commit. */
+static void
+test_visit_cap_pending_tune_does_not_fire(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_max_visit_ms = 30000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    g_scan_waiting = 1;
+    CHECK("a pending tune publishes no deadline", dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) < 0.0);
+    CHECK("a pending tune never expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 1.0e6) == 0);
+    dsd_engine_scan_visit_tick(fix.opts, fix.state, 200.0);
+    CHECK("a pending tick leaves the anchor", fabs(fix.state->scan_visit_since_m - 100.0) < 1e-9);
+    g_scan_waiting = 0;
+    CHECK("a settled transaction arms the cap",
+          fabs(dsd_engine_scan_visit_deadline_m(fix.opts, fix.state) - 130.0) < 1e-9);
+    CHECK("a settled transaction expires", dsd_engine_scan_visit_expired(fix.opts, fix.state, 130.001) == 1);
+    fixture_free(&fix);
+}
+
+/* The cap rides beside the step timer in the same publication: the effective limit stays visible
+ * and the live deadline agrees with the predicate, under the gate and under the legacy rule. */
+static void
+test_visit_cap_publishes_the_visit_deadline(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_max_visit_ms = 45000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.0, 100.0);
+    CHECK("the gate path publishes the cap", fix.state->scan_timing.visit_limit_ms == 45000U);
+    CHECK("the gate path publishes the visit deadline", fabs(fix.state->scan_timing.visit_deadline_m - 145.0) < 1e-6);
+    /* The cap does not become the reason: the qualify window is still what the hop would blame. */
+    CHECK("the gate path keeps its own reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
+    check_visit_deadline_matches_expired(&fix, "gate path holds before the cap", "gate path expires after the cap");
+    /* The legacy hangtime rule has neither a qualify nor a hold window, and the cap applies there
+     * just the same. */
+    fix.opts->scan_voice_only = 0;
+    fix.opts->trunk_hangtime = 2.0f;
+    fix.state->last_cc_sync_time = (time_t)1000;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.25, 1000.25);
+    CHECK("the legacy path keeps its own reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_HANGTIME);
+    CHECK("the legacy path publishes the cap", fix.state->scan_timing.visit_limit_ms == 45000U);
+    CHECK("the legacy path publishes the visit deadline", fabs(fix.state->scan_timing.visit_deadline_m - 145.0) < 1e-6);
+    CHECK("the legacy path has no dwell", fix.state->scan_timing.dwell_ms == 0U);
+    CHECK("the legacy path has no hold", fix.state->scan_timing.hold_ms == 0U);
+    check_visit_deadline_matches_expired(&fix, "legacy path holds before the cap", "legacy path expires after the cap");
+    /* A sub-second cap publishes as off, matching how the engine reads it. */
+    fix.opts->scan_max_visit_ms = 999;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 100.25, 1000.25);
+    CHECK("a sub-second cap publishes off", fix.state->scan_timing.visit_limit_ms == 0U);
+    CHECK("a sub-second cap publishes no deadline", fix.state->scan_timing.visit_deadline_m < 0.0);
+    fixture_free(&fix);
+}
+
+/* Suspension shows up as a paused cap, not a vanished one: the effective limit stays on screen
+ * while the countdown stops, for the operator hold and for a talkgroup hold alike. */
+static void
+test_visit_cap_publication_pauses_under_hold(void) {
+    gate_fixture fix;
+    if (fixture_init(&fix) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: %s: fixture\n", __func__);
+        g_failures++;
+        return;
+    }
+    fix.opts->scan_max_visit_ms = 45000;
+    dsd_scan_voice_gate_note_retune(fix.state, 100.0);
+    dsd_scan_voice_gate_tick(fix.opts, fix.state, 1, 100.0);
+    fix.state->lcn_scan_hold = 1;
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 120.0, 120.0);
+    CHECK("manual hold reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_MANUAL_HOLD);
+    CHECK("manual hold keeps the cap", fix.state->scan_timing.visit_limit_ms == 45000U);
+    CHECK("manual hold pauses the cap", fix.state->scan_timing.visit_deadline_m < 0.0);
+    /* A talkgroup hold on the call being followed pauses the cap while the step timer runs on. */
+    fix.state->lcn_scan_hold = 0;
+    fix.state->tg_hold = 22;
+    open_call_identity(&fix, 0U, DSD_CALL_KIND_GROUP_VOICE, 11, 22, 22, 121.0);
+    dsd_engine_scan_y_timing_tick(fix.opts, fix.state, 122.0, 122.0);
+    CHECK("a talkgroup hold keeps the step reason", fix.state->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
+    CHECK("a talkgroup hold keeps the cap", fix.state->scan_timing.visit_limit_ms == 45000U);
+    CHECK("a talkgroup hold pauses the cap", fix.state->scan_timing.visit_deadline_m < 0.0);
+    fixture_free(&fix);
+}
+
 int
 main(void) {
     test_tick_leaves_phase_alone_without_scanner_mode();
@@ -902,6 +1285,17 @@ main(void) {
     test_y_timing_voice_and_tail_share_the_hold_window();
     test_y_timing_hop_restarts_the_window();
     test_y_timing_seeds_visit_cap_off();
+    test_visit_cap_disabled_never_expires();
+    test_visit_cap_expires_from_the_tune_anchor();
+    test_visit_cap_ignores_sync_refresh();
+    test_visit_cap_ignores_continuous_voice();
+    test_visit_cap_manual_hold_suspends_and_release_restarts();
+    test_visit_cap_tg_hold_match_suspends();
+    test_visit_cap_row_change_restarts();
+    test_visit_cap_needs_a_second_usable_row();
+    test_visit_cap_pending_tune_does_not_fire();
+    test_visit_cap_publishes_the_visit_deadline();
+    test_visit_cap_publication_pauses_under_hold();
     if (g_failures != 0) {
         DSD_FPRINTF(stderr, "%d voice-gate check(s) failed\n", g_failures);
         return 1;

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -7869,6 +7869,22 @@ expect_scan_timing_window(const dsd_state* state, const char* stage, double star
     return 0;
 }
 
+/*
+ * The #507 per-visit cap rides the same publication. No target here configures one, so it
+ * must read as off at every stage -- and off is an explicit negative deadline, since a
+ * zeroed double would render as a deadline at monotonic 0.
+ */
+static int
+expect_scan_timing_no_visit_cap(const dsd_state* state, const char* stage) {
+    const dsd_scan_timing_publication* timing = &state->scan_timing;
+    if (timing->visit_deadline_m >= 0.0 || timing->visit_limit_ms != 0U) {
+        DSD_FPRINTF(stderr, "scan timing visit cap after %s: deadline=%.6f limit=%u, want off\n", stage,
+                    timing->visit_deadline_m, (unsigned)timing->visit_limit_ms);
+        return 1;
+    }
+    return 0;
+}
+
 static int
 expect_scan_timing_conventional(const dsd_state* state, const char* stage, unsigned conventional) {
     if ((unsigned)state->scan_timing.conventional != conventional) {
@@ -7912,6 +7928,7 @@ test_scan_timing_trunked_acquire_follow_and_dwell(void) {
     test_rc |= expect_active_target(&state, "cc acquisition", 0U);
     test_rc |= expect_scan_timing(&state, "cc acquisition", DSD_SCAN_STAY_CC_ACQUIRE, -1.0, 250U, 0U);
     test_rc |= expect_scan_timing_conventional(&state, "cc acquisition", 0U);
+    test_rc |= expect_scan_timing_no_visit_cap(&state, "cc acquisition");
 
     ctx->cc_tune_pending = 0;
     opts.trunk_is_tuned = 1;
@@ -7928,9 +7945,11 @@ test_scan_timing_trunked_acquire_follow_and_dwell(void) {
     test_rc |= expect_scan_timing(&state, "idle dwell", DSD_SCAN_STAY_IDLE_DWELL, 0.85, 250U, 0U);
     test_rc |= expect_scan_timing_window(&state, "idle dwell", 0.60, 250U);
     test_rc |= expect_scan_timing_conventional(&state, "idle dwell", 0U);
+    test_rc |= expect_scan_timing_no_visit_cap(&state, "idle dwell");
 
     dsd_engine_trunk_scan_shutdown(&opts, &state);
     test_rc |= expect_scan_timing(&state, "shutdown", DSD_SCAN_STAY_NONE, -1.0, 0U, 0U);
+    test_rc |= expect_scan_timing_no_visit_cap(&state, "shutdown");
     trunk_scan_test_clear_now();
     cleanup_paths(dir, target_path, NULL);
     return test_rc;

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -7,6 +7,7 @@
 #include <dsd-neo/core/csv_import.h>
 #include <dsd-neo/core/csv_validate.h>
 #include <dsd-neo/core/dmr_key_map.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/enc_lockout.h>
 #include <dsd-neo/core/key_set.h>
 #include <dsd-neo/core/opts.h>
@@ -190,6 +191,57 @@ dmr_sm_tick_ctx(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state) {
         state->trunk_vc_freq[0] = 0;
         state->trunk_vc_freq[1] = 0;
     }
+}
+
+/* The abandon-carrier release the coordinator uses on a forced advance (#507). Mirrors what
+ * the real SM leaves behind: at rest on the control channel with no voice channel to its name,
+ * and no tune of its own. */
+void
+p25_sm_abandon_carrier(p25_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason) {
+    (void)opts;
+    (void)state;
+    (void)reason;
+    if (!ctx) {
+        return;
+    }
+    ctx->state = P25_SM_ON_CC;
+    ctx->vc_freq_hz = 0;
+    ctx->vc_channel = 0;
+    ctx->vc_tg = 0;
+    ctx->vc_src = 0;
+}
+
+void
+dmr_sm_abandon_carrier(dmr_sm_ctx_t* ctx, dsd_opts* opts, dsd_state* state, const char* reason) {
+    (void)opts;
+    (void)state;
+    (void)reason;
+    if (!ctx) {
+        return;
+    }
+    ctx->state = DMR_SM_ON_CC;
+    ctx->vc_freq_hz = 0;
+    ctx->slots[0].voice_active = 0;
+    ctx->slots[1].voice_active = 0;
+}
+
+/* From engine/trunk_tuning.c, which this fixture does not link: the observable subtraction the
+ * coordinator depends on -- the canonical call rows end, the VC mirrors clear, trunk_is_tuned
+ * drops, and nothing tunes. Stamped with the real clock exactly like the original. */
+void
+dsd_engine_release_tuned_call_state(dsd_opts* opts, dsd_state* state) {
+    if (!opts || !state) {
+        return;
+    }
+    const double ended_m = dsd_time_now_monotonic_s();
+    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+        (void)dsd_call_state_end_ex(state, (uint8_t)slot, ended_m, DSD_CALL_END_EXPLICIT);
+    }
+    state->p25_vc_freq[0] = 0;
+    state->p25_vc_freq[1] = 0;
+    state->trunk_vc_freq[0] = 0;
+    state->trunk_vc_freq[1] = 0;
+    opts->trunk_is_tuned = 0;
 }
 
 dsd_trunk_tune_result
@@ -7885,6 +7937,36 @@ expect_scan_timing_no_visit_cap(const dsd_state* state, const char* stage) {
     return 0;
 }
 
+/*
+ * The #507 per-visit cap as a frontend reads it: the effective limit for the row on air, and
+ * the live deadline -- or an explicit negative when no cap is counting, whether it is disabled,
+ * not yet anchored, or suspended by a hold.
+ */
+static int
+expect_scan_visit(const dsd_state* state, const char* stage, unsigned limit_ms, double deadline_m) {
+    const dsd_scan_timing_publication* timing = &state->scan_timing;
+    int rc = 0;
+    if ((unsigned)timing->visit_limit_ms != limit_ms) {
+        DSD_FPRINTF(stderr, "scan visit cap after %s: limit=%u, want %u\n", stage, (unsigned)timing->visit_limit_ms,
+                    limit_ms);
+        rc = 1;
+    }
+    if (deadline_m < 0.0) {
+        if (timing->visit_deadline_m >= 0.0) {
+            DSD_FPRINTF(stderr, "scan visit cap after %s: deadline %.6f, want no live cap\n", stage,
+                        timing->visit_deadline_m);
+            rc = 1;
+        }
+        return rc;
+    }
+    if (timing->visit_deadline_m < 0.0 || fabs(timing->visit_deadline_m - deadline_m) > 1e-6) {
+        DSD_FPRINTF(stderr, "scan visit cap after %s: deadline %.6f, want %.6f\n", stage, timing->visit_deadline_m,
+                    deadline_m);
+        rc = 1;
+    }
+    return rc;
+}
+
 static int
 expect_scan_timing_conventional(const dsd_state* state, const char* stage, unsigned conventional) {
     if ((unsigned)state->scan_timing.conventional != conventional) {
@@ -8259,6 +8341,917 @@ test_scan_timing_pending_retune_then_retry_cooldown(void) {
     return test_rc;
 }
 
+/*
+ * Per-visit cap tests (issue #507). The cap is opt-in, so every case below sets the global
+ * (or a row override) before dsd_engine_trunk_scan_init(): the scan-mode scope captures the
+ * configured value when the coordinator starts and restores it on every row change, so a cap
+ * installed after init would be thrown away by the next switch.
+ */
+static int
+scan_visit_init(const char* header, const char* body, int max_visit_ms, dsd_opts* opts, dsd_state* state, char* dir,
+                size_t dir_sz, char* target_path, size_t path_sz) {
+    if (make_temp_dir(dir, dir_sz) != 0) {
+        return -1;
+    }
+    if (write_targets_file_with_header(dir, header ? header : k_header, body, target_path, path_sz) != 0) {
+        return -1;
+    }
+    reset_scan_opts_state(opts, state);
+    opts->scan_max_visit_ms = max_visit_ms;
+    DSD_SNPRINTF(opts->trunk_scan_targets_csv, sizeof opts->trunk_scan_targets_csv, "%s", target_path);
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    if (dsd_engine_trunk_scan_init(opts, state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "visit cap init failed err=%s\n", err);
+        return -1;
+    }
+    return 0;
+}
+
+/* One active group-voice call row: what a followed call looks like to the coordinator. */
+static int
+seed_active_call_row(dsd_state* state, uint32_t target, uint32_t source, double observed_m) {
+    if (dsd_call_state_ensure(state) <= 0) {
+        DSD_FPRINTF(stderr, "visit cap seed: call-state ensure failed\n");
+        return 1;
+    }
+    dsd_call_observation obs;
+    DSD_MEMSET(&obs, 0, sizeof(obs));
+    obs.protocol = DSD_SYNC_P25P2_POS;
+    obs.slot = 0U;
+    obs.kind = DSD_CALL_KIND_GROUP_VOICE;
+    obs.ota_target_id = target;
+    obs.policy_target_id = target;
+    obs.ota_source_id = source;
+    obs.observed_m = observed_m;
+    if (dsd_call_state_observe(state, &obs, DSD_CALL_BOUNDARY_BEGIN) != 1) {
+        DSD_FPRINTF(stderr, "visit cap seed: observe failed\n");
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_no_active_call_row(const dsd_state* state, const char* stage) {
+    dsd_call_snapshot call;
+    for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
+        if (dsd_call_state_get(state, (uint8_t)slot, &call) > 0 && call.phase == DSD_CALL_PHASE_ACTIVE) {
+            DSD_FPRINTF(stderr, "call row %d after %s: still active\n", slot, stage);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int
+expect_vc_mirrors_clear(const dsd_state* state, const char* stage) {
+    if (state->p25_vc_freq[0] != 0 || state->p25_vc_freq[1] != 0 || state->trunk_vc_freq[0] != 0
+        || state->trunk_vc_freq[1] != 0) {
+        DSD_FPRINTF(stderr, "VC mirrors after %s: p25 %ld/%ld trunk %ld/%ld, want zeroed\n", stage,
+                    state->p25_vc_freq[0], state->p25_vc_freq[1], state->trunk_vc_freq[0], state->trunk_vc_freq[1]);
+        return 1;
+    }
+    return 0;
+}
+
+/*
+ * The cap measures the visit, not the gaps between the calls in it. A trunked row that follows
+ * one call after another re-arms the idle dwell at every release, which is precisely why the
+ * dwell alone can never rotate off a busy system: only the visit anchor, untouched since the
+ * park, still knows how long the receiver has been here.
+ */
+static int
+test_visit_limit_repeated_p25_calls_do_not_restart(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_visit_init(NULL,
+                        "a,p25-trunk,851000000,,250,,\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    static const double marks[] = {0.10, 0.30, 0.40, 0.70, 0.80};
+    for (size_t i = 0; i < sizeof marks / sizeof marks[0]; i++) {
+        /* Follow a call, release it, follow the next: the release re-arms the dwell every time. */
+        opts.trunk_is_tuned = (i % 2U == 0U) ? 1 : 0;
+        trunk_scan_test_set_now(marks[i]);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        test_rc |= expect_active_target(&state, "call follow cycle", 0U);
+    }
+
+    opts.trunk_is_tuned = 1;
+    trunk_scan_test_set_now(0.99);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "just inside the cap", 0U);
+    /* The deadline is still one second after the original park, not after the last call. */
+    test_rc |= expect_scan_visit(&state, "just inside the cap", 1000U, 1.0);
+
+    trunk_scan_test_set_now(1.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "cap expiry", 1U);
+    test_rc |= expect_published_target(&state, "cap expiry", "b", 2U, 2U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * The conventional counterpart: an open microphone refreshes the activity hold on every report,
+ * so the hold window never lapses and the row never rotates. The cap is what ends the visit.
+ */
+static int
+test_visit_limit_continuous_conventional_activity_does_not_restart(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_visit_init(NULL,
+                        "a,dmr-conventional,461000000,,250,250,\n"
+                        "b,dmr-conventional,462000000,,250,250,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    static const double marks[] = {0.10, 0.30, 0.50, 0.70, 0.90};
+    for (size_t i = 0; i < sizeof marks / sizeof marks[0]; i++) {
+        trunk_scan_test_set_now(marks[i]);
+        dsd_engine_trunk_scan_dmr_conventional_activity(&opts, &state, 1001, 2002, 0, 0, 0);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        test_rc |= expect_active_target(&state, "continuous activity", 0U);
+    }
+
+    trunk_scan_test_set_now(0.99);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "activity just inside the cap", 0U);
+    test_rc |=
+        expect_scan_timing(&state, "activity just inside the cap", DSD_SCAN_STAY_ACTIVITY_HOLD, 1.15, 250U, 250U);
+    test_rc |= expect_scan_visit(&state, "activity just inside the cap", 1000U, 1.0);
+
+    trunk_scan_test_set_now(1.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "activity cap expiry", 1U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * The operator's target hold outranks the cap: while it is on, nothing counts down and nothing
+ * expires. The release does not resume a partly spent limit either -- the held row gets a full
+ * fresh one, which is what an operator who just let go expects (requirement 6).
+ */
+static int
+test_visit_limit_manual_hold_suspends_and_release_restarts(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_visit_init(NULL,
+                        "a,p25-trunk,851000000,,250,,\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    test_rc |= expect_control_rc("visit hold on",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 1);
+
+    static const double held_marks[] = {0.5, 3.0, 5.0};
+    for (size_t i = 0; i < sizeof held_marks / sizeof held_marks[0]; i++) {
+        trunk_scan_test_set_now(held_marks[i]);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        test_rc |= expect_active_target(&state, "manual hold past the cap", 0U);
+        /* The cap is configured but not counting: the publication must not invite a frontend
+         * to draw a countdown the coordinator is not running. */
+        test_rc |= expect_scan_visit(&state, "manual hold past the cap", 1000U, -1.0);
+    }
+
+    test_rc |= expect_control_rc("visit hold off",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 0);
+    trunk_scan_test_set_now(5.99);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "release before a full cap", 0U);
+    test_rc |= expect_scan_visit(&state, "release before a full cap", 1000U, 6.0);
+    trunk_scan_test_set_now(6.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "release after a full cap", 1U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * The talkgroup hold suspends the cap only for the call it exists to follow (requirement 7):
+ * cutting that call short is exactly what the operator asked the hold to prevent. A call on
+ * any other talkgroup is ordinary traffic and the cap applies to it.
+ */
+static int
+test_visit_limit_tg_hold_followed_call_suspends(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_visit_init(NULL,
+                        "a,p25-trunk,851000000,,250,,\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    state.tg_hold = 4242U;
+    opts.trunk_is_tuned = 1;
+    test_rc |= seed_active_call_row(&state, 4242U, 2002U, 0.10);
+
+    static const double held_marks[] = {0.5, 2.0, 3.0};
+    for (size_t i = 0; i < sizeof held_marks / sizeof held_marks[0]; i++) {
+        trunk_scan_test_set_now(held_marks[i]);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        test_rc |= expect_active_target(&state, "tg hold followed call", 0U);
+        test_rc |= expect_scan_visit(&state, "tg hold followed call", 1000U, -1.0);
+    }
+
+    /* The call ends; the suspension ends with it and a full fresh limit starts from the last
+     * suspended tick. */
+    if (dsd_call_state_end_ex(&state, 0U, 3.0, DSD_CALL_END_TERMINATOR) != 1) {
+        DSD_FPRINTF(stderr, "visit cap tg hold: ending the held call failed\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(3.99);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "held call ended, inside the cap", 0U);
+    test_rc |= expect_scan_visit(&state, "held call ended, inside the cap", 1000U, 4.0);
+    trunk_scan_test_set_now(4.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "held call ended, cap expiry", 1U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+
+    /* Second half: the hold is on 4242 but the call on air is 9999. Nothing is suspended. */
+    if (scan_visit_init(NULL,
+                        "a,p25-trunk,851000000,,250,,\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    state.tg_hold = 4242U;
+    opts.trunk_is_tuned = 1;
+    test_rc |= seed_active_call_row(&state, 9999U, 2002U, 0.10);
+    trunk_scan_test_set_now(0.99);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "unheld call inside the cap", 0U);
+    test_rc |= expect_scan_visit(&state, "unheld call inside the cap", 1000U, 1.0);
+    trunk_scan_test_set_now(1.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "unheld call cap expiry", 1U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * Off by default, and off must mean untouched: the same clock walk and the same state-restore
+ * assertions as test_coordinator_idle_rotation_and_state_restore(), with the publication
+ * saying no cap applies at every stage (requirement 10).
+ */
+static int
+test_visit_limit_disabled_leaves_rotation_unchanged(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_visit_init(NULL,
+                        "a,p25-trunk,851000000,,250,,\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        0, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = expect_active_target(&state, "disabled cap init", 0U);
+
+    state.p25_iden_fdma[1].base_freq = 12345;
+    dsd_state_set_trunk_chan_freq(&state, 99U, 851012500);
+    state.dmr_rest_channel = 4;
+    state.dmr_lcn_trust[4] = 2;
+    seed_target0_p25_state(&state);
+
+    trunk_scan_test_set_now(0.24);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "disabled cap before the dwell", 0U);
+    test_rc |= expect_scan_visit(&state, "disabled cap before the dwell", 0U, -1.0);
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "disabled cap after the dwell", 1U);
+    test_rc |= expect_scan_visit(&state, "disabled cap after the dwell", 0U, -1.0);
+    test_rc |= expect_empty_target_p25_state(&state);
+
+    state.p25_iden_fdma[1].base_freq = 99999;
+    dsd_state_set_trunk_chan_freq(&state, 99U, 852012500);
+    state.dmr_rest_channel = 8;
+    state.dmr_lcn_trust[4] = 0;
+    state.dmr_lcn_trust[8] = 2;
+    seed_target1_p25_state(&state);
+
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "disabled cap rotation back", 0U);
+    test_rc |= expect_scan_visit(&state, "disabled cap rotation back", 0U, -1.0);
+    if (state.p25_iden_fdma[1].base_freq != 12345 || state.trunk_chan_map[99] != 851012500
+        || state.dmr_rest_channel != 4 || state.dmr_lcn_trust[4] != 2 || state.dmr_lcn_trust[8] != 0) {
+        DSD_FPRINTF(stderr, "disabled cap: target state leaked across scan targets\n");
+        test_rc = 1;
+    }
+    test_rc |= expect_target0_p25_state(&state);
+
+    /* Long past any cap a mistaken reading of a zero limit could invent. */
+    trunk_scan_test_set_now(5.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_visit(&state, "disabled cap long visit", 0U, -1.0);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * With nowhere else to go the cap re-arms instead of firing: no retune loop, no audio teardown
+ * (requirement 5). Two cases with the same shape -- a one-row list, and a two-row list whose
+ * alternate the operator avoided for the session.
+ */
+static int
+test_visit_limit_single_target_does_not_spin(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+
+    /* Every mark 1.01 s past the previous re-arm crosses the cap again; the deadline walks
+     * forward by one limit each time and the tuner is never asked to move. */
+    static const struct {
+        double now_m;
+        double deadline_m;
+    } marks[] = {{1.01, 2.01}, {1.5, 2.01}, {2.02, 3.02}, {3.03, 4.03}, {4.04, 5.04}};
+
+    if (scan_visit_init(NULL, "a,p25-trunk,851000000,,250,,\n", 1000, &opts, &state, dir, sizeof dir, target_path,
+                        sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    const int parked_calls = g_counting_tune_to_cc_calls;
+    opts.trunk_is_tuned = 1;
+    /* The decision is re-armed, not re-taken: with nowhere to go the coordinator must not
+     * announce an eviction -- nor run the advance walk behind it -- on every tick past the
+     * deadline. Capture stderr over the walk so a regression to that is visible. */
+    dsd_test_capture_stderr cap;
+    char log[4096];
+    if (dsd_test_capture_stderr_begin(&cap, "trunkscanvisit") != 0) {
+        DSD_FPRINTF(stderr, "single target cap: stderr capture failed\n");
+        dsd_engine_trunk_scan_shutdown(&opts, &state);
+        trunk_scan_test_clear_now();
+        cleanup_paths(dir, target_path, NULL);
+        return 1;
+    }
+    for (size_t i = 0; i < sizeof marks / sizeof marks[0]; i++) {
+        trunk_scan_test_set_now(marks[i].now_m);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        test_rc |= expect_active_target(&state, "single target past the cap", 0U);
+        test_rc |= expect_scan_visit(&state, "single target past the cap", 1000U, marks[i].deadline_m);
+        if (g_counting_tune_to_cc_calls != parked_calls) {
+            DSD_FPRINTF(stderr, "single target cap retuned: calls=%d, want %d\n", g_counting_tune_to_cc_calls,
+                        parked_calls);
+            test_rc = 1;
+        }
+    }
+    (void)dsd_test_capture_stderr_end(&cap);
+    if (dsd_test_capture_stderr_read(&cap, log, sizeof log) != 0) {
+        DSD_FPRINTF(stderr, "single target cap: stderr read failed\n");
+        log[0] = '\0';
+        test_rc = 1;
+    }
+    int notices = 0;
+    for (const char* found = strstr(log, "visit limit"); found; found = strstr(found + 1, "visit limit")) {
+        notices++;
+    }
+    if (notices != 0) {
+        DSD_FPRINTF(stderr, "single target cap announced %d evictions with nowhere to go\n", notices);
+        test_rc = 1;
+    }
+    if (test_rc != 0) {
+        /* The capture swallowed whatever the assertions above printed; hand it back. */
+        DSD_FPRINTF(stderr, "single target cap captured log:\n%s", log);
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+
+    /* Same shape, two rows, the alternate avoided: avoiding the row the receiver is on steps
+     * onto the other one, so avoid b from b and the receiver lands back on a. */
+    if (scan_visit_init(NULL,
+                        "a,p25-trunk,851000000,,250,,\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    test_rc |= expect_control_rc("avoid step to b",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_ADVANCE), 0);
+    test_rc |= expect_active_target(&state, "avoid step to b", 1U);
+    test_rc |= expect_control_rc("avoid b",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_AVOID_ACTIVE), 0);
+    test_rc |= expect_active_target(&state, "avoid b", 0U);
+    const int avoided_calls = g_counting_tune_to_cc_calls;
+    opts.trunk_is_tuned = 1;
+    for (size_t i = 0; i < sizeof marks / sizeof marks[0]; i++) {
+        trunk_scan_test_set_now(marks[i].now_m);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        test_rc |= expect_active_target(&state, "avoided alternate past the cap", 0U);
+        test_rc |= expect_scan_visit(&state, "avoided alternate past the cap", 1000U, marks[i].deadline_m);
+        if (g_counting_tune_to_cc_calls != avoided_calls) {
+            DSD_FPRINTF(stderr, "avoided alternate cap retuned: calls=%d, want %d\n", g_counting_tune_to_cc_calls,
+                        avoided_calls);
+            test_rc = 1;
+        }
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * The load-bearing case for requirement 8: the cap fires while a P25 call is being followed.
+ * The carrier is released before the outgoing snapshot is saved, so the receiver leaves with
+ * no tuned state and the revisit restores an idle system rather than a call that ended on
+ * another frequency a rotation ago.
+ */
+static int
+test_visit_limit_expiry_during_p25_call_leaves_clean_revisit(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_visit_init(NULL,
+                        "a,p25-trunk,851000000,,250,,\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    p25_sm_ctx_t* ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
+    if (!ctx) {
+        DSD_FPRINTF(stderr, "visit cap call teardown: no active P25 context\n");
+        dsd_engine_trunk_scan_shutdown(&opts, &state);
+        trunk_scan_test_clear_now();
+        cleanup_paths(dir, target_path, NULL);
+        return 1;
+    }
+    /* Parked, granted, following a call on a voice channel. */
+    ctx->state = P25_SM_TUNED;
+    opts.trunk_is_tuned = 1;
+    state.p25_vc_freq[0] = 851112500;
+    state.trunk_vc_freq[0] = 851112500;
+    test_rc |= seed_active_call_row(&state, 1001U, 2002U, 0.10);
+
+    trunk_scan_test_set_now(0.99);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "call follow inside the cap", 0U);
+    test_rc |= expect_scan_timing(&state, "call follow inside the cap", DSD_SCAN_STAY_CALL_FOLLOW, -1.0, 250U, 0U);
+
+    trunk_scan_test_set_now(1.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "cap expiry mid-call", 1U);
+    if (opts.trunk_is_tuned != 0) {
+        DSD_FPRINTF(stderr, "cap expiry mid-call left trunk_is_tuned=%d\n", opts.trunk_is_tuned);
+        test_rc = 1;
+    }
+    test_rc |= expect_vc_mirrors_clear(&state, "cap expiry mid-call");
+    test_rc |= expect_no_active_call_row(&state, "cap expiry mid-call");
+
+    /* Row b runs out its own idle dwell and the rotation comes back to a. */
+    trunk_scan_test_set_now(1.27);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "revisit after a forced advance", 0U);
+    test_rc |= expect_no_active_call_row(&state, "revisit after a forced advance");
+    test_rc |= expect_vc_mirrors_clear(&state, "revisit after a forced advance");
+    if (opts.trunk_is_tuned != 0) {
+        DSD_FPRINTF(stderr, "revisit after a forced advance left trunk_is_tuned=%d\n", opts.trunk_is_tuned);
+        test_rc = 1;
+    }
+    const p25_sm_ctx_t* revisit_ctx = dsd_engine_trunk_scan_active_p25_ctx();
+    if (p25_sm_get_state(revisit_ctx) != P25_SM_ON_CC) {
+        DSD_FPRINTF(stderr, "revisit after a forced advance left the P25 SM in %d\n",
+                    (int)p25_sm_get_state(revisit_ctx));
+        test_rc = 1;
+    }
+    test_rc |= expect_scan_timing(&state, "revisit after a forced advance", DSD_SCAN_STAY_IDLE_DWELL, 1.52, 250U, 0U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * The plain expiry: a trunked row that is following a call all the way to the deadline is
+ * evicted at it, and the publication follows the receiver onto the incoming row with that row's
+ * own cap armed from its own park.
+ */
+static int
+test_visit_limit_expiry_advances_and_publishes(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_visit_init(NULL,
+                        "a,p25-trunk,851000000,,250,,\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    opts.trunk_is_tuned = 1;
+
+    trunk_scan_test_set_now(0.50);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "cap half spent", 0U);
+    test_rc |= expect_scan_timing(&state, "cap half spent", DSD_SCAN_STAY_CALL_FOLLOW, -1.0, 250U, 0U);
+    test_rc |= expect_scan_visit(&state, "cap half spent", 1000U, 1.0);
+
+    trunk_scan_test_set_now(1.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "cap spent", 1U);
+    test_rc |= expect_published_target(&state, "cap spent", "b", 2U, 2U);
+    test_rc |= expect_scan_visit(&state, "cap spent", 1000U, 2.01);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * Every visit gets the whole limit. A row the rotation comes back to is measured from the park
+ * that brought the receiver back, not from the first time it was ever visited -- otherwise a
+ * target would be evicted the moment it was revisited for the rest of the session.
+ */
+static int
+test_visit_limit_revisit_starts_fresh(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_visit_init(NULL,
+                        "a,p25-trunk,851000000,,250,,\n"
+                        "b,p25-trunk,852000000,,250,,\n"
+                        "c,p25-trunk,853000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    /* Idle dwells only: a -> b -> c -> a, the last park landing at 0.78. */
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "rotation to b", 1U);
+    trunk_scan_test_set_now(0.52);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "rotation to c", 2U);
+    trunk_scan_test_set_now(0.78);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "rotation back to a", 0U);
+
+    /* A call arrives on the revisit and holds the row; only the cap can end the visit now. */
+    opts.trunk_is_tuned = 1;
+    trunk_scan_test_set_now(1.05);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "past the first park's cap", 0U);
+    test_rc |= expect_scan_visit(&state, "past the first park's cap", 1000U, 1.78);
+    trunk_scan_test_set_now(1.77);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "just inside the revisit cap", 0U);
+    trunk_scan_test_set_now(1.79);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "revisit cap spent", 1U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * A row's own `--scan-max-visit-ms` wins over the global, a row without one inherits it, and a
+ * row that says `0` has no cap at all even while the global is set -- the same configured versus
+ * effective split the other row options keep.
+ */
+static int
+test_visit_limit_row_override_and_global_inheritance(void) {
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,options\n";
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_visit_init(header,
+                        "a,p25-trunk,851000000,,250,,,--scan-max-visit-ms 2000\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    opts.trunk_is_tuned = 1;
+
+    trunk_scan_test_set_now(1.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "row override past the global cap", 0U);
+    test_rc |= expect_scan_visit(&state, "row override past the global cap", 2000U, 2.0);
+    trunk_scan_test_set_now(2.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "row override spent", 1U);
+    /* Row b carries no option of its own and inherits the global. */
+    test_rc |= expect_scan_visit(&state, "row override spent", 1000U, 3.01);
+    /* The forced advance handed the carrier back, so trunk_is_tuned dropped with it: say that
+     * row b has traffic of its own, or its idle dwell -- not its cap -- ends the visit. */
+    opts.trunk_is_tuned = 1;
+    trunk_scan_test_set_now(2.5);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "inherited cap half spent", 1U);
+    test_rc |= expect_scan_visit(&state, "inherited cap half spent", 1000U, 3.01);
+    opts.trunk_is_tuned = 1;
+    trunk_scan_test_set_now(3.02);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "inherited cap spent", 0U);
+    test_rc |= expect_scan_visit(&state, "inherited cap spent", 2000U, 5.02);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_state_ext_free_all(&state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+
+    /* A row that switches the cap off keeps its visit for as long as the traffic lasts. */
+    if (scan_visit_init(header,
+                        "a,p25-trunk,851000000,,250,,,--scan-max-visit-ms 0\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    opts.trunk_is_tuned = 1;
+    static const double uncapped_marks[] = {1.01, 2.5, 5.0};
+    for (size_t i = 0; i < sizeof uncapped_marks / sizeof uncapped_marks[0]; i++) {
+        trunk_scan_test_set_now(uncapped_marks[i]);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        test_rc |= expect_active_target(&state, "row cap off", 0U);
+        test_rc |= expect_scan_visit(&state, "row cap off", 0U, -1.0);
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_state_ext_free_all(&state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * A retune the backend has not resolved yet is not a visit: there is no park to measure from, so
+ * the cap cannot fire and publishes no deadline. When the request completes, the visit starts at
+ * the completion the backend recorded (requirement 9).
+ */
+static int
+test_visit_limit_pending_retune_does_not_fire(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,p25-trunk,851000000,,250,,\n"
+                             "b,p25-trunk,852000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.scan_max_visit_ms = 1000;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(1.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "visit cap pending-retune init failed: %s\n", err);
+        test_rc = 1;
+    }
+    p25_sm_ctx_t* ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
+    if (!ctx || !ctx->cc_tune_pending || ctx->cc_tune_request_id == 0U) {
+        DSD_FPRINTF(stderr, "visit cap pending-retune left no pending request\n");
+        g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+        dsd_engine_trunk_scan_shutdown(&opts, &state);
+        trunk_scan_test_clear_now();
+        cleanup_paths(dir, target_path, NULL);
+        return 1;
+    }
+
+    trunk_scan_test_set_now(3.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "retune still pending", 0U);
+    test_rc |= expect_scan_timing(&state, "retune still pending", DSD_SCAN_STAY_RETUNE_PENDING, -1.0, 250U, 0U);
+    test_rc |= expect_scan_visit(&state, "retune still pending", 1000U, -1.0);
+
+    /* This fixture stubs the P25 SM, so model the live-loop ordering where its tick observes
+     * completion before the scan coordinator runs. */
+    dsd_trunk_tuning_request_complete(ctx->cc_tune_request_id, DSD_TRUNK_TUNE_RESULT_OK);
+    (void)p25_sm_restart_pending_cc_acquisition(ctx, &opts, &state, 3.0, "test-complete");
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    /* Following a call from here on, so the idle dwell is disarmed and only the cap can move the
+     * receiver: the assertions below are about the cap alone. */
+    opts.trunk_is_tuned = 1;
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "retune completed", 0U);
+    test_rc |= expect_scan_visit(&state, "retune completed", 1000U, 4.0);
+
+    trunk_scan_test_set_now(3.99);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "completed retune inside the cap", 0U);
+    trunk_scan_test_set_now(4.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "completed retune cap spent", 1U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * A park that failed is not a visit either: across the retry cooldown the cap must stay out of
+ * the way entirely, exactly as it does when it is switched off, and the park that finally lands
+ * anchors a fresh limit.
+ */
+static int
+run_visit_failed_retune_case(int max_visit_ms) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,p25-trunk,851000000,,250,,\n"
+                             "b,p25-trunk,852000000,,250,,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.scan_max_visit_ms = max_visit_ms;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    const unsigned want_limit = max_visit_ms >= 1000 ? (unsigned)max_visit_ms : 0U;
+
+    /* Every park fails: the initial one and the alternate the init advance reaches for. */
+    dsd_trunk_tuning_hooks hooks = {0};
+    hooks.tune_to_cc_request = failing_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "visit cap failed-retune init failed: %s\n", err);
+        test_rc = 1;
+    }
+    g_counting_tune_to_cc_calls = 0;
+
+    static const double cooldown_marks[] = {0.5, 1.5};
+    for (size_t i = 0; i < sizeof cooldown_marks / sizeof cooldown_marks[0]; i++) {
+        trunk_scan_test_set_now(cooldown_marks[i]);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        test_rc |= expect_active_target(&state, "failed park cooling down", 0U);
+        test_rc |= expect_scan_timing(&state, "failed park cooling down", DSD_SCAN_STAY_RETUNE_RETRY, 2.0, 250U, 0U);
+        /* Unanchored: there is no live cap to publish and nothing for it to expire. */
+        test_rc |= expect_scan_visit(&state, "failed park cooling down", want_limit, -1.0);
+    }
+
+    hooks.tune_to_cc_request = counting_tune_to_cc;
+    dsd_trunk_tuning_hooks_set(hooks);
+    g_counting_tune_to_cc_failures_remaining = 0;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    trunk_scan_test_set_now(2.3);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "park after the cooldown", 1U);
+    if (g_counting_tune_to_cc_calls != 1) {
+        DSD_FPRINTF(stderr, "failed-retune cooldown made %d attempts after expiry, want 1\n",
+                    g_counting_tune_to_cc_calls);
+        test_rc = 1;
+    }
+    /* Fresh from the park that landed, not from the coordinator's first attempt at 0.0. */
+    test_rc |= expect_scan_visit(&state, "park after the cooldown", want_limit, want_limit != 0U ? 3.3 : -1.0);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+static int
+test_visit_limit_failed_retune_cools_down_not_capped(void) {
+    int test_rc = run_visit_failed_retune_case(1000);
+    test_rc |= run_visit_failed_retune_case(0);
+    return test_rc;
+}
+
+/*
+ * When the forced advance cannot land anywhere the receiver rolls back onto the row it was on.
+ * The cap then re-arms rather than staying expired: a row whose alternates are all cooling down
+ * must not re-decide the eviction on every tick, and the retry has to wait for the next cap
+ * boundary that has somewhere to go.
+ */
+static int
+test_visit_limit_forced_advance_rollback_rearms(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_visit_init(NULL,
+                        "a,p25-trunk,851000000,,250,,\n"
+                        "b,p25-trunk,852000000,,250,,\n",
+                        1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    const int parked_calls = g_counting_tune_to_cc_calls;
+    opts.trunk_is_tuned = 1;
+    /* The alternate's retune fails, and so does the re-park the advance falls back on. */
+    g_counting_tune_to_cc_failures_remaining = 2;
+
+    trunk_scan_test_set_now(1.01);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "forced advance rollback", 0U);
+    test_rc |= expect_published_target(&state, "forced advance rollback", "a", 1U, 2U);
+    if (g_counting_tune_to_cc_calls != parked_calls + 2) {
+        DSD_FPRINTF(stderr, "forced advance made %d attempts, want %d\n", g_counting_tune_to_cc_calls - parked_calls,
+                    2);
+        test_rc = 1;
+    }
+    test_rc |= expect_scan_timing(&state, "forced advance rollback", DSD_SCAN_STAY_RETUNE_RETRY, 3.01, 250U, 0U);
+    /* Re-armed from the failed eviction, so the next boundary is one full limit out. */
+    test_rc |= expect_scan_visit(&state, "forced advance rollback", 1000U, 2.01);
+
+    const int rollback_calls = g_counting_tune_to_cc_calls;
+    static const double quiet_marks[] = {1.5, 1.99, 2.02};
+    for (size_t i = 0; i < sizeof quiet_marks / sizeof quiet_marks[0]; i++) {
+        /* The failed eviction handed the carrier back; the row is still busy. */
+        opts.trunk_is_tuned = 1;
+        trunk_scan_test_set_now(quiet_marks[i]);
+        dsd_engine_trunk_scan_tick(&opts, &state);
+        test_rc |= expect_active_target(&state, "after the rollback", 0U);
+        if (g_counting_tune_to_cc_calls != rollback_calls) {
+            DSD_FPRINTF(stderr, "rollback retried at %.2f: calls=%d, want %d\n", quiet_marks[i],
+                        g_counting_tune_to_cc_calls, rollback_calls);
+            test_rc = 1;
+        }
+    }
+
+    /* 2.02 crossed the re-armed cap but the alternate was still cooling down, so it only re-armed
+     * again; the first boundary with an eligible alternate is the one that moves the receiver. */
+    opts.trunk_is_tuned = 1;
+    trunk_scan_test_set_now(3.03);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "eviction once the alternate is eligible", 1U);
+    if (g_counting_tune_to_cc_calls != rollback_calls + 1) {
+        DSD_FPRINTF(stderr, "eviction after the cooldown made %d attempts, want 1\n",
+                    g_counting_tune_to_cc_calls - rollback_calls);
+        test_rc = 1;
+    }
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -8377,6 +9370,19 @@ main(void) {
     rc |= run_with_default_tune_hook(test_scan_timing_voice_gate_phases);
     rc |= run_with_default_tune_hook(test_scan_timing_row_voice_options_override_effective_values);
     rc |= run_with_default_tune_hook(test_scan_timing_pending_retune_then_retry_cooldown);
+    rc |= run_with_default_tune_hook(test_visit_limit_repeated_p25_calls_do_not_restart);
+    rc |= run_with_default_tune_hook(test_visit_limit_continuous_conventional_activity_does_not_restart);
+    rc |= run_with_default_tune_hook(test_visit_limit_manual_hold_suspends_and_release_restarts);
+    rc |= run_with_default_tune_hook(test_visit_limit_tg_hold_followed_call_suspends);
+    rc |= run_with_default_tune_hook(test_visit_limit_disabled_leaves_rotation_unchanged);
+    rc |= run_with_default_tune_hook(test_visit_limit_single_target_does_not_spin);
+    rc |= run_with_default_tune_hook(test_visit_limit_expiry_during_p25_call_leaves_clean_revisit);
+    rc |= run_with_default_tune_hook(test_visit_limit_expiry_advances_and_publishes);
+    rc |= run_with_default_tune_hook(test_visit_limit_revisit_starts_fresh);
+    rc |= run_with_default_tune_hook(test_visit_limit_row_override_and_global_inheritance);
+    rc |= run_with_default_tune_hook(test_visit_limit_pending_retune_does_not_fire);
+    rc |= run_with_default_tune_hook(test_visit_limit_failed_retune_cools_down_not_capped);
+    rc |= run_with_default_tune_hook(test_visit_limit_forced_advance_rollback_rearms);
     return rc;
 }
 

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -57,6 +57,7 @@ static int g_p25_tick_guard_depth = 0;
 static int g_p25_tick_guard_enter_calls = 0;
 static int g_p25_tick_guard_leave_calls = 0;
 static unsigned int g_fake_rtl_output_rate_hz = 0;
+static int g_explicit_call_ends = 0;
 
 static unsigned int
 fake_rtl_output_rate_hz(void) {
@@ -241,7 +242,9 @@ dsd_engine_release_tuned_call_state(dsd_opts* opts, dsd_state* state) {
     }
     const double ended_m = dsd_time_now_monotonic_s();
     for (int slot = 0; slot < DSD_CALL_STATE_SLOT_COUNT; slot++) {
-        (void)dsd_call_state_end_ex(state, (uint8_t)slot, ended_m, DSD_CALL_END_EXPLICIT);
+        if (dsd_call_state_end_ex(state, (uint8_t)slot, ended_m, DSD_CALL_END_EXPLICIT) > 0) {
+            g_explicit_call_ends++;
+        }
     }
     state->p25_vc_freq[0] = 0;
     state->p25_vc_freq[1] = 0;
@@ -8510,7 +8513,7 @@ test_visit_limit_continuous_conventional_activity_does_not_restart(void) {
     static dsd_opts opts;
     static dsd_state state;
     if (scan_visit_init(NULL,
-                        "a,dmr-conventional,461000000,,250,250,\n"
+                        "a,dmr-conventional,461000000,,250,1200,\n"
                         "b,dmr-conventional,462000000,,250,250,\n",
                         1000, &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
         != 0) {
@@ -8529,12 +8532,21 @@ test_visit_limit_continuous_conventional_activity_does_not_restart(void) {
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "activity just inside the cap", 0U);
     test_rc |=
-        expect_scan_timing(&state, "activity just inside the cap", DSD_SCAN_STAY_ACTIVITY_HOLD, 1.15, 250U, 250U);
+        expect_scan_timing(&state, "activity just inside the cap", DSD_SCAN_STAY_ACTIVITY_HOLD, 2.10, 250U, 1200U);
     test_rc |= expect_scan_visit(&state, "activity just inside the cap", 1000U, 1.0);
 
     trunk_scan_test_set_now(1.01);
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "activity cap expiry", 1U);
+
+    /* Return before the outgoing hold would expire: its ended call cannot hold the revisit. */
+    trunk_scan_test_set_now(1.27);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "conventional revisit", 0U);
+    test_rc |= expect_scan_timing(&state, "conventional revisit is idle", DSD_SCAN_STAY_IDLE_DWELL, 1.52, 250U, 1200U);
+    trunk_scan_test_set_now(1.53);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "revisit leaves after idle dwell", 1U);
 
     dsd_engine_trunk_scan_shutdown(&opts, &state);
     trunk_scan_test_clear_now();
@@ -8574,13 +8586,25 @@ test_visit_limit_manual_hold_suspends_and_release_restarts(void) {
         test_rc |= expect_scan_visit(&state, "manual hold past the cap", 1000U, -1.0);
     }
 
+    /* Input can stall between the last held tick and the command that releases it. */
+    trunk_scan_test_set_now(10.0);
     test_rc |= expect_control_rc("visit hold off",
                                  dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 0);
-    trunk_scan_test_set_now(5.99);
+    test_rc |= expect_scan_visit(&state, "release command starts a full cap", 1000U, 11.0);
+    trunk_scan_test_set_now(10.99);
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "release before a full cap", 0U);
-    test_rc |= expect_scan_visit(&state, "release before a full cap", 1000U, 6.0);
-    trunk_scan_test_set_now(6.01);
+    test_rc |= expect_scan_visit(&state, "release before a full cap", 1000U, 11.0);
+    /* Two queued toggles can also arrive without any intervening decoder tick. */
+    test_rc |= expect_control_rc("queued hold on",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 1);
+    test_rc |= expect_control_rc("queued hold off",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 0);
+    trunk_scan_test_set_now(11.5);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "queued release before a full cap", 0U);
+    test_rc |= expect_scan_visit(&state, "queued release before a full cap", 1000U, 11.99);
+    trunk_scan_test_set_now(12.0);
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "release after a full cap", 1U);
 
@@ -8621,17 +8645,16 @@ test_visit_limit_tg_hold_followed_call_suspends(void) {
         test_rc |= expect_scan_visit(&state, "tg hold followed call", 1000U, -1.0);
     }
 
-    /* The call ends; the suspension ends with it and a full fresh limit starts from the last
-     * suspended tick. */
-    if (dsd_call_state_end_ex(&state, 0U, 3.0, DSD_CALL_END_TERMINATOR) != 1) {
+    /* The call ends after input stalls. Its next tick starts the fresh cap. */
+    if (dsd_call_state_end_ex(&state, 0U, 9.0, DSD_CALL_END_TERMINATOR) != 1) {
         DSD_FPRINTF(stderr, "visit cap tg hold: ending the held call failed\n");
         test_rc = 1;
     }
-    trunk_scan_test_set_now(3.99);
+    trunk_scan_test_set_now(9.0);
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "held call ended, inside the cap", 0U);
-    test_rc |= expect_scan_visit(&state, "held call ended, inside the cap", 1000U, 4.0);
-    trunk_scan_test_set_now(4.01);
+    test_rc |= expect_scan_visit(&state, "held call ended, inside the cap", 1000U, 10.0);
+    trunk_scan_test_set_now(10.01);
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "held call ended, cap expiry", 1U);
 
@@ -8871,16 +8894,16 @@ run_visit_limit_ineligible_alternate_rearms(int cooldown) {
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_scan_visit(&state, "alternate unavailable before deadline", 1000U, -1.0);
     if (!cooldown) {
-        trunk_scan_test_set_now(0.99);
+        trunk_scan_test_set_now(10.0);
         test_rc |=
-            expect_control_rc("clear avoids just before original deadline",
+            expect_control_rc("clear avoids after stalled input",
                               dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_AVOID_CLEAR), 1);
     }
-    trunk_scan_test_set_now(offset + 1.01);
+    trunk_scan_test_set_now(10.0);
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "fresh cap after alternate becomes eligible", 0U);
-    test_rc |= expect_scan_visit(&state, "fresh cap after alternate becomes eligible", 1000U, offset + 1.98);
-    trunk_scan_test_set_now(offset + 1.981);
+    test_rc |= expect_scan_visit(&state, "fresh cap after alternate becomes eligible", 1000U, 11.0);
+    trunk_scan_test_set_now(11.01);
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "fresh cap eventually expires", 1U);
     dsd_engine_trunk_scan_shutdown(&opts, &state);
@@ -9279,10 +9302,8 @@ test_visit_limit_failed_retune_cools_down_not_capped(void) {
  * When the forced advance cannot land anywhere the receiver rolls back onto the row it was on.
  * Two things have to hold afterwards. The cap re-arms rather than staying expired, so a row whose
  * alternates are all cooling down does not re-decide the eviction on every tick. And the carrier
- * stays released: the advance's rollback restores the snapshot it took before the release, call
- * rows and VC mirrors included, so without a re-scrub the row would carry a phantom ACTIVE call
- * that nothing ages out -- baked into its snapshot on the next ordinary departure and restored on
- * every revisit from then on (requirement 8).
+ * stays released: rollback preserves the ended call and its event bookkeeping, without
+ * resurrecting a phantom ACTIVE call or ending the same epoch twice (requirement 8).
  */
 static int
 test_visit_limit_forced_advance_rollback_rearms(void) {
@@ -9306,6 +9327,7 @@ test_visit_limit_forced_advance_rollback_rearms(void) {
     test_rc |= seed_active_call_row(&state, 1001U, 2002U, 0.10);
     /* The alternate's retune fails, and so does the re-park the advance falls back on. */
     g_counting_tune_to_cc_failures_remaining = 2;
+    const int ends_before = g_explicit_call_ends;
 
     trunk_scan_test_set_now(1.01);
     dsd_engine_trunk_scan_tick(&opts, &state);
@@ -9314,6 +9336,10 @@ test_visit_limit_forced_advance_rollback_rearms(void) {
     /* The receiver never left, but the carrier was handed back before the first attempt: the
      * rollback must not resurrect it. */
     test_rc |= expect_no_active_call_row(&state, "forced advance rollback");
+    if (g_explicit_call_ends != ends_before + 1) {
+        DSD_FPRINTF(stderr, "failed eviction ended the same call %d times\n", g_explicit_call_ends - ends_before);
+        test_rc = 1;
+    }
     test_rc |= expect_vc_mirrors_clear(&state, "forced advance rollback");
     if (opts.trunk_is_tuned != 0) {
         DSD_FPRINTF(stderr, "forced advance rollback left trunk_is_tuned=%d\n", opts.trunk_is_tuned);

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -7827,6 +7827,419 @@ test_parser_optional_headers_are_case_insensitive(void) {
     return test_rc;
 }
 
+/*
+ * Scan timing publication (#508). The coordinator owns every deadline, so these read the
+ * absolute monotonic anchors straight out of dsd_state; nothing here asks for a remaining
+ * time, which is the renderer's job. Doubles are compared with a tolerance.
+ */
+static int
+expect_scan_timing(const dsd_state* state, const char* stage, unsigned reason, double deadline_m, unsigned dwell_ms,
+                   unsigned hold_ms) {
+    const dsd_scan_timing_publication* timing = &state->scan_timing;
+    int rc = 0;
+    if ((unsigned)timing->reason != reason || (unsigned)timing->dwell_ms != dwell_ms
+        || (unsigned)timing->hold_ms != hold_ms) {
+        DSD_FPRINTF(stderr, "scan timing after %s: reason=%u dwell=%u hold=%u, want %u/%u/%u\n", stage,
+                    (unsigned)timing->reason, (unsigned)timing->dwell_ms, (unsigned)timing->hold_ms, reason, dwell_ms,
+                    hold_ms);
+        rc = 1;
+    }
+    if (deadline_m < 0.0) {
+        if (timing->deadline_m >= 0.0) {
+            DSD_FPRINTF(stderr, "scan timing after %s: deadline %.6f, want no live timer\n", stage, timing->deadline_m);
+            rc = 1;
+        }
+        return rc;
+    }
+    if (timing->deadline_m < 0.0 || fabs(timing->deadline_m - deadline_m) > 1e-6) {
+        DSD_FPRINTF(stderr, "scan timing after %s: deadline %.6f, want %.6f\n", stage, timing->deadline_m, deadline_m);
+        rc = 1;
+    }
+    return rc;
+}
+
+static int
+expect_scan_timing_window(const dsd_state* state, const char* stage, double started_m, unsigned span_ms) {
+    const dsd_scan_timing_publication* timing = &state->scan_timing;
+    if (fabs(timing->started_m - started_m) > 1e-6 || (unsigned)timing->span_ms != span_ms) {
+        DSD_FPRINTF(stderr, "scan timing window after %s: started=%.6f span=%u, want %.6f/%u\n", stage,
+                    timing->started_m, (unsigned)timing->span_ms, started_m, span_ms);
+        return 1;
+    }
+    return 0;
+}
+
+static int
+expect_scan_timing_conventional(const dsd_state* state, const char* stage, unsigned conventional) {
+    if ((unsigned)state->scan_timing.conventional != conventional) {
+        DSD_FPRINTF(stderr, "scan timing conventional flag after %s: %u, want %u\n", stage,
+                    (unsigned)state->scan_timing.conventional, conventional);
+        return 1;
+    }
+    return 0;
+}
+
+/*
+ * A trunked row walks acquisition -> call following -> idle dwell. Neither trunking reason
+ * carries a coordinator-owned deadline (the protocol SM owns those), and a trunked row never
+ * publishes an activity hold. Shutdown takes the publication down with the label.
+ */
+static int
+test_scan_timing_trunked_acquire_follow_and_dwell(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_control_init("a,p25-trunk,851000000,,250,,\n"
+                          "b,p25-trunk,852000000,,250,,\n",
+                          &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    p25_sm_ctx_t* ctx = (p25_sm_ctx_t*)dsd_engine_trunk_scan_active_p25_ctx();
+    if (!ctx) {
+        DSD_FPRINTF(stderr, "scan timing: no active P25 context\n");
+        dsd_engine_trunk_scan_shutdown(&opts, &state);
+        trunk_scan_test_clear_now();
+        cleanup_paths(dir, target_path, NULL);
+        return 1;
+    }
+
+    ctx->cc_tune_pending = 1;
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "cc acquisition", 0U);
+    test_rc |= expect_scan_timing(&state, "cc acquisition", DSD_SCAN_STAY_CC_ACQUIRE, -1.0, 250U, 0U);
+    test_rc |= expect_scan_timing_conventional(&state, "cc acquisition", 0U);
+
+    ctx->cc_tune_pending = 0;
+    opts.trunk_is_tuned = 1;
+    trunk_scan_test_set_now(0.50);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "call follow", 0U);
+    test_rc |= expect_scan_timing(&state, "call follow", DSD_SCAN_STAY_CALL_FOLLOW, -1.0, 250U, 0U);
+
+    /* The release re-arms the dwell on this very tick, so the deadline is a full dwell out. */
+    opts.trunk_is_tuned = 0;
+    trunk_scan_test_set_now(0.60);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "idle dwell", 0U);
+    test_rc |= expect_scan_timing(&state, "idle dwell", DSD_SCAN_STAY_IDLE_DWELL, 0.85, 250U, 0U);
+    test_rc |= expect_scan_timing_window(&state, "idle dwell", 0.60, 250U);
+    test_rc |= expect_scan_timing_conventional(&state, "idle dwell", 0U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "shutdown", DSD_SCAN_STAY_NONE, -1.0, 0U, 0U);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/*
+ * A conventional row's activity hold is the one window the coordinator owns outright: later
+ * activity pushes the same deadline out rather than opening a second one, and the expiry tick
+ * re-arms the idle dwell.
+ */
+static int
+test_scan_timing_conventional_activity_hold_restarts(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_control_init("a,dmr-conventional,461000000,,250,250,\n"
+                          "b,dmr-conventional,462000000,,250,250,\n",
+                          &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_dmr_conventional_activity(&opts, &state, 1001, 2002, 0, 0, 0);
+    trunk_scan_test_set_now(0.20);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "activity hold", 0U);
+    test_rc |= expect_scan_timing(&state, "activity hold", DSD_SCAN_STAY_ACTIVITY_HOLD, 0.35, 250U, 250U);
+    test_rc |= expect_scan_timing_window(&state, "activity hold", 0.10, 250U);
+    test_rc |= expect_scan_timing_conventional(&state, "activity hold", 1U);
+
+    trunk_scan_test_set_now(0.30);
+    dsd_engine_trunk_scan_dmr_conventional_activity(&opts, &state, 1001, 2002, 0, 0, 0);
+    trunk_scan_test_set_now(0.31);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "refreshed hold", 0U);
+    test_rc |= expect_scan_timing(&state, "refreshed hold", DSD_SCAN_STAY_ACTIVITY_HOLD, 0.55, 250U, 250U);
+    test_rc |= expect_scan_timing_window(&state, "refreshed hold", 0.30, 250U);
+
+    /* The hold lapses at 0.55; the first tick past it re-arms the dwell in place. */
+    trunk_scan_test_set_now(0.56);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "hold expiry", 0U);
+    test_rc |= expect_scan_timing(&state, "hold expiry", DSD_SCAN_STAY_IDLE_DWELL, 0.81, 250U, 250U);
+    test_rc |= expect_scan_timing_conventional(&state, "hold expiry", 1U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "conventional shutdown", DSD_SCAN_STAY_NONE, -1.0, 0U, 0U);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* An operator hold pauses the dwell: no deadline at all, and the release re-arms a full one. */
+static int
+test_scan_timing_manual_hold_pauses_and_release_rearms(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_control_init("a,p25-trunk,851000000,,250,,\n"
+                          "b,p25-trunk,852000000,,250,,\n",
+                          &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    test_rc |= expect_control_rc("hold on",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 1);
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "manual hold", 0U);
+    test_rc |= expect_scan_timing(&state, "manual hold", DSD_SCAN_STAY_MANUAL_HOLD, -1.0, 250U, 0U);
+    trunk_scan_test_set_now(3.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "manual hold past the dwell", DSD_SCAN_STAY_MANUAL_HOLD, -1.0, 250U, 0U);
+
+    test_rc |= expect_control_rc("hold off",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_HOLD_TOGGLE), 0);
+    trunk_scan_test_set_now(3.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "hold release", 0U);
+    test_rc |= expect_scan_timing(&state, "hold release", DSD_SCAN_STAY_IDLE_DWELL, 3.35, 250U, 0U);
+    test_rc |= expect_scan_timing_window(&state, "hold release", 3.10, 250U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* The publication follows the receiver: an advancing tick publishes the incoming row's own
+ * effective dwell and hold, not the outgoing row's. */
+static int
+test_scan_timing_rotation_publishes_incoming_row(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_control_init("a,dmr-conventional,461000000,,250,250,\n"
+                          "b,dmr-conventional,462000000,,400,600,\n",
+                          &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "row a dwell", DSD_SCAN_STAY_IDLE_DWELL, 0.25, 250U, 250U);
+
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "rotation", 1U);
+    test_rc |= expect_scan_timing(&state, "rotation", DSD_SCAN_STAY_IDLE_DWELL, 0.66, 400U, 600U);
+    test_rc |= expect_scan_timing_window(&state, "rotation", 0.26, 400U);
+    test_rc |= expect_scan_timing_conventional(&state, "rotation", 1U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* When every alternate retune fails the advance falls back on the original row: the tick still
+ * publishes exactly once, for the row the receiver never left, and says it is cooling down. */
+static int
+test_scan_timing_fallback_to_original_publishes_retry(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    static dsd_opts opts;
+    static dsd_state state;
+    if (scan_control_init("a,p25-trunk,851000000,,250,,\n"
+                          "b,p25-trunk,852000000,,250,,\n",
+                          &opts, &state, dir, sizeof dir, target_path, sizeof target_path)
+        != 0) {
+        return 1;
+    }
+    int test_rc = 0;
+    g_counting_tune_to_cc_failures_remaining = 2;
+    trunk_scan_test_set_now(0.26);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    g_counting_tune_to_cc_failures_remaining = 0;
+    test_rc |= expect_active_target(&state, "failed alternates", 0U);
+    test_rc |= expect_published_target(&state, "failed alternates", "a", 1U, 2U);
+    test_rc |= expect_scan_timing(&state, "failed alternates", DSD_SCAN_STAY_RETUNE_RETRY, 2.26, 250U, 0U);
+    test_rc |= expect_scan_timing_window(&state, "failed alternates", 0.26, 2000U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* The voice gate decides which conventional phrase the row publishes: VOICE while media is
+ * live, the tail as an activity hold on the same window, and the qualify window as the dwell. */
+static int
+test_scan_timing_voice_gate_phases(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,dmr-conventional,461000000,,250,250,\n"
+                             "b,dmr-conventional,462000000,,250,250,\n",
+                             target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.scan_voice_only = 1;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "scan timing voice-gate init failed: %s\n", err);
+        test_rc = 1;
+    }
+    if (seed_voice_gate_media_epoch(&state, 0.10, 0.25, DSD_CALL_CRYPTO_CLEAR) != 0) {
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(0.30);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "voice", DSD_SCAN_STAY_VOICE, 0.50, 250U, 250U);
+    test_rc |= expect_scan_timing_window(&state, "voice", 0.25, 250U);
+
+    if (dsd_call_state_update_media(&state, 0U, 1, 0.49) != 1) {
+        DSD_FPRINTF(stderr, "scan timing voice-gate media refresh failed\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.49);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    if (dsd_call_state_end_ex(&state, 0U, 0.50, DSD_CALL_END_SYNC_LOSS) != 1) {
+        DSD_FPRINTF(stderr, "scan timing voice-gate epoch end failed\n");
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.70);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "voice tail", DSD_SCAN_STAY_ACTIVITY_HOLD, 0.74, 250U, 250U);
+    test_rc |= expect_scan_timing_window(&state, "voice tail", 0.49, 250U);
+
+    trunk_scan_test_set_now(0.75);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "qualify", 0U);
+    test_rc |= expect_scan_timing(&state, "qualify", DSD_SCAN_STAY_IDLE_DWELL, 1.00, 250U, 250U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_state_ext_free_all(&state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* A row's own --scan-voice-qualify-ms/--scan-voice-hold-ms replace the CSV columns while the
+ * gate is on, so the published dwell and hold have to be the effective ones. */
+static int
+test_scan_timing_row_voice_options_override_effective_values(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_temp_dir(dir, sizeof dir) != 0) {
+        return 1;
+    }
+    static const char header[] = "id,type,frequency_hz,chan_csv,dwell_ms,activity_hold_ms,notes,options\n";
+    static const char body[] =
+        "a,dmr-conventional,461000000,,250,250,,--scan-voice-qualify-ms 1000 --scan-voice-hold-ms 900\n"
+        "b,dmr-conventional,462000000,,250,250,,\n";
+    if (write_targets_file_with_header(dir, header, body, target_path, sizeof target_path) != 0) {
+        cleanup_paths(dir, NULL, NULL);
+        return 1;
+    }
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    opts.scan_voice_only = 1;
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(0.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "scan timing row-options init failed: %s\n", err);
+        test_rc = 1;
+    }
+    trunk_scan_test_set_now(0.10);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "row voice options", 0U);
+    test_rc |= expect_scan_timing(&state, "row voice options", DSD_SCAN_STAY_IDLE_DWELL, 1.00, 1000U, 900U);
+    test_rc |= expect_scan_timing_window(&state, "row voice options", 0.0, 1000U);
+
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    dsd_state_ext_free_all(&state);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
+/* An unresolved backend retune has no deadline the coordinator can name; the failure that
+ * follows starts the retry cooldown, and that one it does own. */
+static int
+test_scan_timing_pending_retune_then_retry_cooldown(void) {
+    char dir[DSD_TEST_PATH_MAX];
+    char target_path[DSD_TEST_PATH_MAX];
+    if (make_runtime_targets("a,nxdn-trunk,461000000,,250,,\n", target_path, sizeof target_path, dir, sizeof dir)
+        != 0) {
+        return 1;
+    }
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_scan_opts_state(&opts, &state);
+    DSD_SNPRINTF(opts.trunk_scan_targets_csv, sizeof opts.trunk_scan_targets_csv, "%s", target_path);
+    g_counting_tune_to_cc_calls = 0;
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_PENDING;
+
+    char err[256] = {0};
+    trunk_scan_test_set_now(1.0);
+    int test_rc = 0;
+    if (dsd_engine_trunk_scan_init(&opts, &state, err, sizeof err) != 0) {
+        DSD_FPRINTF(stderr, "scan timing pending-retune init failed: %s\n", err);
+        test_rc = 1;
+    }
+    const uint64_t request_id = dsd_trunk_tuning_pending_request();
+    if (request_id == 0U) {
+        DSD_FPRINTF(stderr, "scan timing pending-retune left no request\n");
+        test_rc = 1;
+    }
+
+    trunk_scan_test_set_now(2.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "pending retune", DSD_SCAN_STAY_RETUNE_PENDING, -1.0, 250U, 0U);
+
+    dsd_trunk_tuning_request_publish(request_id, DSD_TRUNK_TUNE_RESULT_FAILED);
+    trunk_scan_test_set_now(3.0);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "retry cooldown", 0U);
+    test_rc |= expect_scan_timing(&state, "retry cooldown", DSD_SCAN_STAY_RETUNE_RETRY, 5.0, 250U, 0U);
+    test_rc |= expect_scan_timing_window(&state, "retry cooldown", 3.0, 2000U);
+
+    g_counting_tune_to_cc_result = DSD_TRUNK_TUNE_RESULT_OK;
+    dsd_engine_trunk_scan_shutdown(&opts, &state);
+    test_rc |= expect_scan_timing(&state, "pending shutdown", DSD_SCAN_STAY_NONE, -1.0, 0U, 0U);
+    trunk_scan_test_clear_now();
+    cleanup_paths(dir, target_path, NULL);
+    return test_rc;
+}
+
 int
 main(void) {
     int rc = 0;
@@ -7937,6 +8350,14 @@ main(void) {
     rc |= run_with_default_tune_hook(test_trunk_scan_rejects_global_p25_bandplan);
     rc |= run_with_default_tune_hook(test_target_p25_bandplan_loads_and_survives_rotation);
     rc |= run_with_default_tune_hook(test_p25_bandplan_export_collects_every_target);
+    rc |= run_with_default_tune_hook(test_scan_timing_trunked_acquire_follow_and_dwell);
+    rc |= run_with_default_tune_hook(test_scan_timing_conventional_activity_hold_restarts);
+    rc |= run_with_default_tune_hook(test_scan_timing_manual_hold_pauses_and_release_rearms);
+    rc |= run_with_default_tune_hook(test_scan_timing_rotation_publishes_incoming_row);
+    rc |= run_with_default_tune_hook(test_scan_timing_fallback_to_original_publishes_retry);
+    rc |= run_with_default_tune_hook(test_scan_timing_voice_gate_phases);
+    rc |= run_with_default_tune_hook(test_scan_timing_row_voice_options_override_effective_values);
+    rc |= run_with_default_tune_hook(test_scan_timing_pending_retune_then_retry_cooldown);
     return rc;
 }
 

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -9183,9 +9183,12 @@ test_visit_limit_failed_retune_cools_down_not_capped(void) {
 
 /*
  * When the forced advance cannot land anywhere the receiver rolls back onto the row it was on.
- * The cap then re-arms rather than staying expired: a row whose alternates are all cooling down
- * must not re-decide the eviction on every tick, and the retry has to wait for the next cap
- * boundary that has somewhere to go.
+ * Two things have to hold afterwards. The cap re-arms rather than staying expired, so a row whose
+ * alternates are all cooling down does not re-decide the eviction on every tick. And the carrier
+ * stays released: the advance's rollback restores the snapshot it took before the release, call
+ * rows and VC mirrors included, so without a re-scrub the row would carry a phantom ACTIVE call
+ * that nothing ages out -- baked into its snapshot on the next ordinary departure and restored on
+ * every revisit from then on (requirement 8).
  */
 static int
 test_visit_limit_forced_advance_rollback_rearms(void) {
@@ -9202,7 +9205,11 @@ test_visit_limit_forced_advance_rollback_rearms(void) {
     }
     int test_rc = 0;
     const int parked_calls = g_counting_tune_to_cc_calls;
+    /* Following a call, exactly as a row that is about to be evicted mid-call is. */
     opts.trunk_is_tuned = 1;
+    state.p25_vc_freq[0] = 851112500;
+    state.trunk_vc_freq[0] = 851112500;
+    test_rc |= seed_active_call_row(&state, 1001U, 2002U, 0.10);
     /* The alternate's retune fails, and so does the re-park the advance falls back on. */
     g_counting_tune_to_cc_failures_remaining = 2;
 
@@ -9210,6 +9217,14 @@ test_visit_limit_forced_advance_rollback_rearms(void) {
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "forced advance rollback", 0U);
     test_rc |= expect_published_target(&state, "forced advance rollback", "a", 1U, 2U);
+    /* The receiver never left, but the carrier was handed back before the first attempt: the
+     * rollback must not resurrect it. */
+    test_rc |= expect_no_active_call_row(&state, "forced advance rollback");
+    test_rc |= expect_vc_mirrors_clear(&state, "forced advance rollback");
+    if (opts.trunk_is_tuned != 0) {
+        DSD_FPRINTF(stderr, "forced advance rollback left trunk_is_tuned=%d\n", opts.trunk_is_tuned);
+        test_rc = 1;
+    }
     if (g_counting_tune_to_cc_calls != parked_calls + 2) {
         DSD_FPRINTF(stderr, "forced advance made %d attempts, want %d\n", g_counting_tune_to_cc_calls - parked_calls,
                     2);
@@ -9234,15 +9249,33 @@ test_visit_limit_forced_advance_rollback_rearms(void) {
         }
     }
 
+    /* An ordinary departure now, once the alternates are out of their cooldown: the operator's
+     * advance carries no forced release, so it saves whatever the rolled-back row is holding into
+     * that row's snapshot. This is the path a phantom call would become permanent on. */
+    opts.trunk_is_tuned = 0;
+    trunk_scan_test_set_now(3.05);
+    test_rc |= expect_control_rc("ordinary advance after the rollback",
+                                 dsd_engine_trunk_scan_control(&opts, &state, DSD_TRUNK_SCAN_CONTROL_ADVANCE), 0);
+    test_rc |= expect_active_target(&state, "ordinary advance after the rollback", 1U);
+
+    /* Row b's own idle dwell brings the rotation back to a, restoring that snapshot. */
+    trunk_scan_test_set_now(3.31);
+    dsd_engine_trunk_scan_tick(&opts, &state);
+    test_rc |= expect_active_target(&state, "revisit after the rollback", 0U);
+    test_rc |= expect_no_active_call_row(&state, "revisit after the rollback");
+    test_rc |= expect_vc_mirrors_clear(&state, "revisit after the rollback");
+
     /* 2.02 crossed the re-armed cap but the alternate was still cooling down, so it only re-armed
-     * again; the first boundary with an eligible alternate is the one that moves the receiver. */
+     * again. The cap still owns the revisit: one boundary later, with somewhere to go, it evicts
+     * with exactly one retune attempt. */
+    const int revisit_calls = g_counting_tune_to_cc_calls;
     opts.trunk_is_tuned = 1;
-    trunk_scan_test_set_now(3.03);
+    trunk_scan_test_set_now(4.32);
     dsd_engine_trunk_scan_tick(&opts, &state);
     test_rc |= expect_active_target(&state, "eviction once the alternate is eligible", 1U);
-    if (g_counting_tune_to_cc_calls != rollback_calls + 1) {
-        DSD_FPRINTF(stderr, "eviction after the cooldown made %d attempts, want 1\n",
-                    g_counting_tune_to_cc_calls - rollback_calls);
+    if (g_counting_tune_to_cc_calls != revisit_calls + 1) {
+        DSD_FPRINTF(stderr, "eviction after the revisit made %d attempts, want 1\n",
+                    g_counting_tune_to_cc_calls - revisit_calls);
         test_rc = 1;
     }
 

--- a/tests/engine/test_engine_trunk_scan.c
+++ b/tests/engine/test_engine_trunk_scan.c
@@ -8704,12 +8704,11 @@ test_visit_limit_single_target_does_not_spin(void) {
     static dsd_opts opts;
     static dsd_state state;
 
-    /* Every mark 1.01 s past the previous re-arm crosses the cap again; the deadline walks
-     * forward by one limit each time and the tuner is never asked to move. */
-    static const struct {
-        double now_m;
-        double deadline_m;
-    } marks[] = {{1.01, 2.01}, {1.5, 2.01}, {2.02, 3.02}, {3.03, 4.03}, {4.04, 5.04}};
+    /* Every mark 1.01 s past the previous re-arm crosses the cap again, and the tuner is never
+     * asked to move. The publication abstains throughout rather than counting down to a deadline
+     * that cannot fire: with nowhere to go a frontend would otherwise draw a sawtooth countdown
+     * that resets at every boundary. The effective limit stays on screen. */
+    static const double marks[] = {1.01, 1.5, 2.02, 3.03, 4.04};
 
     if (scan_visit_init(NULL, "a,p25-trunk,851000000,,250,,\n", 1000, &opts, &state, dir, sizeof dir, target_path,
                         sizeof target_path)
@@ -8732,10 +8731,10 @@ test_visit_limit_single_target_does_not_spin(void) {
         return 1;
     }
     for (size_t i = 0; i < sizeof marks / sizeof marks[0]; i++) {
-        trunk_scan_test_set_now(marks[i].now_m);
+        trunk_scan_test_set_now(marks[i]);
         dsd_engine_trunk_scan_tick(&opts, &state);
         test_rc |= expect_active_target(&state, "single target past the cap", 0U);
-        test_rc |= expect_scan_visit(&state, "single target past the cap", 1000U, marks[i].deadline_m);
+        test_rc |= expect_scan_visit(&state, "single target past the cap", 1000U, -1.0);
         if (g_counting_tune_to_cc_calls != parked_calls) {
             DSD_FPRINTF(stderr, "single target cap retuned: calls=%d, want %d\n", g_counting_tune_to_cc_calls,
                         parked_calls);
@@ -8783,10 +8782,10 @@ test_visit_limit_single_target_does_not_spin(void) {
     const int avoided_calls = g_counting_tune_to_cc_calls;
     opts.trunk_is_tuned = 1;
     for (size_t i = 0; i < sizeof marks / sizeof marks[0]; i++) {
-        trunk_scan_test_set_now(marks[i].now_m);
+        trunk_scan_test_set_now(marks[i]);
         dsd_engine_trunk_scan_tick(&opts, &state);
         test_rc |= expect_active_target(&state, "avoided alternate past the cap", 0U);
-        test_rc |= expect_scan_visit(&state, "avoided alternate past the cap", 1000U, marks[i].deadline_m);
+        test_rc |= expect_scan_visit(&state, "avoided alternate past the cap", 1000U, -1.0);
         if (g_counting_tune_to_cc_calls != avoided_calls) {
             DSD_FPRINTF(stderr, "avoided alternate cap retuned: calls=%d, want %d\n", g_counting_tune_to_cc_calls,
                         avoided_calls);
@@ -9231,8 +9230,11 @@ test_visit_limit_forced_advance_rollback_rearms(void) {
         test_rc = 1;
     }
     test_rc |= expect_scan_timing(&state, "forced advance rollback", DSD_SCAN_STAY_RETUNE_RETRY, 3.01, 250U, 0U);
-    /* Re-armed from the failed eviction, so the next boundary is one full limit out. */
-    test_rc |= expect_scan_visit(&state, "forced advance rollback", 1000U, 2.01);
+    /* The anchor is re-armed from the failed eviction, but every alternate is cooling down from it,
+     * so there is nothing the cap could advance to: the publication abstains until one of them is
+     * eligible again rather than showing a countdown that cannot fire. The quiet marks below are
+     * what pin the re-arm -- no second eviction attempt on any tick past the old boundary. */
+    test_rc |= expect_scan_visit(&state, "forced advance rollback", 1000U, -1.0);
 
     const int rollback_calls = g_counting_tune_to_cc_calls;
     static const double quiet_marks[] = {1.5, 1.99, 2.02};

--- a/tests/protocol/dmr/test_dmr_t3_sm_release.c
+++ b/tests/protocol/dmr/test_dmr_t3_sm_release.c
@@ -159,6 +159,27 @@ main(int argc, char** argv) {
     assert(opts.trunk_is_tuned == 0);
     assert(ctx->state == DMR_SM_ON_CC);
 
+    // Abandoning the carrier (#507) is the same teardown minus the return-to-CC tune: the
+    // caller owns the tuner and is already moving it, so the SM must come to rest on the
+    // control channel without asking the tuner for anything.
+    dmr_sm_emit_group_grant(&opts, &state, vc, 0, 100, 1234);
+    assert(opts.trunk_is_tuned == 1);
+    assert(ctx->state == DMR_SM_TUNED);
+    dmr_sm_emit_voice_sync(&opts, &state, 0);
+    assert(ctx->slots[0].voice_active == 1);
+
+    g_return_to_cc_calls = 0;
+    state.trunk_sm_force_release = 1;
+    dmr_sm_abandon_carrier(ctx, &opts, &state, "scan-visit-limit");
+    assert(g_return_to_cc_calls == 0);
+    assert(state.trunk_sm_force_release == 0);
+    assert(opts.trunk_is_tuned == 0);
+    assert(state.trunk_vc_freq[0] == 0);
+    assert(state.trunk_vc_freq[1] == 0);
+    assert(ctx->vc_freq_hz == 0);
+    assert(ctx->slots[0].voice_active == 0);
+    assert(ctx->state == DMR_SM_ON_CC);
+
     printf("DMR_T3_SM_RELEASE: OK\n");
     return 0;
 }

--- a/tests/protocol/p25/test_p25_p1_trunk_sm.c
+++ b/tests/protocol/p25/test_p25_p1_trunk_sm.c
@@ -10,6 +10,7 @@
  * and next-CC iteration behavior.
  */
 
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/protocol/p25/p25_cc_candidates.h>
@@ -30,12 +31,16 @@
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #endif
 
+static int g_tune_requests = 0;
+static int g_return_requests = 0;
+
 static dsd_trunk_tune_result
 test_tune_request(dsd_opts* opts, dsd_state* state, long int freq, int ted_sps, uint64_t request_id) {
     (void)opts;
     (void)state;
     (void)ted_sps;
     (void)request_id;
+    g_tune_requests++;
     return freq > 0 ? DSD_TRUNK_TUNE_RESULT_OK : DSD_TRUNK_TUNE_RESULT_FAILED;
 }
 
@@ -44,6 +49,7 @@ test_return_request(dsd_opts* opts, dsd_state* state, uint64_t request_id) {
     (void)opts;
     (void)state;
     (void)request_id;
+    g_return_requests++;
     return DSD_TRUNK_TUNE_RESULT_OK;
 }
 
@@ -155,6 +161,34 @@ main(int argc, char** argv) {
     p25_sm_release(p25_sm_get_ctx(), &opts, &state, "explicit-release");
     rc |= expect_eq("release_count", state.p25_sm_release_count, 1);
     rc |= expect_eq("cc_return_count", state.p25_sm_cc_return_count, 1);
+
+    // Abandoning the carrier (#507) is the same teardown minus the return-to-CC tune: the
+    // caller owns the tuner and is already moving it somewhere else, so the SM must come to
+    // rest on the control channel without asking for a single tune of its own.
+    // A decoded control-channel message after the return ends the CC acquisition the release
+    // started; without it the next grant is deferred rather than tuned.
+    state.p25_last_cc_msg_time_m = dsd_time_now_monotonic_s();
+    int channel2 = (iden << 12) | 0x0003;
+    p25_sm_event(p25_sm_get_ctx(), &opts, &state,
+                 &(p25_sm_event_t){.type = P25_SM_EV_GRANT,
+                                   .slot = -1,
+                                   .channel = channel2,
+                                   .tg = 4321,
+                                   .src = 8765,
+                                   .svc_bits = svc,
+                                   .is_group = 1});
+    rc |= expect_eq("tune_count after regrant", state.p25_sm_tune_count, 2);
+    const int tunes_before_abandon = g_tune_requests;
+    const int returns_before_abandon = g_return_requests;
+    p25_sm_abandon_carrier(p25_sm_get_ctx(), &opts, &state, "scan-visit-limit");
+    rc |= expect_eq("abandon issued no tune", g_tune_requests, tunes_before_abandon);
+    rc |= expect_eq("abandon issued no cc return", g_return_requests, returns_before_abandon);
+    rc |= expect_eq("abandon release_count", state.p25_sm_release_count, 2);
+    rc |= expect_eq("abandon cc_return_count", state.p25_sm_cc_return_count, 2);
+    rc |= expect_eq("abandon vc freq", state.p25_vc_freq[0], 0);
+    rc |= expect_eq("abandon trunk vc freq", state.trunk_vc_freq[0], 0);
+    rc |= expect_eq("abandon trunk_is_tuned", opts.trunk_is_tuned, 0);
+    rc |= expect_eq("abandon sm state", p25_sm_get_state(p25_sm_get_ctx()), P25_SM_ON_CC);
 
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});
     return rc;

--- a/tests/protocol/p25/test_p25_p2_release_partial_audio.c
+++ b/tests/protocol/p25/test_p25_p2_release_partial_audio.c
@@ -14,6 +14,7 @@
  */
 
 #include <dsd-neo/core/call_state.h>
+#include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/opts.h>
 #include <dsd-neo/core/state.h>
 #include <dsd-neo/core/state_ext.h>
@@ -118,6 +119,7 @@ void
 dsd_p25p2_flush_partial_audio(dsd_opts* opts, dsd_state* state) {
     (void)opts;
     g_p25p2_flush_called++;
+    record_end_order('F');
     if (!state) {
         return;
     }
@@ -239,6 +241,36 @@ main(void) {
     rc |= expect_eq_int("s_r4 cleared", st.s_r4[0][0], 0);
     rc |= expect_eq_int("voice_counter[0] reset", st.voice_counter[0], 0);
     rc |= expect_eq_int("voice_counter[1] reset", st.voice_counter[1], 0);
+
+    // A capped departure flushes before ending the call, without tuning back to the CC.
+    st.p25_last_cc_msg_time_m = dsd_time_now_monotonic_s();
+    p25_sm_event(p25_sm_get_ctx(), &opts, &st,
+                 &(p25_sm_event_t){.type = P25_SM_EV_GRANT,
+                                   .slot = -1,
+                                   .channel = ch_tdma + 2,
+                                   .tg = 4321,
+                                   .src = 8765,
+                                   .svc_bits = 0,
+                                   .is_group = 1});
+    rc |= expect_eq_int("capped PTT accepted", p25_sm_emit_ptt_call(&opts, &st, 0, 4321, 0, 8765, 1, 0), 1);
+    st.s_l4[0][0] = 123;
+    st.s_r4[0][0] = -456;
+    st.voice_counter[0] = 1;
+    st.voice_counter[1] = 1;
+    g_p25p2_flush_called = 0;
+    g_return_to_cc_called = 0;
+    g_end_order_len = 0U;
+    g_end_order[0] = '\0';
+    g_track_end_order = 1;
+    p25_sm_abandon_carrier(p25_sm_get_ctx(), &opts, &st, "scan-visit-limit");
+    g_track_end_order = 0;
+    rc |= expect_eq_int("cap flushes partial audio", g_p25p2_flush_called, 1);
+    rc |= expect_eq_int("cap flush precedes call end", strcmp(g_end_order, "FE"), 0);
+    rc |= expect_eq_int("cap does not return to CC", g_return_to_cc_called, 0);
+    rc |= expect_eq_int("cap clears left audio", st.s_l4[0][0], 0);
+    rc |= expect_eq_int("cap clears right audio", st.s_r4[0][0], 0);
+    p25_sm_abandon_carrier(p25_sm_get_ctx(), &opts, &st, "idle-visit-limit");
+    rc |= expect_eq_int("idle cap does not flush again", g_p25p2_flush_called, 1);
 
     dsd_p25_optional_hooks_set((dsd_p25_optional_hooks){0});
     dsd_trunk_tuning_hooks_set((dsd_trunk_tuning_hooks){0});

--- a/tests/runtime/test_config_profile.cpp
+++ b/tests/runtime/test_config_profile.cpp
@@ -649,6 +649,39 @@ test_profile_inherits_scan_voice_qualify_ms(void) {
 }
 
 static int
+test_profile_inherits_scan_max_visit_ms(void) {
+    static const char* ini = "[trunking]\n"
+                             "scan_max_visit_ms = 20000\n"
+                             "\n"
+                             "[profile.scan_cap]\n"
+                             "mode.decode = \"dmr\"\n";
+
+    char path[DSD_TEST_PATH_MAX];
+    if (write_temp_config(ini, path, sizeof path) != 0) {
+        return 1;
+    }
+
+    dsdneoUserConfig cfg;
+    DSD_MEMSET(&cfg, 0, sizeof(cfg));
+
+    int rc = dsd_user_config_load_profile(path, "scan_cap", &cfg);
+
+    int result = 0;
+    if (rc != 0) {
+        DSD_FPRINTF(stderr, "FAIL: load with scan_cap profile failed (rc=%d)\n", rc);
+        result = 1;
+    }
+    if (cfg.trunk_scan_max_visit_ms != 20000) {
+        DSD_FPRINTF(stderr, "FAIL: expected profile to inherit scan_max_visit_ms 20000, got %d\n",
+                    cfg.trunk_scan_max_visit_ms);
+        result = 1;
+    }
+
+    (void)remove(path);
+    return result;
+}
+
+static int
 test_profile_soapy_settings(void) {
     static const char* ini = "[input]\n"
                              "source = \"pulse\"\n"
@@ -1118,6 +1151,7 @@ main(void) {
     rc |= test_profile_rtl_settings();
     rc |= test_profile_invalid_int_preserves_inherited_value();
     rc |= test_profile_inherits_scan_voice_qualify_ms();
+    rc |= test_profile_inherits_scan_max_visit_ms();
     rc |= test_profile_soapy_settings();
     rc |= test_include_directive();
     rc |= test_include_override();

--- a/tests/runtime/test_config_template.cpp
+++ b/tests/runtime/test_config_template.cpp
@@ -195,6 +195,12 @@ test_template_contains_keys(void) {
         DSD_FPRINTF(stderr, "FAIL: template missing scan_voice_hold_ms range hint or default\n");
         rc = 1;
     }
+    /* The cap's schema minimum is 0, not its 1000 ms floor: the writer always emits the key,
+     * so a minimum of 1000 would make the generated template contradict its own default. */
+    if (!strstr(content, "# Range: 0 to 3600000\n# scan_max_visit_ms = 0\n")) {
+        DSD_FPRINTF(stderr, "FAIL: template missing scan_max_visit_ms range hint or default\n");
+        rc = 1;
+    }
     if (strstr(content, "version =") != NULL) {
         DSD_FPRINTF(stderr, "FAIL: template must not emit the persisted version marker\n");
         rc = 1;

--- a/tests/runtime/test_config_validation.cpp
+++ b/tests/runtime/test_config_validation.cpp
@@ -1196,6 +1196,61 @@ test_scan_voice_ms_out_of_range(void) {
     return rc;
 }
 
+/* The loader is deliberately range-free, so a 1..999 cap - a value the engine treats as
+ * disabled - is only caught here. It is a WARNING, not an error: the rest of the config still
+ * loads, matching how an unknown key is treated. */
+static int
+run_scan_max_visit_ms_case(const char* ini, int expect_warning) {
+    char path[DSD_TEST_PATH_MAX];
+    if (write_temp_config(ini, path, sizeof path) != 0) {
+        return 1;
+    }
+
+    dsdcfg_diagnostics_t diags;
+    DSD_MEMSET(&diags, 0, sizeof(diags));
+    (void)dsd_user_config_validate(path, &diags);
+
+    int result = 0;
+    int found = 0;
+    for (int i = 0; i < diags.count; i++) {
+        if (diags.items[i].level == DSDCFG_DIAG_WARNING && strstr(diags.items[i].key, "scan_max_visit_ms")) {
+            found++;
+        }
+    }
+    if (expect_warning && found == 0) {
+        DSD_FPRINTF(stderr, "FAIL: expected a scan_max_visit_ms warning for:\n%s", ini);
+        result = 1;
+    }
+    if (!expect_warning && found != 0) {
+        DSD_FPRINTF(stderr, "FAIL: unexpected %d scan_max_visit_ms warning(s) for:\n%s", found, ini);
+        result = 1;
+    }
+    if (diags.error_count != 0) {
+        DSD_FPRINTF(stderr, "FAIL: scan_max_visit_ms case reported %d error(s) for:\n%s", diags.error_count, ini);
+        result = 1;
+    }
+
+    dsdcfg_diags_free(&diags);
+    (void)remove(path);
+    return result;
+}
+
+static int
+test_scan_max_visit_ms_validation(void) {
+    int rc = 0;
+    /* Below the 1000 ms floor: inside the schema window (min 0) but ignored by the engine. */
+    rc |= run_scan_max_visit_ms_case("[trunking]\nscan_max_visit_ms = 500\n", 1);
+    /* Above the ceiling: the schema walk warns. */
+    rc |= run_scan_max_visit_ms_case("[trunking]\nscan_max_visit_ms = 3600001\n", 1);
+    /* 0 disables the cap, and both bounds of the accepted window are silent. */
+    rc |= run_scan_max_visit_ms_case("[trunking]\nscan_max_visit_ms = 0\n", 0);
+    rc |= run_scan_max_visit_ms_case("[trunking]\nscan_max_visit_ms = 1000\n", 0);
+    rc |= run_scan_max_visit_ms_case("[trunking]\nscan_max_visit_ms = 3600000\n", 0);
+    /* The composed rule is paired onto profiles the same way the other composed rules are. */
+    rc |= run_scan_max_visit_ms_case("[profile.cap]\ntrunking.scan_max_visit_ms = 500\n", 1);
+    return rc;
+}
+
 static int
 test_input_warn_db_double_validation(void) {
     // In-range double: no diagnostics for the key
@@ -1749,6 +1804,7 @@ main(void) {
     rc |= test_int_out_of_range();
     rc |= test_int_out_of_range_negative_max();
     rc |= test_scan_voice_ms_out_of_range();
+    rc |= test_scan_max_visit_ms_validation();
     rc |= test_input_warn_db_double_validation();
     rc |= test_dmr_lrrp_ports_validation();
     rc |= test_diags_have_line_numbers();

--- a/tests/runtime/test_runtime_cli_compact.c
+++ b/tests/runtime/test_runtime_cli_compact.c
@@ -206,6 +206,31 @@ test_scan_voice_long_opts_are_removed(void) {
     return 0;
 }
 
+/* The per-visit cap (issue #507) must leave this pre-getopt pass in BOTH spellings. A
+ * surviving bare value token looks like a positional argument to
+ * bootstrap_compacted_arg_disables_inherited_trunk_scan(), which would switch off a
+ * config-inherited trunk scan. */
+static int
+test_scan_max_visit_long_opts_are_removed(void) {
+    char arg0[] = "dsd-neo";
+    char arg1[] = "--scan-max-visit-ms";
+    char arg2[] = "20000";
+    char arg3[] = "--scan-max-visit-ms=25000";
+    char arg4[] = "-fi";
+    char* argv[] = {arg0, arg1, arg2, arg3, arg4, NULL};
+
+    int new_argc = dsd_cli_compact_args(5, argv);
+    if (new_argc != 2) {
+        DSD_FPRINTF(stderr, "expected new_argc=2, got %d\n", new_argc);
+        return 1;
+    }
+    if (argv[1] == NULL || strcmp(argv[1], "-fi") != 0) {
+        DSD_FPRINTF(stderr, "expected argv[1] to be \"-fi\", got \"%s\"\n", argv[1] ? argv[1] : "(null)");
+        return 1;
+    }
+    return 0;
+}
+
 static int
 test_dmr_debug_burst_long_option_is_removed(void) {
     char arg0[] = "dsd-neo";
@@ -578,5 +603,6 @@ main(void) {
     rc |= test_src_csv_long_opts_are_removed();
     rc |= test_p25_bandplan_long_opts_are_removed();
     rc |= test_scan_voice_long_opts_are_removed();
+    rc |= test_scan_max_visit_long_opts_are_removed();
     return rc;
 }

--- a/tests/runtime/test_runtime_cli_parse.c
+++ b/tests/runtime/test_runtime_cli_parse.c
@@ -7276,6 +7276,276 @@ test_bootstrap_inherited_scan_voice_preserves_timing_overrides(void) {
     return test_rc;
 }
 
+/* --scan-max-visit-ms (issue #507) parses in both long-option spellings and reaches dsd_opts. */
+static int
+test_scan_max_visit_long_option_parses(void) {
+    int test_rc = 0;
+    for (int shape = 0; shape < 2; shape++) {
+        dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+        dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+        if (!opts || !state) {
+            free(opts);
+            free(state);
+            return 1;
+        }
+        initOpts(opts);
+        initState(state);
+
+        char arg0[] = "dsd-neo";
+        char arg_flag[] = "--scan-max-visit-ms";
+        char arg_value[] = "20000";
+        char arg_equals[] = "--scan-max-visit-ms=20000";
+        /* Shape 0 exercises the space form, shape 1 the equals form. */
+        char* argv_space[] = {arg0, arg_flag, arg_value, NULL};
+        char* argv_equals[] = {arg0, arg_equals, NULL};
+        char** argv = (shape == 0) ? argv_space : argv_equals;
+        const int argc = (shape == 0) ? 3 : 2;
+        int argc_effective = 0;
+        /* A clean parse leaves exit_rc untouched, so seed it with the success code: a nonzero
+         * value afterwards means the parser asked for a failing exit. */
+        int exit_rc = 0;
+        int rc = dsd_parse_args(argc, argv, opts, state, &argc_effective, &exit_rc);
+
+        if (rc != DSD_PARSE_CONTINUE || exit_rc != 0 || opts->scan_max_visit_ms != 20000) {
+            DSD_FPRINTF(stderr, "shape %d: scan max visit parse mismatch rc=%d exit_rc=%d max_visit=%d\n", shape, rc,
+                        exit_rc, opts->scan_max_visit_ms);
+            test_rc = 1;
+        }
+
+        freeState(state);
+        free(opts);
+        free(state);
+    }
+    return test_rc;
+}
+
+/* 1..999 is rejected outright rather than silently ignored, so 0 stays the only way to say
+ * "no cap"; the ceiling and a missing value are refused too, and nothing lands in dsd_opts. */
+static int
+test_scan_max_visit_rejects_ms_values_outside_range(void) {
+    const char* argv_sets[][3] = {
+        {"dsd-neo", "--scan-max-visit-ms", "999"}, {"dsd-neo", "--scan-max-visit-ms=3600001", NULL},
+        {"dsd-neo", "--scan-max-visit-ms", "1"},   {"dsd-neo", "--scan-max-visit-ms=-1", NULL},
+        {"dsd-neo", "--scan-max-visit-ms", NULL},
+    };
+    const int argc_values[] = {3, 2, 3, 2, 2};
+    int test_rc = 0;
+
+    for (size_t i = 0; i < sizeof(argc_values) / sizeof(argc_values[0]); i++) {
+        dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+        dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+        if (!opts || !state) {
+            free(opts);
+            free(state);
+            return 1;
+        }
+        initOpts(opts);
+        initState(state);
+
+        char arg0[32];
+        char arg1[64];
+        char arg2[32];
+        DSD_SNPRINTF(arg0, sizeof arg0, "%s", argv_sets[i][0]);
+        DSD_SNPRINTF(arg1, sizeof arg1, "%s", argv_sets[i][1]);
+        if (argv_sets[i][2]) {
+            DSD_SNPRINTF(arg2, sizeof arg2, "%s", argv_sets[i][2]);
+        }
+        char* argv[] = {arg0, arg1, argv_sets[i][2] ? arg2 : NULL, NULL};
+
+        int argc_effective = 0;
+        int exit_rc = -1;
+        int rc = dsd_parse_args(argc_values[i], argv, opts, state, &argc_effective, &exit_rc);
+        if (rc != DSD_PARSE_ERROR || exit_rc != 1 || opts->scan_max_visit_ms != 0) {
+            DSD_FPRINTF(stderr, "expected scan-max-visit option %s to fail, got rc=%d exit_rc=%d max_visit=%d\n", arg1,
+                        rc, exit_rc, opts->scan_max_visit_ms);
+            test_rc = 1;
+        }
+
+        freeState(state);
+        free(opts);
+        free(state);
+    }
+
+    return test_rc;
+}
+
+/* 0 disables the cap and both bounds of the 1000..3600000 window parse. The space and equals
+ * handlers carry separate range constants, so every (value, form) pair is pinned. */
+static int
+test_scan_max_visit_boundary_and_off_values_parse(void) {
+    static const int wanted[] = {0, 1000, 3600000};
+    int test_rc = 0;
+
+    for (size_t i = 0; i < sizeof wanted / sizeof wanted[0]; i++) {
+        for (int equals = 0; equals < 2; equals++) {
+            dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+            dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+            if (!opts || !state) {
+                free(opts);
+                free(state);
+                return 1;
+            }
+            initOpts(opts);
+            initState(state);
+            /* Poison the field so an accepted 0 is proven to be parsed, not just the default. */
+            opts->scan_max_visit_ms = -1;
+
+            char arg0[] = "dsd-neo";
+            char arg_flag[] = "--scan-max-visit-ms";
+            char value[16];
+            char equals_form[48];
+            DSD_SNPRINTF(value, sizeof value, "%d", wanted[i]);
+            DSD_SNPRINTF(equals_form, sizeof equals_form, "--scan-max-visit-ms=%d", wanted[i]);
+            char* argv_space[] = {arg0, arg_flag, value, NULL};
+            char* argv_equals[] = {arg0, equals_form, NULL};
+            char** argv = equals ? argv_equals : argv_space;
+            const int argc = equals ? 2 : 3;
+
+            int argc_effective = 0;
+            int exit_rc = 0;
+            int rc = dsd_parse_args(argc, argv, opts, state, &argc_effective, &exit_rc);
+            if (rc != DSD_PARSE_CONTINUE || exit_rc != 0 || opts->scan_max_visit_ms != wanted[i]) {
+                DSD_FPRINTF(stderr, "%s form: expected scan-max-visit %d to parse, got rc=%d exit_rc=%d max_visit=%d\n",
+                            equals ? "equals" : "space", wanted[i], rc, exit_rc, opts->scan_max_visit_ms);
+                test_rc = 1;
+            }
+
+            freeState(state);
+            free(opts);
+            free(state);
+        }
+    }
+    return test_rc;
+}
+
+/* The cap only acts under -Y or --trunk-scan. Asking for it with neither is not an error and
+ * the value is kept, but it has to say so - the same treatment --scan-voice-only gets. */
+static int
+test_scan_max_visit_warns_without_scan_mode(void) {
+    static const char* const expected_warning = "--scan-max-visit-ms has no effect without -Y or --trunk-scan.";
+    int test_rc = 0;
+
+    for (int with_scanner = 0; with_scanner < 2; with_scanner++) {
+        dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+        dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+        if (!opts || !state) {
+            free(opts);
+            free(state);
+            return 1;
+        }
+        initOpts(opts);
+        initState(state);
+
+        char arg0[] = "dsd-neo";
+        char arg_flag[] = "--scan-max-visit-ms";
+        char arg_value[] = "5000";
+        char arg_scanner[] = "-Y";
+        char* argv_plain[] = {arg0, arg_flag, arg_value, NULL};
+        char* argv_scanner[] = {arg0, arg_flag, arg_value, arg_scanner, NULL};
+        char** argv = with_scanner ? argv_scanner : argv_plain;
+        const int argc = with_scanner ? 4 : 3;
+
+        char output[4096];
+        int argc_effective = 0;
+        int exit_rc = 0;
+        int rc = parse_args_capture_stderr(argc, argv, opts, state, &argc_effective, &exit_rc, output, sizeof(output));
+
+        if (rc != DSD_PARSE_CONTINUE || exit_rc != 0 || opts->scan_max_visit_ms != 5000) {
+            DSD_FPRINTF(stderr, "scanner=%d: expected a non-fatal cap, got rc=%d exit_rc=%d max_visit=%d\n",
+                        with_scanner, rc, exit_rc, opts->scan_max_visit_ms);
+            test_rc = 1;
+        }
+        const int warned = (strstr(output, expected_warning) != NULL) ? 1 : 0;
+        if (warned == with_scanner) {
+            DSD_FPRINTF(stderr, "scanner=%d: unexpected warning state warned=%d, stderr was \"%s\"\n", with_scanner,
+                        warned, output);
+            test_rc = 1;
+        }
+
+        freeState(state);
+        free(opts);
+        free(state);
+    }
+    return test_rc;
+}
+
+/* A config-inherited trunk scan survives a CLI cap override in both spellings: the pre-getopt
+ * compaction has to consume the flag and its value, or the bare value token reads as a
+ * positional input and the inherited trunk scan is switched off. */
+static int
+test_bootstrap_inherited_trunk_scan_preserves_max_visit_override(void) {
+    static const char* ini = "[trunk_scan]\n"
+                             "enabled = true\n"
+                             "targets_csv = \"targets.csv\"\n"
+                             "\n"
+                             "[trunking]\n"
+                             "scan_max_visit_ms = 30000\n";
+    int test_rc = 0;
+
+    for (int equals = 0; equals < 2; equals++) {
+        dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
+        dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+        if (!opts || !state) {
+            free(opts);
+            free(state);
+            DSD_FPRINTF(stderr, "out of memory\n");
+            return 1;
+        }
+
+        initOpts(opts);
+        initState(state);
+
+        (void)dsd_unsetenv("DSD_NEO_CONFIG");
+        (void)dsd_setenv("DSD_NEO_NO_BOOTSTRAP", "1", 1);
+
+        char cfg_path[1024];
+        if (test_create_temp_ini_with_contents(ini, cfg_path, sizeof cfg_path) != 0) {
+            DSD_FPRINTF(stderr, "failed to create temp max visit ini\n");
+            freeState(state);
+            free(opts);
+            free(state);
+            return 1;
+        }
+
+        char arg0[] = "dsd-neo";
+        char arg1[] = "--config";
+        char arg2[1024];
+        char arg_flag[] = "--scan-max-visit-ms";
+        char arg_value[] = "20000";
+        char arg_equals[] = "--scan-max-visit-ms=20000";
+        DSD_SNPRINTF(arg2, sizeof arg2, "%s", cfg_path);
+        char* argv_space[] = {arg0, arg1, arg2, arg_flag, arg_value, NULL};
+        char* argv_equals[] = {arg0, arg1, arg2, arg_equals, NULL};
+        char** argv = equals ? argv_equals : argv_space;
+        const int argc = equals ? 4 : 5;
+
+        int argc_effective = 0;
+        int exit_rc = -1;
+        int rc = dsd_runtime_bootstrap(argc, argv, opts, state, &argc_effective, &exit_rc);
+
+        if (rc != DSD_BOOTSTRAP_CONTINUE || exit_rc != 0) {
+            DSD_FPRINTF(stderr, "%s form: expected cap override to continue, got rc=%d exit_rc=%d\n",
+                        equals ? "equals" : "space", rc, exit_rc);
+            test_rc = 1;
+        }
+        if (opts->trunk_scan_enabled != 1 || strcmp(opts->trunk_scan_targets_csv, "targets.csv") != 0
+            || opts->scan_max_visit_ms != 20000) {
+            DSD_FPRINTF(stderr,
+                        "%s form: expected inherited trunk scan with cap 20000, got enabled=%d targets=%s "
+                        "max_visit=%d\n",
+                        equals ? "equals" : "space", opts->trunk_scan_enabled, opts->trunk_scan_targets_csv,
+                        opts->scan_max_visit_ms);
+            test_rc = 1;
+        }
+
+        (void)remove(cfg_path);
+        freeState(state);
+        free(opts);
+        free(state);
+    }
+    return test_rc;
+}
+
 static int
 test_bootstrap_config_file_rate_rescales_manual_m3_override(void) {
     dsd_opts* opts = (dsd_opts*)calloc(1, sizeof(dsd_opts));
@@ -7877,6 +8147,11 @@ main(void) {
     rc |= test_scan_voice_long_options_parse();
     rc |= test_scan_voice_rejects_ms_values_outside_range();
     rc |= test_bootstrap_inherited_scan_voice_preserves_timing_overrides();
+    rc |= test_scan_max_visit_long_option_parses();
+    rc |= test_scan_max_visit_rejects_ms_values_outside_range();
+    rc |= test_scan_max_visit_boundary_and_off_values_parse();
+    rc |= test_scan_max_visit_warns_without_scan_mode();
+    rc |= test_bootstrap_inherited_trunk_scan_preserves_max_visit_override();
     rc |= test_input_source_tcp_ipv4_roundtrip();
     rc |= test_trunk_scan_long_options_parse();
     rc |= test_trunk_scan_conflicts_with_scanner_mode();

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -16,6 +16,7 @@
 #include <dsd-neo/runtime/config.h>
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/rdio_export.h>
+#include <dsd-neo/runtime/scan_mode.h>
 #include <errno.h>
 #include <math.h>
 #include <memory>
@@ -2334,6 +2335,7 @@ test_persistence_gap_schema_rows(void) {
         {"trunking", "scan_voice_only"},
         {"trunking", "scan_voice_qualify_ms"},
         {"trunking", "scan_voice_hold_ms"},
+        {"trunking", "scan_max_visit_ms"},
     };
 
     for (size_t i = 0; i < sizeof expected / sizeof expected[0]; i++) {
@@ -2468,6 +2470,128 @@ test_scan_voice_gate_roundtrip(void) {
         return 1;
     }
     rc |= expect_contains_quiet("trunking scan voice off", rendered, "scan_voice_only = false\n");
+    return rc;
+}
+
+/*
+ * The global per-visit cap (issue #507) rides the same rails as the voice gate: INI -> cfg ->
+ * opts -> snapshot -> render. Disabled renders as an explicit 0 so a saved config pins "off"
+ * instead of inheriting whatever the previous session left in opts.
+ */
+static int
+test_scan_max_visit_roundtrip(void) {
+    static const char* ini = "[trunking]\n"
+                             "scan_max_visit_ms = 20000\n";
+
+    char path[DSD_TEST_PATH_MAX];
+    if (write_temp_config(ini, path, sizeof path) != 0) {
+        return 1;
+    }
+    dsdneoUserConfig cfg;
+    int load_rc = dsd_user_config_load(path, &cfg);
+    (void)remove(path);
+    if (load_rc != 0) {
+        DSD_FPRINTF(stderr, "scan max visit config failed to load\n");
+        return 1;
+    }
+
+    int rc = 0;
+    if (cfg.trunk_scan_max_visit_ms != 20000) {
+        DSD_FPRINTF(stderr, "FAIL: [trunking] scan_max_visit_ms did not load, got %d\n", cfg.trunk_scan_max_visit_ms);
+        rc |= 1;
+    }
+
+    static dsd_opts opts;
+    static dsd_state state;
+    reset_opts_and_state(opts, state);
+    dsd_apply_user_config_to_opts(&cfg, &opts, &state);
+    if (opts.scan_max_visit_ms != 20000) {
+        DSD_FPRINTF(stderr, "FAIL: [trunking] scan_max_visit_ms did not reach dsd_opts, got %d\n",
+                    opts.scan_max_visit_ms);
+        rc |= 1;
+    }
+
+    dsdneoUserConfig snap;
+    dsd_snapshot_opts_to_user_config(&opts, &state, &snap);
+    if (snap.trunk_scan_max_visit_ms != 20000) {
+        DSD_FPRINTF(stderr, "FAIL: snapshot dropped scan_max_visit_ms, got %d\n", snap.trunk_scan_max_visit_ms);
+        rc |= 1;
+    }
+
+    char rendered[8192];
+    if (render_config_to_buffer(&snap, rendered, sizeof rendered) != 0) {
+        return 1;
+    }
+    rc |= expect_contains_quiet("trunking scan max visit", rendered, "scan_max_visit_ms = 20000\n");
+
+    /* Disabled must round-trip as an explicit 0, not as an omitted key. */
+    reset_opts_and_state(opts, state);
+    dsdneoUserConfig off_snap;
+    dsd_snapshot_opts_to_user_config(&opts, &state, &off_snap);
+    if (render_config_to_buffer(&off_snap, rendered, sizeof rendered) != 0) {
+        return 1;
+    }
+    rc |= expect_contains_quiet("trunking scan max visit off", rendered, "scan_max_visit_ms = 0\n");
+    return rc;
+}
+
+/*
+ * A parked row's own --scan-max-visit-ms is effective state, not a user default. The save path
+ * has to read the configured baseline through dsd_scan_mode_configured_view(), or a
+ * Config->Save taken while a row override is active would pin the row's value for every
+ * future session.
+ */
+static int
+test_scan_max_visit_snapshot_uses_configured_not_row_override(void) {
+    auto opts_storage = std::unique_ptr<dsd_opts>(new dsd_opts{});
+    auto state_storage = std::unique_ptr<dsd_state>(new dsd_state{});
+    dsd_opts& opts = *opts_storage;
+    dsd_state& state = *state_storage;
+    reset_opts_and_state(opts, state);
+    opts.scan_max_visit_ms = 20000; /* the configured global */
+
+    if (dsd_scan_mode_begin(&opts, &state) != 0 || dsd_scan_mode_enter(&opts, &state, DSD_SCAN_MODE_INHERIT) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: could not open a scan scope\n");
+        return 1;
+    }
+
+    int rc = 0;
+    dsd_scan_option_values row;
+    DSD_MEMSET(&row, 0, sizeof row);
+    row.present = DSD_SCAN_OPT_MAX_VISIT;
+    row.max_visit_ms = 5000;
+    if (dsd_scan_mode_options(&opts, &state, &row) != 0) {
+        DSD_FPRINTF(stderr, "FAIL: could not install the row cap override\n");
+        dsd_scan_mode_leave(&opts, &state);
+        return 1;
+    }
+    if (opts.scan_max_visit_ms != 5000) {
+        DSD_FPRINTF(stderr, "FAIL: row cap override did not reach dsd_opts, got %d\n", opts.scan_max_visit_ms);
+        rc |= 1;
+    }
+
+    dsdneoUserConfig snap;
+    dsd_snapshot_opts_to_user_config(&opts, &state, &snap);
+    if (snap.trunk_scan_max_visit_ms != 20000) {
+        DSD_FPRINTF(stderr, "FAIL: snapshot saved the row cap instead of the configured one, got %d\n",
+                    snap.trunk_scan_max_visit_ms);
+        rc |= 1;
+    }
+
+    char rendered[8192];
+    if (render_config_to_buffer(&snap, rendered, sizeof rendered) != 0) {
+        dsd_scan_mode_leave(&opts, &state);
+        return 1;
+    }
+    rc |= expect_contains_quiet("trunking configured scan max visit", rendered, "scan_max_visit_ms = 20000\n");
+    rc |= expect_absent_quiet("trunking row scan max visit", rendered, "scan_max_visit_ms = 5000\n");
+
+    dsd_scan_mode_leave(&opts, &state);
+    if (opts.scan_max_visit_ms != 20000) {
+        DSD_FPRINTF(stderr, "FAIL: leaving the scope did not restore the configured cap, got %d\n",
+                    opts.scan_max_visit_ms);
+        rc |= 1;
+    }
     return rc;
 }
 
@@ -3054,6 +3178,8 @@ main(void) {
     rc |= test_dmr_lrrp_ports_bad_entries_are_skipped();
     rc |= test_scanner_and_candidates_roundtrip();
     rc |= test_scan_voice_gate_roundtrip();
+    rc |= test_scan_max_visit_roundtrip();
+    rc |= test_scan_max_visit_snapshot_uses_configured_not_row_override();
     rc |= test_src_csv_roundtrip();
     rc |= test_p25_bandplan_csv_roundtrip();
     rc |= test_edacs_variant_roundtrip();

--- a/tests/runtime/test_runtime_config_user.cpp
+++ b/tests/runtime/test_runtime_config_user.cpp
@@ -17,6 +17,7 @@
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/rdio_export.h>
 #include <dsd-neo/runtime/scan_mode.h>
+#include <dsd-neo/runtime/scan_options.h>
 #include <errno.h>
 #include <math.h>
 #include <memory>

--- a/tests/runtime/test_runtime_scan_mode.c
+++ b/tests/runtime/test_runtime_scan_mode.c
@@ -131,9 +131,85 @@ test_row_option_edits_are_not_acquisition_changes(void) {
     free(o);
 }
 
+/* The per-visit cap (issue #507) is a row-scoped override: it reaches dsd_opts so the
+ * scanner sees it, never the configured baseline a save would persist, and it can never
+ * restage the parked tune. */
+static void
+test_max_visit_row_override_scope(void) {
+    dsd_opts* o = (dsd_opts*)calloc(1, sizeof(*o));
+    dsd_state* s = (dsd_state*)calloc(1, sizeof(*s));
+    assert(o && s);
+    o->wav_sample_rate = 48000;
+    o->audio_in_type = AUDIO_IN_WAV;
+    o->frame_dmr = 1;
+    o->scan_max_visit_ms = 45000; /* the configured global */
+    assert(dsd_scan_mode_begin(o, s) == 0);
+    assert(dsd_scan_mode_enter(o, s, DSD_SCAN_MODE_DMR) == 0);
+    assert(o->scan_max_visit_ms == 45000);
+
+    dsd_scan_option_values row = {0};
+    row.present = DSD_SCAN_OPT_MAX_VISIT;
+    row.max_visit_ms = 5000;
+    assert(dsd_scan_mode_options(o, s, &row) == 0);
+    assert(o->scan_max_visit_ms == 5000);
+    const dsd_scan_settings* configured = dsd_scan_mode_configured_view(s);
+    assert(configured && configured->scan_max_visit_ms == 45000);
+
+    /* A row value is policy, not acquisition: changing it must not restage the tune. */
+    dsd_scan_settings before;
+    dsd_scan_settings_capture(o, s, &before);
+    row.max_visit_ms = 7000;
+    assert(dsd_scan_mode_options(o, s, &row) == 0);
+    assert(o->scan_max_visit_ms == 7000);
+    dsd_scan_settings after;
+    dsd_scan_settings_capture(o, s, &after);
+    assert(dsd_scan_settings_equal(&before, &after, 1));
+
+    /* An explicit row 0 disables the cap for that row even though the global is set. */
+    row.max_visit_ms = 0;
+    assert(dsd_scan_mode_options(o, s, &row) == 0);
+    assert(o->scan_max_visit_ms == 0);
+    /* A row without the bit inherits the global again, as does clearing the row options. */
+    row.present = 0;
+    assert(dsd_scan_mode_options(o, s, &row) == 0);
+    assert(o->scan_max_visit_ms == 45000);
+    row.present = DSD_SCAN_OPT_MAX_VISIT;
+    row.max_visit_ms = 5000;
+    assert(dsd_scan_mode_options(o, s, &row) == 0);
+    assert(o->scan_max_visit_ms == 5000);
+    assert(dsd_scan_mode_options(o, s, NULL) == 0);
+    assert(o->scan_max_visit_ms == 45000);
+
+    /* An operator edit beneath the row survives the row override, and leaving the scope
+     * restores the configured global. */
+    assert(dsd_scan_mode_options(o, s, &row) == 0);
+    assert(dsd_scan_mode_suspend(o, s));
+    assert(o->scan_max_visit_ms == 45000);
+    o->scan_max_visit_ms = 60000;
+    assert(dsd_scan_mode_resume(o, s) == 0);
+    assert(o->scan_max_visit_ms == 5000);
+    assert(dsd_scan_mode_configured_view(s)->scan_max_visit_ms == 60000);
+
+    /* A row update installed while the scope is suspended is recorded and takes effect at
+     * resume, which restores the new row value rather than the pre-suspend one. */
+    assert(dsd_scan_mode_suspend(o, s));
+    assert(o->scan_max_visit_ms == 60000);
+    row.max_visit_ms = 9000;
+    assert(dsd_scan_mode_options(o, s, &row) == 0);
+    assert(o->scan_max_visit_ms == 60000);
+    assert(dsd_scan_mode_resume(o, s) == 0);
+    assert(o->scan_max_visit_ms == 9000);
+    dsd_scan_mode_leave(o, s);
+    assert(o->scan_max_visit_ms == 60000);
+    dsd_state_ext_free_all(s);
+    free(s);
+    free(o);
+}
+
 int
 main(void) {
     test_row_option_edits_are_not_acquisition_changes();
+    test_max_visit_row_override_scope();
     dsd_opts* o = (dsd_opts*)calloc(1, sizeof(*o));
     dsd_state* s = (dsd_state*)calloc(1, sizeof(*s));
     dsd_state* copy = (dsd_state*)calloc(1, sizeof(*copy));

--- a/tests/runtime/test_runtime_scan_options.c
+++ b/tests/runtime/test_runtime_scan_options.c
@@ -95,6 +95,26 @@ main(void) {
            == 0);
     assert(parsed.values.present == (DSD_SCAN_OPT_DATA | DSD_SCAN_OPT_ENC));
     assert(parsed.values.tune_data_calls == 0 && parsed.values.tune_enc_calls == 1);
+    /* The per-visit cap (issue #507) is accepted on every trunk-scan target type: trunked
+     * rows (conventional = 0) as well as conventional and untyped ones. */
+    assert(dsd_scan_options_parse("--scan-max-visit-ms 20000", DSD_SCAN_MODE_P25, 0, &parsed, error, sizeof(error))
+           == 0);
+    assert(parsed.values.present == DSD_SCAN_OPT_MAX_VISIT && parsed.values.max_visit_ms == 20000);
+    assert(dsd_scan_options_parse("--scan-max-visit-ms 20000", DSD_SCAN_MODE_DMR, 1, &parsed, error, sizeof(error))
+           == 0);
+    assert(parsed.values.present == DSD_SCAN_OPT_MAX_VISIT && parsed.values.max_visit_ms == 20000);
+    assert(dsd_scan_options_parse("--scan-max-visit-ms 20000", DSD_SCAN_MODE_INHERIT, 1, &parsed, error, sizeof(error))
+           == 0);
+    assert(parsed.values.present == DSD_SCAN_OPT_MAX_VISIT && parsed.values.max_visit_ms == 20000);
+    /* 0 disables the cap for that row alone, and both bounds are stored verbatim. */
+    assert(dsd_scan_options_parse("--scan-max-visit-ms 0", DSD_SCAN_MODE_P25, 0, &parsed, error, sizeof(error)) == 0);
+    assert(parsed.values.present == DSD_SCAN_OPT_MAX_VISIT && parsed.values.max_visit_ms == 0);
+    assert(dsd_scan_options_parse("--scan-max-visit-ms=1000", DSD_SCAN_MODE_P25, 0, &parsed, error, sizeof(error))
+           == 0);
+    assert(parsed.values.present == DSD_SCAN_OPT_MAX_VISIT && parsed.values.max_visit_ms == 1000);
+    assert(dsd_scan_options_parse("--scan-max-visit-ms 3600000", DSD_SCAN_MODE_P25, 0, &parsed, error, sizeof(error))
+           == 0);
+    assert(parsed.values.present == DSD_SCAN_OPT_MAX_VISIT && parsed.values.max_visit_ms == 3600000);
 
     const struct {
         const char* text;
@@ -130,6 +150,13 @@ main(void) {
                    {"--scan-voice-hold-ms 4000", DSD_SCAN_MODE_P25, 0},
                    {"--scan-voice-hold-ms 99", DSD_SCAN_MODE_DMR, 1},
                    {"--scan-voice-qualify-ms 600001", DSD_SCAN_MODE_DMR, 1},
+                   {"--scan-max-visit-ms 999", DSD_SCAN_MODE_DMR, 1},
+                   {"--scan-max-visit-ms 1", DSD_SCAN_MODE_P25, 0},
+                   {"--scan-max-visit-ms 3600001", DSD_SCAN_MODE_DMR, 1},
+                   {"--scan-max-visit-ms -1", DSD_SCAN_MODE_DMR, 1},
+                   {"--scan-max-visit-ms", DSD_SCAN_MODE_DMR, 1},
+                   {"--scan-max-visit-ms 2000 --scan-max-visit-ms 3000", DSD_SCAN_MODE_DMR, 1},
+                   {"--scan-max-visit-ms 20x", DSD_SCAN_MODE_DMR, 1},
                    {"-G 'unterminated", DSD_SCAN_MODE_DMR, 1},
                    {"-G", DSD_SCAN_MODE_DMR, 1},
                    {"-G ''", DSD_SCAN_MODE_DMR, 1},

--- a/tests/ui/qml/tst_monitor_scan_target.qml
+++ b/tests/ui/qml/tst_monitor_scan_target.qml
@@ -35,6 +35,9 @@ Item {
             testContext.setMetric("scanDwellState", 0);
             testContext.setMetric("scanHoldMs", 0);
             testContext.setMetric("scanHangMs", 0);
+            testContext.setMetric("scanVisitMs", 0);
+            testContext.setMetric("scanVisitLive", false);
+            testContext.setMetric("scanVisitRemainingDs", 0);
         }
 
         function test_target_rotation_and_hold() {
@@ -80,6 +83,18 @@ Item {
             testContext.setMetric("scanDwellState", 3);
             testContext.setMetric("scanHangMs", 0);
             tryCompare(row, "text", "Manual hold  dwell 3.0s (paused)");
+            // The per-visit cap (issue #507) closes the row, in the same grammar: two
+            // spaces before it, one decimal place, and the word `paused` where a hold has
+            // suspended the cap rather than a countdown that would read as expiry.
+            testContext.setMetric("scanVisitMs", 20000);
+            testContext.setMetric("scanVisitLive", false);
+            tryCompare(row, "text", "Manual hold  dwell 3.0s (paused)  Visit: paused");
+            testContext.setMetric("scanVisitLive", true);
+            testContext.setMetric("scanVisitRemainingDs", 123);
+            tryCompare(row, "text", "Manual hold  dwell 3.0s (paused)  Visit: 12.3s/20.0s");
+            // No cap in force: the view withholds the width, so the row closes as before.
+            testContext.setMetric("scanVisitMs", 0);
+            tryCompare(row, "text", "Manual hold  dwell 3.0s (paused)");
             cleanup();
             tryCompare(row, "visible", false);
         }
@@ -104,6 +119,9 @@ Item {
             testContext.setMetric("scanDwellState", 2);
             testContext.setMetric("scanHoldMs", 600000);
             testContext.setMetric("scanHangMs", 600000);
+            testContext.setMetric("scanVisitMs", 3600000);
+            testContext.setMetric("scanVisitLive", true);
+            testContext.setMetric("scanVisitRemainingDs", 35999);
             testContext.setMetric("scanTimingVisible", true);
             waitForRendering(screen);
             var names = ["runningSiteChooserButton", "openSpectrumButton", "monitorLiveStatus", "monitorHeaderTitle", "scanTimingRow"];

--- a/tests/ui/qml/tst_monitor_scan_target.qml
+++ b/tests/ui/qml/tst_monitor_scan_target.qml
@@ -25,6 +25,16 @@ Item {
             testContext.setMetric("scanTargetOrdinal", 0);
             testContext.setMetric("scanTargetCount", 0);
             testContext.setMetric("scanHold", false);
+            testContext.setMetric("scanTimingVisible", false);
+            testContext.setMetric("scanStayReason", 0);
+            testContext.setMetric("scanStayPhrase", "");
+            testContext.setMetric("scanTimerLive", false);
+            testContext.setMetric("scanTimerRemainingDs", 0);
+            testContext.setMetric("scanTimerSpanMs", 0);
+            testContext.setMetric("scanDwellMs", 0);
+            testContext.setMetric("scanDwellState", 0);
+            testContext.setMetric("scanHoldMs", 0);
+            testContext.setMetric("scanHangMs", 0);
         }
 
         function test_target_rotation_and_hold() {
@@ -40,6 +50,40 @@ Item {
             tryCompare(header, "text", "");
         }
 
+        // Mirrors the terminal's Scan Timing grammar (issue #508): one space before
+        // the countdown, two between groups, seconds to one decimal place.
+        function test_scan_timing_row() {
+            var row = findChild(screen, "scanTimingRow");
+            verify(row !== null, "the monitor carries a scan timing row");
+            verify(!row.visible, "nothing published: the row stays down");
+            testContext.setMetric("scanStayPhrase", "Idle dwell");
+            testContext.setMetric("scanTimerLive", true);
+            testContext.setMetric("scanTimerRemainingDs", 18);
+            testContext.setMetric("scanTimerSpanMs", 3000);
+            testContext.setMetric("scanHoldMs", 2000);
+            testContext.setMetric("scanTimingVisible", true);
+            tryCompare(row, "visible", true);
+            tryCompare(row, "text", "Idle dwell 1.8s/3.0s  hold 2.0s");
+            // A followed call: no countdown, the dwell disarmed under it, and the -t
+            // hangtime. A trunked row never carries a conventional hold.
+            testContext.setMetric("scanStayPhrase", "Following call");
+            testContext.setMetric("scanTimerLive", false);
+            testContext.setMetric("scanTimerRemainingDs", 0);
+            testContext.setMetric("scanTimerSpanMs", 0);
+            testContext.setMetric("scanHoldMs", 0);
+            testContext.setMetric("scanDwellMs", 3000);
+            testContext.setMetric("scanDwellState", 2);
+            testContext.setMetric("scanHangMs", 2000);
+            tryCompare(row, "text", "Following call  dwell 3.0s (suspended)  hang 2.0s");
+            // The operator hold pauses the dwell rather than expiring it.
+            testContext.setMetric("scanStayPhrase", "Manual hold");
+            testContext.setMetric("scanDwellState", 3);
+            testContext.setMetric("scanHangMs", 0);
+            tryCompare(row, "text", "Manual hold  dwell 3.0s (paused)");
+            cleanup();
+            tryCompare(row, "visible", false);
+        }
+
         function test_header_controls_do_not_overlap_data() {
             return [{tag: "phone", w: 411, h: 900, scale: 1},
                     {tag: "large text", w: 411, h: 900, scale: 1.6},
@@ -50,8 +94,19 @@ Item {
             Ui.Theme.fontScale = data.scale;
             screen.sitesAvailable = true;
             testContext.setMetric("radioInput", true);
+            // The widest thing the timing row can say, shown: a row that only fits
+            // because it is hidden is not a layout that works.
+            testContext.setMetric("scanStayPhrase", "Acquiring control");
+            testContext.setMetric("scanTimerLive", true);
+            testContext.setMetric("scanTimerRemainingDs", 5999);
+            testContext.setMetric("scanTimerSpanMs", 600000);
+            testContext.setMetric("scanDwellMs", 600000);
+            testContext.setMetric("scanDwellState", 2);
+            testContext.setMetric("scanHoldMs", 600000);
+            testContext.setMetric("scanHangMs", 600000);
+            testContext.setMetric("scanTimingVisible", true);
             waitForRendering(screen);
-            var names = ["runningSiteChooserButton", "openSpectrumButton", "monitorLiveStatus", "monitorHeaderTitle"];
+            var names = ["runningSiteChooserButton", "openSpectrumButton", "monitorLiveStatus", "monitorHeaderTitle", "scanTimingRow"];
             for (var i = 0; i < names.length; ++i) {
                 var a = findChild(screen, names[i]);
                 var ap = a.mapToItem(screen, 0, 0);

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -1731,6 +1731,10 @@ class Setup : public QObject {
         metrics[QStringLiteral("scanDwellState")] = 0;
         metrics[QStringLiteral("scanHoldMs")] = 0;
         metrics[QStringLiteral("scanHangMs")] = 0;
+        // The per-visit cap (#507): no cap in force at rest, so nothing to print.
+        metrics[QStringLiteral("scanVisitMs")] = 0;
+        metrics[QStringLiteral("scanVisitLive")] = false;
+        metrics[QStringLiteral("scanVisitRemainingDs")] = 0;
         // Whether an automatic controller owns the tuner, which one, and where it
         // points. The two named owners word a message; tunerControlled is the gate.
         metrics[QStringLiteral("tunerControlled")] = false;

--- a/tests/ui/qml_test_context.h
+++ b/tests/ui/qml_test_context.h
@@ -1719,6 +1719,18 @@ class Setup : public QObject {
         metrics[QStringLiteral("scanTargetCount")] = 0;
         metrics[QStringLiteral("scanAvoidCount")] = 0;
         metrics[QStringLiteral("scanTargetAvoided")] = false;
+        // Why the rotation is staying and how long is left (#508). Nothing is
+        // published at rest, so the row is down and every budget reads 0.
+        metrics[QStringLiteral("scanTimingVisible")] = false;
+        metrics[QStringLiteral("scanStayReason")] = 0;
+        metrics[QStringLiteral("scanStayPhrase")] = QString();
+        metrics[QStringLiteral("scanTimerLive")] = false;
+        metrics[QStringLiteral("scanTimerRemainingDs")] = 0;
+        metrics[QStringLiteral("scanTimerSpanMs")] = 0;
+        metrics[QStringLiteral("scanDwellMs")] = 0;
+        metrics[QStringLiteral("scanDwellState")] = 0;
+        metrics[QStringLiteral("scanHoldMs")] = 0;
+        metrics[QStringLiteral("scanHangMs")] = 0;
         // Whether an automatic controller owns the tuner, which one, and where it
         // points. The two named owners word a message; tunerControlled is the gate.
         metrics[QStringLiteral("tunerControlled")] = false;

--- a/tests/ui/test_app_control_frontend_public_boundary.c
+++ b/tests/ui/test_app_control_frontend_public_boundary.c
@@ -9,6 +9,7 @@
 #include <dsd-neo/app_control/history.h>
 #include <dsd-neo/app_control/p25_metrics.h>
 #include <dsd-neo/app_control/p25_network.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/app_control/snapshot.h>
 #include <dsd-neo/app_control/trunk_scan_validate.h>
 #include <dsd-neo/core/frontend_types.h>

--- a/tests/ui/test_app_control_frontend_public_boundary.c
+++ b/tests/ui/test_app_control_frontend_public_boundary.c
@@ -60,5 +60,6 @@ main(void) {
     (void)&dsd_app_get_latest_opts_snapshot;
     (void)&dsd_app_frontend_get_metrics_for_snapshot;
     (void)&dsd_app_trunk_scan_validate_targets_csv;
+    (void)&dsd_app_scan_timing_view;
     return 0;
 }

--- a/tests/ui/test_app_control_scan_timing_view.c
+++ b/tests/ui/test_app_control_scan_timing_view.c
@@ -10,9 +10,10 @@
 #include <assert.h>
 #include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/opts_fwd.h>
 #include <dsd-neo/core/safe_api.h>
 #include <dsd-neo/core/state.h>
-#include <stddef.h>
+#include <dsd-neo/core/state_fwd.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -59,7 +60,7 @@ assert_phrase(const dsd_app_scan_timing* view, const char* phrase) {
    disarmed until it does, and a conventional row still states its activity hold. */
 static void
 test_retune_pending_row(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -86,7 +87,7 @@ test_retune_pending_row(void) {
 /* A failed retune cooling down in place: the cooldown is the live window. */
 static void
 test_retune_retry_row(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -108,7 +109,7 @@ test_retune_retry_row(void) {
    no deadline to count down and no conventional hold to state. */
 static void
 test_cc_acquire_row(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -129,7 +130,7 @@ test_cc_acquire_row(void) {
    naming beside the suspended dwell. */
 static void
 test_call_follow_row_shows_hangtime(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -167,7 +168,7 @@ test_hangtime_is_only_shown_while_following_a_call(void) {
         DSD_SCAN_STAY_RETUNE_PENDING, DSD_SCAN_STAY_RETUNE_RETRY, DSD_SCAN_STAY_CC_ACQUIRE, DSD_SCAN_STAY_VOICE,
         DSD_SCAN_STAY_ACTIVITY_HOLD,  DSD_SCAN_STAY_MANUAL_HOLD,  DSD_SCAN_STAY_IDLE_DWELL, DSD_SCAN_STAY_HANGTIME,
     };
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -187,7 +188,7 @@ test_hangtime_is_only_shown_while_following_a_call(void) {
    budget would print the same number twice. */
 static void
 test_voice_row(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -211,7 +212,7 @@ test_voice_row(void) {
    voice frame has already gone by. */
 static void
 test_activity_hold_row_names_the_tail(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -241,7 +242,7 @@ test_activity_hold_row_names_the_tail(void) {
    air is holding the row and nothing will release it but the operator. */
 static void
 test_manual_hold_row_pauses_the_dwell(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -262,7 +263,7 @@ test_manual_hold_row_pauses_the_dwell(void) {
    as a budget; the -Y qualify window is the same window under another name. */
 static void
 test_idle_dwell_row_and_qualify_variant(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -295,7 +296,7 @@ test_idle_dwell_row_and_qualify_variant(void) {
    or hold to state beside it. */
 static void
 test_hangtime_row(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -326,7 +327,7 @@ test_hangtime_row(void) {
    the decoder decides when to move, and the UI must not imply it already has not. */
 static void
 test_remaining_clamps_at_zero(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -350,7 +351,7 @@ test_remaining_clamps_at_zero(void) {
    publishes none; neither half of that rule may be the only one holding the line. */
 static void
 test_hold_is_conventional_only(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -370,7 +371,7 @@ test_hold_is_conventional_only(void) {
 /* A dwell nobody configured is not a budget worth a column. */
 static void
 test_dwell_needs_a_value(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -387,7 +388,7 @@ test_dwell_needs_a_value(void) {
 /* Every reason answers with a phrase; a row with none would render a bare label. */
 static void
 test_every_reason_has_a_phrase(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -412,7 +413,7 @@ test_every_reason_has_a_phrase(void) {
    session must not put a countdown on a receiver that is not scanning. */
 static void
 test_inactive_without_a_scanner(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -439,7 +440,7 @@ test_inactive_without_a_scanner(void) {
    rather than a phrase for reason zero. */
 static void
 test_inactive_when_reason_is_none(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 
@@ -454,7 +455,7 @@ test_inactive_when_reason_is_none(void) {
 
 static void
 test_null_arguments_are_safe(void) {
-    dsd_opts opts;
+    static dsd_opts opts;
     dsd_state* state = make_state();
     dsd_app_scan_timing view;
 

--- a/tests/ui/test_app_control_scan_timing_view.c
+++ b/tests/ui/test_app_control_scan_timing_view.c
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+/*
+ * Copyright (C) 2026 by arancormonk <180709949+arancormonk@users.noreply.github.com>
+ */
+
+/*
+ * Shared scan-timing display decision, independent of any frontend (issue #508).
+ */
+
+#include <assert.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
+#include <dsd-neo/core/opts.h>
+#include <dsd-neo/core/safe_api.h>
+#include <dsd-neo/core/state.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* dsd_state is far too large for the stack; the view only reads scan_timing and the
+   voice-gate phase, both of which a zeroed block already answers for. */
+static dsd_state*
+make_state(void) {
+    dsd_state* state = (dsd_state*)calloc(1, sizeof(dsd_state));
+    assert(state != NULL);
+    return state;
+}
+
+/* A scanner is running and a target is on air: the precondition every row shares. */
+static void
+make_opts(dsd_opts* opts) {
+    DSD_MEMSET(opts, 0, sizeof(*opts));
+    opts->trunk_scan_enabled = 1;
+}
+
+/* One published stay, stamped the way the decoder stamps it: an absolute deadline, or
+   a negative one when nothing is counting down. */
+static void
+publish(dsd_state* state, uint8_t reason, uint8_t conventional, double deadline_m, uint32_t span_ms, uint32_t dwell_ms,
+        uint32_t hold_ms) {
+    DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
+    state->scan_timing.reason = reason;
+    state->scan_timing.conventional = conventional;
+    state->scan_timing.started_m = (deadline_m >= 0.0) ? deadline_m - ((double)span_ms / 1000.0) : -1.0;
+    state->scan_timing.deadline_m = deadline_m;
+    state->scan_timing.span_ms = span_ms;
+    state->scan_timing.dwell_ms = dwell_ms;
+    state->scan_timing.hold_ms = hold_ms;
+}
+
+static void
+assert_phrase(const dsd_app_scan_timing* view, const char* phrase) {
+    assert(view->phrase != NULL);
+    assert(strcmp(view->phrase, phrase) == 0);
+}
+
+/* A backend retune that has not resolved: nothing counts down, the idle dwell is
+   disarmed until it does, and a conventional row still states its activity hold. */
+static void
+test_retune_pending_row(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_RETUNE_PENDING, 1U, -1.0, 0U, 3000U, 1200U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.active == 1U);
+    assert(view.reason == (uint8_t)DSD_SCAN_STAY_RETUNE_PENDING);
+    assert_phrase(&view, "Retune pending");
+    assert(view.timer_live == 0U);
+    assert(view.remaining_ms == 0U);
+    assert(view.span_ms == 0U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_ms == 3000U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 1U);
+    assert(view.hold_ms == 1200U);
+    assert(view.show_hang == 0U);
+    assert(view.hang_ms == 0U);
+
+    free(state);
+}
+
+/* A failed retune cooling down in place: the cooldown is the live window. */
+static void
+test_retune_retry_row(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_RETUNE_RETRY, 0U, 102.0, 2000U, 3000U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Retune retry");
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 2000U);
+    assert(view.span_ms == 2000U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 0U);
+
+    free(state);
+}
+
+/* Hunting a control channel: the trunking state machine owns the clock, so there is
+   no deadline to count down and no conventional hold to state. */
+static void
+test_cc_acquire_row(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_CC_ACQUIRE, 0U, -1.0, 0U, 3000U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Acquiring control");
+    assert(view.timer_live == 0U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 0U);
+    assert(view.show_hang == 0U);
+
+    free(state);
+}
+
+/* Following a trunked call: -t is what ends the stay, so it is the one budget worth
+   naming beside the suspended dwell. */
+static void
+test_call_follow_row_shows_hangtime(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    opts.trunk_hangtime = 2.0f;
+    publish(state, DSD_SCAN_STAY_CALL_FOLLOW, 0U, -1.0, 0U, 3000U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Following call");
+    assert(view.timer_live == 0U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 0U);
+    assert(view.show_hang == 1U);
+    assert(view.hang_ms == 2000U);
+
+    /* A fractional -t rounds to the nearest millisecond rather than truncating. */
+    opts.trunk_hangtime = 1.25f;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.hang_ms == 1250U);
+
+    /* -t 0 leaves nothing to state. */
+    opts.trunk_hangtime = 0.0f;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_hang == 0U);
+    assert(view.hang_ms == 0U);
+
+    free(state);
+}
+
+/* Hangtime belongs to a followed trunked call and to nothing else: no other row may
+   claim -t, whatever it is set to. */
+static void
+test_hangtime_is_only_shown_while_following_a_call(void) {
+    static const uint8_t others[] = {
+        DSD_SCAN_STAY_RETUNE_PENDING, DSD_SCAN_STAY_RETUNE_RETRY, DSD_SCAN_STAY_CC_ACQUIRE, DSD_SCAN_STAY_VOICE,
+        DSD_SCAN_STAY_ACTIVITY_HOLD,  DSD_SCAN_STAY_MANUAL_HOLD,  DSD_SCAN_STAY_IDLE_DWELL, DSD_SCAN_STAY_HANGTIME,
+    };
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    opts.trunk_hangtime = 2.0f;
+    for (size_t i = 0; i < sizeof(others) / sizeof(others[0]); i++) {
+        publish(state, others[i], 1U, -1.0, 0U, 3000U, 1200U);
+        assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+        assert(view.show_hang == 0U);
+        assert(view.hang_ms == 0U);
+    }
+
+    free(state);
+}
+
+/* Conventional voice on air: the hold window is the live timer, so restating it as a
+   budget would print the same number twice. */
+static void
+test_voice_row(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_VOICE, 1U, 101.2, 2000U, 3000U, 2000U);
+    state->scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_VOICE;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Voice");
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 1200U);
+    assert(view.span_ms == 2000U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 0U);
+    assert(view.hold_ms == 2000U);
+
+    free(state);
+}
+
+/* The activity hold reads as a voice tail only while the voice gate says the last
+   voice frame has already gone by. */
+static void
+test_activity_hold_row_names_the_tail(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_ACTIVITY_HOLD, 1U, 100.8, 2000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Activity hold");
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 800U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_SUSPENDED);
+    assert(view.show_hold == 0U);
+
+    state->scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_TAIL;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Voice tail");
+
+    /* QUALIFY and VOICE are not a tail: only TAIL renames this row. */
+    state->scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_QUALIFY;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Activity hold");
+
+    free(state);
+}
+
+/* An operator hold: the dwell is paused rather than suspended, because nothing on the
+   air is holding the row and nothing will release it but the operator. */
+static void
+test_manual_hold_row_pauses_the_dwell(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_MANUAL_HOLD, 1U, -1.0, 0U, 3000U, 1200U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Manual hold");
+    assert(view.timer_live == 0U);
+    assert(view.show_dwell == 1U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_PAUSED);
+    assert(view.show_hold == 1U);
+    assert(view.hold_ms == 1200U);
+
+    free(state);
+}
+
+/* The idle dwell is the live window, so the row shows it as a countdown and not also
+   as a budget; the -Y qualify window is the same window under another name. */
+static void
+test_idle_dwell_row_and_qualify_variant(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Idle dwell");
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 1800U);
+    assert(view.span_ms == 3000U);
+    assert(view.show_dwell == 0U);
+    assert(view.dwell_ms == 3000U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_NONE);
+    assert(view.show_hold == 1U);
+    assert(view.hold_ms == 2000U);
+
+    state->scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_QUALIFY;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Qualify");
+
+    /* Any other phase is the plain idle dwell again. */
+    state->scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_TAIL;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Idle dwell");
+
+    free(state);
+}
+
+/* The -Y legacy rule: the whole stay is -t since the last sync, so there is no dwell
+   or hold to state beside it. */
+static void
+test_hangtime_row(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.scanner_mode = 1;
+    opts.trunk_hangtime = 2.0f;
+    publish(state, DSD_SCAN_STAY_HANGTIME, 1U, 101.4, 2000U, 0U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert_phrase(&view, "Hangtime");
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 1400U);
+    assert(view.span_ms == 2000U);
+    assert(view.show_dwell == 0U);
+    assert(view.show_hold == 0U);
+    assert(view.show_hang == 0U);
+
+    /* No anchor yet (never synced): the reason still holds, the countdown does not. */
+    publish(state, DSD_SCAN_STAY_HANGTIME, 1U, -1.0, 0U, 0U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.timer_live == 0U);
+    assert(view.remaining_ms == 0U);
+    assert(view.span_ms == 0U);
+
+    free(state);
+}
+
+/* A deadline the poll arrived after reads as zero, never as a wrapped unsigned age:
+   the decoder decides when to move, and the UI must not imply it already has not. */
+static void
+test_remaining_clamps_at_zero(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 97.5, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 0U);
+    assert(view.span_ms == 3000U);
+
+    /* Exactly on the deadline is zero too, not a rounded-up millisecond. */
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 100.0, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.timer_live == 1U);
+    assert(view.remaining_ms == 0U);
+
+    free(state);
+}
+
+/* A trunked row has no conventional activity hold to state, and the coordinator
+   publishes none; neither half of that rule may be the only one holding the line. */
+static void
+test_hold_is_conventional_only(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 0U, 101.8, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_hold == 0U);
+
+    /* Conventional with nothing configured stays quiet as well. */
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 0U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_hold == 0U);
+
+    free(state);
+}
+
+/* A dwell nobody configured is not a budget worth a column. */
+static void
+test_dwell_needs_a_value(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_MANUAL_HOLD, 1U, -1.0, 0U, 0U, 1200U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_dwell == 0U);
+    assert(view.dwell_state == DSD_APP_SCAN_DWELL_NONE);
+    assert(view.show_hold == 1U);
+
+    free(state);
+}
+
+/* Every reason answers with a phrase; a row with none would render a bare label. */
+static void
+test_every_reason_has_a_phrase(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    for (uint8_t reason = (uint8_t)DSD_SCAN_STAY_RETUNE_PENDING; reason <= (uint8_t)DSD_SCAN_STAY_HANGTIME; reason++) {
+        publish(state, reason, 1U, -1.0, 0U, 3000U, 1200U);
+        assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+        assert(view.reason == reason);
+        assert(view.phrase != NULL);
+        assert(view.phrase[0] != '\0');
+    }
+
+    /* A reason from a newer decoder than this build knows is not rendered at all. */
+    publish(state, (uint8_t)(DSD_SCAN_STAY_HANGTIME + 1), 1U, -1.0, 0U, 3000U, 1200U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 0);
+    assert(view.active == 0U);
+
+    free(state);
+}
+
+/* No scanner is running: a publication left over from an earlier -Y or --trunk-scan
+   session must not put a countdown on a receiver that is not scanning. */
+static void
+test_inactive_without_a_scanner(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 0);
+    assert(view.active == 0U);
+    assert(view.phrase == NULL);
+    assert(view.remaining_ms == 0U);
+    assert(view.show_dwell == 0U);
+    assert(view.show_hold == 0U);
+
+    /* Either scanner is enough. */
+    opts.scanner_mode = 1;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    opts.scanner_mode = 0;
+    opts.trunk_scan_enabled = 1;
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+
+    free(state);
+}
+
+/* Nothing holds the row and nothing is published: the surface renders no row at all
+   rather than a phrase for reason zero. */
+static void
+test_inactive_when_reason_is_none(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_NONE, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 0);
+    assert(view.active == 0U);
+    assert(view.phrase == NULL);
+
+    free(state);
+}
+
+static void
+test_null_arguments_are_safe(void) {
+    dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+
+    /* A rejected call still leaves the caller's view zeroed, so a frontend that
+       ignores the status cannot render a stale row. */
+    DSD_MEMSET(&view, 0xFF, sizeof(view));
+    assert(dsd_app_scan_timing_view(NULL, state, 100.0, &view) == -1);
+    assert(view.active == 0U);
+    assert(view.phrase == NULL);
+
+    DSD_MEMSET(&view, 0xFF, sizeof(view));
+    assert(dsd_app_scan_timing_view(&opts, NULL, 100.0, &view) == -1);
+    assert(view.active == 0U);
+
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, NULL) == -1);
+
+    free(state);
+}
+
+int
+main(void) {
+    test_retune_pending_row();
+    test_retune_retry_row();
+    test_cc_acquire_row();
+    test_call_follow_row_shows_hangtime();
+    test_hangtime_is_only_shown_while_following_a_call();
+    test_voice_row();
+    test_activity_hold_row_names_the_tail();
+    test_manual_hold_row_pauses_the_dwell();
+    test_idle_dwell_row_and_qualify_variant();
+    test_hangtime_row();
+    test_remaining_clamps_at_zero();
+    test_hold_is_conventional_only();
+    test_dwell_needs_a_value();
+    test_every_reason_has_a_phrase();
+    test_inactive_without_a_scanner();
+    test_inactive_when_reason_is_none();
+    test_null_arguments_are_safe();
+    printf("APP_CONTROL_SCAN_TIMING_VIEW ok\n");
+    return 0;
+}

--- a/tests/ui/test_app_control_scan_timing_view.c
+++ b/tests/ui/test_app_control_scan_timing_view.c
@@ -41,6 +41,10 @@ static void
 publish(dsd_state* state, uint8_t reason, uint8_t conventional, double deadline_m, uint32_t span_ms, uint32_t dwell_ms,
         uint32_t hold_ms) {
     DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
+    /* A zeroed block leaves visit_deadline_m at 0.0, which reads as a per-visit deadline
+       at monotonic 0 -- long past. The decoder never publishes that: an unanchored cap is
+       negative (#507), so the seed says so too. */
+    state->scan_timing.visit_deadline_m = -1.0;
     state->scan_timing.reason = reason;
     state->scan_timing.conventional = conventional;
     state->scan_timing.started_m = (deadline_m >= 0.0) ? deadline_m - ((double)span_ms / 1000.0) : -1.0;
@@ -54,6 +58,15 @@ static void
 assert_phrase(const dsd_app_scan_timing* view, const char* phrase) {
     assert(view->phrase != NULL);
     assert(strcmp(view->phrase, phrase) == 0);
+}
+
+/* The per-visit cap on top of a published stay (issue #507). Separate from publish()
+   because the cap is not a property of the stay reason: the engine anchors it at parking
+   and it rides whatever else happens to be holding the row. */
+static void
+seed_visit(dsd_state* state, uint32_t limit_ms, double visit_deadline_m) {
+    state->scan_timing.visit_limit_ms = limit_ms;
+    state->scan_timing.visit_deadline_m = visit_deadline_m;
 }
 
 /* A backend retune that has not resolved: nothing counts down, the idle dwell is
@@ -453,6 +466,111 @@ test_inactive_when_reason_is_none(void) {
     free(state);
 }
 
+/* No cap configured: nothing to show, whatever else the row says. A stale visit
+   deadline without a limit is not a cap either -- the engine only anchors one while a
+   limit is in force, and a leftover stamp must not put a countdown on the row. */
+static void
+test_visit_cap_off_is_not_shown(void) {
+    static dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_visit == 0U);
+    assert(view.visit_ms == 0U);
+    assert(view.visit_live == 0U);
+    assert(view.visit_remaining_ms == 0U);
+
+    seed_visit(state, 0U, 118.0);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_visit == 0U);
+    assert(view.visit_live == 0U);
+    assert(view.visit_remaining_ms == 0U);
+
+    free(state);
+}
+
+/* A cap anchored at parking counts down against the same clock the windows use, and
+   floors at zero once the poll lands after it: the decoder decides when the receiver
+   moves on, so the row must not imply it already should have. */
+static void
+test_visit_cap_counts_down(void) {
+    static dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    seed_visit(state, 20000U, 112.3);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_visit == 1U);
+    assert(view.visit_ms == 20000U);
+    assert(view.visit_live == 1U);
+    assert(view.visit_remaining_ms == 12300U);
+
+    seed_visit(state, 20000U, 97.5);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_visit == 1U);
+    assert(view.visit_live == 1U);
+    assert(view.visit_remaining_ms == 0U);
+
+    free(state);
+}
+
+/* Suspended or not yet anchored: the cap still applies to the row, so its width is worth
+   stating, but there is no countdown to report and zero would read as expiry. */
+static void
+test_visit_cap_suspended_is_not_live(void) {
+    static dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    publish(state, DSD_SCAN_STAY_MANUAL_HOLD, 1U, -1.0, 0U, 3000U, 1200U);
+    seed_visit(state, 20000U, -1.0);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+    assert(view.show_visit == 1U);
+    assert(view.visit_ms == 20000U);
+    assert(view.visit_live == 0U);
+    assert(view.visit_remaining_ms == 0U);
+
+    free(state);
+}
+
+/* The cap is not driven by the stay reason the way the dwell, hold and hang budgets are:
+   it governs the whole visit, so every reason reports it. */
+static void
+test_visit_cap_applies_to_every_reason(void) {
+    static dsd_opts opts;
+    dsd_state* state = make_state();
+    dsd_app_scan_timing view;
+
+    make_opts(&opts);
+    opts.trunk_hangtime = 2.0f;
+    for (uint8_t reason = (uint8_t)DSD_SCAN_STAY_RETUNE_PENDING; reason <= (uint8_t)DSD_SCAN_STAY_HANGTIME; reason++) {
+        publish(state, reason, 1U, -1.0, 0U, 3000U, 1200U);
+        seed_visit(state, 45000U, 130.0);
+        assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 1);
+        assert(view.show_visit == 1U);
+        assert(view.visit_ms == 45000U);
+        assert(view.visit_live == 1U);
+        assert(view.visit_remaining_ms == 30000U);
+    }
+
+    /* Nothing is rotating: a leftover cap says nothing about a receiver parked by hand. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    publish(state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    seed_visit(state, 45000U, 130.0);
+    assert(dsd_app_scan_timing_view(&opts, state, 100.0, &view) == 0);
+    assert(view.show_visit == 0U);
+    assert(view.visit_ms == 0U);
+    assert(view.visit_remaining_ms == 0U);
+
+    free(state);
+}
+
 static void
 test_null_arguments_are_safe(void) {
     static dsd_opts opts;
@@ -494,6 +612,10 @@ main(void) {
     test_hold_is_conventional_only();
     test_dwell_needs_a_value();
     test_every_reason_has_a_phrase();
+    test_visit_cap_off_is_not_shown();
+    test_visit_cap_counts_down();
+    test_visit_cap_suspended_is_not_live();
+    test_visit_cap_applies_to_every_reason();
     test_inactive_without_a_scanner();
     test_inactive_when_reason_is_none();
     test_null_arguments_are_safe();

--- a/tests/ui/test_ui_cmd_queue.c
+++ b/tests/ui/test_ui_cmd_queue.c
@@ -1942,6 +1942,9 @@ test_scan_hold_avoid_commands(void) {
     state.trunk_lcn_freq[3] = 858000000L;
     state.lcn_freq_roll = 2; /* row 1 (857 MHz) is on air */
     state.last_cc_sync_time_m = 42.0;
+    opts.scan_max_visit_ms = 1000;
+    state.scan_visit_since_m = 42.0;
+    state.scan_visit_roll_seen = state.lcn_freq_roll;
     reset_io_control_tune_stub(RTL_STREAM_TUNE_OK);
     reset_cc_tune_stub(DSD_TRUNK_TUNE_RESULT_OK);
 
@@ -1958,6 +1961,9 @@ test_scan_hold_avoid_commands(void) {
     rc |= expect_int("scan hold release drained", dsd_app_drain_cmds(&opts, &state), 1);
     rc |= expect_int("scan hold release clears flag", state.lcn_scan_hold, 0);
     rc |= expect_true("scan hold release restarts dwell", state.last_cc_sync_time_m > 42.0);
+    rc |= expect_true("scan hold release restarts the cap", state.scan_visit_since_m >= state.last_cc_sync_time_m);
+    rc |= expect_true("scan hold release publishes a full cap",
+                      state.scan_timing.visit_deadline_m >= state.last_cc_sync_time_m + 1.0);
     rc |= expect_contains("scan hold release toast", state.ui_msg, "hold off");
     rc |= expect_int("scan release publishes hangtime", state.scan_timing.reason, DSD_SCAN_STAY_HANGTIME);
     rc |= expect_true("scan release publishes a fresh deadline",

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -2149,6 +2149,10 @@ static void
 seed_scan_timing(dsd_state* state, uint8_t reason, uint8_t conventional, double deadline_m, uint32_t span_ms,
                  uint32_t dwell_ms, uint32_t hold_ms) {
     DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
+    /* A zeroed block leaves visit_deadline_m at 0.0, which reads as a per-visit deadline
+       at monotonic 0 -- long past. The decoder never publishes that: an unanchored cap is
+       negative (#507), so the seed says so too. */
+    state->scan_timing.visit_deadline_m = -1.0;
     state->scan_timing.reason = reason;
     state->scan_timing.conventional = conventional;
     state->scan_timing.started_m = (deadline_m >= 0.0) ? deadline_m - ((double)span_ms / 1000.0) : -1.0;
@@ -2156,6 +2160,14 @@ seed_scan_timing(dsd_state* state, uint8_t reason, uint8_t conventional, double 
     state->scan_timing.span_ms = span_ms;
     state->scan_timing.dwell_ms = dwell_ms;
     state->scan_timing.hold_ms = hold_ms;
+}
+
+/* The per-visit cap on top of a published stay (issue #507): its own seed because the cap
+   is anchored at parking and rides whatever reason happens to be holding the row. */
+static void
+seed_visit(dsd_state* state, uint32_t limit_ms, double visit_deadline_m) {
+    state->scan_timing.visit_limit_ms = limit_ms;
+    state->scan_timing.visit_deadline_m = visit_deadline_m;
 }
 
 /* The formatter is pure and takes the clock, so a golden can be the exact bytes rather
@@ -2246,6 +2258,45 @@ test_scan_timing_row_clamps_expired_timers(void) {
     opts.trunk_scan_enabled = 1;
     seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 95.0, 3000U, 3000U, 2000U);
     assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 0.0s/3.0s  hold 2.0s");
+}
+
+/* The per-visit cap closes the row (issue #507): the widest budget, and the only one that
+   can read as a word instead of a countdown. Two spaces before it, like every other group,
+   and one decimal place, like every other number. */
+static void
+test_scan_timing_row_visit_cap(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.trunk_scan_enabled = 1;
+
+    /* No cap configured: the row is byte-for-byte the one #510 pinned. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 1.8s/3.0s  hold 2.0s");
+
+    /* A cap counting down against the same clock as the window above it. */
+    seed_visit(&state, 20000U, 112.3);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 1.8s/3.0s  hold 2.0s  Visit: 12.3s/20.0s");
+
+    /* A poll that lands after the cap floors at zero rather than wrapping, the same rule
+       the window countdown follows. */
+    seed_visit(&state, 20000U, 97.5);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 1.8s/3.0s  hold 2.0s  Visit: 0.0s/20.0s");
+
+    /* A hold suspends the cap: there is no deadline to count from, and printing 0.0s would
+       read as a visit that just ran out. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_MANUAL_HOLD, 1U, -1.0, 0U, 3000U, 0U);
+    seed_visit(&state, 20000U, -1.0);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Manual hold  dwell 3.0s (paused)  Visit: paused");
+
+    /* The cap is not a stay reason, so it appears beside the -t hangtime too. */
+    opts.trunk_hangtime = 2.0f;
+    seed_scan_timing(&state, DSD_SCAN_STAY_CALL_FOLLOW, 0U, -1.0, 0U, 3000U, 0U);
+    seed_visit(&state, 45000U, 130.0);
+    assert_scan_timing_row(&opts, &state,
+                           "| Scan Timing: Following call  dwell 3.0s (suspended)  hang 2.0s  Visit: 30.0s/45.0s");
 }
 
 static void
@@ -2351,6 +2402,7 @@ main(void) {
     test_trunk_scan_status_row_rendering();
     test_scan_timing_row_phrases();
     test_scan_timing_row_clamps_expired_timers();
+    test_scan_timing_row_visit_cap();
     test_scan_timing_row_is_silent_without_a_scan();
     test_scan_timing_row_placement();
     test_scan_timing_row_truncates_to_panel_width();

--- a/tests/ui/test_ui_ncurses_printer_helpers.c
+++ b/tests/ui/test_ui_ncurses_printer_helpers.c
@@ -191,10 +191,15 @@ whline(WINDOW* win, chtype ch, int n) { // NOLINT(misc-use-internal-linkage)
     return 0;
 }
 
+/* Terminal width the printer sees. Settable so a test can narrow it and check that a row
+   which does not fit is cut rather than wrapped; 80 is the default every other test
+   renders against, and a test that changes it restores it. */
+static int g_stub_max_x = 80;
+
 int
 getmaxx(const WINDOW* win) { // NOLINT(misc-use-internal-linkage)
     (void)win;
-    return 80;
+    return g_stub_max_x;
 }
 
 int
@@ -2138,6 +2143,197 @@ test_voice_average_units(void) {
     g_voice_average_valid = 0;
 }
 
+/* One published stay, stamped the way the decoder stamps it: an absolute monotonic
+   deadline, or a negative one when nothing is counting down. */
+static void
+seed_scan_timing(dsd_state* state, uint8_t reason, uint8_t conventional, double deadline_m, uint32_t span_ms,
+                 uint32_t dwell_ms, uint32_t hold_ms) {
+    DSD_MEMSET(&state->scan_timing, 0, sizeof(state->scan_timing));
+    state->scan_timing.reason = reason;
+    state->scan_timing.conventional = conventional;
+    state->scan_timing.started_m = (deadline_m >= 0.0) ? deadline_m - ((double)span_ms / 1000.0) : -1.0;
+    state->scan_timing.deadline_m = deadline_m;
+    state->scan_timing.span_ms = span_ms;
+    state->scan_timing.dwell_ms = dwell_ms;
+    state->scan_timing.hold_ms = hold_ms;
+}
+
+/* The formatter is pure and takes the clock, so a golden can be the exact bytes rather
+   than a substring: the Qt panel renders the same grammar from the same view. */
+static void
+assert_scan_timing_row(const dsd_opts* opts, const dsd_state* state, const char* expected) {
+    char line[192];
+    int len = ui_format_scan_timing_row(opts, state, 100.0, line, sizeof(line));
+    assert(len == (int)strlen(expected));
+    assert(strcmp(line, expected) == 0);
+}
+
+static void
+test_scan_timing_row_phrases(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.trunk_scan_enabled = 1;
+    opts.trunk_hangtime = 2.0f;
+
+    /* Trunked rows carry no conventional activity hold, so none is printed beside them. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_RETUNE_RETRY, 0U, 102.0, 2000U, 3000U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Retune retry 2.0s/2.0s  dwell 3.0s (suspended)");
+
+    seed_scan_timing(&state, DSD_SCAN_STAY_CC_ACQUIRE, 0U, -1.0, 0U, 3000U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Acquiring control  dwell 3.0s (suspended)");
+
+    /* -t is what ends a followed call, so it is the budget named beside the dwell. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_CALL_FOLLOW, 0U, -1.0, 0U, 3000U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Following call  dwell 3.0s (suspended)  hang 2.0s");
+
+    seed_scan_timing(&state, DSD_SCAN_STAY_MANUAL_HOLD, 0U, -1.0, 0U, 3000U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Manual hold  dwell 3.0s (paused)");
+
+    /* Conventional rows add the effective activity hold, except where that hold is
+       already the window counting down. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_RETUNE_PENDING, 1U, -1.0, 0U, 3000U, 1200U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Retune pending  dwell 3.0s (suspended)  hold 1.2s");
+
+    seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 1.8s/3.0s  hold 2.0s");
+
+    seed_scan_timing(&state, DSD_SCAN_STAY_VOICE, 1U, 101.2, 2000U, 3000U, 2000U);
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_VOICE;
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Voice 1.2s/2.0s  dwell 3.0s (suspended)");
+
+    /* Both voice-gate variants: the same reason reads differently once the gate says
+       where in a transmission the hold is. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_ACTIVITY_HOLD, 1U, 101.5, 2000U, 3000U, 2000U);
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_OFF;
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Activity hold 1.5s/2.0s  dwell 3.0s (suspended)");
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_TAIL;
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Voice tail 1.5s/2.0s  dwell 3.0s (suspended)");
+
+    seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 100.6, 1000U, 1000U, 2000U);
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_OFF;
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 0.6s/1.0s  hold 2.0s");
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_QUALIFY;
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Qualify 0.6s/1.0s  hold 2.0s");
+
+    /* The -Y legacy rule: -t since the last sync is the whole stay, with no dwell or hold
+       of its own to state. */
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    opts.scanner_mode = 1;
+    opts.trunk_hangtime = 2.0f;
+    state.scan_voice_gate_phase = DSD_SCAN_VOICE_GATE_OFF;
+    seed_scan_timing(&state, DSD_SCAN_STAY_HANGTIME, 1U, 101.4, 2000U, 0U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Hangtime 1.4s/2.0s");
+
+    /* Nothing has synced on this row yet: the reason holds, the countdown has no anchor
+       to run from, and an unanchored timer is left off rather than shown as zero. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_HANGTIME, 1U, -1.0, 0U, 0U, 0U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Hangtime");
+}
+
+/* The decoder decides when the receiver moves. A poll that lands after the deadline is a
+   frame late, not a scanner that overstayed, so the row floors at zero instead of
+   reporting a negative age that wrapped through an unsigned. */
+static void
+test_scan_timing_row_clamps_expired_timers(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.trunk_scan_enabled = 1;
+    seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 95.0, 3000U, 3000U, 2000U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Idle dwell 0.0s/3.0s  hold 2.0s");
+}
+
+static void
+test_scan_timing_row_is_silent_without_a_scan(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    char line[192];
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    /* No scanner is running: a publication left over from an earlier session says nothing
+       about a receiver now parked by hand. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_IDLE_DWELL, 1U, 101.8, 3000U, 3000U, 2000U);
+    assert(ui_format_scan_timing_row(&opts, &state, 100.0, line, sizeof(line)) == 0);
+    assert(line[0] == '\0');
+
+    /* Scanning, but nothing holds the row and nothing is published for it. */
+    opts.trunk_scan_enabled = 1;
+    seed_scan_timing(&state, DSD_SCAN_STAY_NONE, 1U, -1.0, 0U, 0U, 0U);
+    assert(ui_format_scan_timing_row(&opts, &state, 100.0, line, sizeof(line)) == 0);
+    assert(line[0] == '\0');
+}
+
+/* The row sits directly under whichever scanner row is on screen, and there is only ever
+   one of it: with both scanners running the stay belongs to the trunk-scan target. */
+static void
+test_scan_timing_row_placement(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+    reset_lcn_name_stub();
+
+    /* A stay with no live timer, so the rendered bytes do not depend on the wall clock
+       the renderer reads for itself. */
+    seed_scan_timing(&state, DSD_SCAN_STAY_MANUAL_HOLD, 1U, -1.0, 0U, 3000U, 0U);
+
+    opts.scanner_mode = 1;
+    opts.trunk_hangtime = 2.0f;
+    state.lcn_freq_count = 1;
+    state.lcn_freq_roll = 1;
+    state.trunk_lcn_freq[0] = 462012500;
+    reset_printw_capture();
+    ui_render_scanner_and_reverse_status(&opts, &state);
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec \n"
+                          "| Scan Timing: Manual hold  dwell 3.0s (paused)\n");
+
+    opts.scanner_mode = 0;
+    opts.trunk_scan_enabled = 1;
+    DSD_SNPRINTF(state.trunk_scan_active_id, sizeof(state.trunk_scan_active_id), "county-p25");
+    state.trunk_scan_active_ordinal = 3;
+    state.trunk_scan_target_count = 6;
+    reset_printw_capture();
+    ui_render_scanner_and_reverse_status(&opts, &state);
+    assert_capture_equals("| Trunk Scan:  Target: county-p25 (3/6)\n"
+                          "| Scan Timing: Manual hold  dwell 3.0s (paused)\n");
+
+    opts.scanner_mode = 1;
+    reset_printw_capture();
+    ui_render_scanner_and_reverse_status(&opts, &state);
+    assert_capture_equals("| Scan Mode:  Frequency: 462.012500 MHz Speed: 2.00 sec \n"
+                          "| Trunk Scan:  Target: county-p25 (3/6)\n"
+                          "| Scan Timing: Manual hold  dwell 3.0s (paused)\n");
+}
+
+/* A narrow terminal cuts the row instead of wrapping it: this line redraws several times
+   a second as the countdown moves, and a wrapped one would push every row below it down
+   by one for as long as the phrase stayed long. */
+static void
+test_scan_timing_row_truncates_to_panel_width(void) {
+    static dsd_opts opts;
+    static dsd_state state;
+    DSD_MEMSET(&opts, 0, sizeof(opts));
+    DSD_MEMSET(&state, 0, sizeof(state));
+
+    opts.trunk_scan_enabled = 1;
+    seed_scan_timing(&state, DSD_SCAN_STAY_RETUNE_PENDING, 1U, -1.0, 0U, 3000U, 1200U);
+    assert_scan_timing_row(&opts, &state, "| Scan Timing: Retune pending  dwell 3.0s (suspended)  hold 1.2s");
+
+    g_stub_max_x = 40;
+    reset_printw_capture();
+    ui_render_scan_timing_row(&opts, &state);
+    g_stub_max_x = 80;
+    assert_capture_equals("| Scan Timing: Retune pending  dwell 3.0\n");
+    assert(strlen(g_printw_capture) == 41U);
+    assert(strchr(g_printw_capture, '\n') == g_printw_capture + 40);
+}
+
 int
 main(void) {
     test_voice_average_units();
@@ -2153,6 +2349,11 @@ main(void) {
     test_scanner_status_row_rendering();
     test_scan_voice_gate_status_rendering();
     test_trunk_scan_status_row_rendering();
+    test_scan_timing_row_phrases();
+    test_scan_timing_row_clamps_expired_timers();
+    test_scan_timing_row_is_silent_without_a_scan();
+    test_scan_timing_row_placement();
+    test_scan_timing_row_truncates_to_panel_width();
     test_call_info_channel_line_rendering();
     test_history_and_sort_helpers();
     test_history_color_pair_policy();

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -518,13 +518,43 @@ test_scan_timing() {
     model.refresh(&opts, &state);
     expect("the countdown moves on the tenth", model.scanTimerRemainingDs() == 17 && changes > quiet);
 
+    /* The per-visit cap (#507) rides the same row. It is not driven by the stay reason,
+     * so it reads out beside whatever else holds the receiver, and its countdown is in
+     * tenths for the same reason the window's is. */
+    g_stub_scan_timing.show_visit = 1U;
+    g_stub_scan_timing.visit_ms = 20000U;
+    g_stub_scan_timing.visit_live = 1U;
+    g_stub_scan_timing.visit_remaining_ms = 12349U;
+    model.refresh(&opts, &state);
+    expect("the visit cap reads out with its countdown",
+           model.scanVisitMs() == 20000 && model.scanVisitLive() && model.scanVisitRemainingDs() == 123);
+    const int capped = changes;
+    g_stub_scan_timing.visit_remaining_ms = 12301U;
+    model.refresh(&opts, &state);
+    expect("a cap moving inside one tenth notifies nothing", changes == capped && model.scanVisitRemainingDs() == 123);
+
+    /* Suspended by a hold: the cap still applies to the row, so its width is stated, but
+     * there is no countdown -- zero tenths would read as a visit that just ran out. */
+    g_stub_scan_timing.visit_live = 0U;
+    g_stub_scan_timing.visit_remaining_ms = 0U;
+    model.refresh(&opts, &state);
+    expect("a suspended cap keeps its width and drops the countdown",
+           model.scanVisitMs() == 20000 && !model.scanVisitLive() && model.scanVisitRemainingDs() == 0);
+    expect("suspending the cap notifies the control group", changes > capped);
+
+    /* Withheld by the view: no cap is in force, so no number the row could print arrives. */
+    g_stub_scan_timing.show_visit = 0U;
+    model.refresh(&opts, &state);
+    expect("no cap on air leaves nothing to print", model.scanVisitMs() == 0);
+
     model.clear();
     expect("a stopped session leaves no scan timing behind",
            !model.scanTimingVisible() && model.scanStayReason() == DSD_SCAN_STAY_NONE
                && model.scanStayPhrase().isEmpty() && !model.scanTimerLive() && model.scanTimerRemainingDs() == 0
                && model.scanTimerSpanMs() == 0 && model.scanDwellMs() == 0
                && model.scanDwellState() == DSD_APP_SCAN_DWELL_NONE && model.scanHoldMs() == 0
-               && model.scanHangMs() == 0);
+               && model.scanHangMs() == 0 && model.scanVisitMs() == 0 && !model.scanVisitLive()
+               && model.scanVisitRemainingDs() == 0);
 
     /* Plain trunking and a plain single system are not rotations: there is no row to
      * stay on, so the view says nothing and the panel shows nothing. */

--- a/tests/ui/test_ui_qt_metrics_model.cpp
+++ b/tests/ui/test_ui_qt_metrics_model.cpp
@@ -23,6 +23,7 @@
 #include <stdio.h>
 
 #include <dsd-neo/app_control/frontend.h>
+#include <dsd-neo/app_control/scan_timing_view.h>
 #include <dsd-neo/core/call_state.h>
 #include <dsd-neo/core/dsd_time.h>
 #include <dsd-neo/core/init.h>
@@ -45,6 +46,10 @@ int g_failures = 0;
 /* What the stubbed frontend reports for the channel width. Per-case, because
  * every other case wants the at-rest 0. */
 static int g_stub_channel_bandwidth_hz = 0;
+
+/* The scan-timing view a case feeds the model. Zeroed between cases: reason NONE
+ * is the contract's "nothing to show", which is what every other case wants. */
+static dsd_app_scan_timing g_stub_scan_timing;
 
 void
 expect(const char* what, bool ok) {
@@ -72,6 +77,36 @@ dsd_app_frontend_get_metrics_for_snapshot(const dsd_opts* opts, const dsd_state*
     *out = dsd_frontend_metrics{};
     out->channel_bandwidth_hz = g_stub_channel_bandwidth_hz;
     return 0;
+}
+
+/*
+ * The scan-timing view, stubbed through the same link seam as the frontend metrics
+ * above, so a case can hand the model a view it built by hand.
+ *
+ * Deliberately not the real one: the reason -> phrase / show-this-budget table is
+ * app-control's and is pinned by APP_CONTROL_SCAN_TIMING_VIEW. What this suite owns
+ * is the copy out of the view into the published frame, and running the real table
+ * here would only pin it twice. The one rule reproduced is the contract's `active`
+ * gate, because the model deliberately has no gate of its own -- "is anything
+ * scanning" is decided once, in the view.
+ */
+extern "C" int
+dsd_app_scan_timing_view(const dsd_opts* opts, const dsd_state* state, double now_m, dsd_app_scan_timing* out) {
+    if (out == nullptr) {
+        return -1;
+    }
+    *out = dsd_app_scan_timing{};
+    if (opts == nullptr || state == nullptr) {
+        return -1;
+    }
+    (void)now_m;
+    const bool scanning = opts->trunk_scan_enabled == 1 || opts->scanner_mode == 1;
+    if (!scanning || g_stub_scan_timing.reason == DSD_SCAN_STAY_NONE) {
+        return 0;
+    }
+    *out = g_stub_scan_timing;
+    out->active = 1U;
+    return 1;
 }
 
 extern "C" dsd_frontend_snr_readout
@@ -409,10 +444,107 @@ test_options_readiness() {
     freeState(&state);
 }
 
+/*
+ * Why the rotation is staying on the row on air, and how long is left (#508).
+ *
+ * The countdown is published in tenths of a second rather than milliseconds on
+ * purpose: the reading decides whether controlChanged fires, so at millisecond
+ * resolution every 250 ms poll would move it and re-evaluate every binding on the
+ * control group for a row that renders one decimal place.
+ */
+static void
+test_scan_timing() {
+    static dsd_opts opts;
+    static dsd_state state;
+    initOpts(&opts);
+    initState(&state);
+    dsd_qt::MetricsModel model;
+    int changes = 0;
+    QObject::connect(&model, &dsd_qt::MetricsModel::controlChanged, [&]() { ++changes; });
+
+    /* A trunked target following a call: no countdown, the dwell disarmed while the
+     * call holds the row, and the -t hangtime that will release it. */
+    opts.trunk_scan_enabled = 1;
+    g_stub_scan_timing = dsd_app_scan_timing{};
+    g_stub_scan_timing.reason = DSD_SCAN_STAY_CALL_FOLLOW;
+    g_stub_scan_timing.phrase = "Following call";
+    g_stub_scan_timing.show_dwell = 1U;
+    g_stub_scan_timing.dwell_ms = 3000U;
+    g_stub_scan_timing.dwell_state = DSD_APP_SCAN_DWELL_SUSPENDED;
+    /* Carried by the publication but withheld by the view: a trunked row has no
+     * conventional activity hold, and printing one would invent a budget. */
+    g_stub_scan_timing.hold_ms = 2000U;
+    g_stub_scan_timing.show_hang = 1U;
+    g_stub_scan_timing.hang_ms = 2000U;
+    model.refresh(&opts, &state);
+    expect("a followed call names why the scanner stays",
+           model.scanTimingVisible() && model.scanStayReason() == DSD_SCAN_STAY_CALL_FOLLOW
+               && model.scanStayPhrase() == QStringLiteral("Following call"));
+    expect("a followed call runs no countdown",
+           !model.scanTimerLive() && model.scanTimerRemainingDs() == 0 && model.scanTimerSpanMs() == 0);
+    expect("the suspended dwell still reads out",
+           model.scanDwellMs() == 3000 && model.scanDwellState() == DSD_APP_SCAN_DWELL_SUSPENDED);
+    expect("a trunked row never shows a conventional hold", model.scanHoldMs() == 0);
+    expect("a followed call shows the hangtime that will release it", model.scanHangMs() == 2000);
+    expect("scan timing rides the control group", changes > 0);
+    const int settled = changes;
+    model.refresh(&opts, &state);
+    expect("an unchanged scan timing does not notify twice", changes == settled);
+
+    /* A conventional row counting its idle dwell down, with the activity hold that
+     * would extend the stay if something showed up. */
+    opts.trunk_scan_enabled = 0;
+    opts.scanner_mode = 1;
+    g_stub_scan_timing = dsd_app_scan_timing{};
+    g_stub_scan_timing.reason = DSD_SCAN_STAY_IDLE_DWELL;
+    g_stub_scan_timing.phrase = "Idle dwell";
+    g_stub_scan_timing.timer_live = 1U;
+    g_stub_scan_timing.remaining_ms = 1849U;
+    g_stub_scan_timing.span_ms = 3000U;
+    g_stub_scan_timing.show_hold = 1U;
+    g_stub_scan_timing.hold_ms = 2000U;
+    model.refresh(&opts, &state);
+    expect("an idle dwell counts down", model.scanTimerLive() && model.scanTimerSpanMs() == 3000);
+    expect("the countdown reaches the row in tenths", model.scanTimerRemainingDs() == 18);
+    expect("a conventional row shows its activity hold", model.scanHoldMs() == 2000);
+    expect("the dwell the countdown already shows is not printed twice", model.scanDwellMs() == 0);
+
+    const int quiet = changes;
+    g_stub_scan_timing.remaining_ms = 1801U;
+    model.refresh(&opts, &state);
+    expect("a countdown moving inside one tenth notifies nothing",
+           changes == quiet && model.scanTimerRemainingDs() == 18);
+    g_stub_scan_timing.remaining_ms = 1799U;
+    model.refresh(&opts, &state);
+    expect("the countdown moves on the tenth", model.scanTimerRemainingDs() == 17 && changes > quiet);
+
+    model.clear();
+    expect("a stopped session leaves no scan timing behind",
+           !model.scanTimingVisible() && model.scanStayReason() == DSD_SCAN_STAY_NONE
+               && model.scanStayPhrase().isEmpty() && !model.scanTimerLive() && model.scanTimerRemainingDs() == 0
+               && model.scanTimerSpanMs() == 0 && model.scanDwellMs() == 0
+               && model.scanDwellState() == DSD_APP_SCAN_DWELL_NONE && model.scanHoldMs() == 0
+               && model.scanHangMs() == 0);
+
+    /* Plain trunking and a plain single system are not rotations: there is no row to
+     * stay on, so the view says nothing and the panel shows nothing. */
+    opts.scanner_mode = 0;
+    g_stub_scan_timing.reason = DSD_SCAN_STAY_IDLE_DWELL;
+    opts.trunk_enable = 1;
+    model.refresh(&opts, &state);
+    expect("nothing is rotating: the row stays down",
+           !model.scanTimingVisible() && model.scanStayPhrase().isEmpty() && model.scanDwellMs() == 0);
+    opts.trunk_enable = 0;
+
+    g_stub_scan_timing = dsd_app_scan_timing{};
+    freeState(&state);
+}
+
 int
 main(int argc, char** argv) {
     QCoreApplication app(argc, argv);
     test_options_readiness();
+    test_scan_timing();
     test_decryption_metadata();
     test_site();
     test_quality();

--- a/tests/ui/test_ui_snapshot_event_history.c
+++ b/tests/ui/test_ui_snapshot_event_history.c
@@ -20,6 +20,7 @@
 #include <dsd-neo/runtime/decode_mode.h>
 #include <dsd-neo/runtime/scan_mode.h>
 #include <dsd-neo/runtime/trunk_cc_candidates.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -127,6 +128,15 @@ assert_render_fields(const dsd_state* snap) {
     assert(snap->trunk_scan_hold == 1U);
     assert(snap->trunk_scan_active_avoided == 1U);
     assert(snap->trunk_scan_avoided_count == 3U);
+    /* The scan timing publication rides the same inline range. The renderer differences
+       its absolute anchors against its own clock, so every field has to survive the copy. */
+    assert(snap->scan_timing.reason == (uint8_t)DSD_SCAN_STAY_IDLE_DWELL);
+    assert(snap->scan_timing.conventional == 1U);
+    assert(fabs(snap->scan_timing.started_m - 120.5) < 1e-6);
+    assert(fabs(snap->scan_timing.deadline_m - 123.5) < 1e-6);
+    assert(snap->scan_timing.span_ms == 3000U);
+    assert(snap->scan_timing.dwell_ms == 3000U);
+    assert(snap->scan_timing.hold_ms == 2000U);
 }
 
 static void
@@ -216,6 +226,13 @@ main(void) {
     state->trunk_scan_hold = 1U;
     state->trunk_scan_active_avoided = 1U;
     state->trunk_scan_avoided_count = 3U;
+    state->scan_timing.reason = (uint8_t)DSD_SCAN_STAY_IDLE_DWELL;
+    state->scan_timing.conventional = 1U;
+    state->scan_timing.started_m = 120.5;
+    state->scan_timing.deadline_m = 123.5;
+    state->scan_timing.span_ms = 3000U;
+    state->scan_timing.dwell_ms = 3000U;
+    state->scan_timing.hold_ms = 2000U;
 
     assert(dsd_trunk_cc_candidates_add(state, 851006250L, 1, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) == 1);
     assert(dsd_trunk_cc_candidates_add(state, 852006250L, 1, DSD_TRUNK_CC_CANDIDATE_CURRENT_SITE) == 1);


### PR DESCRIPTION
## Summary

Busy trunked systems and continuously transmitting conventional channels can keep the scanner on one target indefinitely. `--scan-max-visit-ms` adds an optional maximum per visit so other eligible targets receive listening time, including during continuous DMR base-station voice.

- Supports conventional `-Y` and every `--trunk-scan` target type. The CLI, `[trunking] scan_max_visit_ms`, and CSV `options` accept a global limit with per-row overrides: `0` disables it; otherwise `1000..3600000` ms. An absent row value inherits the global; row `0` exempts that target. Configuration export preserves the configured global value.
- Measures from successful parking using the monotonic clock. Activity, grants, internal control/voice-channel retunes, and idle-timer resets do not extend a visit. Continuous DMR checks the deadline through a runtime hook and unwinds at a burst boundary before the engine retunes.
- Expiry advances even mid-call. Operator target hold takes precedence; talkgroup hold suspends the cap while the followed call matches. Holds and periods with no eligible alternate re-arm the timer, so eligibility returning does not cause an immediate eviction.
- Forced eviction clears the outgoing call before saving its target snapshot. P25/DMR release counters count actual released calls, and abandoning a P25 carrier does not count a control-channel return. If every alternate and the fallback park fail, recovery retries the original control channel after cooldown. Pending fallback parks remain unarmed until completion.
- Adds the effective cap and its live countdown to the terminal and Qt Scan Timing row. Includes CLI/config/CSV examples and documentation. Incorporates current `main`, preserving the scan-timing fixes from #510 and the P25 lockout fix from #511.

Closes https://github.com/arancormonk/dsd-neo/issues/507

Known caveats: duplicate frequencies in legacy `-Y` lists can hop to the same frequency; two busy targets can alternate at the configured limits; the Qt/Android scan-list editor does not model the row option (use Extra decoder arguments or edit the CSV); failed-eviction rollback can record a second call-end event when scrubbing restored call state.

Claude Opus at xhigh effort reviewed the PR. The three original review items and three additional findings are addressed, with regressions for continuous DMR, delayed first ticks after parking, avoid/cooldown eligibility transitions, release counters, and synchronous/asynchronous fallback recovery.

## Review

- [x] Changes were reviewed against the surrounding module design.
- [ ] Behavior, ownership boundaries, and failure modes were reviewed by a human.
- [x] Risky or broad changes received a second model review (Claude Opus, xhigh). Human review remains pending.
- [x] High-risk areas touched are marked: parser (CSV `options` grammar, CLI, INI) / none of security, workflow, release, crypto, dependency, network input.
- [x] Outside review completed: Claude Opus (xhigh), followed by independent assessment and fixes.
- [x] Copied, generated, or bulk-written code has been read, understood, and adapted to DSD-neo conventions.
- [x] Non-trivial commits include a DCO sign-off, or the exception is explained.

## Quality Review

- [x] New parser, decoder, file input, network/radio input, allocator, thread, or dependency changes include focused tests.
- [x] Protocol, crypto, runtime, IO, workflow, dependency, and release changes received extra scrutiny.
- [x] Static-analysis suppressions include a reason and are limited to the narrowest scope. (none added)
- [x] No new raw C memory/string/formatting APIs, direct third-party includes, shell execution, or broad workflow permissions were added without justification.

## Tests And Guardrails

- [x] `cmake --build --preset dev-debug -j`
- [x] `ctest --preset dev-debug --output-on-failure` — all 670 registered tests pass.
- [x] Repository pre-push checks (architecture, formatting, complexity, Semgrep, clang-tidy, GCC analyzer, cppcheck, and IWYU).
- [ ] `tools/quality_preflight.sh` for broad or high-risk changes
- [x] `tools/cmake_format_check.sh` for CMake changes (`tests/CMakeLists.txt`)
- [ ] `tools/zizmor.sh` for workflow changes (n/a)
- [ ] `tools/osv_scan.sh` for dependency input changes (n/a)
- [ ] security-sensitive workflow/release checks (n/a)

## Risk

- Security/dependency impact: none. New CSV/CLI/INI inputs are bounded integers validated by the existing range parsers.
- CLI/UI behavior impact: none unless `--scan-max-visit-ms` / `scan_max_visit_ms` / a row option is set (default `0` keeps rotation byte-for-byte unchanged; verified by regression tests). When set, an ongoing call can be cut short at the limit by design. New `Visit:` field in the Scan Timing row only when a cap applies.
- Compatibility or packaging impact: one new INI key rendered unconditionally on save (`scan_max_visit_ms = 0`); an older build's `--validate-config` reports it as an unknown-key warning (0 errors) and otherwise ignores it. Publication struct grows by two scalars (internal).


